### PR TITLE
Do not parallelize definition building if it gives no advantage

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
@@ -239,7 +239,7 @@ final class ServiceScanner<S> {
 
         @Override
         public void collect(Collection<S> values, boolean allowFork) {
-            if (allowFork) {
+            if (allowFork && ForkJoinPool.getCommonPoolParallelism() > 1) {
                 ForkJoinPool.commonPool().invoke(this);
                 for (RecursiveActionValuesCollector<S> task : tasks) {
                     task.join();


### PR DESCRIPTION
For the cases with 1 or 2 cores the fork join pool is of size 1 and therefore does not achieve parallelized execution. For this case, we can load definitions on the main thread.

This did not produce significant performance improvements on my machine when I set `-XX:ActiveProcessorCount=1` JVM option, so the overhead of using the pool is probably minimal. But this will get rid of the case when the main thread is on the same thread as the fork-join pool worker and is waiting for it, which I could not test on my machine.