### PR TITLE
KSP: Fix computation of Kotlin Defaults Mask in Data Classes with 32+ parameters.

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/WriterUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/WriterUtils.java
@@ -261,7 +261,7 @@ public final class WriterUtils {
                 writer.push(0);
                 writer.storeLocal(maskLocal);
                 int maskIndex = 1;
-                int paramIndex = 0;
+                int paramIndex = fromIndex;
                 for (ParameterElement parameter : params) {
                     if (parameter instanceof KotlinParameterElement kp && kp.hasDefault()) {
                         writeMask(writer, argumentValuePusher, argumentValueIsPresentPusher, kp, paramIndex, maskIndex, maskLocal);

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/core/beans/KotlinBeanIntrospectionSpec.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/core/beans/KotlinBeanIntrospectionSpec.kt
@@ -2,6 +2,7 @@ package io.micronaut.core.beans
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.time.LocalDate.now
 import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -169,5 +170,67 @@ class KotlinBeanIntrospectionSpec {
         assertEquals("s6", bean.s6)
         assertEquals("s5", bean.s5)
         assertEquals("s32", bean.s32)
+    }
+
+    @Test
+    fun `Should create a bean with correct attributes`() {
+        val introspection = BeanIntrospection.getIntrospection(TestEntity7::class.java)
+        val attributes = arrayOf(
+            "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9",
+            "a10", "a11", "a12", "a13", "a14", "a15", "a16", "a17", "a18", "a19",
+            "a20", "a21", "a22", "a23", "a24", "a25", "a26", "a27", "a28", "a29",
+            "a30", "a31",
+            now().plusDays(32),
+            now().plusDays(33),
+            now().plusDays(34),
+            now().plusDays(35),
+            now().plusDays(36),
+            now().plusDays(37),
+            now().plusDays(38),
+            now().plusDays(39),
+        )
+
+        val bean = introspection.instantiate(*attributes)
+
+        assertEquals(bean.a0, attributes[0])
+        assertEquals(bean.a1, attributes[1])
+        assertEquals(bean.a2, attributes[2])
+        assertEquals(bean.a3, attributes[3])
+        assertEquals(bean.a4, attributes[4])
+        assertEquals(bean.a5, attributes[5])
+        assertEquals(bean.a6, attributes[6])
+        assertEquals(bean.a7, attributes[7])
+        assertEquals(bean.a8, attributes[8])
+        assertEquals(bean.a9, attributes[9])
+        assertEquals(bean.a10, attributes[10])
+        assertEquals(bean.a11, attributes[11])
+        assertEquals(bean.a12, attributes[12])
+        assertEquals(bean.a13, attributes[13])
+        assertEquals(bean.a14, attributes[14])
+        assertEquals(bean.a15, attributes[15])
+        assertEquals(bean.a16, attributes[16])
+        assertEquals(bean.a17, attributes[17])
+        assertEquals(bean.a18, attributes[18])
+        assertEquals(bean.a19, attributes[19])
+        assertEquals(bean.a20, attributes[20])
+        assertEquals(bean.a21, attributes[21])
+        assertEquals(bean.a22, attributes[22])
+        assertEquals(bean.a23, attributes[23])
+        assertEquals(bean.a24, attributes[24])
+        assertEquals(bean.a25, attributes[25])
+        assertEquals(bean.a26, attributes[26])
+        assertEquals(bean.a27, attributes[27])
+        assertEquals(bean.a28, attributes[28])
+        assertEquals(bean.a29, attributes[29])
+        assertEquals(bean.a30, attributes[30])
+        assertEquals(bean.a31, attributes[31])
+        assertEquals(bean.a32, attributes[32])
+        assertEquals(bean.a33, attributes[33])
+        assertEquals(bean.a34, attributes[34])
+        assertEquals(bean.a35, attributes[35])
+        assertEquals(bean.a36, attributes[36])
+        assertEquals(bean.a37, attributes[37])
+        assertEquals(bean.a38, attributes[38])
+        assertEquals(bean.a39, attributes[39])
     }
 }

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/core/beans/TestEntity7.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/core/beans/TestEntity7.kt
@@ -1,0 +1,48 @@
+package io.micronaut.core.beans
+
+import io.micronaut.core.annotation.Introspected
+import java.time.LocalDate
+
+@Introspected
+class TestEntity7(
+    val a0: String,
+    val a1: String,
+    val a2: String,
+    val a3: String,
+    val a4: String,
+    val a5: String,
+    val a6: String,
+    val a7: String,
+    val a8: String,
+    val a9: String,
+    val a10: String,
+    val a11: String,
+    val a12: String,
+    val a13: String,
+    val a14: String,
+    val a15: String,
+    val a16: String,
+    val a17: String,
+    val a18: String,
+    val a19: String,
+    val a20: String,
+    val a21: String,
+    val a22: String,
+    val a23: String,
+    val a24: String,
+    val a25: String,
+    val a26: String,
+    val a27: String,
+    val a28: String,
+    val a29: String,
+    val a30: String,
+    val a31: String = "a31",
+    val a32: LocalDate = LocalDate.now(),
+    val a33: LocalDate,
+    val a34: LocalDate,
+    val a35: LocalDate,
+    val a36: LocalDate,
+    val a37: LocalDate,
+    val a38: LocalDate,
+    val a39: LocalDate,
+)


### PR DESCRIPTION
Related to the problem in Micronaut Serialization: https://github.com/micronaut-projects/micronaut-core/issues/10730