### PR TITLE
Fix some instance check type pollution

### DIFF
--- a/core-reactive/src/main/java/io/micronaut/core/async/publisher/Publishers.java
+++ b/core-reactive/src/main/java/io/micronaut/core/async/publisher/Publishers.java
@@ -424,12 +424,16 @@ public class Publishers {
      * @return True if it is
      */
     public static boolean isConvertibleToPublisher(Class<?> type) {
+        // first, check for some common types without instanceof
+        if (type == Publisher.class) {
+            return true;
+        }
+        if (type.isPrimitive() || type.getName().startsWith("java.") || type.isArray()) {
+            return false;
+        }
         if (Publisher.class.isAssignableFrom(type)) {
             return true;
         } else {
-            if (type.isPrimitive() || type.getName().startsWith("java.")) {
-                return false;
-            }
             for (Class<?> reactiveType : REACTIVE_TYPES) {
                 if (reactiveType.isAssignableFrom(type)) {
                     return true;
@@ -454,7 +458,10 @@ public class Publishers {
      * @return True if it is
      */
     public static boolean isConvertibleToPublisher(Object object) {
-        if (object == null) {
+        if (object == null ||
+            // check some common types for performance
+            object instanceof String || object instanceof byte[]) {
+
             return false;
         }
         if (object instanceof Publisher) {

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -434,7 +434,9 @@ public final class RouteExecutor {
     }
 
     private ExecutionFlow<MutableHttpResponse<?>> fromImperativeExecute(PropagatedContext propagatedContext, HttpRequest<?> request, RouteInfo<?> routeInfo, Object body) {
-        if (body instanceof HttpResponse<?> httpResponse) {
+        // performance optimization: check for common body types
+        //noinspection ConditionCoveredByFurtherCondition
+        if (!(body instanceof String) && !(body instanceof byte[]) && body instanceof HttpResponse<?> httpResponse) {
             MutableHttpResponse<?> outgoingResponse = httpResponse.toMutableResponse();
             final Argument<?> bodyArgument = routeInfo.getReturnType().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
             if (bodyArgument.isAsyncOrReactive()) {

--- a/router/src/main/java/io/micronaut/web/router/DefaultUriRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultUriRouteMatch.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * @since 1.0
  */
 @Internal
-class DefaultUriRouteMatch<T, R> extends AbstractRouteMatch<T, R> implements UriRouteMatch<T, R> {
+public final class DefaultUriRouteMatch<T, R> extends AbstractRouteMatch<T, R> implements UriRouteMatch<T, R> {
 
     private final UriMatchInfo matchInfo;
     private final UriRouteInfo<T, R> uriRouteInfo;


### PR DESCRIPTION
Measured using https://github.com/RedHatPerf/type-pollution-agent in the techempower benchmarks.

This patch fixes some of the instanceof type pollution that could cause scalability issues with many CPUs, and also some instanceof misses that are less problematic but still worth avoiding.