### PR TITLE
Add API to access SSL session

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -91,11 +91,11 @@ import io.netty.util.concurrent.GenericFutureListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.security.cert.Certificate;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -397,8 +397,8 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
     }
 
     @Override
-    public Optional<Certificate> getCertificate() {
-        Supplier<Certificate> sup = channelHandlerContext.channel().attr(HttpPipelineBuilder.CERTIFICATE_SUPPLIER_ATTRIBUTE.get()).get();
+    public Optional<SSLSession> getSslSession() {
+        Supplier<SSLSession> sup = channelHandlerContext.channel().attr(HttpPipelineBuilder.SSL_SESSION_ATTRIBUTE.get()).get();
         return sup == null ? Optional.empty() : Optional.ofNullable(sup.get());
     }
 

--- a/http/src/main/java/io/micronaut/http/HttpRequestWrapper.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequestWrapper.java
@@ -18,6 +18,7 @@ package io.micronaut.http;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.cookie.Cookies;
 
+import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.Principal;
@@ -82,6 +83,11 @@ public class HttpRequestWrapper<B> extends HttpMessageWrapper<B> implements Http
     @Override
     public Optional<Certificate> getCertificate() {
         return getDelegate().getCertificate();
+    }
+
+    @Override
+    public Optional<SSLSession> getSslSession() {
+        return getDelegate().getSslSession();
     }
 
     @Override


### PR DESCRIPTION
This is useful for e.g. the session ID.

Because I replaced the getCertificate implementation with this, this is already covered by tests.