### PR TITLE
Update SslSpec.groovy

### DIFF
--- a/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/SslSpec.groovy
+++ b/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/SslSpec.groovy
@@ -39,7 +39,7 @@ class SslSpec extends Specification {
                 'https://wrong.host.badssl.com/',
                 'https://self-signed.badssl.com/',
                 'https://untrusted-root.badssl.com/',
-                'https://revoked.badssl.com/',
+                //'https://revoked.badssl.com/', needs jvm option
                 //'https://pinning-test.badssl.com/', // not implemented
                 'https://no-subject.badssl.com/',
                 'https://reversed-chain.badssl.com/',


### PR DESCRIPTION
They updated the cert for revoked.badssl.com from a revoked AND expired cert to a cert that is only revoked. Since revocation checking is not enabled, this test fails now.