### PR TITLE
Force secure WebSocket connections to use http/1.1

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpVersionSelection.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpVersionSelection.java
@@ -63,6 +63,12 @@ public final class HttpVersionSelection {
         true
     );
 
+    private static final HttpVersionSelection WEBSOCKET_1 = new HttpVersionSelection(
+        HttpVersionSelection.PlaintextMode.HTTP_1,
+        true,
+        new String[]{HttpVersionSelection.ALPN_HTTP_1},
+        false);
+
     private final PlaintextMode plaintextMode;
     private final boolean alpn;
     private final String[] alpnSupportedProtocols;
@@ -98,6 +104,17 @@ public final class HttpVersionSelection {
             default:
                 throw new IllegalArgumentException("HTTP version " + httpVersion + " not supported here");
         }
+    }
+
+    /**
+     * Get the {@link HttpVersionSelection} to be used for a WebSocket connection, which will enable
+     * ALPN but constrain the mode to HTTP 1.1.
+     *
+     * @return The version selection for WebSocket
+     */
+    @NonNull
+    public static HttpVersionSelection forWebsocket() {
+        return WEBSOCKET_1;
     }
 
     /**

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -215,7 +215,7 @@ public class ConnectionManager {
         SslContext oldWebsocketSslContext = websocketSslContext;
         if (configuration.getSslConfiguration().isEnabled()) {
             sslContext = nettyClientSslBuilder.build(configuration.getSslConfiguration(), httpVersion);
-            websocketSslContext = nettyClientSslBuilder.build(configuration.getSslConfiguration(), HttpVersionSelection.forLegacyVersion(HttpVersion.HTTP_1_1));
+            websocketSslContext = nettyClientSslBuilder.build(configuration.getSslConfiguration(), HttpVersionSelection.forWebsocket());
         } else {
             sslContext = null;
             websocketSslContext = null;
@@ -376,7 +376,9 @@ public class ConnectionManager {
             }
         }
         ReferenceCountUtil.release(sslContext);
+        ReferenceCountUtil.release(websocketSslContext);
         sslContext = null;
+        websocketSslContext = null;
     }
 
     /**

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -454,6 +454,7 @@ public class ConnectionManager {
                         sslCtx = websocketSslContext;
                         if (sslCtx == null) {
                             sslCtx = nettyClientSslBuilder.build(configuration.getSslConfiguration(), HttpVersionSelection.forWebsocket());
+                            websocketSslContext = sslCtx;
                         }
                     }
                 }


### PR DESCRIPTION
`ConnectionManager` is updated to use a separate `SSLContext` for WebSocket client connections that will only advertise http/1.1 in the list of supported protocols in the ALPN section of the TLS handshake.

WebSocket is not currently supported over HTTP 2 connections, thus if an HTTP 2 connection is established through ALPN, the subsequent upgrade to the WebSocket protocol would fail.

This resolves #10744