### PR TITLE
Set Accept header correctly in declarative client

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
@@ -177,14 +177,6 @@ class ClientIntroductionAdviceSpec extends Specification {
             }
             return "<answer>success</answer>"
         }
-
-        @Get(value = "/xml-annotated", produces = MediaType.APPLICATION_XML)
-        String xmlAnnotated(HttpRequest<?> request) {
-            if (!request.accept().contains(MediaType.APPLICATION_XML_TYPE)) {
-                throw new IllegalStateException("Accept should be set to XML")
-            }
-            return "<answer>success</answer>"
-        }
     }
 
     @Requires(property = 'spec.name', value = 'ClientIntroductionAdviceSpec')
@@ -259,7 +251,7 @@ class ClientIntroductionAdviceSpec extends Specification {
         String xml()
 
         @Consumes(MediaType.APPLICATION_XML)
-        @Get("/xml-annotated")
+        @Get("/xml")
         String xmlAnnotated()
 
     }


### PR DESCRIPTION
`HttpClientIntroductionAdvice` is updated to ensure the Accept header is correctly set in all cases.

Tests are added to verify the header is being set as expected.

**Background:**
I discovered a bug in the recently refactored `HttpClientIntroductionAdvice` while debugging https://github.com/micronaut-projects/micronaut-discovery-client/pull/604.

The Accept header was only being set correctly for the streaming publisher branch of the code, due to a mistake I made in the refactoring, and none of the existing tests were checking for the header. :/