### PR TITLE
#10797 Re-add Try-Catch for ConfigurationExceptions To DefaultPropertyPlaceholderResolver

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
@@ -394,14 +394,18 @@ public class DefaultPropertyPlaceholderResolver implements PropertyPlaceholderRe
 
         @Override
         public <T> Optional<T> findValue(Class<T> type) {
-            for (String expression: expressions) {
-                Optional<T> optionalValue = resolveOptionalExpression(expression, type);
-                if (optionalValue.isPresent()) {
-                    return optionalValue;
+            try {
+                for (String expression: expressions) {
+                    Optional<T> optionalValue = resolveOptionalExpression(expression, type);
+                    if (optionalValue.isPresent()) {
+                        return optionalValue;
+                    }
                 }
-            }
-            if (defaultValue != null) {
-                return conversionService.convert(defaultValue, type);
+                if (defaultValue != null) {
+                    return conversionService.convert(defaultValue, type);
+                }
+            } catch (ConfigurationException e) {
+                // Swallow exception.
             }
             return Optional.empty();
         }

--- a/test-suite/src/test/java/io/micronaut/docs/config/value/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/value/Engine.java
@@ -19,4 +19,6 @@ public interface Engine {
     int getCylinders();
 
     String start();
+
+    String getDescription();
 }

--- a/test-suite/src/test/java/io/micronaut/docs/config/value/EngineImpl.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/value/EngineImpl.java
@@ -17,6 +17,7 @@ package io.micronaut.docs.config.value;
 
 // tag::imports[]
 import io.micronaut.context.annotation.Value;
+import io.micronaut.core.annotation.Nullable;
 
 import jakarta.inject.Singleton;
 // end::imports[]
@@ -28,6 +29,10 @@ public class EngineImpl implements Engine {
     @Value("${my.engine.cylinders:6}") // <1>
     protected int cylinders;
 
+    @Nullable
+    @Value("${my.engine.description}")
+    protected String description;
+
     @Override
     public int getCylinders() {
         return cylinders;
@@ -36,6 +41,11 @@ public class EngineImpl implements Engine {
     @Override
     public String start() {// <2>
         return "Starting V" + getCylinders() + " Engine";
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
     }
 
 }

--- a/test-suite/src/test/java/io/micronaut/docs/config/value/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/value/VehicleSpec.java
@@ -68,7 +68,6 @@ class VehicleSpec {
         applicationContext.start();
 
         Vehicle vehicle = applicationContext.getBean(Vehicle.class);
-        DefaultGroovyMethods.println(this, vehicle.start());
         // end::start[]
 
         assertEquals("V8 Engine", vehicle.getEngine().getDescription());
@@ -84,7 +83,6 @@ class VehicleSpec {
         applicationContext.start();
 
         Vehicle vehicle = applicationContext.getBean(Vehicle.class);
-        DefaultGroovyMethods.println(this, vehicle.start());
         // end::start[]
 
         assertNull(vehicle.getEngine().getDescription());

--- a/test-suite/src/test/java/io/micronaut/docs/config/value/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/value/VehicleSpec.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class VehicleSpec {
 
@@ -56,4 +57,36 @@ class VehicleSpec {
         assertEquals("Starting V6 Engine", vehicle.start());
     }
 
+    @Test
+    void testStartVehicleWithNonEmptyPlaceholder() {
+        // tag::start[]
+        ApplicationContext applicationContext = new DefaultApplicationContext("test");
+        LinkedHashMap<String, Object> map = new LinkedHashMap(1);
+        map.put("my.engine.description", "${DESCRIPTION}");
+        map.put("DESCRIPTION", "V8 Engine");
+        applicationContext.getEnvironment().addPropertySource(PropertySource.of("test", map));
+        applicationContext.start();
+
+        Vehicle vehicle = applicationContext.getBean(Vehicle.class);
+        DefaultGroovyMethods.println(this, vehicle.start());
+        // end::start[]
+
+        assertEquals("V8 Engine", vehicle.getEngine().getDescription());
+    }
+
+    @Test
+    void testStartVehicleWithEmptyPlaceholder() {
+        // tag::start[]
+        ApplicationContext applicationContext = new DefaultApplicationContext("test");
+        LinkedHashMap<String, Object> map = new LinkedHashMap(1);
+        map.put("my.engine.description", "${DESCRIPTION}");
+        applicationContext.getEnvironment().addPropertySource(PropertySource.of("test", map));
+        applicationContext.start();
+
+        Vehicle vehicle = applicationContext.getBean(Vehicle.class);
+        DefaultGroovyMethods.println(this, vehicle.start());
+        // end::start[]
+
+        assertNull(vehicle.getEngine().getDescription());
+    }
 }


### PR DESCRIPTION
# Summary
This PR fixes a regression that was introduced in PR #9701, which removed a try-catch statement within an implementation of the `Segment::findValue()` function.

The contract for this interface implies that no exception should be thrown from it, and indeed the default implementation directly catches `ConfigurationException`s and returns `Optional.empty()`. 

The regression manifests itself as an exception when trying to resolve property placeholders that are expected to be nullable, and thus are not present in the environment or any other property resolver. 

Prior behavior simply returned a value of null for these missing and nullable placeholders, which is the expected behavior.

This PR restores this behavior.