### PR TITLE
Handle parsing of form attributes with no value

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/MicronautHttpData.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/MicronautHttpData.java
@@ -513,7 +513,7 @@ public abstract sealed class MicronautHttpData<D extends HttpData> extends Abstr
 
         @Override
         public void setValue(String value) throws IOException {
-            throw new UnsupportedOperationException();
+            setContent(Unpooled.copiedBuffer(value.toCharArray(), factory.characterEncoding));
         }
 
         @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/MicronautHttpData.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/MicronautHttpData.java
@@ -513,7 +513,7 @@ public abstract sealed class MicronautHttpData<D extends HttpData> extends Abstr
 
         @Override
         public void setValue(String value) throws IOException {
-            setContent(Unpooled.copiedBuffer(value.toCharArray(), factory.characterEncoding));
+            setContent(Unpooled.copiedBuffer(value, factory.characterEncoding));
         }
 
         @Override

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/AbstractMicronautSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/AbstractMicronautSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.netty
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.BlockingHttpClient
 import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
@@ -37,8 +38,8 @@ abstract class AbstractMicronautSpec extends Specification {
     @Shared int serverPort = embeddedServer.getPort()
     @Shared URL server = embeddedServer.getURL()
     @Shared @AutoCleanup ApplicationContext applicationContext = embeddedServer.applicationContext
-    @Shared @AutoCleanup HttpClient rxClient = applicationContext.createBean(HttpClient, server)
-
+    @Shared @AutoCleanup HttpClient httpClient = applicationContext.createBean(HttpClient, server)
+    @Shared @AutoCleanup BlockingHttpClient client = httpClient.toBlocking()
 
     Collection<String> configurationNames() {
         ['io.micronaut.configuration.jackson','io.micronaut.web.router']

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/RequestCertificateSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/RequestCertificateSpec.groovy
@@ -20,7 +20,7 @@ class RequestCertificateSpec extends AbstractMicronautSpec {
 
     void "test certificate extraction"() {
         when:
-        def response = Flux.from(rxClient
+        def response = Flux.from(httpClient
                 .exchange('/ssl', String))
                 .blockFirst()
         then:

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/CookieBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/CookieBindingSpec.groovy
@@ -22,7 +22,6 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.cookie.Cookies
 import io.micronaut.http.server.netty.AbstractMicronautSpec
-import reactor.core.publisher.Flux
 import spock.lang.Unroll
 
 /**
@@ -37,7 +36,7 @@ class CookieBindingSpec extends AbstractMicronautSpec {
         for (header in headers) {
             request = request.header(header.key, header.value)
         }
-        rxClient.toBlocking().retrieve(request) == result
+        httpClient.toBlocking().retrieve(request) == result
 
         where:
         uri                | result              | headers

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/CustomParameterBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/CustomParameterBindingSpec.groovy
@@ -20,7 +20,7 @@ class CustomParameterBindingSpec extends AbstractMicronautSpec {
     void "test bind HTTP parameters for URI #httpMethod #uri"() {
         given:
         HttpRequest<?> req = HttpRequest.create(HttpMethod.CUSTOM, uri, httpMethod)
-        Publisher<HttpResponse<?>> exchange = rxClient.exchange(req, String)
+        Publisher<HttpResponse<?>> exchange = httpClient.exchange(req, String)
         HttpResponse<?> response = Flux.from(exchange).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
                 return Flux.just(((HttpClientResponseException) t).response)
@@ -74,7 +74,7 @@ class CustomParameterBindingSpec extends AbstractMicronautSpec {
 
     void "test exploded with no default constructor"() {
         when:
-        Flux<HttpResponse<String>> exchange = rxClient.exchange(HttpRequest.create(HttpMethod.CUSTOM, "/parameter/exploded?title=The%20Stand", "REPORT"), String)
+        Flux<HttpResponse<String>> exchange = httpClient.exchange(HttpRequest.create(HttpMethod.CUSTOM, "/parameter/exploded?title=The%20Stand", "REPORT"), String)
         HttpResponse<String> response = exchange.blockFirst()
 
         then:

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/DefaultJsonErrorHandlingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/DefaultJsonErrorHandlingSpec.groovy
@@ -16,7 +16,7 @@ class DefaultJsonErrorHandlingSpec extends AbstractMicronautSpec {
 
         when:
         def json = '{"title":"The Stand"'
-        Flux.from(rxClient.exchange(
+        Flux.from(httpClient.exchange(
                 HttpRequest.POST('/errors/map', json), String
         )).blockFirst()
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
@@ -41,10 +41,10 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
 
     void "test simple string-based body parsing"() {
         when:
-        HttpResponse<?> response = Flux.from(rxClient.exchange(HttpRequest.POST('/form/simple', [
+        HttpResponse<?> response = client.exchange(HttpRequest.POST('/form/simple', [
                 name:"Fred",
                 age:"10"
-        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst()
+        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)
 
         then:
         response.status == HttpStatus.OK
@@ -54,11 +54,11 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
 
     void "test pojo body parsing"() {
         when:
-        HttpResponse<?> response = Flux.from(rxClient.exchange(HttpRequest.POST('/form/pojo', [
+        HttpResponse<?> response = client.exchange(HttpRequest.POST('/form/pojo', [
                 name:"Fred",
                 age:"10",
                 something: "else"
-        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst()
+        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)
 
         then:
         response.status == HttpStatus.OK
@@ -68,9 +68,9 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
 
     void "test simple string-based body parsing with missing data"() {
         when:
-        Flux.from(rxClient.exchange(HttpRequest.POST('/form/simple', [
+        client.exchange(HttpRequest.POST('/form/simple', [
                 name:"Fred"
-        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst()
+        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)
 
         then:
         HttpClientResponseException e = thrown()
@@ -81,8 +81,8 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
     @Unroll
     void "test application/x-www-form-urlencoded String #body is parsed to #parsedMapString"() {
         when:
-        String result = Flux.from(rxClient.exchange(HttpRequest.POST('/form/map', body)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst().getBody(String.class).get()
+        String result = client.exchange(HttpRequest.POST('/form/map', body)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).getBody(String.class).get()
 
         then:
         result == parsedMapString
@@ -122,8 +122,8 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
     void "test application/x-www-form-urlencoded String #body with single key fails to parse"() {
         // NOTE - Parsing is expected to fail here unless HttpPostStandardRequestDecoder is corrected
         when:
-        String result = Flux.from(rxClient.exchange(HttpRequest.POST('/form/map', body)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst().getBody(String.class).get()
+        String result = client.exchange(HttpRequest.POST('/form/map', body)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).getBody(String.class).get()
 
         then:
         def ex = thrown(HttpClientResponseException)
@@ -141,8 +141,8 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
     void "test application/x-www-form-urlencoded String #body with single key as the last attribute fails to parse to #parsedMapString"() {
         // NOTE - Parsing is expected to fail here unless HttpPostStandardRequestDecoder is corrected
         when:
-        String result = Flux.from(rxClient.exchange(HttpRequest.POST('/form/map', body)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst().getBody(String.class).get()
+        String result = client.exchange(HttpRequest.POST('/form/map', body)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).getBody(String.class).get()
 
         then:
         result != parsedMapString
@@ -160,8 +160,8 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
         // scenarios are exercised than the above that uses a raw String body. The key with empty value works here because it is
         // sent as key= instead of just key, and Netty parses that correctly on the server end.
         when:
-        String result = Flux.from(rxClient.exchange(HttpRequest.POST('/form/map', body)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst().getBody(String.class).get()
+        String result = client.exchange(HttpRequest.POST('/form/map', body)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).getBody(String.class).get()
 
         then:
         result == parsedMapString
@@ -196,8 +196,8 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
     void "test POST SAML form multipart form data"() {
         given:
         MultipartBody body = MultipartBody.builder().addPart("SAMLResponse", SAML_DATA).build()
-        String data = Flux.from(rxClient.retrieve(HttpRequest.POST("/form/saml/test/form-data", body)
-                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE), String)).blockFirst()
+        String data = client.retrieve(HttpRequest.POST("/form/saml/test/form-data", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE), String)
 
         expect:
         data == SAML_DATA
@@ -238,10 +238,10 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/2263")
     void "test binding directly to a string"() {
         when:
-        HttpResponse<String> response = Flux.from(rxClient.exchange(HttpRequest.POST('/form/string', [
+        HttpResponse<String> response = client.exchange(HttpRequest.POST('/form/string', [
                 name:"Fred",
                 age:"10"
-        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst()
+        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)
 
         then:
         response.status == HttpStatus.OK
@@ -251,10 +251,10 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
 
     void "test binding directly to a reactive string"() {
         when:
-        HttpResponse<String> response = Flux.from(rxClient.exchange(HttpRequest.POST('/form/maybe-string', [
+        HttpResponse<String> response = client.exchange(HttpRequest.POST('/form/maybe-string', [
                 name:"Fred",
                 age:"10"
-        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst()
+        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)
 
         then:
         response.status == HttpStatus.OK

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/HeaderBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/HeaderBindingSpec.groovy
@@ -23,7 +23,6 @@ import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
 import io.micronaut.http.server.netty.AbstractMicronautSpec
-import reactor.core.publisher.Flux
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -53,7 +52,7 @@ class HeaderBindingSpec extends AbstractMicronautSpec {
         for (header in headers) {
             request = request.header(header.key, header.value)
         }
-        rxClient.toBlocking().retrieve(request) == result
+        httpClient.toBlocking().retrieve(request) == result
 
         where:
         uri                       | result                       | headers

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/HttpResponseSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/HttpResponseSpec.groovy
@@ -43,7 +43,7 @@ class HttpResponseSpec extends AbstractMicronautSpec {
     void "test custom HTTP response for java action #action"() {
 
         when:
-        HttpResponse<?> response = Flux.from(rxClient.exchange("/java/response/$action", String))
+        HttpResponse<?> response = Flux.from(httpClient.exchange("/java/response/$action", String))
                 .onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
                 return Flux.just(((HttpClientResponseException) t).response)
@@ -85,7 +85,7 @@ class HttpResponseSpec extends AbstractMicronautSpec {
     @Unroll
     void "test custom HTTP response for action #action"() {
         when:
-        HttpResponse<?> response = Flux.from(rxClient.exchange("/java/response/$action", String))
+        HttpResponse<?> response = Flux.from(httpClient.exchange("/java/response/$action", String))
                 .onErrorResume(t -> {
                     if (t instanceof HttpClientResponseException) {
                         return Flux.just(((HttpClientResponseException) t).response)
@@ -121,7 +121,7 @@ class HttpResponseSpec extends AbstractMicronautSpec {
 
     void "test content encoding"() {
         when:
-        HttpResponse<String> response = Flux.from(rxClient.exchange(HttpRequest.GET("/java/response/ok-with-body").header("Accept-Encoding", "gzip"), String))
+        HttpResponse<String> response = Flux.from(httpClient.exchange(HttpRequest.GET("/java/response/ok-with-body").header("Accept-Encoding", "gzip"), String))
                 .onErrorResume(t -> {
                     if (t instanceof HttpClientResponseException) {
                         return Flux.just(((HttpClientResponseException) t).response)
@@ -138,7 +138,7 @@ class HttpResponseSpec extends AbstractMicronautSpec {
 
     void "test custom headers"() {
         when:
-        HttpResponse<?> response = Flux.from(rxClient.exchange(HttpRequest.GET("/java/response/custom-headers")))
+        HttpResponse<?> response = Flux.from(httpClient.exchange(HttpRequest.GET("/java/response/custom-headers")))
                 .onErrorResume(t -> {
                     if (t instanceof HttpClientResponseException) {
                         return Flux.just(((HttpClientResponseException) t).response)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/JsonBodyBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/JsonBodyBindingSpec.groovy
@@ -29,7 +29,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test JSON is not parsed when the body is a raw body type"() {
         when:
         String json = '{"title":"The Stand"'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/string', json), String
         )).blockFirst()
 
@@ -41,7 +41,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test JSON is not parsed when the body is a raw body type in a request argument"() {
         when:
         String json = '{"title":"The Stand"'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/request-string', json), String
         )).blockFirst()
 
@@ -53,7 +53,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test parse body into parameters if no @Body specified"() {
         when:
         String json = '{"name":"Fred", "age":10}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/params', json), String
         )).blockFirst()
 
@@ -66,7 +66,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
 
         when:
         String json = '{"title":The Stand}'
-        Flux.from(rxClient.exchange(
+        Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/map', json), String
         )).blockFirst()
 
@@ -91,7 +91,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test simple map body parsing"() {
         when:
         String json = '{"title":"The Stand"}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/map', json), String
         )).blockFirst()
 
@@ -102,7 +102,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test simple string-based body parsing"() {
         when:
         String json = '{"title":"The Stand"}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/string', json), String
         )).blockFirst()
 
@@ -113,7 +113,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test binding to part of body with @Body(name)"() {
         when:
         String json = '{"title":"The Stand"}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/body-title', json), String
         )).blockFirst()
 
@@ -124,7 +124,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void  "test simple string-based body parsing with request argument"() {
         when:
         String json = '{"title":"The Stand"}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/request-string', json), String
         )).blockFirst()
 
@@ -135,7 +135,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test simple string-based body parsing with invalid mime type"() {
         when:
         String json = '{"title":"The Stand"}'
-        Flux.from(rxClient.exchange(
+        Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/map', json).contentType(io.micronaut.http.MediaType.APPLICATION_ATOM_XML_TYPE), String
         )).blockFirst()
 
@@ -147,7 +147,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test simple POGO body parsing"() {
         when:
         String json = '{"name":"Fred", "age":10}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/object', json), String
         )).blockFirst()
 
@@ -158,7 +158,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test simple POGO body parse and return"() {
         when:
         String json = '{"name":"Fred","age":10}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/object-to-object', json), String
         )).blockFirst()
 
@@ -169,7 +169,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test array POGO body parsing"() {
         when:
         String json = '[{"name":"Fred", "age":10},{"name":"Barney", "age":11}]'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/array', json), String
         )).blockFirst()
 
@@ -180,7 +180,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test array POGO body parsing and return"() {
         when:
         String json = '[{"name":"Fred","age":10},{"name":"Barney","age":11}]'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/array-to-array', json), String
         )).blockFirst()
 
@@ -191,7 +191,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test list POGO body parsing"() {
         when:
         String json = '[{"name":"Fred", "age":10},{"name":"Barney", "age":11}]'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/list', json), String
         )).blockFirst()
 
@@ -202,7 +202,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test future argument handling with string"() {
         when:
         String json = '{"name":"Fred","age":10}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/future', json), String
         )).blockFirst()
 
@@ -213,7 +213,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test future argument handling with map"() {
         when:
         String json = '{"name":"Fred","age":10}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/future-map', json), String
         )).blockFirst()
 
@@ -224,7 +224,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test future argument handling with POGO"() {
         when:
         String json = '{"name":"Fred","age":10}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/future-object', json), String
         )).blockFirst()
 
@@ -235,7 +235,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test publisher argument handling with POGO"() {
         when:
         String json = '{"name":"Fred","age":10}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/publisher-object', json), String
         )).blockFirst()
 
@@ -246,7 +246,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test singe argument handling"() {
         when:
         String json = '{"message":"foo"}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/single', json), String
         )).blockFirst()
 
@@ -257,7 +257,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test request generic type binding"() {
         when:
         String json = '{"name":"Fred","age":10}'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/request-generic', json), String
         )).blockFirst()
 
@@ -268,7 +268,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test request generic type no body"() {
         when:
         String json = ''
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/request-generic', json), String
         )).blockFirst()
 
@@ -280,7 +280,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test request generic type conversion error"() {
         when:
         String json = '[1,2,3]'
-        Flux.from(rxClient.exchange(
+        Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/request-generic', json), String
         )).blockFirst()
 
@@ -295,7 +295,7 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
     void "test deserializing a wrapper of list of pojos"() {
         when:
         String json = '[{"name":"Joe"},{"name":"Sally"}]'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/json/deserialize-listwrapper', json), String
         )).blockFirst()
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
@@ -38,7 +38,7 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
     void "test bind HTTP parameters for URI #httpMethod #uri"() {
         given:
         HttpRequest req = httpMethod == HttpMethod.GET ? HttpRequest.GET(uri) : HttpRequest.POST(uri, '{}')
-        Flux exchange = Flux.from(rxClient.exchange(req, String))
+        Flux exchange = Flux.from(httpClient.exchange(req, String))
         HttpResponse response = exchange.onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
                 return Flux.just(((HttpClientResponseException) t).response)
@@ -94,7 +94,7 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
     void "test list to single error"() {
         given:
         HttpRequest req = HttpRequest.GET('/parameter/exploded?title=The%20Stand&age=20&age=30')
-        Flux exchange = Flux.from(rxClient.exchange(req, String))
+        Flux exchange = Flux.from(httpClient.exchange(req, String))
         HttpResponse response = exchange.onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
                 return Flux.just(((HttpClientResponseException) t).response)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/QueryParameterFormattingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/QueryParameterFormattingSpec.groovy
@@ -23,7 +23,7 @@ public class QueryParameterFormattingSpec extends AbstractMicronautSpec {
         given:
         var encodedUri = uri.replace("|", PIPE).replace(" ", "+")
         HttpRequest<?> req = HttpRequest.create(HttpMethod.GET, encodedUri)
-        Publisher<HttpResponse<?>> exchange = rxClient.exchange(req, String)
+        Publisher<HttpResponse<?>> exchange = httpClient.exchange(req, String)
         HttpResponse<?> response = Flux.from(exchange).blockFirst()
         def body = response.body()
 
@@ -60,7 +60,7 @@ public class QueryParameterFormattingSpec extends AbstractMicronautSpec {
     void "test bind formatted query parameters object initialization error"() {
         when:
         HttpRequest<?> req = HttpRequest.create(HttpMethod.GET, '/formatted/o/csv')
-        Publisher<HttpResponse<?>> exchange = rxClient.exchange(req, String)
+        Publisher<HttpResponse<?>> exchange = httpClient.exchange(req, String)
         Flux.from(exchange).blockFirst()
         then:
         var e = thrown(HttpClientResponseException)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/RegexBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/RegexBindingSpec.groovy
@@ -28,7 +28,7 @@ class RegexBindingSpec extends AbstractMicronautSpec {
 
     void "test regex matches"() {
         when:
-        HttpResponse response = rxClient.toBlocking().exchange(HttpRequest.GET("/test-binding/regex/blue"))
+        HttpResponse response = httpClient.toBlocking().exchange(HttpRequest.GET("/test-binding/regex/blue"))
 
         then:
         response.status() == HttpStatus.OK
@@ -36,7 +36,7 @@ class RegexBindingSpec extends AbstractMicronautSpec {
 
     void "test regex does not match"() {
         when:
-        rxClient.toBlocking().exchange(HttpRequest.GET("/test-binding/regex/yellow"))
+        httpClient.toBlocking().exchange(HttpRequest.GET("/test-binding/regex/yellow"))
 
         then:
         def e = thrown(HttpClientResponseException)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/RequestAttributeBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/RequestAttributeBindingSpec.groovy
@@ -14,15 +14,13 @@ import io.micronaut.http.filter.HttpServerFilter
 import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.http.server.netty.AbstractMicronautSpec
 import org.reactivestreams.Publisher
-import spock.lang.Issue
-
 import jakarta.annotation.Nullable
 
 class RequestAttributeBindingSpec extends AbstractMicronautSpec {
 
     void "test request attribute binding from a filter"() {
         given:
-        BlockingHttpClient client = rxClient.toBlocking()
+        BlockingHttpClient client = httpClient.toBlocking()
 
         expect:
         client.retrieve("/attribute/filter/implicit") == "Sally"

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/ConsumesMatchesRouteSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/ConsumesMatchesRouteSpec.groovy
@@ -20,7 +20,6 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.*
 import io.micronaut.http.server.netty.AbstractMicronautSpec
-import reactor.core.publisher.Flux
 import spock.lang.Unroll
 
 import static io.micronaut.http.MediaType.*
@@ -29,14 +28,14 @@ class ConsumesMatchesRouteSpec extends AbstractMicronautSpec {
 
     void "test routes are filtered by consumes"() {
         when:
-        String body = rxClient.toBlocking().retrieve(HttpRequest.POST("/test-consumes", [x: 1]).contentType(APPLICATION_JSON_TYPE))
+        String body = httpClient.toBlocking().retrieve(HttpRequest.POST("/test-consumes", [x: 1]).contentType(APPLICATION_JSON_TYPE))
 
         then:
         noExceptionThrown()
         body == "json"
 
         when:
-        body = rxClient.toBlocking().retrieve(HttpRequest.POST("/test-consumes", "abc").contentType(APPLICATION_GRAPHQL_TYPE))
+        body = httpClient.toBlocking().retrieve(HttpRequest.POST("/test-consumes", "abc").contentType(APPLICATION_GRAPHQL_TYPE))
 
         then:
         noExceptionThrown()
@@ -65,14 +64,14 @@ class ConsumesMatchesRouteSpec extends AbstractMicronautSpec {
 
     void "test routes are not filtered by content-type when consumes=all"() {
         when:
-        String body = rxClient.toBlocking().retrieve(HttpRequest.POST("/test-consumes-all", "true").contentType(APPLICATION_JSON_TYPE))
+        String body = httpClient.toBlocking().retrieve(HttpRequest.POST("/test-consumes-all", "true").contentType(APPLICATION_JSON_TYPE))
 
         then:
         noExceptionThrown()
         body == "all:true"
 
         when:
-        body = rxClient.toBlocking().retrieve(HttpRequest.POST("/test-consumes-all", "graphql").contentType(APPLICATION_GRAPHQL_TYPE))
+        body = httpClient.toBlocking().retrieve(HttpRequest.POST("/test-consumes-all", "graphql").contentType(APPLICATION_GRAPHQL_TYPE))
 
         then:
         noExceptionThrown()
@@ -101,7 +100,7 @@ class ConsumesMatchesRouteSpec extends AbstractMicronautSpec {
 
     void "test accept matching has priority over route complexity"() {
         when:
-        String body = rxClient.toBlocking().retrieve(HttpRequest.POST("/test-accept/foo", [x: 1]).contentType(APPLICATION_JSON_TYPE))
+        String body = httpClient.toBlocking().retrieve(HttpRequest.POST("/test-accept/foo", [x: 1]).contentType(APPLICATION_JSON_TYPE))
 
         then:
         noExceptionThrown()
@@ -111,7 +110,7 @@ class ConsumesMatchesRouteSpec extends AbstractMicronautSpec {
     @Unroll
     void "test pick most specific route for #uri"() {
         given:
-        String result = rxClient.toBlocking().retrieve(HttpRequest.GET("/hello$uri").accept("text/html", "*/*;q=0.8"))
+        String result = httpClient.toBlocking().retrieve(HttpRequest.GET("/hello$uri").accept("text/html", "*/*;q=0.8"))
 
         expect:
         result == expected

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/RouteComplexitySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/RouteComplexitySpec.groovy
@@ -6,50 +6,48 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.server.netty.AbstractMicronautSpec
-import reactor.core.publisher.Flux
-
 import jakarta.annotation.Nullable
 
 class RouteComplexitySpec extends AbstractMicronautSpec {
 
     void "test route complexity"() {
         when:
-        String body = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/id/somefile.xls"))
+        String body = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/id/somefile.xls"))
 
         then:
         noExceptionThrown()
         body == "fallback"
 
         when:
-        body = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/id/somefile.csv"))
+        body = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/id/somefile.csv"))
 
         then:
         noExceptionThrown()
         body == "csv"
 
         when:
-        body = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/other/a/b/c/d"))
+        body = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/other/a/b/c/d"))
 
         then:
         noExceptionThrown()
         body == "ab/c"
 
         when:
-        body = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/other2/a/b/c"))
+        body = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/other2/a/b/c"))
 
         then:
         noExceptionThrown()
         body == "ab/c"
 
         when:
-        body = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/list"))
+        body = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/list"))
 
         then:
         noExceptionThrown()
         body == "list"
 
         when:
-        body = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/length/abc"))
+        body = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-complexity/length/abc"))
 
         then:
         noExceptionThrown()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/NettyCorsSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/NettyCorsSpec.groovy
@@ -50,7 +50,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test non cors request"() {
         when:
-        HttpResponse response = rxClient.toBlocking().exchange('/test')
+        HttpResponse response = httpClient.toBlocking().exchange('/test')
         Set<String> headerNames = response.getHeaders().names()
 
         then:
@@ -61,7 +61,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test cors request without configuration"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/test')
                            .header(ORIGIN, 'fooBar.com')
         )).blockFirst()
@@ -76,7 +76,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test cors request with a controller that returns map"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/test/arbitrary')
                         .header(ORIGIN, 'foo.com')
         )).blockFirst()
@@ -98,7 +98,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test cors request with controlled method"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/test')
                         .header(ORIGIN, 'foo.com')
         )).blockFirst()
@@ -120,7 +120,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test cors request with controlled headers"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/test')
                         .header(ORIGIN, 'bar.com')
                         .header(ACCEPT, 'application/json')
@@ -144,7 +144,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test cors request with invalid method"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/test', [:])
                         .header(ORIGIN, 'foo.com')
 
@@ -165,7 +165,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test cors request with invalid header"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/test')
                         .header(ORIGIN, 'bar.com')
                         .header(ACCESS_CONTROL_REQUEST_HEADERS, 'Foo, Accept')
@@ -177,7 +177,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test preflight request with invalid header"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.OPTIONS('/test')
                         .header(ACCESS_CONTROL_REQUEST_METHOD, 'GET')
                         .header(ORIGIN, 'bar.com')
@@ -195,7 +195,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test preflight request with invalid method"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.OPTIONS('/test')
                         .header(ACCESS_CONTROL_REQUEST_METHOD, 'POST')
                         .header(ORIGIN, 'foo.com')
@@ -212,7 +212,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test preflight request with controlled method"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.OPTIONS('/test')
                         .header(ACCESS_CONTROL_REQUEST_METHOD, 'GET')
                         .header(ORIGIN, 'foo.com')
@@ -235,7 +235,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test preflight request with controlled headers"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.OPTIONS('/test')
                         .header(ACCESS_CONTROL_REQUEST_METHOD, 'POST')
                         .header(ORIGIN, 'bar.com')
@@ -259,7 +259,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test preflight request with controlled headers but http method doesn't exists"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.OPTIONS('/test/arbitrary')
                         .header(ACCESS_CONTROL_REQUEST_METHOD, 'POST')
                         .header(ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK, StringUtils.TRUE)
@@ -278,7 +278,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test control headers are applied to error response routes"() {
         when:
-        Flux.from(rxClient.exchange(
+        Flux.from(httpClient.exchange(
                 HttpRequest.GET('/test/error')
                         .header(ORIGIN, 'foo.com')
         )).blockFirst()
@@ -292,7 +292,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test control headers are applied to error responses with no handler"() {
         when:
-        Flux.from(rxClient.exchange(
+        Flux.from(httpClient.exchange(
                 HttpRequest.GET('/test/error-checked')
                         .header(ORIGIN, 'foo.com')
         )).blockFirst()
@@ -306,7 +306,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
     void "test control headers are applied to http error responses"() {
         when:
-        Flux.from(rxClient.exchange(
+        Flux.from(httpClient.exchange(
                 HttpRequest.GET('/test/error-response')
                         .header(ORIGIN, 'foo.com')
         )).blockFirst()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/errors/ErrorSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/errors/ErrorSpec.groovy
@@ -67,7 +67,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test 500 server error"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/server-error')
         )).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
@@ -84,7 +84,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test 500 server error IOException"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/io-error')
 
         )).onErrorResume(t -> {
@@ -102,7 +102,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test an error route throwing the same exception it handles"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/loop')
 
         )).onErrorResume(t -> {
@@ -120,7 +120,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test an exception handler throwing the same exception it handles"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/loop/handler')
 
         )).onErrorResume(t -> {
@@ -138,7 +138,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test 404 error"() {
         when:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/blah')
         )).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
@@ -161,7 +161,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test 405 error"() {
         when:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.POST('/errors/server-error', 'blah')
         )).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
@@ -184,7 +184,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test content type for error handler"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/handler-content-type-error')
         )).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
