### PR TITLE
Allow customising endpoints context path

### DIFF
--- a/http/src/main/java/io/micronaut/http/annotation/ServerFilter.java
+++ b/http/src/main/java/io/micronaut/http/annotation/ServerFilter.java
@@ -74,6 +74,7 @@ public @interface ServerFilter {
 
     /**
      * @return Whether the contextPath should be concatenated into the filter pattern
+     * @since 4.5.1
      */
     boolean appendContextPath() default true;
 }

--- a/http/src/main/java/io/micronaut/http/annotation/ServerFilter.java
+++ b/http/src/main/java/io/micronaut/http/annotation/ServerFilter.java
@@ -71,4 +71,9 @@ public @interface ServerFilter {
      * @return The methods to match. Defaults to all
      */
     HttpMethod[] methods() default {};
+
+    /**
+     * @return Whether the contextPath should be concatenated into the filter pattern
+     */
+    boolean appendContextPath() default true;
 }

--- a/http/src/main/java/io/micronaut/http/filter/BaseFilterProcessor.java
+++ b/http/src/main/java/io/micronaut/http/filter/BaseFilterProcessor.java
@@ -168,7 +168,7 @@ public abstract class BaseFilterProcessor<A extends Annotation> implements Execu
                 .toList();
         }
 
-        if (patterns != null) {
+        if (patterns != null && (beanLevel.appendContextPath == null || beanLevel.appendContextPath)) {
             patterns = prependContextPath(patterns);
         }
 
@@ -189,7 +189,8 @@ public abstract class BaseFilterProcessor<A extends Annotation> implements Execu
             order,
             methodLevel.executeOn == null ? beanLevel.executeOn : methodLevel.executeOn,
             beanLevel.serviceId, // only present on bean level
-            beanLevel.excludeServiceId // only present on bean level
+            beanLevel.excludeServiceId, // only present on bean level
+            beanLevel.appendContextPath // Define if contextPath is appended
         );
     }
 
@@ -224,6 +225,7 @@ public abstract class BaseFilterProcessor<A extends Annotation> implements Execu
         OptionalInt order = annotationMetadata.intValue(Order.class);
         String[] serviceId = annotationMetadata.stringValues(annotationType, "serviceId"); // only on ClientFilter
         String[] excludeServiceId = annotationMetadata.stringValues(annotationType, "excludeServiceId"); // only on ClientFilter
+        Optional<Boolean> appendContextPath = annotationMetadata.booleanValue(annotationType, "appendContextPath");
         return new FilterMetadata(
             annotationMetadata.enumValue(annotationType, "patternStyle", FilterPatternStyle.class).orElse(FilterPatternStyle.ANT),
             ArrayUtils.isNotEmpty(patterns) ? Arrays.asList(patterns) : null,
@@ -231,7 +233,8 @@ public abstract class BaseFilterProcessor<A extends Annotation> implements Execu
             order.isPresent() ? new FilterOrder.Fixed(order.getAsInt()) : null,
             annotationMetadata.stringValue(ExecuteOn.class).orElse(null),
             ArrayUtils.isNotEmpty(serviceId) ? Arrays.asList(serviceId) : null,
-            ArrayUtils.isNotEmpty(excludeServiceId) ? Arrays.asList(excludeServiceId) : null
+            ArrayUtils.isNotEmpty(excludeServiceId) ? Arrays.asList(excludeServiceId) : null,
+            appendContextPath.orElse(null)
         );
     }
 
@@ -242,7 +245,8 @@ public abstract class BaseFilterProcessor<A extends Annotation> implements Execu
         @Nullable FilterOrder order,
         @Nullable String executeOn,
         @Nullable List<String> serviceId,
