### PR TITLE
Remove unnecessary noise printed during a normal build.

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -170,7 +170,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
             // process remaining
             int count = beanDefinitions.size();
             if (count > 0) {
-                note("Creating bean classes for %s type elements", count);
                 ElementAnnotationMetadataFactory annotationMetadataFactory = javaVisitorContext.getElementAnnotationMetadataFactory().readOnly();
                 for (String className : beanDefinitions) {
                     if (processed.add(className)) {


### PR DESCRIPTION
This change prevents IntelliJ opening the log window when using the "Show log on stderr" option just due to a non-actionable diagnostic being printed. Users don't need to see this and the convention in Java builds is to not print anything unless there's a problem.