### PR TITLE
ci: delete static analysis step

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -56,11 +56,6 @@ jobs:
         run: |
           ./gradlew check --no-daemon --continue
 
-      - name: "🔎 Run static analysis"
-        if: env.SONAR_TOKEN != ''
-        run: |
-          ./gradlew sonar
-
       - name: "📊 Publish Test Report"
         if: always()
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
ci is failing with:

```

> Task :sonarqube FAILED
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':sonarqube'.
> The plugin [java] does not support Java 11.0.22
289 actionable tasks: 85 executed, 204 up-to-date
```