### PR TITLE
Implement HTTP/2 access logging

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/Http2AccessLogConnectionEncoder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/Http2AccessLogConnectionEncoder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.handler.accesslog;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.http.server.netty.handler.accesslog.element.AccessLog;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http2.DecoratingHttp2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.HttpConversionUtil;
+import io.netty.util.AsciiString;
+
+/**
+ * Special {@link Http2ConnectionEncoder} that logs the response data.
+ *
+ * @author Jonas Konrad
+ * @since 4.4.2
+ */
+@Internal
+public final class Http2AccessLogConnectionEncoder extends DecoratingHttp2ConnectionEncoder {
+    private final Http2AccessLogManager manager;
+
+    public Http2AccessLogConnectionEncoder(Http2ConnectionEncoder delegate, Http2AccessLogManager manager) {
+        super(delegate);
+        this.manager = manager;
+    }
+
+    @Override
+    public ChannelFuture writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding, boolean endStream, ChannelPromise promise) {
+        promise = writeHeaders0(ctx, streamId, headers, endStream, promise);
+        return super.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
+    }
+
+    @Override
+    public ChannelFuture writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endStream, ChannelPromise promise) {
+        promise = writeHeaders0(ctx, streamId, headers, endStream, promise);
+        return super.writeHeaders(ctx, streamId, headers, streamDependency, weight, exclusive, padding, endStream, promise);
+    }
+
+    private ChannelPromise writeHeaders0(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endStream, ChannelPromise promise) {
+        if (AsciiString.contentEquals(headers.status(), HttpResponseStatus.CONTINUE.codeAsText())) {
+            return promise;
+        }
+        AccessLog accessLog = manager.connection.stream(streamId).getProperty(manager.accessLogKey);
+        if (accessLog == null) {
+            return promise;
+        }
+        HttpResponse response;
+        try {
+            response = HttpConversionUtil.toHttpResponse(streamId, headers, false);
+        } catch (Http2Exception e) {
+            throw new RuntimeException(e);
+        }
+        accessLog.onResponseHeaders(ctx, response.headers(), response.status().codeAsText().toString());
+        if (endStream) {
+            accessLog.onLastResponseWrite(0);
+            promise = promise.unvoid();
+            finish(accessLog, promise);
+        }
+        return promise;
+    }
+
+    @Override
+    public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endStream, ChannelPromise promise) {
+        AccessLog accessLog = manager.connection.stream(streamId).getProperty(manager.accessLogKey);
+        if (accessLog != null) {
+            if (endStream) {
+                accessLog.onLastResponseWrite(data.readableBytes());
+                promise = promise.unvoid();
+                finish(accessLog, promise);
+            } else {
+                accessLog.onResponseWrite(data.readableBytes());
+            }
+        }
+
+        return super.writeData(ctx, streamId, data, padding, endStream, promise);
+    }
+
+    private void finish(AccessLog accessLog, ChannelPromise promise) {
+        promise.addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) {
+                accessLog.log(manager.logger);
+                manager.logForReuse = accessLog;
+            }
+        });
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/Http2AccessLogFrameListener.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/Http2AccessLogFrameListener.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.handler.accesslog;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.http.server.netty.handler.accesslog.element.AccessLog;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2FrameListener;
+import io.netty.handler.codec.http2.Http2FrameListenerDecorator;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.HttpConversionUtil;
+
+/**
+ * Special {@link Http2FrameListener} that logs the request data.
+ *
+ * @author Jonas Konrad
+ * @since 4.4.2
+ */
+@Internal
+public final class Http2AccessLogFrameListener extends Http2FrameListenerDecorator {
+    private final Http2AccessLogManager manager;
+
+    public Http2AccessLogFrameListener(Http2FrameListener listener, Http2AccessLogManager manager) {
+        super(listener);
+        this.manager = manager;
+    }
+
+    private void logHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers) throws Http2Exception {
+        if (!manager.logger.isInfoEnabled()) {
+            return;
+        }
+        HttpRequest request = HttpConversionUtil.toHttpRequest(streamId, headers, false);
+        if (manager.uriInclusion != null && !manager.uriInclusion.test(request.uri())) {
+            return;
+        }
+
+        AccessLog accessLog;
+        if (manager.logForReuse != null) {
+            accessLog = manager.logForReuse;
+            manager.logForReuse = null;
+        } else {
+            accessLog = manager.formatParser.newAccessLogger();
+        }
+        manager.connection.stream(streamId).setProperty(manager.accessLogKey, accessLog);
+        accessLog.onRequestHeaders((SocketChannel) ctx.channel(), request.method().name(), request.headers(), request.uri(), HttpAccessLogHandler.H2_PROTOCOL_NAME);
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding, boolean endStream) throws Http2Exception {
+        logHeaders(ctx, streamId, headers);
+        super.onHeadersRead(ctx, streamId, headers, padding, endStream);
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) throws Http2Exception {
+        logHeaders(ctx, streamId, headers);
+        super.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive, padding, endStream);
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/Http2AccessLogManager.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/Http2AccessLogManager.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.handler.accesslog;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.http.server.netty.handler.accesslog.element.AccessLog;
+import io.micronaut.http.server.netty.handler.accesslog.element.AccessLogFormatParser;
+import io.netty.handler.codec.http2.Http2Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Predicate;
+
+/**
+ * This class manages the shared state between {@link Http2AccessLogConnectionEncoder} and
+ * {@link Http2AccessLogFrameListener}.
+ *
+ * @since 4.4.2
+ * @author Jonas Konrad
+ */
+@Internal
+public final class Http2AccessLogManager {
+    final Http2Connection connection;
+    final Http2Connection.PropertyKey accessLogKey;
+    final AccessLogFormatParser formatParser;
+    final Logger logger;
+    final Predicate<String> uriInclusion;
+
+    AccessLog logForReuse;
+
+    public Http2AccessLogManager(Factory factory, Http2Connection connection) {
+        this.connection = connection;
+        this.accessLogKey = connection.newKey();
+        this.formatParser = new AccessLogFormatParser(factory.spec);
+        this.logger = factory.logger == null ? LoggerFactory.getLogger(HttpAccessLogHandler.HTTP_ACCESS_LOGGER) : factory.logger;
+        this.uriInclusion = factory.uriInclusion;
+    }
+
+    public record Factory(Logger logger, String spec, Predicate<String> uriInclusion) {
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -56,8 +56,8 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
      */
     public static final String HTTP_ACCESS_LOGGER = "HTTP_ACCESS_LOGGER";
 
+    static final String H2_PROTOCOL_NAME = "HTTP/2.0";
     private static final AttributeKey<AccessLogHolder> ACCESS_LOGGER = AttributeKey.valueOf("ACCESS_LOGGER");
-    private static final String H2_PROTOCOL_NAME = "HTTP/2.0";
 
     private final Logger logger;
     private final AccessLogFormatParser accessLogFormatParser;

--- a/test-suite/src/test/groovy/io/micronaut/http/Http2AccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/Http2AccessLoggerSpec.groovy
@@ -1,0 +1,13 @@
+package io.micronaut.http
+
+import io.micronaut.context.annotation.Property
+
+@Property(name = 'micronaut.server.http-version', value = '2.0')
+@Property(name = 'micronaut.server.ssl.enabled', value = 'true')
+@Property(name = 'micronaut.server.ssl.build-self-signed', value = 'true')
+@Property(name = 'micronaut.http.client.ssl.insecure-trust-all-certificates', value = 'true')
+@Property(name = "micronaut.server.netty.log-level", value = 'trace')
+@Property(name = "micronaut.http.client.log-level", value = 'trace')
+@Property(name = 'micronaut.server.netty.access-logger.enabled', value = 'true')
+class Http2AccessLoggerSpec extends HttpAccessLoggerSpec {
+}

--- a/test-suite/src/test/groovy/io/micronaut/http/HttpAccessLogger.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/HttpAccessLogger.groovy
@@ -26,11 +26,11 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.session.Session
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
+import spock.lang.IgnoreIf
 import spock.lang.Specification
-
-import jakarta.inject.Inject
 
 /**
  * @author Christophe Roudet
@@ -108,6 +108,7 @@ class HttpAccessLoggerSpec extends Specification {
 
     }
 
+    @IgnoreIf({ instance instanceof Http2AccessLoggerSpec }) // micronaut-session uses channel attributes to get the request, which is broken
      void "test simple session - access logger"() {
         when:
         appender.events.clear()

--- a/test-suite/src/test/groovy/io/micronaut/http2/Http2AccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http2/Http2AccessLoggerSpec.groovy
@@ -25,9 +25,6 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
-// Netty + HTTP/2 on JDKs less than 9 require tcnative setup
-// which is not included in this test suite
-//@IgnoreIf({ !Jvm.current.isJava9Compatible() })
 class Http2AccessLoggerSpec extends Specification {
     @Shared @AutoCleanup EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
             'micronaut.server.ssl.enabled': true,
@@ -38,7 +35,6 @@ class Http2AccessLoggerSpec extends Specification {
             "micronaut.http.client.log-level" : "TRACE",
             "micronaut.server.netty.log-level" : "TRACE",
             'micronaut.server.netty.access-logger.enabled': true,
-            'micronaut.server.netty.legacy-multiplex-handlers': true,
             'micronaut.http.client.ssl.insecure-trust-all-certificates': true
     ])
     HttpClient client = server.getApplicationContext().getBean(HttpClient)


### PR DESCRIPTION
Another feature for #10596.

The session ID test fails because micronaut-session uses a channel attribute that we cannot support with HTTP/2. It's flawed even for HTTP/1, but would probably need an API change to fix.