### PR TITLE
bug: Writeable responses not being offloaded since 4.0.0

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/body/WriteableOffloadSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/body/WriteableOffloadSpec.groovy
@@ -1,0 +1,84 @@
+package io.micronaut.http.body
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.io.Writable
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+
+@MicronautTest
+@Property(name = "spec.name", value = "WriteableOffloadSpec")
+class WriteableOffloadSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    HttpClient client
+
+    void "writeable is offloaded"() {
+        when:
+        def result = client.toBlocking().retrieve("/writeable")
+
+        then:
+        result.startsWith(expectedThreadNamePrefix)
+        result.endsWith("Hello")
+    }
+
+    String getExpectedThreadNamePrefix() {
+        Runtime.version().feature() > 17 ? 'virtual-executor' : 'io-executor'
+    }
+
+    @SuppressWarnings('unused')
+    @Requires(property = "spec.name", value = "WriteableOffloadSpec")
+    @Filter(Filter.MATCH_ALL_PATTERN)
+    static class WriteableOffloadFilter implements HttpServerFilter {
+
+        @Override
+        Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+            return Flux.from(chain.proceed(request))
+                    .map { response ->
+                        response.contentType(MediaType.TEXT_PLAIN)
+                        response.body(new ThreadWriteable(response.body()))
+                    }
+        }
+    }
+
+    @Requires(property = "spec.name", value = "WriteableOffloadSpec")
+    @Controller
+    static class WriteableOffloadController {
+
+        @Get("/writeable")
+        String get() {
+            "Hello"
+        }
+    }
+
+
+    static class ThreadWriteable<B> implements Writable {
+
+        private final B body;
+
+        ThreadWriteable(B body) {
+            this.body = body;
+        }
+
+        @Override
+        void writeTo(Writer out) throws IOException {
+            out.write(Thread.currentThread().getName())
+            out.write(" ")
+            out.write(body.toString())
+        }
+    }
+}


### PR DESCRIPTION
In the documentation for [Writing Response Data](https://docs.micronaut.io/latest/guide/index.html#serverIO) we have a section for Writeables which states:

> When returning a [Writable](https://docs.micronaut.io/latest/api/io/micronaut/core/io/Writable.html), the blocking I/O operation is shifted to the I/O thread pool so the Netty event loop is not blocked.

This is true in Micronaut 3.x, but does not happen in certain cases for 4.x

This PR provides a test which passes when added to the 3.10.x branch, but fails on all the current 4.x.x branches

This was discovered whilst investigating fixing views https://github.com/micronaut-projects/micronaut-views/issues/757 as the views were not being delegated to an IO thread pool despite the current documentation there as well