### PR TITLE
Mark fd-based EpollServerDomainSocketChannel as active

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollEventLoopGroupFactory.java
@@ -168,7 +168,7 @@ public class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
             case SERVER_SOCKET -> new EpollServerSocketChannel(fd);
             case CLIENT_SOCKET -> new EpollSocketChannel(fd);
             case DOMAIN_SOCKET -> new EpollDomainSocketChannel(fd);
-            case DOMAIN_SERVER_SOCKET -> new EpollServerDomainSocketChannel(fd);
+            case DOMAIN_SERVER_SOCKET -> new EpollServerDomainSocketChannel(fd, true);
             case DATAGRAM_SOCKET -> new EpollDatagramChannel(fd);
         };
     }


### PR DESCRIPTION
This is necessary for socket activation, otherwise the server will be stuck and not accept any sockets.

See https://github.com/netty/netty/pull/13877