### PR TITLE
fix: Ensure Netty Cookie Encoder/Decoder take precedence

### DIFF
--- a/http-netty/src/test/groovy/io/micronaut/http/netty/cookies/NettyLaxClientCookieEncoderSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/cookies/NettyLaxClientCookieEncoderSpec.groovy
@@ -1,8 +1,9 @@
 package io.micronaut.http.netty.cookies
 
+import io.micronaut.core.order.OrderUtil
 import io.micronaut.http.cookie.ClientCookieEncoder
 import io.micronaut.http.cookie.Cookie
-
+import io.micronaut.http.cookie.DefaultClientCookieEncoder
 import spock.lang.Specification
 
 class NettyLaxClientCookieEncoderSpec extends Specification {
@@ -16,5 +17,30 @@ class NettyLaxClientCookieEncoderSpec extends Specification {
 
         then:
         "SID=31d4d96e407aad42" == cookieEncoder.encode(cookie)
+    }
+
+    void "ClientCookieEncoder is NettyLaxClientCookieDecoder"() {
+        expect:
+        ClientCookieEncoder.INSTANCE instanceof NettyLaxClientCookieEncoder
+    }
+
+    void "NettyLaxServerCookieDecoder is loaded before Default"() {
+        when:
+        List<ClientCookieEncoder> l = [new NettyLaxClientCookieEncoder(), new DefaultClientCookieEncoder()]
+
+        then:
+        sortAndGetFirst(l) instanceof NettyLaxClientCookieEncoder
+
+        when:
+        l = [new DefaultClientCookieEncoder(), new NettyLaxClientCookieEncoder()]
+
+        then:
+        sortAndGetFirst(l) instanceof NettyLaxClientCookieEncoder
+    }
+
+    private static ClientCookieEncoder sortAndGetFirst(List<ClientCookieEncoder> l) {
+        l.stream()
+                .min(OrderUtil.COMPARATOR)
+                .orElse(null)
     }
 }

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/cookies/NettyLaxServerCookieDecoderSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/cookies/NettyLaxServerCookieDecoderSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.http.netty.cookies
+
+import io.micronaut.core.order.OrderUtil
+import io.micronaut.http.cookie.DefaultServerCookieDecoder
+import io.micronaut.http.cookie.ServerCookieDecoder
+import spock.lang.Specification
+
+class NettyLaxServerCookieDecoderSpec extends Specification {
+
+    void "ServerCookieDecoder is NettyLaxServerCookieDecoder"() {
+        expect:
+        ServerCookieDecoder.INSTANCE instanceof NettyLaxServerCookieDecoder
+    }
+
+    void "NettyLaxServerCookieDecoder is loaded before Default"() {
+        when:
+        List<ServerCookieDecoder> l = [new NettyLaxServerCookieDecoder(), new DefaultServerCookieDecoder()]
+
+        then:
+        sortAndGetFirst(l) instanceof NettyLaxServerCookieDecoder
+
+        when:
+        l = [new DefaultServerCookieDecoder(), new NettyLaxServerCookieDecoder()]
+
+        then:
+        sortAndGetFirst(l) instanceof NettyLaxServerCookieDecoder
+    }
+
+    private static ServerCookieDecoder sortAndGetFirst(List<ServerCookieDecoder> l) {
+        l.stream()
+                .min(OrderUtil.COMPARATOR)
+                .orElse(null)
+    }
+}

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/cookies/NettyServerCookieEncoderSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/cookies/NettyServerCookieEncoderSpec.groovy
@@ -1,6 +1,8 @@
 package io.micronaut.http.netty.cookies
 
+import io.micronaut.core.order.OrderUtil
 import io.micronaut.http.cookie.Cookie
+import io.micronaut.http.cookie.DefaultServerCookieEncoder
 import io.micronaut.http.cookie.SameSite
 import io.micronaut.http.cookie.ServerCookieEncoder
 import spock.lang.Specification
