### PR TITLE
Remove build time initialisation of user metadata for GraalVM

### DIFF
--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -4,9 +4,18 @@
 #
 # and edit them there. Note that it will be sync'ed to all the Micronaut repos
 name: GraalVM Dev CI
+#on:
+#  schedule:
+#    - cron: "0 1 * * 1-5" # Mon-Fri at 1am UTC
 on:
-  schedule:
-    - cron: "0 1 * * 1-5" # Mon-Fri at 1am UTC
+  push:
+    branches:
+      - master
+      - '[1-9]+.[0-9]+.x'
+  pull_request:
+    branches:
+      - master
+      - '[1-9]+.[0-9]+.x'
 jobs:
   build_matrix:
     if: github.repository != 'micronaut-projects/micronaut-project-template'

--- a/core/src/main/java/io/micronaut/core/beans/BeanReadProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanReadProperty.java
@@ -144,6 +144,4 @@ public interface BeanReadProperty<B, T> extends AnnotatedElement, AnnotationMeta
     default Argument<T> asArgument() {
         return Argument.of(getType());
     }
-
-
 }

--- a/core/src/main/java/io/micronaut/core/io/service/ServiceLoaderInitialization.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceLoaderInitialization.java
@@ -15,24 +15,12 @@
  */
 package io.micronaut.core.io.service;
 
-import io.micronaut.core.annotation.AnnotationClassValue;
-import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.beans.BeanInfo;
-import io.micronaut.core.beans.EnumBeanIntrospection;
 import io.micronaut.core.graal.GraalReflectionConfigurer;
 import io.micronaut.core.io.IOUtils;
 import io.micronaut.core.io.service.ServiceScanner.StaticServiceDefinitions;
 import io.micronaut.core.reflect.exception.InstantiationException;
-import io.micronaut.core.util.ArrayUtils;
-import org.graalvm.nativeimage.ImageSingletons;
-import org.graalvm.nativeimage.hosted.Feature;
-import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
-import org.graalvm.nativeimage.hosted.RuntimeReflection;
-
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -47,10 +35,11 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
-
-import static io.micronaut.core.util.StringUtils.EMPTY_STRING_ARRAY;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
 /**
  * Integrates {@link io.micronaut.core.io.service.SoftServiceLoader} with GraalVM Native Image.

--- a/test-suite-http-server-tck-netty/build.gradle
+++ b/test-suite-http-server-tck-netty/build.gradle
@@ -49,6 +49,7 @@ graalvmNative {
     }
     binaries {
         all {
+            buildArgs.add("-H:+ReportExceptionStackTraces")
             resources.autodetect()
         }
     }


### PR DESCRIPTION
Seems with strict image heap it is not safe to initialise anything that could represent user code. Previously we could get away with initialising our generated classes, but since this reference user classes the viral nature of build time init results in initialising user code. 

This manifested in dev builds failing with an error on the `LogLevel` enum, I attempted to mark this is build time init but there are 2 problems with this:

1. It means any user defined enum will need to be marked as build time init
2. Once fixed I hit another problem with expression language expressions which also need to be build time initialised. These are again user defined and we cannot know what the are.

So unfortunately the only solution I see going forward is to completely remove the build time init or our generated metadata. This change does this and in local benchmarks does not seem to have a major impact on memory or startup, however does increase the image size by 2mb.

Fixes #10630 