### PR TITLE
Fix file uploads beyond MMAP_SEGMENT_SIZE

### DIFF
--- a/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/SslSpec.groovy
+++ b/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/SslSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.ssl.ClientSslConfiguration
 import spock.lang.PendingFeature
+import spock.lang.Retry
 import spock.lang.Specification
 
 import javax.net.ssl.SSLHandshakeException
@@ -13,6 +14,7 @@ import java.time.Duration
 // See http-client/src/test/groovy/io/micronaut/http/client/SslSpec.groovy
 class SslSpec extends Specification {
 
+    @Retry(count = 5) // sometimes badssl.com times out
     void 'bad server ssl cert'() {
         given:
         def cfg = new DefaultHttpClientConfiguration()

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslSpec.groovy
@@ -32,6 +32,7 @@ import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.ssl.SslHandshakeTimeoutException
 import reactor.core.publisher.Flux
 import spock.lang.Ignore
+import spock.lang.Retry
 import spock.lang.Specification
 
 import javax.net.ssl.SSLHandshakeException
@@ -111,6 +112,7 @@ class SslSpec extends Specification {
         }
     }
 
+    @Retry(count = 5) // sometimes badssl.com times out
     void 'bad server ssl cert'() {
         given:
         def cfg = new DefaultHttpClientConfiguration()

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NonReentrantLock.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NonReentrantLock.java
@@ -1,0 +1,50 @@
+package io.micronaut.http.server.netty;
+
+import io.micronaut.core.annotation.NonNull;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Non-reentrant {@link Lock} implementation based on a semaphore.
+ *
+ * @author Jonas Konrad
+ */
+final class NonReentrantLock extends Semaphore implements Lock {
+    public NonReentrantLock() {
+        super(1);
+    }
+
+    @Override
+    public void lock() {
+        acquireUninterruptibly();
+    }
+
+    @Override
+    public void lockInterruptibly() throws InterruptedException {
+        acquire();
+    }
+
+    @Override
+    public boolean tryLock() {
+        return tryAcquire();
+    }
+
+    @Override
+    public boolean tryLock(long time, @NonNull TimeUnit unit) throws InterruptedException {
+        return tryAcquire(time, unit);
+    }
+
+    @Override
+    public void unlock() {
+        release();
+    }
+
+    @NonNull
+    @Override
+    public Condition newCondition() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NonReentrantLock.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NonReentrantLock.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.server.netty;
 
 import io.micronaut.core.annotation.NonNull;

--- a/test-suite/src/test/groovy/io/micronaut/upload/UploadController.java
+++ b/test-suite/src/test/groovy/io/micronaut/upload/UploadController.java
@@ -105,6 +105,22 @@ public class UploadController {
         }
     }
 
+    @Post(value = "/receive-completed-file-upload-huge", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    public String receiveCompletedFileUploadHuge(CompletedFileUpload data) {
+        try (InputStream is = data.getInputStream()) {
+            long n = 0;
+            byte[] arr = new byte[4096];
+            while (true) {
+                int o = is.read(arr);
+                if (o < 0) break;
+                n += o;
+            }
+            return data.getFilename() + ": " + n;
+        } catch (IOException e) {
+            return e.getMessage();
+        }
+    }
+
     @Post(value = "/receive-completed-file-upload-stream", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public String receiveCompletedFileUploadStream(CompletedFileUpload data) {
         try {


### PR DESCRIPTION
The code path was not covered by tests and was broken.

I also replaced the ReentrantLock by a NonReentrantLock that is based on a Semaphore. This is because there are some semantic checks in Chunk that might not work with a reentrant lock (e.g. repeated deallocate calls could lead to ref count errors). But this is unrelated to the bug.

Fixes #10666