### PR TITLE
Make behaviour of @DefaultImplementation consistent

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/Order.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Order.java
@@ -24,8 +24,23 @@ import java.lang.annotation.Target;
 /**
  * Annotation for objects that are ordered.
  *
+ * <p>Order in a Micronaut application is important in multiple aspects including but note limited to:</p>
+ *
+ * <ul>
+ *     <li>Controlling bean selection and prioritization</li>
+ *     <li>Ordering injected {@link java.util.List} collections.</li>
+ *     <li>Ordering AOP method interceptors</li>
+ *     <li>Ordering HTTP filters</li>
+ * </ul>
+ *
+ * <p>This annotation can be used to control the order by specifying a numerical value
+ * that sorts components in the desired order</p>
+ *
  * @author Sean Carroll
  * @since 2.0
+ * @see io.micronaut.core.order.Ordered
+ * @see io.micronaut.core.order.Ordered#HIGHEST_PRECEDENCE
+ * @see io.micronaut.core.order.Ordered#LOWEST_PRECEDENCE
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})

--- a/core/src/main/java/io/micronaut/core/order/Ordered.java
+++ b/core/src/main/java/io/micronaut/core/order/Ordered.java
@@ -18,8 +18,15 @@ package io.micronaut.core.order;
 /**
  * Interface for objects that are ordered.
  *
+ * <p>Provides a programmatic alternative to {@link io.micronaut.core.annotation.Order}.</p>
+ *
+ * <p>Note that this interface only applies to injected collection types since the beans have
+ * to be instantiated to resolve the order therefore unlike {@link io.micronaut.core.annotation.Order}
+ * it cannot be used for the purposes of prioritizing bean selection.</p>
+ *
  * @author Graeme Rocher
  * @since 1.0
+ * @see io.micronaut.core.annotation.Order
  */
 public interface Ordered {
     /**

--- a/inject-java/src/test/groovy/io/micronaut/inject/defaultimpl/DefaultImplementationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/defaultimpl/DefaultImplementationSpec.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.inject.defaultimpl
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class DefaultImplementationSpec
+    extends AbstractTypeElementSpec {
+
+    void "test pick default implementation when multiple candidates"() {
+        given:
+        def ctx = buildContext( '''
+package test;
+
+import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.DefaultImplementation;
+
+@DefaultImplementation(TestImpl.class)
+interface Test {
+}
+
+@Singleton
+class TestImpl implements Test {
+
+}
+
+@Singleton
+class TestImpl2 implements Test {
+
+}
+''')
+        def cls = ctx.classLoader.loadClass('test.Test')
+
+        expect:"no non-unique bean exception is thrown and the default impl is returned"
+        ctx.getBean(cls).class.simpleName == 'TestImpl'
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -3241,16 +3241,14 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
 
         // try resolve @DefaultImplementation
-        for (BeanDefinition<T> candidate : candidates) {
-            if (candidate.hasStereotype(DefaultImplementation.class)) {
-                String n = candidate.stringValue(DefaultImplementation.class, "name").orElse(null);
-                if (n != null) {
-                    for (BeanDefinition<T> bd : candidates) {
-                        if (bd.getBeanType().getName().equals(n)) {
-                            return candidate;
-                        }
+        BeanDefinition<T> first = candidates.iterator().next();
+        if (first.hasStereotype(DefaultImplementation.class)) {
+            String n = first.stringValue(DefaultImplementation.class, "name").orElse(null);
+            if (n != null) {
+                for (BeanDefinition<T> bd : candidates) {
+                    if (bd.getBeanType().getName().equals(n)) {
+                        return bd;
                     }
-                    break;
                 }
             }
         }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -3240,6 +3240,20 @@ public class DefaultBeanContext implements InitializableBeanContext {
             return bean;
         }
 
+        // try resolve @DefaultImplementation
+        for (BeanDefinition<T> candidate : candidates) {
+            if (candidate.hasStereotype(DefaultImplementation.class)) {
+                String n = candidate.stringValue(DefaultImplementation.class, "name").orElse(null);
+                if (n != null) {
+                    for (BeanDefinition<T> bd : candidates) {
+                        if (bd.getBeanType().getName().equals(n)) {
+                            return candidate;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
         Collection<BeanDefinition<T>> exactMatches = filterExactMatch(beanType.getType(), candidates);
         if (exactMatches.size() == 1) {
             return exactMatches.iterator().next();

--- a/inject/src/main/java/io/micronaut/context/annotation/DefaultImplementation.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/DefaultImplementation.java
@@ -27,7 +27,17 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * <p>An annotation to apply to an interface to indicate which implementation
- * is the default implementation. The initial use case is to redirect {@link Replaces}
+ * is the default implementation.</p>
+ *
+ * <p>When a bean is looked up and if there are multiple possible candidates with
+ * no concrete {@link Primary} this annotation will impact bean selection by
+ * selecting the default implementation.</p>
+ *
+ * <p>It should be noted that {@link Primary} and {@link io.micronaut.core.order.Ordered}
+ * take precedence over this an annotation and a fallback to the default implementation only
+ * occurs if no primary candidate can be established.</p>
+ *
+ * <p>Note that this annotation also has an impact on bean replacement via {@link Replaces}
  * to another class to allow the replacement of an implementation that isn't
  * accessible due to visibility restrictions.</p>
  *

--- a/src/main/docs/guide/ioc/replaces.adoc
+++ b/src/main/docs/guide/ioc/replaces.adoc
@@ -43,7 +43,13 @@ The `BookFactory#novel()` method will not be replaced because the TextBook class
 
 === Default Implementation
 
-When exposing an API, it may be desirable to not expose the default implementation of an interface as part of the public API. Doing so prevents users from being able to replace the implementation because they will not be able to reference the class. The solution is to annotate the interface with api:context.annotation.DefaultImplementation[] to indicate which implementation to replace if a user creates a bean that `@Replaces(YourInterface.class)`.
+When exposing an API, you may want to define an implementation of the interface that is used as the default when injecting a particular interface. For this you can use the ann:context.annotation.DefaultImplementation[] annotation.
+
+It may also be desirable to not expose the default implementation of an interface as part of the public API by making it package private in Java.
+
+Doing so prevents users from being able to replace the implementation because they will not be able to reference the class.
+
+The ann:context.annotation.DefaultImplementation[] annotation allows the framework to establish the implementation to replace if a user creates a bean that declares `@Replaces(YourInterface.class)`.
 
 For example consider:
 


### PR DESCRIPTION
The `@DefaultImplementation` annotation is currently confusing since it doesn't influence bean selection but only the result of `@Replaces`. This PR makes it so that the annotation can also be used to control bean selection which makes it more logical and less confusing. 