### PR TITLE
HTTP/2 prior knowledge support

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -295,7 +295,8 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
         if (pipeline != null) {
             return pipeline.httpVersion;
         }
-        return HttpVersion.HTTP_1_1;
+        // Http2ServerHandler case
+        return findConnectionHandler() == null ? HttpVersion.HTTP_1_1 : HttpVersion.HTTP_2_0;
     }
 
     @Override

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/Http2CompressionSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/Http2CompressionSpec.groovy
@@ -9,6 +9,7 @@ class Http2CompressionSpec extends CompressionSpec {
 
                 'micronaut.server.http-version': '2.0',
                 'micronaut.server.ssl.enabled': true,
+                'micronaut.server.ssl.port': 0,
                 'micronaut.server.ssl.build-self-signed': true,
         ] as Map<String, Object>
     }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/context/ContextURISpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/context/ContextURISpec.groovy
@@ -23,11 +23,11 @@ class ContextURISpec extends Specification {
     void "test getContextURI returns the base URI when context path is not set"() {
         when:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
-                'micronaut.server.port': 60006
+                'micronaut.server.port': 60007
         ])
 
         then:
-        embeddedServer.getContextURI().toString() == 'http://localhost:60006'
+        embeddedServer.getContextURI().toString() == 'http://localhost:60007'
 
         cleanup:
         embeddedServer.close()
@@ -37,11 +37,11 @@ class ContextURISpec extends Specification {
         when:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
                 'micronaut.server.context-path': '',
-                'micronaut.server.port': 60006
+                'micronaut.server.port': 60008
         ])
 
         then:
-        embeddedServer.getContextURI().toString() == 'http://localhost:60006'
+        embeddedServer.getContextURI().toString() == 'http://localhost:60008'
 
         cleanup:
         embeddedServer.close()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
@@ -229,6 +229,72 @@ class H2cSpec extends Specification {
         content.release()
     }
 
+    def 'prior knowledge'() {
+        given:
+        def responseFuture = new CompletableFuture()
+
+        def group = new NioEventLoopGroup(1)
+        def bootstrap = new Bootstrap()
+                .remoteAddress(embeddedServer.host, embeddedServer.port)
+                .group(group)
+                .channel(NioSocketChannel.class)
+                .handler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(@NonNull SocketChannel ch) throws Exception {
+                        def http2Connection = new DefaultHttp2Connection(false)
+                        def inboundAdapter = new InboundHttp2ToHttpAdapterBuilder(http2Connection)
+                                .maxContentLength(1000000)
+                                .validateHttpHeaders(true)
+                                .propagateSettings(true)
+                                .build()
+                        def connectionHandler = new HttpToHttp2ConnectionHandlerBuilder()
+                                .connection(http2Connection)
+                                .frameListener(new DelegatingDecompressorFrameListener(http2Connection, inboundAdapter))
+                                .build()
+
+                        ch.pipeline()
+                                .addLast(connectionHandler)
+                                .addLast(new ChannelInboundHandlerAdapter() {
+                                    @Override
+                                    void channelRead(@NonNull ChannelHandlerContext ctx, @NonNull Object msg) throws Exception {
+                                        ctx.read()
+                                        if (msg instanceof HttpMessage) {
+                                            if (msg.headers().getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), -1) != 3) {
+                                                responseFuture.completeExceptionally(new AssertionError("Response must be on stream 3"));
+                                            }
+                                            responseFuture.complete(ReferenceCountUtil.retain(msg))
+                                        }
+                                        super.channelRead(ctx, msg)
+                                    }
+
+                                    @Override
+                                    void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                                        super.exceptionCaught(ctx, cause)
+                                        cause.printStackTrace()
+                                        responseFuture.completeExceptionally(cause)
+                                    }
+                                })
+
+                    }
+                })
+
+        def channel = (SocketChannel) bootstrap.connect().await().channel()
+
+        def request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/h2c/test')
+        request.headers().set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http")
+        channel.writeAndFlush(request)
+        channel.read()
+
+        expect:
+        def resp = responseFuture.get(10, TimeUnit.SECONDS)
+        resp != null
+
+        cleanup:
+        channel.close()
+        resp.release()
+        group.shutdownGracefully()
+    }
+
     @Controller("/h2c")
     @Requires(property = "spec.name", value = "H2cSpec")
     static class TestController {


### PR DESCRIPTION
When accepting HTTP/2 plaintext connections, also accept prior knowledge HTTP/2. This actually already mostly worked for the new Http2ServerHandler, the changes are only necessary for the old multiplex handler.

Also fixed some test flakiness.

Fixes #6301