### PR TITLE
Implement HTTP/2 server push

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
@@ -186,7 +186,7 @@ public final class Http2ServerHandler extends MultiplexedServerHandler implement
     /**
      * {@link Http2ConnectionHandler} implementation containing the {@link Http2ServerHandler}.
      */
-    static final class ConnectionHandler extends Http2ConnectionHandler {
+    public static final class ConnectionHandler extends Http2ConnectionHandler {
         private final Http2ServerHandler handler;
 
         private ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder, Http2Settings initialSettings, boolean decoupleCloseAndGoAway, boolean flushPreface, Http2ServerHandler handler) {
@@ -236,15 +236,27 @@ public final class Http2ServerHandler extends MultiplexedServerHandler implement
             if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent upgrade) {
                 FullHttpRequest fhr = upgrade.upgradeRequest();
                 io.netty.handler.codec.http2.Http2Stream cs = connection().stream(1);
-                Http2ServerHandler.Http2Stream stream = handler.new Http2Stream(cs);
-                cs.setProperty(handler.streamKey, stream);
-                boolean empty = !fhr.content().isReadable();
-                stream.onHeadersRead(fhr, empty);
-                if (!empty) {
-                    stream.onDataRead(fhr.content(), true);
-                }
+                handleFakeRequest(cs, fhr);
             }
             super.userEventTriggered(ctx, evt);
+        }
+
+        /**
+         * Handle a request on the given stream that did not actually come in as an HTTP/2 request.
+         * This is used for the h2c upgrade request which is an HTTP/1.1 request that expects an
+         * HTTP/2 response, and for push promises where the request is initiated by the application.
+         *
+         * @param onStream The stream that the response should be sent on
+         * @param fhr      The fake request
+         */
+        public void handleFakeRequest(io.netty.handler.codec.http2.Http2Stream onStream, FullHttpRequest fhr) {
+            Http2Stream stream = handler.new Http2Stream(onStream);
+            onStream.setProperty(handler.streamKey, stream);
+            boolean empty = !fhr.content().isReadable();
+            stream.onHeadersRead(fhr, empty);
+            if (!empty) {
+                stream.onDataRead(fhr.content(), true);
+            }
         }
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2ServerPushSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2ServerPushSpec.groovy
@@ -56,7 +56,6 @@ import java.util.concurrent.CompletableFuture
 @Property(name = "micronaut.server.ssl.enabled", value = "true")
 @Property(name = "micronaut.server.ssl.port", value = "-1")
 @Property(name = "micronaut.server.ssl.buildSelfSigned", value = "true")
-@Property(name = "micronaut.server.netty.legacy-multiplex-handlers", value = "true")
 @Property(name = "spec.name", value = "Http2ServerPushSpec")
 class Http2ServerPushSpec extends Specification {
     @Inject


### PR DESCRIPTION
Another feature for #10596. Once again no separate tests, this functionality is covered by Http2ServerPushSpec when legacy-multiplex-handlers is off.

Added to 4.4.x because nobody uses the new handler yet anyway. There's no need for this to make it into platform 4.4.0 so I'm not adding it to the project.