### PR TITLE
improve BeanProvider API by adding lookup methods

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/provider/BeanProviderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/provider/BeanProviderSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.context.exceptions.NonUniqueBeanException
+import io.micronaut.core.type.Argument
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.annotation.MutableAnnotationMetadata
@@ -172,7 +173,10 @@ class Bar {}
 ''')
         when:
         def bean = getBean(context, 'test.Test')
-        def fooProvider = context.getProvider(context.classLoader.loadClass('test.Foo'))
+
+        def type = context.classLoader.loadClass('test.Foo')
+        def fooProvider = context.getProvider(type)
+        def fooProvider2 = context.getProvider(Argument.of(type))
 
         then:
         bean.provider.isPresent()
@@ -180,6 +184,8 @@ class Bar {}
         bean.provider.find(null).isPresent()
         !bean.barProvider.find(null).isPresent()
         bean.provider.get().is(fooProvider.get())
+        fooProvider.get().is(fooProvider2.get())
+        fooProvider.asJakartaProvider().get().is(fooProvider.get())
 
         when:
         bean.barProvider.get()

--- a/inject-java/src/test/groovy/io/micronaut/inject/provider/BeanProviderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/provider/BeanProviderSpec.groovy
@@ -172,12 +172,14 @@ class Bar {}
 ''')
         when:
         def bean = getBean(context, 'test.Test')
+        def fooProvider = context.getProvider(context.classLoader.loadClass('test.Foo'))
 
         then:
         bean.provider.isPresent()
         !bean.barProvider.isPresent()
         bean.provider.find(null).isPresent()
         !bean.barProvider.find(null).isPresent()
+        bean.provider.get().is(fooProvider.get())
 
         when:
         bean.barProvider.get()

--- a/inject/src/main/java/io/micronaut/context/BeanLocator.java
+++ b/inject/src/main/java/io/micronaut/context/BeanLocator.java
@@ -20,6 +20,7 @@ import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.GenericArgument;
 import io.micronaut.inject.BeanDefinition;
 
 import java.util.Collection;
@@ -96,6 +97,69 @@ public interface BeanLocator {
         return getBean(
                 beanType,
                 null
+        );
+    }
+
+    /**
+     * Obtains a {@link BeanProvider} for the given type and qualifier.
+     *
+     * @param beanType  The bean type
+     * @param qualifier The qualifier
+     * @param <T>       The bean type parameter
+     * @return The provider
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     * @since 4.5.0
+     */
+    default @NonNull <T> BeanProvider<T> getProvider(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return getProvider(Argument.of(beanType), qualifier);
+    }
+
+    /**
+     * Obtains a {@link BeanProvider} for the given type and qualifier.
+     *
+     * @param beanType  The bean type
+     * @param <T>       The bean type parameter
+     * @return The provider
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     * @since 4.5.0
+     */
+    default @NonNull <T> BeanProvider<T> getProvider(@NonNull Class<T> beanType) {
+        return getProvider(Argument.of(beanType), null);
+    }
+
+    /**
+     * Obtains a {@link BeanProvider} for the given type and qualifier.
+     *
+     * @param beanType  The potentially parameterized bean type
+     * @param qualifier The qualifier
+     * @param <T>       The bean type parameter
+     * @return The provider
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     * @since 4.5.0
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    default @NonNull <T> BeanProvider<T> getProvider(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        Argument providerArgument = Argument.of(BeanProvider.class, beanType);
+        return (BeanProvider<T>) getBean(
+            providerArgument,
+            qualifier
+        );
+    }
+
+    /**
+     * Obtains a {@link BeanProvider} for the given type and qualifier.
+     *
+     * @param beanType  The potentially parameterized bean type
+     * @param <T>       The bean type parameter
+     * @return A provider
+     *                                                                for the given type
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     * @since 4.5.0
+     */
+    default @NonNull <T> BeanProvider<T> getProvider(@NonNull Argument<T> beanType) {
+        return getProvider(
+            beanType,
+            null
         );
     }
 

--- a/inject/src/main/java/io/micronaut/context/BeanProvider.java
+++ b/inject/src/main/java/io/micronaut/context/BeanProvider.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
 
+import jakarta.inject.Provider;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
@@ -54,6 +55,15 @@ public interface BeanProvider<T> extends Iterable<T> {
      */
     @NonNull
     T get();
+
+    /**
+     * Convert this provider into a jakarta provider.
+     * @return The jakarta provider.
+     * @since 4.5.0
+     */
+    default @NonNull Provider<T> asJakartaProvider() {
+        return this::get;
+    }
 
     /**
      * Finds a bean for the optionally specified qualifier. Return empty if non-exists.


### PR DESCRIPTION
Currently there is no easy way to lookup a `BeanProvider` programmatically, they always have to be injected. There is also no easy way to convert from our `BeanProvider` interface to the Jakarta one. This adds two small improvements to enable that.