### PR TITLE
Support ExecuteOn annotation with ServerWebSocket

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/AbstractNettyWebSocketHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/AbstractNettyWebSocketHandler.java
@@ -220,7 +220,7 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
                 Object target = errorMethod.getTarget();
                 Object result;
                 try {
-                    result = boundExecutable.invoke(target);
+                    result = invokeExecutable(boundExecutable, errorMethod);
                 } catch (Exception e) {
 
                     if (LOG.isErrorEnabled()) {
@@ -230,8 +230,8 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
                     return;
                 }
                 if (Publishers.isConvertibleToPublisher(result)) {
-                    Flux<?> flowable = Flux.from(instrumentPublisher(ctx, result));
-                    flowable.collectList().subscribe(objects -> fallback.accept(cause), throwable -> {
+                    Mono<?> unhandled = Mono.from(instrumentPublisher(ctx, result));
+                    unhandled.subscribe(unhandledResult -> fallback.accept(cause), throwable -> {
                         if (throwable != null && LOG.isErrorEnabled()) {
                             LOG.error("Error subscribing to @OnError handler {}.{}: {}", target.getClass().getSimpleName(), errorMethod.getExecutableMethod(), throwable.getMessage(), throwable);
                         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
@@ -17,7 +17,6 @@ package io.micronaut.http.server.netty.websocket;
 
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.BoundExecutable;
@@ -69,8 +68,6 @@ import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
@@ -199,6 +199,8 @@ public final class NettyServerWebSocketUpgradeHandler implements RequestHandler 
                     msg,
                     routeMatch,
                     ctx,
+                    serverConfiguration.getThreadSelection(),
+                    routeExecutor.getExecutorSelector(),
                     routeExecutor.getCoroutineHelper().orElse(null));
                 pipeline.addBefore(ctx.name(), NettyServerWebSocketHandler.ID, webSocketHandler);
 

--- a/http-server-netty/src/test/groovy/io/micronaut/websocket/WebsocketExecuteOnSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/websocket/WebsocketExecuteOnSpec.groovy
@@ -1,0 +1,214 @@
+package io.micronaut.websocket
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.LoomSupport
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.websocket.annotation.*
+import jakarta.inject.Inject
+import org.reactivestreams.Publisher
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+import spock.lang.Unroll
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.Future
+import java.util.function.Predicate
+import java.util.function.Supplier
+import java.util.stream.Collectors
+
+@Property(name = "spec.name", value = "WebsocketExecuteOnSpec")
+@MicronautTest
+class WebsocketExecuteOnSpec extends Specification {
+
+    static final Logger LOG = LoggerFactory.getLogger(WebsocketExecuteOnSpec.class)
+
+    @Inject
+    EmbeddedServer embeddedServer
+
+    @Unroll
+    void "#type websocket server methods can run outside of the event loop with ExecuteOn"() {
+        given:
+        WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient.class, embeddedServer.getURL())
+        String threadName = (LoomSupport.isSupported() ? "virtual" : TaskExecutors.IO) + "-executor"
+        String expectedJoined = "joined on thread " + threadName
+        String expectedEcho = "Hello from thread " + threadName
+
+        expect:
+        wsClient
+
+        when:
+        EchoClientWebSocket echoClientWebSocket = Flux.from(wsClient.connect(EchoClientWebSocket, "/echo/${type}")).blockFirst()
+
+        then:
+        noExceptionThrown()
+        new PollingConditions().eventually {
+            echoClientWebSocket.receivedMessages() == [expectedJoined]
+        }
+
+        when:
+        echoClientWebSocket.send('Hello')
+
+        then:
+        new PollingConditions().eventually {
+            echoClientWebSocket.receivedMessages() == [expectedJoined, expectedEcho]
+        }
+
+        cleanup:
+        echoClientWebSocket.close()
+
+        where:
+        type        | _
+        "sync"      | _
+        "reactive"  | _
+        "async"     | _
+    }
+
+    @Requires(property = "spec.name", value = "WebsocketExecuteOnSpec")
+    @ServerWebSocket("/echo/sync")
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    static class SynchronousEchoServerWebSocket {
+        public static final String JOINED = "joined on thread %s"
+        public static final String DISCONNECTED = "disconnected on thread %s"
+        public static final String ECHO = "%s from thread %s"
+
+        @Inject
+        WebSocketBroadcaster broadcaster
+
+        @OnOpen
+        void onOpen(WebSocketSession session) {
+            broadcaster.broadcastSync(JOINED.formatted(Thread.currentThread().getName()), isValid(session))
+        }
+
+        @OnMessage
+        void onMessage(String message, WebSocketSession session) {
+            broadcaster.broadcastSync(ECHO.formatted(message, Thread.currentThread().getName()), isValid(session))
+        }
+
+        @OnClose
+        void onClose(WebSocketSession session) {
+            broadcaster.broadcastSync(DISCONNECTED.formatted(Thread.currentThread().getName()), isValid(session))
+        }
+
+        private static Predicate<WebSocketSession> isValid(WebSocketSession session) {
+            return { s -> s == session }
+        }
+    }
+
+    @Requires(property = "spec.name", value = "WebsocketExecuteOnSpec")
+    @ServerWebSocket("/echo/reactive")
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    static class ReactiveEchoServerWebSocket {
+        public static final String JOINED = "joined on thread %s"
+        public static final String DISCONNECTED = "disconnected on thread %s"
+        public static final String ECHO = " from thread %s"
+
+        @Inject
+        WebSocketBroadcaster broadcaster
+
+        Supplier<String> formatMessage(String message) {
+            () -> message.formatted(Thread.currentThread().getName())
+        }
+
+        @OnOpen
+        Publisher<String> onOpen(WebSocketSession session) {
+            Mono.fromSupplier(formatMessage(JOINED))
+                    .flatMap(message -> Mono.from(broadcaster.broadcast(message)))
+        }
+
+        @OnMessage
+        Publisher<String> onMessage(String message, WebSocketSession session) {
+            Mono.fromSupplier(formatMessage(message + ECHO))
+                    .flatMap(m -> Mono.from(broadcaster.broadcast(m)))
+        }
+
+        @OnClose
+        Publisher<String> onClose(WebSocketSession session) {
+            Mono.just(session)
+                .flatMap(s -> {
+                    LOG.info(DISCONNECTED.formatted(Thread.currentThread().getName()))
+                    return Mono.just("closed")
+                })
+        }
+    }
+
+    @Requires(property = "spec.name", value = "WebsocketExecuteOnSpec")
+    @ServerWebSocket("/echo/async")
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    static class AsyncEchoServerWebSocket {
+        public static final String JOINED = "joined on thread %s"
+        public static final String DISCONNECTED = "disconnected on thread %s"
+        public static final String ECHO = " from thread %s"
+
+        @Inject
+        WebSocketBroadcaster broadcaster
+
+        Supplier<String> formatMessage(String message) {
+            () -> message.formatted(Thread.currentThread().getName())
+        }
+
+        @OnOpen
+        Future<String> onOpen(WebSocketSession session) {
+            Mono.fromSupplier(formatMessage(JOINED))
+                    .flatMap(message -> Mono.from(broadcaster.broadcast(message))).toFuture();
+        }
+
+        @OnMessage
+        Future<String> onMessage(String message, WebSocketSession session) {
+            Mono.fromSupplier(formatMessage(message + ECHO))
+                    .flatMap(m -> Mono.from(broadcaster.broadcast(m))).toFuture()
+        }
+
+        @OnClose
+        Future<String> onClose(WebSocketSession session) {
+            Mono.just(session)
+                    .flatMap(s -> {
+                        LOG.info(DISCONNECTED.formatted(Thread.currentThread().getName()))
+                        return Mono.just("closed")
+                    }).toFuture()
+        }
+    }
+
+    @Requires(property = "spec.name", value = "WebsocketExecuteOnSpec")
+    @ClientWebSocket
+    static abstract class EchoClientWebSocket implements AutoCloseable {
+
+        static final String RECEIVED = "RECEIVED:"
+
+        private WebSocketSession session
+        private List<String> replies = new ArrayList<>()
+
+        @OnOpen
+        void onOpen(WebSocketSession session) {
+            this.session = session
+        }
+        List<String> getReplies() {
+            return replies
+        }
+
+        @OnMessage
+        void onMessage(String message) {
+            replies.add(RECEIVED + message)
+        }
+
+        abstract void send(String message)
+
+        List<String> receivedMessages() {
+            return filterMessagesByType(RECEIVED)
+        }
+
+        List<String> filterMessagesByType(String type) {
+            replies.stream()
+                    .filter(str -> str.contains(type))
+                    .map(str -> str.replaceAll(type, ""))
+                    .map(str -> str.substring(0, str.length()-(1)).replace("-thread-", ""))
+                    .collect(Collectors.toList())
+        }
+    }
+}

--- a/src/main/docs/guide/httpServer/websocket/websocketServer.adoc
+++ b/src/main/docs/guide/httpServer/websocket/websocketServer.adoc
@@ -33,6 +33,10 @@ The ann:websocket.annotation.OnMessage[] method can define a parameter for the m
 
 A method annotated with ann:websocket.annotation.OnError[] can be added to implement custom error handling. The `@OnError` method can define a parameter that receives the exception type to be handled. If no `@OnError` handling is present and an unrecoverable exception occurs, the WebSocket is automatically closed.
 
+=== Using @ExecuteOn For Blocking Methods
+
+The callback methods of a ann:websocket.annotation.ServerWebSocket[] are invoked on the main Netty server event loop by default. If you do any blocking I/O operations in your WebSocket handler methods, then you must offload those tasks to a separate thread pool in the same manner as with HTTP. As with a ann:http.annotation.Controller[] or ann:http.annotation.Filter[], the ann:scheduling.annotation.ExecuteOn[] annotation can be applied to a ann:websocket.annotation.ServerWebSocket[] handler at either the type or method level.
+
 === Non-Blocking Message Handling
 
 The previous example uses the `broadcastSync` method of the api:websocket.WebSocketBroadcaster[] interface which blocks until the broadcast is complete. A similar `sendSync` method exists in api:websocket.WebSocketSession[] to send a message to a single receiver in a blocking manner. You can however implement non-blocking WebSocket servers by instead returning a rs:Publisher[] or a link:{jdkapi}/java.base/java/util/concurrent/Future.html[Future] from each WebSocket handler method. For example:


### PR DESCRIPTION
NettyServerWebSocketHandler is updated to check for the ExecuteOn
annotation when invoking any of the callback methods on a
ServerWebSocket annotated class, and to use the specified
ExecutorService when invoking the methods.

A test is added to verify the enhanced behavior.

This resolves #10758
