### PR TITLE
fix: deserialize a JsonError as a GenericResource

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/hateoas/JsonErrorSerdeTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/hateoas/JsonErrorSerdeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.tests.hateoas;
+
+import io.micronaut.http.hateoas.Resource;
+import io.micronaut.http.tck.ServerUnderTest;
+import io.micronaut.http.tck.ServerUnderTestProviderUtils;
+import io.micronaut.json.JsonMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SuppressWarnings({
+        "java:S5960", // We're allowed assertions, as these are used in tests only
+        "checkstyle:MissingJavadocType",
+        "checkstyle:DesignForExtension"
+})
+public class JsonErrorSerdeTest {
+    private static final String JSON_ERROR = """
+            {"_links":{"self":[{"href":"/resolve","templated":false}]},"_embedded":{"errors":[{"message":"Internal Server Error: Something bad happened"}]},"message":"Internal Server Error"}""";
+    private static final String SPEC_NAME = "JsonErrorSerdeTest";
+
+    /**
+     * @throws IOException Exception thrown while getting the server under test.
+     */
+    @Test
+    void canDeserializeAJsonErrorAsAGenericResource() throws IOException {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME, Collections.emptyMap())) {
+            JsonMapper jsonMapper = server.getApplicationContext().getBean(JsonMapper.class);
+            //when:
+            Resource resource = jsonMapper.readValue(JSON_ERROR, Resource.class);
+            //then:
+            assertTrue(resource.getEmbedded().getFirst("errors").isPresent());
+            assertTrue(resource.getLinks().getFirst("self").isPresent());
+            assertEquals("/resolve", resource.getLinks().getFirst("self").get().getHref());
+            assertFalse(resource.getLinks().getFirst("self").get().isTemplated());
+        }
+    }
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/hateoas/JsonErrorSerdeTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/hateoas/JsonErrorSerdeTest.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.tck.tests.hateoas;
 
+import io.micronaut.http.hateoas.JsonError;
 import io.micronaut.http.hateoas.Resource;
 import io.micronaut.http.tck.ServerUnderTest;
 import io.micronaut.http.tck.ServerUnderTestProviderUtils;
@@ -50,6 +51,22 @@ public class JsonErrorSerdeTest {
             assertTrue(resource.getLinks().getFirst("self").isPresent());
             assertEquals("/resolve", resource.getLinks().getFirst("self").get().getHref());
             assertFalse(resource.getLinks().getFirst("self").get().isTemplated());
+        }
+    }
+
+    /**
+     * @throws IOException Exception thrown while getting the server under test.
+     */
+    @Test
+    void jsonErrorShouldBeDeserializableFromAString() throws IOException {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME, Collections.emptyMap())) {
+            JsonMapper jsonMapper = server.getApplicationContext().getBean(JsonMapper.class);
+            JsonError jsonError = jsonMapper.readValue(JSON_ERROR, JsonError.class);
+            assertEquals("Internal Server Error", jsonError.getMessage());
+            assertTrue(jsonError.getEmbedded().getFirst("errors").isPresent());
+            assertTrue(jsonError.getLinks().getFirst("self").isPresent());
+            assertEquals("/resolve", jsonError.getLinks().getFirst("self").get().getHref());
+            assertFalse(jsonError.getLinks().getFirst("self").get().isTemplated());
         }
     }
 }

--- a/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
@@ -38,6 +38,7 @@ import java.util.*;
  */
 @Produces(MediaType.APPLICATION_HAL_JSON)
 @Introspected
+@SuppressWarnings("java:S119") // Impl is a better name than T
 public abstract class AbstractResource<Impl extends AbstractResource<Impl>> implements Resource {
 
     private final Map<CharSequence, List<Link>> linkMap = new LinkedHashMap<>(1);
@@ -148,9 +149,8 @@ public abstract class AbstractResource<Impl extends AbstractResource<Impl>> impl
                 link(name, linkMap);
             } else if (value instanceof Collection<?> collection) {
                 for (Object o : collection) {
-                    if (o instanceof Map) {
-                        Map<String, Object> linkMap = (Map<String, Object>) o;
-                        link(name, linkMap);
+                    if (o instanceof Map aMap) {
+                        link(name, aMap);
                     }
                 }
             }

--- a/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
@@ -18,6 +18,7 @@ package io.micronaut.http.hateoas;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.util.StringUtils;
@@ -25,9 +26,13 @@ import io.micronaut.core.value.OptionalMultiValues;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Produces;
 
-import io.micronaut.core.annotation.Nullable;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * An abstract implementation of {@link Resource}.

--- a/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
@@ -26,12 +26,8 @@ import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Produces;
 
 import io.micronaut.core.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+
+import java.util.*;
 
 /**
  * An abstract implementation of {@link Resource}.
@@ -42,7 +38,7 @@ import java.util.Optional;
  */
 @Produces(MediaType.APPLICATION_HAL_JSON)
 @Introspected
-public abstract class AbstractResource<Impl extends AbstractResource> implements Resource {
+public abstract class AbstractResource<Impl extends AbstractResource<Impl>> implements Resource {
 
     private final Map<CharSequence, List<Link>> linkMap = new LinkedHashMap<>(1);
     private final Map<CharSequence, List<Resource>> embeddedMap = new LinkedHashMap<>(1);
@@ -150,6 +146,13 @@ public abstract class AbstractResource<Impl extends AbstractResource> implements
             if (value instanceof Map) {
                 Map<String, Object> linkMap = (Map<String, Object>) value;
                 link(name, linkMap);
+            } else if (value instanceof Collection<?> collection) {
+                for (Object o : collection) {
+                    if (o instanceof Map) {
+                        Map<String, Object> linkMap = (Map<String, Object>) o;
+                        link(name, linkMap);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This pull request adds the JsonError test to verify JsonMapper can deserialize a JsonError as a GenericResource introduced in #10526 as a TCK test.