### PR TITLE
build: Use only one jackson version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ wiremock = "2.33.2"
 managed-groovy = "4.0.21"
 managed-jakarta-annotation-api = "2.1.1"
 managed-jackson = "2.17.0"
+#@NextMajorVersion @Deprecated Delete in Micronaut Framework 5.
 managed-jackson-databind = "2.17.0"
 managed-kotlin = "1.9.23"
 managed-kotlin-coroutines = "1.7.3"
@@ -106,7 +107,7 @@ managed-jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotati
 
 managed-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "managed-jackson" }
 managed-jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "managed-jackson" }
-managed-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "managed-jackson-databind" }
+managed-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "managed-jackson" }
 managed-jackson-datatype-jdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jdk8", version.ref = "managed-jackson" }
 managed-jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "managed-jackson" }
 managed-jackson-module-afterburner = { module = "com.fasterxml.jackson.module:jackson-module-afterburner", version.ref = "managed-jackson" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ wiremock = "2.33.2"
 #
 managed-groovy = "4.0.21"
 managed-jakarta-annotation-api = "2.1.1"
-managed-jackson = "2.16.1"
+managed-jackson = "2.17.0"
 managed-jackson-databind = "2.17.0"
 managed-kotlin = "1.9.23"
 managed-kotlin-coroutines = "1.7.3"


### PR DESCRIPTION
Close: #10745

Use `managed-jackson` version everywhere.

Use `managed-jackson-databaind` should be removed in Micronaut Framework 5.