### PR TITLE
allow registering bean definitions prior to startup

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/context/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -18,6 +18,7 @@ package io.micronaut.runtime;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.DefaultApplicationContextBuilder;
+import io.micronaut.context.RuntimeBeanDefinition;
 import io.micronaut.context.banner.Banner;
 import io.micronaut.context.banner.MicronautBanner;
 import io.micronaut.context.banner.ResourceBanner;
@@ -218,6 +219,11 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
     @Override
     public @NonNull Micronaut singletons(Object... beans) {
         return (Micronaut) super.singletons(beans);
+    }
+
+    @Override
+    public Micronaut beanDefinitions(@NonNull RuntimeBeanDefinition<?>... definitions) {
+        return (Micronaut) super.beanDefinitions(definitions);
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionSpec.groovy
@@ -17,6 +17,19 @@ class RuntimeBeanDefinitionSpec extends AbstractTypeElementSpec {
     @Shared
     BeanContext sharedContext = BeanContext.build()
 
+    void "test runtime bean definition registered with builder"() {
+        given:
+        def foo = new Foo()
+        def context = ApplicationContext.builder()
+            .beanDefinitions(RuntimeBeanDefinition.of(foo))
+            .build()
+            .start()
+
+        expect:
+        context.getBeanDefinition(Foo)
+        context.getBean(Foo).is(foo)
+    }
+
     void 'test simple runtime bean definition'() {
         given:
 

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -97,6 +97,16 @@ public interface ApplicationContextBuilder {
     @NonNull ApplicationContextBuilder singletons(@Nullable Object... beans);
 
     /**
+     * Register additional runtime bean definitions prior to startup.
+     * @param definitions The definitions.
+     * @return The context builder
+     * @since 4.5.0
+     */
+    default @NonNull ApplicationContextBuilder beanDefinitions(@NonNull RuntimeBeanDefinition<?>... definitions) {
+        return this;
+    };
+
+    /**
      * If set to {@code true} (the default is {@code true}) Micronaut will attempt to automatically deduce the environment
      * it is running in using environment variables and/or stack trace inspection.
      *

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -49,6 +49,7 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING_ARRAY;
  */
 public class DefaultApplicationContextBuilder implements ApplicationContextBuilder, ApplicationContextConfiguration {
     private final List<Object> singletons = new ArrayList<>();
+    private final List<RuntimeBeanDefinition<?>> beanDefinitions = new ArrayList<>();
     private final List<String> environments = new ArrayList<>();
     private final List<String> defaultEnvironments = new ArrayList<>();
     private final List<String> packages = new ArrayList<>();
@@ -149,6 +150,14 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     public @NonNull ApplicationContextBuilder singletons(Object... beans) {
         if (beans != null) {
             singletons.addAll(Arrays.asList(beans));
+        }
+        return this;
+    }
+
+    @Override
+    public ApplicationContextBuilder beanDefinitions(@NonNull RuntimeBeanDefinition<?>... definitions) {
+        if (definitions != null) {
+            beanDefinitions.addAll(Arrays.asList(definitions));
         }
         return this;
     }
@@ -343,6 +352,12 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
         if (!singletons.isEmpty()) {
             for (Object singleton : singletons) {
                 applicationContext.registerSingleton(singleton);
+            }
+        }
+
+        if (!beanDefinitions.isEmpty()) {
+            for (RuntimeBeanDefinition<?> beanDefinition : beanDefinitions) {
+                applicationContext.registerBeanDefinition(beanDefinition);
             }
         }
 


### PR DESCRIPTION
Allows adding new bean definitions with all the options of RuntimeBeanDefinition prior to startup. Currently we only support singletons in the `ApplicationContextBuilder` interface.