-        @Nullable List<String> excludeServiceId
+        @Nullable List<String> excludeServiceId,
+        @Nullable Boolean appendContextPath
     ) {
     }
 

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
@@ -41,6 +41,11 @@ public class EndpointDefaultConfiguration {
     public static final String PATH = "endpoints.all.path";
 
     /**
+     * The context for endpoints settings.
+     */
+    public static final String CONTEXT_PATH = "endpoints.all.context.path";
+
+    /**
      * The path for endpoints settings.
      */
     public static final String PORT = "endpoints.all.port";
@@ -50,10 +55,16 @@ public class EndpointDefaultConfiguration {
      */
     public static final String DEFAULT_ENDPOINT_BASE_PATH = "/";
 
+    /**
+     * The default context path.
+     */
+    public static final String DEFAULT_ENDPOINT_CONTEXT_PATH = null;
+
     private Boolean enabled;
     private Boolean sensitive;
     private Integer port;
     private String path = DEFAULT_ENDPOINT_BASE_PATH;
+    private String contextPath = DEFAULT_ENDPOINT_CONTEXT_PATH;
 
     /**
      *
@@ -61,6 +72,14 @@ public class EndpointDefaultConfiguration {
      */
     public String getPath() {
         return path;
+    }
+
+    /**
+     *
+     * @return endpoints Context Path (defaults is null)
+     */
+    public @Nullable String getContextPath() {
+        return contextPath;
     }
 
     /**
@@ -102,6 +121,16 @@ public class EndpointDefaultConfiguration {
     public void setPath(String path) {
         if (StringUtils.isNotEmpty(path)) {
             this.path = path;
+        }
+    }
+
+    /**
+     * The endpoints context path. Default value is null.
+     * @param contextPath The Context Path
+     */
+    public void setContextPath(String contextPath) {
+        if (StringUtils.isNotEmpty(contextPath)) {
+            this.contextPath = contextPath;
         }
     }
 

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilter.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilter.java
@@ -42,7 +42,7 @@ import java.util.Optional;
  * @since 1.0
  */
 @Requires(missingBeans = EndpointSensitivityHandler.class)
-@ServerFilter(Filter.MATCH_ALL_PATTERN)
+@ServerFilter(value = Filter.MATCH_ALL_PATTERN, appendContextPath = false)
 @Internal
 public class EndpointsFilter implements Ordered {
 

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
@@ -168,7 +168,10 @@ abstract class AbstractEndpointRouteBuilder extends DefaultRouteBuilder implemen
         if (path.charAt(0) == '/') {
             path = path.substring(1);
         }
-        return uriNamingStrategy.resolveUri(path);
+        var completePath = endpointDefaultConfiguration.getContextPath() == null
+            ? uriNamingStrategy.resolveUri(path)
+            : NameUtils.hyphenate(StringUtils.prependUri(endpointDefaultConfiguration.getContextPath(), path));
+        return completePath.charAt(0) == '/' ? completePath : "/".concat(completePath);
     }
 
     /**

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsContextPathSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsContextPathSpec.groovy
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.management.endpoint.annotation.Endpoint
+import io.micronaut.management.endpoint.annotation.Read
+import io.micronaut.management.endpoint.annotation.Selector
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+class EndpointsContextPathSpec extends Specification {
+
+    def "due to the change of endpoints context path to /admin, Health endpoint is available at /admin/health"() {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': getClass().simpleName,
+                'endpoints.all.context-path': '/admin',
+                'endpoints.all.enabled': true
+        ])
+        HttpClient rxClient = server.applicationContext.createBean(HttpClient.class, server.getURL())
+
+        when:
+        rxClient.toBlocking().retrieve('/admin/health')
+
+        then:
+        noExceptionThrown()
+
+        when:
+        rxClient.toBlocking().retrieve('/health')
+
+        then:
+        def e = thrown(HttpClientResponseException)
+
+        when:
+        def response = e.response
+
+        then:
+        response.status == HttpStatus.NOT_FOUND
+
+        cleanup:
+        rxClient.close()
+        server.close()
+    }
+
+    void "test routes with a server context path and endpoints context path"() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': getClass().simpleName,
+                'micronaut.server.context-path': '/myapp',
+                'endpoints.all.context-path': '/test',
+        ])
+        HttpClient client = server.applicationContext.createBean(HttpClient.class, server.getURL())
+
+        when:
+        client.toBlocking().retrieve('/test/my-endpoint/any', String)
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.UNAUTHORIZED
+
+        cleanup:
+        client.close()
+        server.close()
+    }
+
+    void "test routes with a server context path and all context path without leading slash"() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': getClass().simpleName,
+                'micronaut.server.context-path': '/myapp',
+                'endpoints.all.context-path': 'endpoints'
+        ])
+        HttpClient client = server.applicationContext.createBean(HttpClient.class, server.getURL())
+
+        when:
+        client.toBlocking().retrieve('/endpoints/my-endpoint/hello', String)
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.UNAUTHORIZED
+
+        cleanup:
+        client.close()
+        server.close()
+    }
+
+    void "test routes with a server context path and context path without leading slash"() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': getClass().simpleName,
+                'micronaut.server.context-path': 'myapp',
+                'endpoints.all.context-path': 'endpoints'
+        ])
+        HttpClient client = server.applicationContext.createBean(HttpClient.class, server.getURL())
+
+        when:
+        client.toBlocking().retrieve('/endpoints/my-endpoint/hello', String)
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.UNAUTHORIZED
+
+        cleanup:
+        client.close()
+        server.close()
+    }
+
+    void "test routes with a server context path no all context path"() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': getClass().simpleName,
+                'micronaut.server.context-path': '/myapp',
+        ])
+        HttpClient client = server.applicationContext.createBean(HttpClient.class, server.getURL())
+
+        when:
+        client.toBlocking().retrieve('/myapp/my-endpoint/hello', String)
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.UNAUTHORIZED
+
+        cleanup:
+        client.close()
+        server.close()
+    }
+
+    @Endpoint(id = "myEndpoint")
+    @Requires(property = "spec.name", value = "EndpointsContextPathSpec")
+    static class MyEndpoint {
+
+        @Read
+        String name(@Selector String name) {
+            name
+        }
+    }
+}

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsContextPathSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsContextPathSpec.groovy
@@ -63,7 +63,7 @@ class EndpointsContextPathSpec extends Specification {
     void "test routes with a server context path and endpoints context path"() {
         EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
                 'spec.name': getClass().simpleName,
-                'micronaut.server.context-path': '/myapp',
+                'micronaut.server.context-path': '/any',
                 'endpoints.all.context-path': '/test',
         ])
         HttpClient client = server.applicationContext.createBean(HttpClient.class, server.getURL())
@@ -144,7 +144,7 @@ class EndpointsContextPathSpec extends Specification {
     static class MyEndpoint {
 
         @Read
-        String name(@Selector String name) {
+        String anyMethodNameForTest(@Selector String name) {
             name
         }
     }


### PR DESCRIPTION
Allows global customisation of endpoints context path with `endpoints.all.context-path`
