### PR TITLE
Correct clients getting shutdown by request scope

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -210,7 +210,6 @@ public class ConnectionManager {
 
 
         refresh();
-        running.set(true);
     }
 
     final void refresh() {
@@ -228,6 +227,7 @@ public class ConnectionManager {
             http3SslContext = null;
         }
         initBootstrap();
+        running.set(true);
         for (Pool pool : pools.values()) {
             pool.forEachConnection(c -> ((Pool.ConnectionHolder) c).windDownConnection());
         }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -136,6 +136,8 @@ public class ConnectionManager {
     private final ClientSslBuilder nettyClientSslBuilder;
     private EventLoopGroup group;
     private final boolean shutdownGroup;
+
+    private final AtomicBoolean running = new AtomicBoolean(false);
     private final ThreadFactory threadFactory;
     private final ChannelFactory<? extends Channel> socketChannelFactory;
     private final ChannelFactory<? extends Channel> udpChannelFactory;
@@ -206,7 +208,9 @@ public class ConnectionManager {
             shutdownGroup = true;
         }
 
+
         refresh();
+        running.set(true);
     }
 
     final void refresh() {
@@ -315,10 +319,12 @@ public class ConnectionManager {
      * @see DefaultHttpClient#start()
      */
     public final void start() {
-        // only need to start new group if it's managed by us
-        if (shutdownGroup) {
-            group = createEventLoopGroup(configuration, threadFactory);
-            initBootstrap(); // rebuild bootstrap with new group
+        if (running.compareAndSet(false, true)) {
+            // only need to start new group if it's managed by us
+            if (shutdownGroup) {
+                group = createEventLoopGroup(configuration, threadFactory);
+                initBootstrap(); // rebuild bootstrap with new group
+            }
         }
     }
 
@@ -352,31 +358,34 @@ public class ConnectionManager {
      * @see DefaultHttpClient#stop()
      */
     public final void shutdown() {
-        for (Pool pool : pools.values()) {
-            pool.shutdown();
-        }
-        if (shutdownGroup) {
-            Duration shutdownTimeout = configuration.getShutdownTimeout()
-                .orElse(Duration.ofMillis(HttpClientConfiguration.DEFAULT_SHUTDOWN_TIMEOUT_MILLISECONDS));
-            Duration shutdownQuietPeriod = configuration.getShutdownQuietPeriod()
-                .orElse(Duration.ofMillis(HttpClientConfiguration.DEFAULT_SHUTDOWN_QUIET_PERIOD_MILLISECONDS));
+        if (running.compareAndSet(true, false)) {
 
-            Future<?> future = group.shutdownGracefully(
-                shutdownQuietPeriod.toMillis(),
-                shutdownTimeout.toMillis(),
-                TimeUnit.MILLISECONDS
-            );
-            try {
-                future.await(shutdownTimeout.toMillis());
-            } catch (InterruptedException e) {
-                // ignore
-                Thread.currentThread().interrupt();
+            for (Pool pool : pools.values()) {
+                pool.shutdown();
             }
+            if (shutdownGroup) {
+                Duration shutdownTimeout = configuration.getShutdownTimeout()
+                    .orElse(Duration.ofMillis(HttpClientConfiguration.DEFAULT_SHUTDOWN_TIMEOUT_MILLISECONDS));
+                Duration shutdownQuietPeriod = configuration.getShutdownQuietPeriod()
+                    .orElse(Duration.ofMillis(HttpClientConfiguration.DEFAULT_SHUTDOWN_QUIET_PERIOD_MILLISECONDS));
+
+                Future<?> future = group.shutdownGracefully(
+                    shutdownQuietPeriod.toMillis(),
+                    shutdownTimeout.toMillis(),
+                    TimeUnit.MILLISECONDS
+                );
+                try {
+                    future.await(shutdownTimeout.toMillis());
+                } catch (InterruptedException e) {
+                    // ignore
+                    Thread.currentThread().interrupt();
+                }
+            }
+            ReferenceCountUtil.release(sslContext);
+            ReferenceCountUtil.release(websocketSslContext);
+            sslContext = null;
+            websocketSslContext = null;
         }
-        ReferenceCountUtil.release(sslContext);
-        ReferenceCountUtil.release(websocketSslContext);
-        sslContext = null;
-        websocketSslContext = null;
     }
 
     /**
@@ -385,7 +394,7 @@ public class ConnectionManager {
      * @return Whether this connection manager is still running and can serve requests
      */
     public final boolean isRunning() {
-        return !group.isShutdown();
+        return running.get() && !group.isShutdown();
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1204,7 +1204,7 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
                 }
             }
         }
-        if (beanToDestroy instanceof LifeCycle<?> cycle) {
+        if (beanToDestroy instanceof LifeCycle<?> cycle && !dependent) {
             destroyLifeCycleBean(cycle, definition);
         }
         if (registration instanceof BeanDisposingRegistration) {


### PR DESCRIPTION
* Dependent bean shutdown should not automatically call lifecycle hooks (these are for top level beans managed by the context only)
* Fix bugs in connection manager `isRunning()` method
* Fixes #10888