### PR TITLE
Improve ability to introspect bean context prior to start

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/context/ApplicationContextConfigurerSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/context/ApplicationContextConfigurerSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.inject.context
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class ApplicationContextConfigurerSpec
+    extends Specification {
+
+    void 'test context configurer registers bean'() {
+        given:
+        def ctx = ApplicationContext.run()
+
+        expect:"bean is registered"
+        ctx.getBean(Foo)
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/context/TestContextConfigurer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/context/TestContextConfigurer.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.context;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ApplicationContextConfigurer;
+import io.micronaut.context.RuntimeBeanDefinition;
+import io.micronaut.context.annotation.ContextConfigurer;
+
+@ContextConfigurer
+public class TestContextConfigurer
+    implements ApplicationContextConfigurer {
+    @Override
+    public void configure(ApplicationContext applicationContext) {
+        applicationContext.registerBeanDefinition(
+            RuntimeBeanDefinition.of(new Foo())
+        );
+    }
+}
+
+class Foo {}

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -31,6 +31,8 @@ import java.util.Map;
  *
  * @author graemerocher
  * @since 1.0
+ * @see ApplicationContextConfigurer
+ * @see ApplicationContext#builder()
  */
 public interface ApplicationContextBuilder {
 
@@ -53,6 +55,7 @@ public interface ApplicationContextBuilder {
      * @return The context builder
      * @since 2.0
      */
+    @SuppressWarnings("unchecked")
     default @NonNull ApplicationContextBuilder eagerInitSingletons(boolean eagerInitSingletons) {
         if (eagerInitSingletons) {
             return eagerInitAnnotated(Singleton.class);
@@ -77,6 +80,7 @@ public interface ApplicationContextBuilder {
      * @return The context builder
      * @since 2.0
      */
+    @SuppressWarnings("unchecked")
     @NonNull ApplicationContextBuilder eagerInitAnnotated(Class<? extends Annotation>... annotations);
 
     /**

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
@@ -34,6 +34,15 @@ import java.util.Optional;
 public interface ApplicationContextConfiguration extends BeanContextConfiguration {
 
     /**
+     * The loaded {@link ApplicationContextConfigurer}.
+     * @return The context configurer.
+     * @since 4.5.0
+     */
+    default Optional<ApplicationContextConfigurer> getContextConfigurer() {
+        return Optional.empty();
+    }
+
+    /**
      * @return The environment names
      */
     @NonNull List<String> getEnvironments();

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfigurer.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfigurer.java
@@ -24,13 +24,13 @@ import io.micronaut.core.order.Ordered;
  * for configuring an application context before the
  * application/function is started.
  *
- * Application context configurers must be registered
+ * <p>Application context configurers must be registered
  * as services. Those services are automatically called
- * whenever a new application context builder is created.
+ * whenever a new application context builder is created.</p>
  *
- * An application context annotated with
+ * <p>An application context annotated with
  * {@link io.micronaut.context.annotation.ContextConfigurer}
- * will automatically be registered as a service provider.
+ * will automatically be registered as a service provider.</p>
  *
  * @since 3.2
  */
@@ -45,9 +45,28 @@ public interface ApplicationContextConfigurer extends Ordered {
 
     /**
      * Configures the application context builder.
+     *
+     * <p>This method allows the programmatic enhancement of the context prior to construction.</p>
+     *
+     * <p>The {@link ApplicationContextBuilder} interface features methods to add environments, property sources etc.</p>
+     *
      * @param builder the builder to configure
+     * @see ApplicationContextBuilder
      */
     default void configure(@NonNull ApplicationContextBuilder builder) {
+        // no-op
+    }
 
+    /**
+     * Configures the application context.
+     *
+     * <p>This method will be called after the context is fully configured but
+     * prior to starting the context.</p>
+     *
+     * @param applicationContext The context.
+     * @since 4.5.0
+     */
+    default void configure(@NonNull ApplicationContext applicationContext) {
+        // no-op
     }
 }

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextProvider.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextProvider.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.context;
 
+import io.micronaut.core.annotation.NonNull;
+
 /**
  * An interface for classes that provide an {@link ApplicationContext}.
  *
@@ -28,5 +30,5 @@ public interface ApplicationContextProvider {
      *
      * @return The {@link ApplicationContext}
      */
-    ApplicationContext getApplicationContext();
+    @NonNull ApplicationContext getApplicationContext();
 }

--- a/inject/src/main/java/io/micronaut/context/ConfigurableApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/ConfigurableApplicationContext.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+/**
+ * Extended version of the {@link ApplicationContext} that
+ * allows loading the context configuration without starting the context.
+ *
+ * @see ConfigurableBeanContext#configure()
+ * @since 4.5.0
+ */
+public interface ConfigurableApplicationContext
+    extends ApplicationContext, ConfigurableBeanContext {
+}

--- a/inject/src/main/java/io/micronaut/context/ConfigurableBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/ConfigurableBeanContext.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+/**
+ * Extends {@link BeanContext} interface and allows the bean context to be configured but not started.
+ *
+ * @since 4.5.0
+ */
+public interface ConfigurableBeanContext
+    extends BeanContext {
+    void configure();
+}

--- a/inject/src/main/java/io/micronaut/context/ConfigurableBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/ConfigurableBeanContext.java
@@ -22,5 +22,17 @@ package io.micronaut.context;
  */
 public interface ConfigurableBeanContext
     extends BeanContext {
+
+    /**
+     * Configures the bean context loading all bean definitions
+     * required to perform successful startup without starting the context itself.
+     *
+     * <p>Once called the methods of the {@link BeanDefinitionRegistry} interface will
+     * return results allowing inspection of the context without needing to run the context.</p>
+     *
+     * @see io.micronaut.inject.BeanDefinition
+     * @see #getBeanDefinition(Class)
+     * @see #start()
+     */
     void configure();
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -132,6 +132,15 @@ public class DefaultApplicationContext extends DefaultBeanContext implements Con
     }
 
     @Override
+    @Internal
+    final void configureContextInternal() {
+        super.configureContextInternal();
+        configuration.getContextConfigurer().ifPresent(configurer ->
+            configurer.configure(this)
+        );
+    }
+
+    @Override
     public @NonNull
     <T> ApplicationContext registerSingleton(@NonNull Class<T> type, @NonNull T singleton, @Nullable Qualifier<T> qualifier, boolean inject) {
         return (ApplicationContext) super.registerSingleton(type, singleton, qualifier, inject);

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -68,7 +68,7 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING_ARRAY;
  * @author Graeme Rocher
  * @since 1.0
  */
-public class DefaultApplicationContext extends DefaultBeanContext implements ApplicationContext {
+public class DefaultApplicationContext extends DefaultBeanContext implements ConfigurableApplicationContext {
 
     private final ClassPathResourceLoader resourceLoader;
     private final ApplicationContextConfiguration configuration;

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -342,7 +342,6 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
                     LOG.debug("Starting BeanContext");
                 }
                 registerConversionService();
-                readAllBeanConfigurations();
                 configureAndStartContext();
                 if (LOG.isDebugEnabled()) {
                     String activeConfigurations = beanConfigurations
@@ -3283,7 +3282,7 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     }
 
     private void configureAndStartContext() {
-        this.startupBeans = readBeanDefinitionReferences();
+        configureContextInternal();
         initializeEventListeners();
         initializeContext(
             startupBeans.eagerInitBeans,
@@ -3718,7 +3717,6 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
 
     @Override
     public void finalizeConfiguration() {
-        readAllBeanConfigurations();
         configureAndStartContext();
     }
 
@@ -3741,7 +3739,11 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
         configureContextInternal();
     }
 
-    private void configureContextInternal() {
+    /**
+     * Configures the context reading all bean definitions.
+     */
+    @Internal
+    void configureContextInternal() {
         if (configured.compareAndSet(false, true)) {
             readAllBeanConfigurations();
             readBeanDefinitionReferences();

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -115,7 +115,6 @@ import io.micronaut.inject.qualifiers.Qualified;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.inject.validation.BeanDefinitionValidator;
 import jakarta.inject.Singleton;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -343,7 +342,8 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
                     LOG.debug("Starting BeanContext");
                 }
                 registerConversionService();
-                finalizeConfiguration();
+                readAllBeanConfigurations();
+                configureAndStartContext();
                 if (LOG.isDebugEnabled()) {
                     String activeConfigurations = beanConfigurations
                             .values()
@@ -3282,8 +3282,8 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
         return list;
     }
 
-    private void readAllBeanDefinitionClasses() {
-        this.startupBeans = configureBeanDefinitionReferences();
+    private void configureAndStartContext() {
+        this.startupBeans = readBeanDefinitionReferences();
         initializeEventListeners();
         initializeContext(
             startupBeans.eagerInitBeans,
@@ -3293,7 +3293,7 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     }
 
     @NonNull
-    private StartupBeans configureBeanDefinitionReferences() {
+    private StartupBeans readBeanDefinitionReferences() {
         if (startupBeans == null) {
 
             List<BeanDefinitionProducer> eagerInitBeans = new ArrayList<>(20);
@@ -3719,7 +3719,7 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     @Override
     public void finalizeConfiguration() {
         readAllBeanConfigurations();
-        readAllBeanDefinitionClasses();
+        configureAndStartContext();
     }
 
     @Override
@@ -3728,7 +3728,7 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     }
 
     @Override
-    public synchronized final void configure() {
+    public final synchronized void configure() {
         if (this.running.get()) {
             configurationFailure("already running");
         }
@@ -3744,7 +3744,7 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     private void configureContextInternal() {
         if (configured.compareAndSet(false, true)) {
             readAllBeanConfigurations();
-            configureBeanDefinitionReferences();
+            readBeanDefinitionReferences();
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/InitializableBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/InitializableBeanContext.java
@@ -26,7 +26,7 @@ import io.micronaut.core.annotation.Internal;
  * @deprecated Use {@link ConfigurableBeanContext} instead
  */
 @Internal
-@Deprecated
+@Deprecated(forRemoval = true, since = "4.5.0")
 public interface InitializableBeanContext extends BeanContext {
     /**
      * Performs operations required before starting the application

--- a/inject/src/main/java/io/micronaut/context/InitializableBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/InitializableBeanContext.java
@@ -23,8 +23,10 @@ import io.micronaut.core.annotation.Internal;
  * but not necessarily started yet.
  *
  * @since 3.2.2
+ * @deprecated Use {@link ConfigurableBeanContext} instead
  */
 @Internal
+@Deprecated
 public interface InitializableBeanContext extends BeanContext {
     /**
      * Performs operations required before starting the application

--- a/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
@@ -1,9 +1,49 @@
 package io.micronaut.context
 
 import io.micronaut.context.env.PropertySource
+import io.micronaut.context.exceptions.BeanContextException
+import io.micronaut.context.exceptions.NoSuchBeanException
+import io.micronaut.runtime.ApplicationConfiguration
 import spock.lang.Specification
 
 class ApplicationContextBuilderSpec extends Specification {
+
+    void "test configure() context"() {
+        when:"a context is built"
+        ApplicationContextBuilder builder = ApplicationContext.builder()
+        def context = builder.build()
+
+        then:"it is configurable"
+        context instanceof ConfigurableApplicationContext
+
+        when:"the configure() method is called"
+        context.configure()
+
+        then:"Then bean definitions are available"
+        !context.beanDefinitionReferences.isEmpty()
+        !context.isRunning()
+        context.getBeanDefinition(ApplicationConfiguration)
+
+        when:
+        context.getBean(ApplicationConfiguration)
+
+        then:
+        thrown(BeanContextException)
+
+        when:"The context is started"
+        context.start()
+
+        then:"The context is running and beans are available"
+        context.isRunning()
+        context.getBean(ApplicationConfiguration)
+
+        when:
+        context.close()
+
+        then:
+        !context.isRunning()
+        context.beanDefinitionReferences.isEmpty()
+    }
 
     void "test disable default property sources"() {
         given:


### PR DESCRIPTION
The existing `InitializableBeanContext` is problematic because it still creates context scoped beans and runs event listeners. We need a way to configure the context and allow it to be introspected prior to start so this deprecates `InitializableBeanContext` and replaces it with `ConfigurableBeanContext` and `ConfigurableApplicationContext` interfaces.

These feature a `configure()` method that loads the bean definitions and state needed to start the context but doesn't actually start it.

The PR also adds logic to assert the context is running when resolving beans which was missing before and could lead to odd behaviour.