### PR TITLE
docs: remove obsolete "CI" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,4 @@ If you wish to contribute to the development of Micronaut Framework please read 
 
 ## Versioning
 
-Micronaut Framework is using Semantic Versioning 2.0.0. To understand what that means, please see the specification [documentation](https://semver.org/). Exclusions to Micronaut Framework's public API include any classes annotated with `@Experimental` or `@Internal`, which reside in the `io.micronaut.core.annotation` package.
-
-## CI
-
-[GitHub Actions](https://github.com/micronaut-projects/micronaut-core/actions) are used to build Micronaut Framework. If a build fails in `master`, check the [test reports](https://micronaut-projects.github.io/micronaut-core/index.html).
-
-
-
+Micronaut Framework uses Semantic Versioning 2.0.0. To understand what that means, please see the specification [documentation](https://semver.org/). Exclusions to Micronaut Framework's public API include any classes annotated with `@Experimental` or `@Internal`, which reside in the `io.micronaut.core.annotation` package.


### PR DESCRIPTION
Test reports implied by the removed links are not published. Furthermore, the most current information for CI is all exposed by the Github Actions, Develocity, and Sonarcloud icon links at the top of the README page.

fixes #10763