### PR TITLE
fix: KSP processing for package private properties

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2522,4 +2522,24 @@ class Holder<A extends Animal> {
             animal.isTypeVariable()
     }
 
+    void "test package private field instrospection"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Test', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.inject.visitor.MySuperclass
+
+@Introspected
+class Test extends MySuperclass {
+
+    String name
+}
+''')
+        then:
+        introspection.getProperty("name").orElse(null)
+
+        and: 'the package private superclass is not introspected'
+        !introspection.getProperty("field").orElse(null)
+    }
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2522,7 +2522,7 @@ class Holder<A extends Animal> {
             animal.isTypeVariable()
     }
 
-    void "test package private field instrospection"() {
+    void "test package private property introspection"() {
         when:
         def introspection = buildBeanIntrospection('test.Test', '''
 package test
@@ -2536,10 +2536,16 @@ class Test extends MySuperclass {
     String name
 }
 ''')
-        then:
+        then: 'the property in this class is introspected'
         introspection.getProperty("name").orElse(null)
 
-        and: 'the package private superclass is not introspected'
-        !introspection.getProperty("field").orElse(null)
+        and: 'the public property in the java superclass is introspected'
+        introspection.getProperty("publicProperty").orElse(null)
+
+        and: 'the private property in the java superclass is not available'
+        !introspection.getProperty("privateProperty").orElse(null)
+
+        and: 'the package private superclass property is not introspected'
+        !introspection.getProperty("packagePrivateProperty").orElse(null)
     }
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2542,10 +2542,36 @@ class Test extends MySuperclass {
         and: 'the public property in the java superclass is introspected'
         introspection.getProperty("publicProperty").orElse(null)
 
-        and: 'the private property in the java superclass is not available'
+        and: 'the private property in the java superclass is not introspected'
         !introspection.getProperty("privateProperty").orElse(null)
 
         and: 'the package private superclass property is not introspected'
         !introspection.getProperty("packagePrivateProperty").orElse(null)
+    }
+
+    void "test package private property introspection in same package"() {
+        when:
+        def introspection = buildBeanIntrospection('io.micronaut.inject.visitor.Test', '''
+package io.micronaut.inject.visitor
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Test extends MySuperclass {
+
+    String name
+}
+''')
+        then: 'the property in this class is introspected'
+        introspection.getProperty("name").orElse(null)
+
+        and: 'the public property in the java superclass is introspected'
+        introspection.getProperty("publicProperty").orElse(null)
+
+        and: 'the private property in the java superclass is not introspected'
+        !introspection.getProperty("privateProperty").orElse(null)
+
+        and: 'the package private superclass property is introspected, as we are in the same package'
+        introspection.getProperty("packagePrivateProperty").orElse(null)
     }
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/MySuperclass.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/MySuperclass.groovy
@@ -1,0 +1,4 @@
+package io.micronaut.inject.visitor
+
+class MySuperclass extends PackagePrivateSuperclass {
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/PackagePrivateSuperclass.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/PackagePrivateSuperclass.java
@@ -1,0 +1,6 @@
+package io.micronaut.inject.visitor;
+
+class PackagePrivateSuperclass {
+
+    String field;
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/PackagePrivateSuperclass.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/PackagePrivateSuperclass.java
@@ -2,5 +2,21 @@ package io.micronaut.inject.visitor;
 
 class PackagePrivateSuperclass {
 
-    String field;
+    String packagePrivateProperty;
+
+    String getPackagePrivateProperty() {
+        return packagePrivateProperty;
+    }
+
+    private String privateProperty;
+
+    private String getPrivateProperty() {
+        return privateProperty;
+    }
+
+    public String publicProperty;
+
+    public String getPublicProperty() {
+        return publicProperty;
+    }
 }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -5258,11 +5258,45 @@ class Test extends MySuperclass {
         and: 'the public property in the java superclass is introspected'
         introspection.getProperty("publicProperty").orElse(null)
 
-        and: 'the private property in the java superclass is not available'
+        and: 'the private property in the java superclass is not introspected'
         !introspection.getProperty("privateProperty").orElse(null)
 
         and: 'the package private superclass property is not introspected'
         !introspection.getProperty("packagePrivateProperty").orElse(null)
+    }
+
+    void "test package private property introspection in same package"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection('io.micronaut.inject.visitor.beans.Test', '''
+package io.micronaut.inject.visitor.beans;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class Test extends MySuperclass {
+
+    private final String name;
+
+    Test(String name) {
+        this.name = name;
+    }
+
+    String getName() {
+        return name;
+    }
+}
+''')
+        then: 'the property in this class is introspected'
+        introspection.getProperty("name").orElse(null)
+
+        and: 'the public property in the java superclass is introspected'
+        introspection.getProperty("publicProperty").orElse(null)
+
+        and: 'the private property in the java superclass is not introspected'
+        !introspection.getProperty("privateProperty").orElse(null)
+
+        and: 'the package private superclass property is introspected, as we are in the same package'
+        introspection.getProperty("packagePrivateProperty").orElse(null)
     }
 
     void "test private property 1"() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -5183,6 +5183,35 @@ class Test {
         !secondNameField.hasStereotype("io.micronaut.inject.visitor.beans.TypeUseClassAnn")
     }
 
+    void "test package private field instrospection"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection('test.Test', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.inject.visitor.beans.MySuperclass;
+
+@Introspected
+class Test extends MySuperclass {
+
+    private final String name;
+
+    Test(String name) {
+        this.name = name;
+    }
+
+    String getName() {
+        return name;
+    }
+}
+''')
+        then:
+        introspection.getProperty("name").orElse(null)
+
+        and: 'the package private superclass is not introspected'
+        !introspection.getProperty("field").orElse(null)
+    }
+
     void "test subtypes"() {
         given:
         BeanIntrospection introspection = buildBeanIntrospection('test.Holder', '''
@@ -5255,6 +5284,7 @@ class OptionalDoubleHolder {
         introspection.getProperty("optionalDouble").get().getType() == OptionalDouble.class
         introspection.getProperty("optionalDouble").get().hasAnnotation(DecimalMin)
     }
+
     void "test private property 2"() {
         given:
         BeanIntrospection introspection = buildBeanIntrospection('test.OptionalStringHolder', '''

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/MySuperclass.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/MySuperclass.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.visitor.beans;
+
+public class MySuperclass extends PackagePrivateSuperclass {
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/PackagePrivateSuperclass.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/PackagePrivateSuperclass.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.visitor.beans;
+
+class PackagePrivateSuperclass {
+
+    String field;
+
+    String getField() {
+        return field;
+    }
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/PackagePrivateSuperclass.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/PackagePrivateSuperclass.java
@@ -2,9 +2,21 @@ package io.micronaut.inject.visitor.beans;
 
 class PackagePrivateSuperclass {
 
-    String field;
+    String packagePrivateProperty;
 
-    String getField() {
-        return field;
+    String getPackagePrivateProperty() {
+        return packagePrivateProperty;
+    }
+
+    private String privateProperty;
+
+    private String getPrivateProperty() {
+        return privateProperty;
+    }
+
+    public String publicProperty;
+
+    public String getPublicProperty() {
+        return publicProperty;
     }
 }

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ import io.micronaut.inject.ast.utils.AstBeanPropertiesUtils
 import io.micronaut.inject.ast.utils.EnclosedElementsQuery
 import io.micronaut.inject.processing.ProcessingException
 import io.micronaut.kotlin.processing.getBinaryName
-import java.util.*
+import java.util.Optional
 import java.util.function.Function
 import java.util.stream.Stream
 

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -23,6 +23,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.getKotlinClassByName
 import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.isConstructor
+import com.google.devtools.ksp.isJavaPackagePrivate
 import com.google.devtools.ksp.isPrivate
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
@@ -815,7 +816,7 @@ internal open class KotlinClassElement(
                 }
 
                 PropertyElement::class.java -> {
-                    classNode.getDeclaredProperties().toList()
+                    classNode.getDeclaredProperties().filter { !it.isJavaPackagePrivate() }.toList()
                 }
 
                 ConstructorElement::class.java -> {

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -2319,6 +2319,24 @@ class Test(val name:  @TypeUseRuntimeAnn String, val secondName: @TypeUseClassAn
             !secondNameField.hasStereotype(TypeUseClassAnn.name)
     }
 
+    void "test package private field instrospection"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Test', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.kotlin.processing.visitor.MySuperclass
+
+@Introspected
+class Test(val name: String) : MySuperclass()
+''')
+        then:
+        introspection.getProperty("name").orElse(null)
+
+        and: 'the package private superclass is not introspected'
+        !introspection.getProperty("field").orElse(null)
+    }
+
     void "test subtypes"() {
         given:
             BeanIntrospection introspection = buildBeanIntrospection('test.Holder', '''

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -2369,11 +2369,34 @@ class Test(val name: String) : MySuperclass()
         and: 'the public property in the java superclass is introspected'
         introspection.getProperty("publicProperty").orElse(null)
 
-        and: 'the private property in the java superclass is not available'
+        and: 'the private property in the java superclass is not introspected'
         !introspection.getProperty("privateProperty").orElse(null)
 
         and: 'the package private superclass property is not introspected'
         !introspection.getProperty("packagePrivateProperty").orElse(null)
+    }
+
+    void "test package private property introspection in same package"() {
+        when:
+        def introspection = buildBeanIntrospection('io.micronaut.kotlin.processing.visitor.Test', '''
+package io.micronaut.kotlin.processing.visitor
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Test(val name: String) : MySuperclass()
+''')
+        then: 'the property in this class is introspected'
+        introspection.getProperty("name").orElse(null)
+
+        and: 'the public property in the java superclass is introspected'
+        introspection.getProperty("publicProperty").orElse(null)
+
+        and: 'the private property in the java superclass is not introspected'
+        !introspection.getProperty("privateProperty").orElse(null)
+
+        and: 'the package private superclass property is introspected, as we are in the same package'
+        introspection.getProperty("packagePrivateProperty").orElse(null)
     }
 
     void "test list property"() {

--- a/inject-kotlin/src/test/java/io/micronaut/kotlin/processing/visitor/MySuperclass.java
+++ b/inject-kotlin/src/test/java/io/micronaut/kotlin/processing/visitor/MySuperclass.java
@@ -1,0 +1,5 @@
+package io.micronaut.kotlin.processing.visitor;
+
+public class MySuperclass extends PackagePrivateSuperclass {
+
+}

--- a/inject-kotlin/src/test/java/io/micronaut/kotlin/processing/visitor/PackagePrivateSuperclass.java
+++ b/inject-kotlin/src/test/java/io/micronaut/kotlin/processing/visitor/PackagePrivateSuperclass.java
@@ -2,5 +2,21 @@ package io.micronaut.kotlin.processing.visitor;
 
 class PackagePrivateSuperclass {
 
-    String field;
+    String packagePrivateProperty;
+
+    String getPackagePrivateProperty() {
+        return packagePrivateProperty;
+    }
+
+    private String privateProperty;
+
+    private String getPrivateProperty() {
+        return privateProperty;
+    }
+
+    public String publicProperty;
+
+    public String getPublicProperty() {
+        return publicProperty;
+    }
 }

--- a/inject-kotlin/src/test/java/io/micronaut/kotlin/processing/visitor/PackagePrivateSuperclass.java
+++ b/inject-kotlin/src/test/java/io/micronaut/kotlin/processing/visitor/PackagePrivateSuperclass.java
@@ -1,0 +1,6 @@
+package io.micronaut.kotlin.processing.visitor;
+
+class PackagePrivateSuperclass {
+
+    String field;
+}


### PR DESCRIPTION
We seem to be processing package private properties when using Ksp.

This is incorrect and they should be skipped.

Package-private isn't really a concept in Kotlin, but the Kotlin classes may be based on Java classes where it is a thing.

I believe when I have a fix, that this will fix https://github.com/micronaut-projects/micronaut-sql/issues/1324

Closes: https://github.com/micronaut-projects/micronaut-sql/issues/1324