### PR TITLE
Update KSP to match Kotlin 1.9.23

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,7 @@ managed-reactive-streams = "1.0.4"
 managed-reactor = "3.5.11"
 managed-snakeyaml = "2.2"
 managed-java-parser-core = "3.25.9"
-managed-ksp = "1.9.22-1.0.18"
+managed-ksp = "1.9.23-1.0.19"
 micronaut-docs = "2.0.0"
 
 [libraries]


### PR DESCRIPTION
Kotlin was updated in https://github.com/micronaut-projects/micronaut-core/pull/10598

We should update KSP to target the same version of Kotlin