### PR TITLE
Delay scheduling until startup

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -663,6 +663,13 @@ public class DefaultApplicationContext extends DefaultBeanContext implements Con
         return getEnvironment().getPlaceholderResolver().resolveRequiredPlaceholders(str);
     }
 
+    @Override
+    protected <T> void destroyLifeCycleBean(LifeCycle<?> cycle, BeanDefinition<T> definition) {
+        if (cycle != environment) { // handle environment separately, see stop() method
+            super.destroyLifeCycleBean(cycle, definition);
+        }
+    }
+
     /**
      * @param beanContext The bean context
      */

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1204,12 +1204,8 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
                 }
             }
         }
-        if (beanToDestroy instanceof LifeCycle cycle) {
-            try {
-                cycle.stop();
-            } catch (Exception e) {
-                throw new BeanDestructionException(definition, e);
-            }
+        if (beanToDestroy instanceof LifeCycle<?> cycle) {
+            destroyLifeCycleBean(cycle, definition);
         }
         if (registration instanceof BeanDisposingRegistration) {
             List<BeanRegistration<?>> dependents = ((BeanDisposingRegistration<T>) registration).getDependents();
@@ -1228,6 +1224,21 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
         }
 
         triggerBeanDestroyedListeners(definition, beanToDestroy);
+    }
+
+    /**
+     * Destroy a lifecycle bean.
+     * @param cycle The cycle
+     * @param definition The definition
+     * @param <T> The bean type
+     */
+    @Internal
+    protected <T> void destroyLifeCycleBean(LifeCycle<?> cycle, BeanDefinition<T> definition) {
+        try {
+            cycle.stop();
+        } catch (Exception e) {
+            throw new BeanDestructionException(definition, e);
+        }
     }
 
     @NonNull


### PR DESCRIPTION
Small change to delay scheduling tasks until startup. Rationale:

* Calling during `process` the context might be shutdown or in active, so better on a startup event
* Startup event listeners are ordered so now someone could write a listener that runs before job scheduling which wasn't possible before