@@ -43,6 +45,31 @@ class NettyServerCookieEncoderSpec extends Specification {
 
         then:
         expected == result || expected2 == result
+    }
+
+    void "ServerCookieEncoder is NettyLaxClientCookieDecoder"() {
+        expect:
+        ServerCookieEncoder.INSTANCE instanceof NettyServerCookieEncoder
+    }
+
+    void "NettyLaxServerCookieDecoder is loaded before Default"() {
+        when:
+        List<ServerCookieEncoder> l = [new NettyServerCookieEncoder(), new DefaultServerCookieEncoder()]
+
+        then:
+        sortAndGetFirst(l) instanceof NettyServerCookieEncoder
+
+        when:
+        l = [new DefaultServerCookieEncoder(), new NettyServerCookieEncoder()]
+
+        then:
+        sortAndGetFirst(l) instanceof NettyServerCookieEncoder
+    }
+
+    private static ServerCookieEncoder sortAndGetFirst(List<ServerCookieEncoder> l) {
+        l.stream()
+                .min(OrderUtil.COMPARATOR)
+                .orElse(null)
     }
 
     private static String expires(Long maxAgeSeconds) {

--- a/http/src/main/java/io/micronaut/http/cookie/ClientCookieEncoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/ClientCookieEncoder.java
@@ -18,6 +18,8 @@ package io.micronaut.http.cookie;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
+import io.micronaut.core.order.OrderUtil;
+import io.micronaut.core.order.Ordered;
 
 /**
  * Encodes a {@link Cookie} into a String. Typically used to set the {@link io.micronaut.http.HttpHeaders#COOKIE} value for example in an HTTP Client.
@@ -27,15 +29,16 @@ import io.micronaut.core.io.service.SoftServiceLoader;
  * @since 4.3.0
  */
 @FunctionalInterface
-public interface ClientCookieEncoder {
+public interface ClientCookieEncoder extends Ordered {
     /**
      * The default {@link ServerCookieEncoder} instance.
      */
     ClientCookieEncoder INSTANCE = SoftServiceLoader
-            .load(ClientCookieEncoder.class)
-            .firstOr("io.micronaut.http.cookie.DefaultClientCookieEncoder", ClientCookieEncoder.class.getClassLoader())
-            .map(ServiceDefinition::load)
-            .orElse(null);
+        .load(ClientCookieEncoder.class)
+        .collectAll()
+        .stream()
+        .min(OrderUtil.COMPARATOR)
+        .orElse(null);
 
     /**
      * Encodes a {@link Cookie} into a String. Typically used to set the {@link io.micronaut.http.HttpHeaders#COOKIE} value for example in an HTTP Client.

--- a/http/src/main/java/io/micronaut/http/cookie/DefaultClientCookieEncoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/DefaultClientCookieEncoder.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.cookie;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.order.Ordered;
 
 /**
  * @author Sergio del Amo
@@ -24,9 +25,14 @@ import io.micronaut.core.annotation.Internal;
 @Internal
 public final class DefaultClientCookieEncoder implements ClientCookieEncoder {
     private static final String EQUAL = "=";
-    
+
     @Override
     public String encode(Cookie cookie) {
         return cookie.getName() + EQUAL + (cookie.getValue() != null ? cookie.getValue() : "");
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
     }
 }

--- a/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
@@ -17,6 +17,7 @@ package io.micronaut.http.cookie;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.order.Ordered;
 
 import java.net.HttpCookie;
 import java.util.List;
@@ -36,5 +37,10 @@ public final class DefaultServerCookieDecoder implements ServerCookieDecoder {
                 .stream()
                 .map(httpCookie -> (Cookie) new CookieHttpCookieAdapter(httpCookie))
                 .toList();
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
     }
 }

--- a/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieEncoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieEncoder.java
@@ -17,6 +17,7 @@ package io.micronaut.http.cookie;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
 
 import java.net.HttpCookie;
@@ -85,4 +86,8 @@ public final class DefaultServerCookieEncoder implements ServerCookieEncoder {
         return gmtDateTime.format(FORMATTER);
     }
 
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
 }

--- a/http/src/main/java/io/micronaut/http/cookie/ServerCookieDecoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/ServerCookieDecoder.java
@@ -16,8 +16,11 @@
 package io.micronaut.http.cookie;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Order;
 import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
+import io.micronaut.core.order.OrderUtil;
+import io.micronaut.core.order.Ordered;
 
 import java.util.List;
 
@@ -27,15 +30,16 @@ import java.util.List;
  * @since 4.3.0
  */
 @FunctionalInterface
-public interface ServerCookieDecoder {
+public interface ServerCookieDecoder extends Ordered {
     /**
      * The default {@link ServerCookieDecoder} instance.
      */
     ServerCookieDecoder INSTANCE = SoftServiceLoader
-            .load(ServerCookieDecoder.class)
-            .firstOr("io.micronaut.http.cookie.DefaultServerCookieDecoder", ServerCookieDecoder.class.getClassLoader())
-            .map(ServiceDefinition::load)
-            .orElse(null);
+        .load(ServerCookieDecoder.class)
+        .collectAll()
+        .stream()
+        .min(OrderUtil.COMPARATOR)
+        .orElse(null);
 
     /**
      *

--- a/http/src/main/java/io/micronaut/http/cookie/ServerCookieEncoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/ServerCookieEncoder.java
@@ -18,6 +18,8 @@ package io.micronaut.http.cookie;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
+import io.micronaut.core.order.OrderUtil;
+import io.micronaut.core.order.Ordered;
 
 import java.util.List;
 
@@ -28,15 +30,16 @@ import java.util.List;
  * @since 4.3.0
  */
 @FunctionalInterface
-public interface ServerCookieEncoder {
+public interface ServerCookieEncoder extends Ordered {
 
     /**
      * The default {@link ServerCookieEncoder} instance.
      */
     ServerCookieEncoder INSTANCE = SoftServiceLoader
             .load(ServerCookieEncoder.class)
-            .firstOr("io.micronaut.http.cookie.DefaultServerCookieEncoder", ServerCookieEncoder.class.getClassLoader())
-            .map(ServiceDefinition::load)
+            .collectAll()
+            .stream()
+            .min(OrderUtil.COMPARATOR)
             .orElse(null);
 
     /**

--- a/http/src/test/java/io/micronaut/http/cookie/DefaultClientCookieEncoderTest.java
+++ b/http/src/test/java/io/micronaut/http/cookie/DefaultClientCookieEncoderTest.java
@@ -1,5 +1,6 @@
 package io.micronaut.http.cookie;
 
+import io.micronaut.core.order.Ordered;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,5 +11,11 @@ class DefaultClientCookieEncoderTest {
         ClientCookieEncoder cookieEncoder = new DefaultClientCookieEncoder();
         Cookie cookie = Cookie.of("SID", "31d4d96e407aad42").path("/").domain("example.com");
         assertEquals("SID=31d4d96e407aad42", cookieEncoder.encode(cookie));
+    }
+
+    @Test
+    void orderIsLowestPrecedence() {
+        ClientCookieEncoder cookieEncoder = new DefaultClientCookieEncoder();
+        assertEquals(Ordered.LOWEST_PRECEDENCE, cookieEncoder.getOrder());
     }
 }

--- a/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
+++ b/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
@@ -1,5 +1,6 @@
 package io.micronaut.http.cookie;
 
+import io.micronaut.core.order.Ordered;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -37,5 +38,11 @@ class DefaultServerCookieDecoderTest {
         assertTrue(cookie.isHttpOnly());
         assertTrue(cookie.isSecure());
         assertTrue(cookie.getSameSite().isEmpty());
+    }
+
+    @Test
+    void orderIsLowestPrecedence() {
+        ServerCookieDecoder decoder = new DefaultServerCookieDecoder();
+        assertEquals(Ordered.LOWEST_PRECEDENCE, decoder.getOrder());
     }
 }

--- a/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieEncoderTest.java
+++ b/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieEncoderTest.java
@@ -1,5 +1,6 @@
 package io.micronaut.http.cookie;
 
+import io.micronaut.core.order.Ordered;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -30,6 +31,13 @@ class DefaultServerCookieEncoderTest {
         cookie = Cookie.of("id", "a3fWa").maxAge(maxAge);
         String result = cookieEncoder.encode(cookie).get(0);
         assertTrue(expected.equals(result) || expected2.equals(result));
+    }
+
+
+    @Test
+    void orderIsLowestPrecedence() {
+        ServerCookieEncoder cookieEncoder = new DefaultServerCookieEncoder();
+        assertEquals(Ordered.LOWEST_PRECEDENCE, cookieEncoder.getOrder());
     }
 
     private static String expires(Long maxAgeSeconds) {


### PR DESCRIPTION
See: https://github.com/micronaut-projects/micronaut-core/issues/10435
Close: https://github.com/micronaut-projects/micronaut-core/pull/10659

This PRs ensure Netty Cookie Encoder/Decoder are loaded before DefaultServerCookieEncoder Decoders

It allows also for users to provider their own implementation which may take precedence.