### PR TITLE
build: expose context-propagation as api from http

### DIFF
--- a/http/build.gradle
+++ b/http/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     annotationProcessor project(":graal")
     api project(":context")
     api project(":core-reactive")
-    implementation project(":context-propagation")
+    api(project(":context-propagation"))
     implementation libs.managed.reactor
     compileOnly libs.managed.kotlinx.coroutines.core
     compileOnly libs.managed.kotlinx.coroutines.reactor


### PR DESCRIPTION
I recently worked on a commercial support ticket where I need to [add the `context-propagation` dependency](https://github.com/sdelamo/mn-log-ip/commit/42b559a165f464a13a45e743b31dbf120c7acf7d). 

[`micronaut-runtime` exposes `context-propagation` as api](https://github.com/micronaut-projects/micronaut-core/blob/4.5.x/runtime/build.gradle#L11). 

However, the application was a groovy app. Thus, it was using `micronaut-runtime-groovy`. [`micronaut-runtime-groovy` does not expose `context-propagation`](https://github.com/micronaut-projects/micronaut-groovy/blob/4.4.x/runtime-groovy/build.gradle).  

I am not sure we should modify `micronaut-runtime-groovy`. Instead, this PR makes the `http` module expose `context-propagation` as `api`. [`http` already exposes `context` as api](https://github.com/micronaut-projects/micronaut-core/blob/4.5.x/http/build.gradle#L9).