@@ -201,7 +201,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test encoding error"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/encoding-error')
         )).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
@@ -219,7 +219,7 @@ class ErrorSpec extends AbstractMicronautSpec {
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/7786')
     void "test encoding error with handler"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/encoding-error/handled')
         )).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
@@ -236,7 +236,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test encoding error with handler loop"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/encoding-error/handled/loop')
         )).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
@@ -253,7 +253,7 @@ class ErrorSpec extends AbstractMicronautSpec {
 
     void "test calling a controller that fails to inject with a local error handler"() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/injection')
         )).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {
@@ -270,7 +270,7 @@ class ErrorSpec extends AbstractMicronautSpec {
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6526')
     def 'test bad request from incorrect use of array'() {
         when:
-        rxClient.toBlocking().exchange(HttpRequest.POST('/errors/feedBirds', '[ { "name": "eagle" }, { "name": "hen" } ]').contentType(MediaType.APPLICATION_JSON))
+        httpClient.toBlocking().exchange(HttpRequest.POST('/errors/feedBirds', '[ { "name": "eagle" }, { "name": "hen" } ]').contentType(MediaType.APPLICATION_JSON))
         then:
         def e = thrown HttpClientResponseException
         e.status == HttpStatus.BAD_REQUEST
@@ -324,7 +324,7 @@ X-Long-Header: $longString\r
 
     def 'missing writer'() {
         given:
-        HttpResponse response = Flux.from(rxClient.exchange(
+        HttpResponse response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/errors/media-type')
         )).onErrorResume(t -> {
             if (t instanceof HttpClientResponseException) {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/errors/HttpStatusExceptionSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/errors/HttpStatusExceptionSpec.groovy
@@ -36,7 +36,7 @@ class HttpStatusExceptionSpec extends AbstractMicronautSpec {
 
     void 'test HttpStatusException'() {
         when:
-        HttpResponse response = Flux.from(rxClient
+        HttpResponse response = Flux.from(httpClient
             .exchange(HttpRequest.GET('/errors')))
                 .onErrorResume( t -> {
                     if (t instanceof HttpClientResponseException) {
@@ -59,7 +59,7 @@ class HttpStatusExceptionSpec extends AbstractMicronautSpec {
 
     void 'test returning an arbitrary POGO'() {
         when:
-        HttpResponse<String> response = Flux.from(rxClient
+        HttpResponse<String> response = Flux.from(httpClient
             .exchange((HttpRequest.GET('/errors/book')), String)).blockFirst()
 
         then:

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/interceptor/HttpFilterContextPathSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/interceptor/HttpFilterContextPathSpec.groovy
@@ -6,7 +6,6 @@ import io.micronaut.http.HttpStatus
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.server.netty.AbstractMicronautSpec
-import reactor.core.publisher.Flux
 
 class HttpFilterContextPathSpec extends AbstractMicronautSpec {
 
@@ -17,7 +16,7 @@ class HttpFilterContextPathSpec extends AbstractMicronautSpec {
 
     void "test interceptor execution and order - proceed"() {
         when:
-        HttpResponse<String> response = rxClient.toBlocking().exchange("/context/path/secure?username=fred", String)
+        HttpResponse<String> response = httpClient.toBlocking().exchange("/context/path/secure?username=fred", String)
 
         then:
         response.status == HttpStatus.OK
@@ -28,7 +27,7 @@ class HttpFilterContextPathSpec extends AbstractMicronautSpec {
 
     void "test a filter on the root url"() {
         when:
-        HttpResponse response = rxClient.toBlocking().exchange("/context/path")
+        HttpResponse response = httpClient.toBlocking().exchange("/context/path")
 
         then:
         response.status == HttpStatus.OK

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ParameterBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ParameterBindingSpec.groovy
@@ -36,7 +36,7 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
     void 'route is build correctly for @Controller("/books") method: @Get("{?max}")'() {
         given:
         HttpRequest request = HttpRequest.GET('/books')
-        def response = rxClient.toBlocking().exchange(request)
+        def response = httpClient.toBlocking().exchange(request)
         def status = response.status
 
         expect:
@@ -46,7 +46,7 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
     void 'route is build correctly for @Controller("/poetry") method: @Get("/{?max}")'() {
         given:
         HttpRequest request = HttpRequest.GET('/poetry')
-        def response = rxClient.toBlocking().exchange(request)
+        def response = httpClient.toBlocking().exchange(request)
         def status = response.status
 
         expect:
@@ -56,7 +56,7 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
     @Unroll
     void "test bind HTTP parameters for URI #uri"() {
         given:
-        HttpResponse<String> response = Flux.from(rxClient.exchange(uri, String))
+        HttpResponse<String> response = Flux.from(httpClient.exchange(uri, String))
                 .onErrorResume(t -> {
                     if (t instanceof HttpClientResponseException) {
                         return Flux.just(((HttpClientResponseException) t).response)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/LinuxNativeTransportSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/LinuxNativeTransportSpec.groovy
@@ -4,7 +4,6 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.netty.channel.EventLoopGroupFactory
 import io.micronaut.http.server.netty.AbstractMicronautSpec
 import io.netty.channel.epoll.EpollServerSocketChannel
-import reactor.core.publisher.Flux
 import spock.lang.Requires
 import spock.util.environment.OperatingSystem
 
@@ -13,7 +12,7 @@ class LinuxNativeTransportSpec extends AbstractMicronautSpec {
 
     void "test a basic request works with mac native transport"() {
         when:
-        String body = rxClient.toBlocking().retrieve(HttpRequest.GET("/native-transport"))
+        String body = httpClient.toBlocking().retrieve(HttpRequest.GET("/native-transport"))
 
         then:
         noExceptionThrown()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/MacNativeTransportSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/MacNativeTransportSpec.groovy
@@ -4,7 +4,6 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.netty.channel.EventLoopGroupFactory
 import io.micronaut.http.server.netty.AbstractMicronautSpec
 import io.netty.channel.kqueue.KQueueServerSocketChannel
-import reactor.core.publisher.Flux
 import spock.lang.Requires
 import spock.util.environment.OperatingSystem
 
@@ -13,7 +12,7 @@ class MacNativeTransportSpec extends AbstractMicronautSpec {
 
     void "test a basic request works with mac native transport"() {
         when:
-        String body = rxClient.toBlocking().retrieve(HttpRequest.GET("/native-transport"))
+        String body = httpClient.toBlocking().retrieve(HttpRequest.GET("/native-transport"))
 
         then:
         noExceptionThrown()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/resources/StaticResourceResolutionSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/resources/StaticResourceResolutionSpec.groovy
@@ -59,7 +59,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
 
     void "test resources from the file system are returned"() {
         when:
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/'+tempFile.getName()), String
         )).blockFirst()
 
@@ -75,7 +75,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
 
     void "test resources from the classpath are returned"() {
         when:
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/index.html'), String
         )).blockFirst()
 
@@ -94,7 +94,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
 
     void "test index.html will be resolved"() {
         when:
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        HttpResponse<String> response = Flux.from(httpClient.exchange(
                 HttpRequest.GET('/'), String
         )).blockFirst()
 
@@ -117,7 +117,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
         File file = new File(tempSubDir, "nowexists.html")
         file.write("<html><head></head><body>HTML Page created after start</body></html>")
 
-        def response = rxClient.toBlocking().exchange(
+        def response = httpClient.toBlocking().exchange(
                 HttpRequest.GET('/nowexists.html'), String)
 
         then:

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/status/CustomStaticMappingGlobalSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/status/CustomStaticMappingGlobalSpec.groovy
@@ -32,7 +32,7 @@ class CustomStaticMappingGlobalSpec extends AbstractMicronautSpec {
 
     void "test that a bad request is handled is handled by a globally marked controller method"() {
         when:
-        rxClient.toBlocking().exchange('/test1/bad')
+        httpClient.toBlocking().exchange('/test1/bad')
 
         then:
         HttpClientResponseException e = thrown()
@@ -40,7 +40,7 @@ class CustomStaticMappingGlobalSpec extends AbstractMicronautSpec {
         e.response.reason() == "You sent me bad stuff - from Test2Controller.badHandler()"
 
         when:
-        rxClient.toBlocking().exchange('/test2/bad')
+        httpClient.toBlocking().exchange('/test2/bad')
 
         then:
         e = thrown(HttpClientResponseException)
@@ -50,7 +50,7 @@ class CustomStaticMappingGlobalSpec extends AbstractMicronautSpec {
 
     void "test that a bad request response for invalid request data can be handled by a globally marked controller method"() {
         when:
-        Flux.from(rxClient.exchange(
+        Flux.from(httpClient.exchange(
                 HttpRequest.POST('/test1/simple', [name:"Fred"])
                         .contentType(MediaType.FORM)
         )).blockFirst()
@@ -61,7 +61,7 @@ class CustomStaticMappingGlobalSpec extends AbstractMicronautSpec {
         e.response.reason() == "You sent me bad stuff - from Test2Controller.badHandler()"
 
         when:
-        rxClient.exchange(
+        httpClient.exchange(
                 HttpRequest.POST('/test2/simple', [name:"Fred"])
                         .contentType(MediaType.FORM)
         ).blockFirst()
@@ -74,7 +74,7 @@ class CustomStaticMappingGlobalSpec extends AbstractMicronautSpec {
 
     void "test that a not found response request data can be handled by a local method"() {
         when:
-        rxClient.exchange('/test1/notFound').blockFirst()
+        httpClient.exchange('/test1/notFound').blockFirst()
 
         then:
         def e = thrown(HttpClientResponseException)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/status/CustomStaticMappingLocalSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/status/CustomStaticMappingLocalSpec.groovy
@@ -33,7 +33,7 @@ class CustomStaticMappingLocalSpec extends AbstractMicronautSpec {
 
     void "test that a bad request is handled is handled by the locally marked controller"() {
         when:
-        rxClient.exchange('/test1/bad').blockFirst()
+        httpClient.exchange('/test1/bad').blockFirst()
 
         then:
         def e = thrown(HttpClientResponseException)
@@ -41,7 +41,7 @@ class CustomStaticMappingLocalSpec extends AbstractMicronautSpec {
         e.response.reason() == "You sent me bad stuff - from Test1Controller.badHandler()"
 
         when:
-        rxClient.exchange('/test2/bad').blockFirst()
+        httpClient.exchange('/test2/bad').blockFirst()
 
         then:
         e = thrown(HttpClientResponseException)
@@ -51,7 +51,7 @@ class CustomStaticMappingLocalSpec extends AbstractMicronautSpec {
 
     void "test that a bad request response for invalid request data can be redirected by the router to the local method"() {
         when:
-        rxClient.exchange(
+        httpClient.exchange(
                 HttpRequest.POST('/test1/simple', [name:"Fred"])
                            .contentType(MediaType.FORM)
         ).blockFirst()
@@ -62,7 +62,7 @@ class CustomStaticMappingLocalSpec extends AbstractMicronautSpec {
         e.response.reason() == "You sent me bad stuff - from Test1Controller.badHandler()"
 
         when:
-        rxClient.exchange(
+        httpClient.exchange(
                 HttpRequest.POST('/test2/simple', [name:"Fred"])
                         .contentType(MediaType.FORM)
         ).blockFirst()
@@ -75,7 +75,7 @@ class CustomStaticMappingLocalSpec extends AbstractMicronautSpec {
 
     void "test that a not found response request data can be handled by a local method"() {
         when:
-        rxClient.exchange('/test1/not-found').blockFirst()
+        httpClient.exchange('/test1/not-found').blockFirst()
 
         then:
         def e = thrown(HttpClientResponseException)
@@ -88,7 +88,7 @@ class CustomStaticMappingLocalSpec extends AbstractMicronautSpec {
      */
     void "test that a unsupported media type is handled by a local method"() {
         when:
-        HttpResponse<String> response = rxClient.exchange(
+        HttpResponse<String> response = httpClient.exchange(
                 HttpRequest.POST('/test1/simple', '<foo></foo>')
                         .contentType(MediaType.APPLICATION_XML),
                 String

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
@@ -67,7 +67,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test returning a file from a controller"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test/html', String)
+        def response = httpClient.toBlocking().exchange('/test/html', String)
 
         then:
         response.code() == HttpStatus.OK.code
@@ -84,7 +84,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         when:
         MutableHttpRequest<?> request = HttpRequest.GET('/test/html')
         request.headers.ifModifiedSince(tempFile.lastModified())
-        def response = rxClient.toBlocking().exchange(request, String)
+        def response = httpClient.toBlocking().exchange(request, String)
 
         then:
         response.code() == HttpStatus.NOT_MODIFIED.code
@@ -95,7 +95,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         when:
         MutableHttpRequest<?> request = HttpRequest.GET('/test/html')
         request.headers.add(RANGE, range)
-        def response = rxClient.toBlocking().exchange(request, String)
+        def response = httpClient.toBlocking().exchange(request, String)
 
         then:
         response.code() == expectedStatus
@@ -122,7 +122,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
     void "test cache control can be overridden"() {
         when:
         MutableHttpRequest<?> request = HttpRequest.GET('/test/custom-cache-control')
-        def response = rxClient.toBlocking().exchange(request, String)
+        def response = httpClient.toBlocking().exchange(request, String)
 
         then:
         response.code() == HttpStatus.OK.code
@@ -132,7 +132,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test what happens when a file isn't found"() {
         when:
-        rxClient.toBlocking().exchange('/test/not-found', String)
+        httpClient.toBlocking().exchange('/test/not-found', String)
 
         then:
         def e = thrown(HttpClientResponseException)
@@ -148,7 +148,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test when an attached file is returned"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test/download', String)
+        def response = httpClient.toBlocking().exchange('/test/download', String)
 
         then:
         response.code() == HttpStatus.OK.code
@@ -163,7 +163,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test when a system file is returned"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test-system/download', String)
+        def response = httpClient.toBlocking().exchange('/test-system/download', String)
 
         then:
         response.code() == HttpStatus.OK.code
@@ -207,7 +207,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test when an attached streamed file is returned"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test-stream/download', String)
+        def response = httpClient.toBlocking().exchange('/test-stream/download', String)
 
         then:
         response.code() == HttpStatus.OK.code
@@ -221,7 +221,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test when an attached file is returned with a name"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test/different-name', String)
+        def response = httpClient.toBlocking().exchange('/test/different-name', String)
 
         then: "the content type is still based on the file extension"
         response.code() == HttpStatus.OK.code
@@ -236,7 +236,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test when a system file is returned with a name"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test-system/different-name', String)
+        def response = httpClient.toBlocking().exchange('/test-system/different-name', String)
 
         then: "the content type is still based on the file extension"
         response.code() == HttpStatus.OK.code
@@ -251,7 +251,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test the content type is honored when an attached file response is returned"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test/custom-content-type', String)
+        def response = httpClient.toBlocking().exchange('/test/custom-content-type', String)
 
         then:
         response.code() == HttpStatus.OK.code
@@ -266,7 +266,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test the content type is honored when a system file response is returned"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test-system/custom-content-type', String)
+        def response = httpClient.toBlocking().exchange('/test-system/custom-content-type', String)
 
         then:
         response.code() == HttpStatus.OK.code
@@ -281,7 +281,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test the content type is honored when a streamed file response is returned"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test-stream/custom-content-type', String)
+        def response = httpClient.toBlocking().exchange('/test-stream/custom-content-type', String)
 
         then:
         response.code() == HttpStatus.OK.code
@@ -295,7 +295,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test using a piped stream"() {
         when:
-        def response = rxClient.toBlocking().exchange('/test-stream/piped-stream', String)
+        def response = httpClient.toBlocking().exchange('/test-stream/piped-stream', String)
 
         then:
         response.code() == HttpStatus.OK.code

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/SslFileTypeHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/SslFileTypeHandlerSpec.groovy
@@ -33,7 +33,7 @@ class SslFileTypeHandlerSpec extends AbstractMicronautSpec {
 
     void "test returning a file from a controller"() {
         when:
-        def response = rxClient.exchange('/test/html', String).blockFirst()
+        def response = httpClient.exchange('/test/html', String).blockFirst()
 
         then:
         response.code() == HttpStatus.OK.code

--- a/http-server-netty/src/test/groovy/io/micronaut/runtime/http/scope/RequestScopeSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/runtime/http/scope/RequestScopeSpec.groovy
@@ -48,7 +48,7 @@ class RequestScopeSpec extends AbstractMicronautSpec {
     void "test dependent beans leak"() {
         when:
         (0..100).each {
-            rxClient.toBlocking().retrieve(HttpRequest.GET("/test-simple-request-scope"), String)
+            httpClient.toBlocking().retrieve(HttpRequest.GET("/test-simple-request-scope"), String)
         }
         def controller = applicationContext.getBean(SimpleTestController)
         then:
@@ -76,7 +76,7 @@ class RequestScopeSpec extends AbstractMicronautSpec {
         ReqTerminatedListener listener = applicationContext.getBean(ReqTerminatedListener)
 
         when:
-        def result = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-request-scope"), String)
+        def result = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-request-scope"), String)
 
         then:
         result == "message count 1, count within request 1"
@@ -92,7 +92,7 @@ class RequestScopeSpec extends AbstractMicronautSpec {
         RequestBean.BEANS_CREATED.clear()
         RequestScopeFactoryBean.BEANS_CREATED.clear()
         listener.callCount = 0
-        result = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-request-scope"), String)
+        result = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-request-scope"), String)
 
         then:
         result == "message count 2, count within request 1"
@@ -108,7 +108,7 @@ class RequestScopeSpec extends AbstractMicronautSpec {
         RequestBean.BEANS_CREATED.clear()
         RequestScopeFactoryBean.BEANS_CREATED.clear()
         listener.callCount = 0
-        result = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-request-scope"), String)
+        result = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-request-scope"), String)
 
         then:
         result == "message count 3, count within request 1"
@@ -124,7 +124,7 @@ class RequestScopeSpec extends AbstractMicronautSpec {
         RequestBean.BEANS_CREATED.clear()
         RequestScopeFactoryBean.BEANS_CREATED.clear()
         listener.callCount = 0
-        result = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-request-scope-stream"), String)
+        result = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-request-scope-stream"), String)
 
         then:
         result == "message count 4, count within request 1"
@@ -139,7 +139,7 @@ class RequestScopeSpec extends AbstractMicronautSpec {
 
     void "test request scope bean that injects the request"() {
         when:
-        String result = rxClient.toBlocking().retrieve(HttpRequest.GET("/test-request-aware"), String)
+        String result = httpClient.toBlocking().retrieve(HttpRequest.GET("/test-request-aware"), String)
 
         then:
         result == "OK"


### PR DESCRIPTION
`MicronautHttpData.AttributeImpl` is updated to provide an implementation of the setValue method. This implementation is needed in the corner cases where Netty's `HttpPostStandardRequestDecoder` successfully parses an attribute with no value such as in the body "a&b=2".

Tests are added to more thoroughly test the various forms of x-www-form-urlencoded bodies as specified by https://url.spec.whatwg.org/#application/x-www-form-urlencoded. These tests include scenarios where we know and expect that `HttpPostStandardRequestDecoder` will currently fail to parse an attribute with a name but no value - namely when that attribute is the last one in a given POST body. If `HttpPostStandardRequestDecoder` is patched in the future, then these expected parsing failures can be moved into the success scenario instead.

This partially resolves #10446.