### PR TITLE
Manage Kotlin plugins in the catalog

### DIFF
--- a/aop/build.gradle
+++ b/aop/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.micronaut.build.internal.convention-core-library"
-    id "org.jetbrains.kotlin.jvm"
+    alias libs.plugins.managed.kotlin.jvm
 }
 
 micronautBuild {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,10 +14,4 @@ dependencies {
     implementation "org.tomlj:tomlj:1.1.1"
     implementation "me.champeau.gradle:japicmp-gradle-plugin:0.4.2"
     implementation "org.graalvm.buildtools.native:org.graalvm.buildtools.native.gradle.plugin:0.10.0"
-
-    // Kotlin plugins
-    implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.managed.kotlin.asProvider().get()}"
-    implementation "org.jetbrains.kotlin:kotlin-allopen:${libs.versions.managed.kotlin.asProvider().get()}"
-    implementation "org.jetbrains.kotlin:kotlin-noarg:${libs.versions.managed.kotlin.asProvider().get()}"
-    implementation "com.google.devtools.ksp:symbol-processing-gradle-plugin:${libs.versions.managed.ksp.get()}"
 }

--- a/context-propagation/build.gradle
+++ b/context-propagation/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "io.micronaut.build.internal.convention-library"
-    id "org.jetbrains.kotlin.jvm"
-    id "org.jetbrains.kotlin.kapt"
+    alias libs.plugins.managed.kotlin.jvm
+    alias libs.plugins.managed.kotlin.kapt
 }
 
 dependencies {

--- a/core-reactive/build.gradle
+++ b/core-reactive/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.micronaut.build.internal.convention-library"
-    id "org.jetbrains.kotlin.jvm"
+    alias libs.plugins.managed.kotlin.jvm
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -279,3 +279,10 @@ wiremock = { module = "com.github.tomakehurst:wiremock-jre8", version.ref = "wir
 
 [bundles]
 asm = ["asm", "asm-commons"]
+
+[plugins]
+managed-kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "managed-kotlin" }
+managed-kotlin-noarg = { id = "org.jetbrains.kotlin.plugin.noarg", version.ref = "managed-kotlin" }
+managed-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "managed-kotlin" }
+managed-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "managed-kotlin" }
+managed-ksp = { id = "com.google.devtools.ksp", version.ref = "managed-ksp" }

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.micronaut.build.internal.convention-library"
-    id "org.jetbrains.kotlin.jvm"
+    alias libs.plugins.managed.kotlin.jvm
 }
 
 dependencies {

--- a/inject-kotlin-test/build.gradle
+++ b/inject-kotlin-test/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.micronaut.build.internal.convention-library"
-    id "org.jetbrains.kotlin.jvm"
+    alias libs.plugins.managed.kotlin.jvm
 }
 
 dependencies {

--- a/inject-kotlin/build.gradle
+++ b/inject-kotlin/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     id "io.micronaut.build.internal.convention-library"
-    id "org.jetbrains.kotlin.jvm"
-    id "com.google.devtools.ksp"
-
+    alias libs.plugins.managed.kotlin.jvm
+    alias libs.plugins.managed.ksp
 }
 
 micronautBuild {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,10 +6,9 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.6.2'
+    id 'io.micronaut.build.shared.settings' version '6.7.0'
 }
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-
 
 rootProject.name = 'micronaut'
 

--- a/test-suite-kotlin-ksp/build.gradle
+++ b/test-suite-kotlin-ksp/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "io.micronaut.build.internal.convention-test-library"
-    id "org.jetbrains.kotlin.jvm"
-    id("com.google.devtools.ksp")
+    alias libs.plugins.managed.kotlin.jvm
+    alias libs.plugins.managed.ksp
 }
 
 micronautBuild {

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "io.micronaut.build.internal.convention-test-library"
-    id "org.jetbrains.kotlin.jvm"
-    id "org.jetbrains.kotlin.kapt"
+    alias libs.plugins.managed.kotlin.jvm
+    alias libs.plugins.managed.kotlin.kapt
 }
 
 micronautBuild {


### PR DESCRIPTION
With the build plugin 6.7.0 we can add managed plugins to the catalog, and these can be used in downstream modules.

This means we can stop defining the version of Kotlin in most modules, and fight to keep them all updated, and instead use:

```
alias(mn.plugins.kotlin.jvm)
```

or

```
alias(mn.plugins.ksp)
```