### PR TITLE
EachBean: Allow to inject the origin bean and the registration

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/Bar.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/Bar.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Bar implements MyService {
+    @Override
+    public String getName() {
+        return "bar";
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/Bar.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/Bar.java
@@ -1,7 +1,9 @@
 package io.micronaut.inject.foreach.noqualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec", value = "EachBeanNoQualifierSpec")
 @Singleton
 public class Bar implements MyService {
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/EachBeanNoQualifierSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/EachBeanNoQualifierSpec.groovy
@@ -5,14 +5,30 @@ import spock.lang.Specification
 
 class EachBeanNoQualifierSpec extends Specification {
 
+    void "test returning a map of beans"() {
+        given:
+            ApplicationContext context = ApplicationContext.run([
+                    'spec': 'EachBeanNoQualifierSpec'
+            ])
+        when:
+            context.getBean(MyMapEachUser)
+        then:
+            def e = thrown(Exception)
+            e.message.contains "Injecting a map of beans requires `@Named` qualifier. Multiple beans were found missing a qualifier resulting in duplicate keys: Duplicate key myEach1"
+        cleanup:
+            context.close()
+    }
+
     void "test mapping each bean without qualifier"() {
         given:
-            ApplicationContext context = ApplicationContext.run()
-
+            ApplicationContext context = ApplicationContext.run([
+                    'spec': 'EachBeanNoQualifierSpec'
+            ])
         when:
             def myEach1Users = context.getBean(MyEach1User)
         then:
             myEach1Users.getAll().size() == 2
+            myEach1Users.getAll().collect { it.myService.name }.containsAll("foo", "bar")
             myEach1Users.getAll().collect { it.myService.name }.containsAll("foo", "bar")
         when:
             def myEach1s = context.getBeansOfType(MyEach1)

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/EachBeanNoQualifierSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/EachBeanNoQualifierSpec.groovy
@@ -1,0 +1,54 @@
+package io.micronaut.inject.foreach.noqualifier
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class EachBeanNoQualifierSpec extends Specification {
+
+    void "test mapping each bean without qualifier"() {
+        given:
+            ApplicationContext context = ApplicationContext.run()
+
+        when:
+            def myEach1Users = context.getBean(MyEach1User)
+        then:
+            myEach1Users.getAll().size() == 2
+            myEach1Users.getAll().collect { it.myService.name }.containsAll("foo", "bar")
+        when:
+            def myEach1s = context.getBeansOfType(MyEach1)
+        then:
+            myEach1s.size() == 2
+            myEach1s.collect { it.myService.name }.containsAll("foo", "bar")
+
+        when:
+            def myEach2Users = context.getBean(MyEach2User)
+        then:
+            myEach2Users.getAll().size() == 2
+            myEach2Users.getAll().collect { it.myServiceBeanReg.bean().name }.containsAll("foo", "bar")
+            myEach2Users.getAll().collect { context.getBean(it.myServiceBeanReg.definition()).name }.containsAll("foo", "bar")
+        when:
+            def myEach2s = context.getBeansOfType(MyEach2)
+        then:
+            myEach2s.size() == 2
+            myEach2s.collect { it.myServiceBeanReg.bean().name }.containsAll("foo", "bar")
+            myEach2s.collect { context.getBean(it.myServiceBeanReg.definition()).name }.containsAll("foo", "bar")
+
+        when:
+            def myEach3Users = context.getBean(MyEach3User)
+        then:
+            myEach3Users.getAll().size() == 2
+            myEach3Users.getAll().collect { it.myServiceBeanReg.bean().name }.containsAll("foo", "bar")
+            myEach3Users.getAll().collect { context.getBean(it.myServiceBeanReg.definition()).name }.containsAll("foo", "bar")
+            myEach3Users.getAll().collect { it.qualifier.toString() }.containsAll("EachBeanQualifier('Definition: io.micronaut.inject.foreach.noqualifier.Bar')", "EachBeanQualifier('Definition: io.micronaut.inject.foreach.noqualifier.Foo')")
+        when:
+            def myEach3s = context.getBeansOfType(MyEach3)
+        then:
+            myEach3s.size() == 2
+            myEach3s.collect { it.myServiceBeanReg.bean().name }.containsAll("foo", "bar")
+            myEach3s.collect { context.getBean(it.myServiceBeanReg.definition()).name }.containsAll("foo", "bar")
+            myEach3s.collect { it.qualifier.toString() }.containsAll("EachBeanQualifier('Definition: io.micronaut.inject.foreach.noqualifier.Bar')", "EachBeanQualifier('Definition: io.micronaut.inject.foreach.noqualifier.Foo')")
+
+        cleanup:
+            context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/Foo.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/Foo.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Foo implements MyService {
+    @Override
+    public String getName() {
+        return "foo";
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/Foo.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/Foo.java
@@ -1,7 +1,9 @@
 package io.micronaut.inject.foreach.noqualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec", value = "EachBeanNoQualifierSpec")
 @Singleton
 public class Foo implements MyService {
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach1.java
@@ -1,7 +1,9 @@
 package io.micronaut.inject.foreach.noqualifier;
 
 import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec", value = "EachBeanNoQualifierSpec")
 @EachBean(MyService.class)
 public class MyEach1 {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach1.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+import io.micronaut.context.annotation.EachBean;
+
+@EachBean(MyService.class)
+public class MyEach1 {
+
+    private final MyService myService;
+
+    public MyEach1(MyService myService) {
+        this.myService = myService;
+    }
+
+    public MyService getMyService() {
+        return myService;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach1User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach1User.java
@@ -1,9 +1,11 @@
 package io.micronaut.inject.foreach.noqualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 import java.util.List;
 
+@Requires(property = "spec", value = "EachBeanNoQualifierSpec")
 @Singleton
 public class MyEach1User {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach1User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach1User.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class MyEach1User {
+
+    private final List<MyEach1> myEach1s;
+
+    public MyEach1User(List<MyEach1> myEach1s) {
+        this.myEach1s = myEach1s;
+    }
+
+    public List<MyEach1> getAll() {
+        return myEach1s;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach2.java
@@ -1,0 +1,18 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.annotation.EachBean;
+
+@EachBean(MyService.class)
+public class MyEach2 {
+
+    private final BeanRegistration<MyService> myServiceBeanReg;
+
+    public MyEach2(BeanRegistration<MyService> myServiceBeanReg) {
+        this.myServiceBeanReg = myServiceBeanReg;
+    }
+
+    public BeanRegistration<MyService> getMyServiceBeanReg() {
+        return myServiceBeanReg;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach2.java
@@ -2,7 +2,9 @@ package io.micronaut.inject.foreach.noqualifier;
 
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec", value = "EachBeanNoQualifierSpec")
 @EachBean(MyService.class)
 public class MyEach2 {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach2User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach2User.java
@@ -1,9 +1,11 @@
 package io.micronaut.inject.foreach.noqualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 import java.util.List;
 
+@Requires(property = "spec", value = "EachBeanNoQualifierSpec")
 @Singleton
 public class MyEach2User {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach2User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach2User.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class MyEach2User {
+
+    private final List<MyEach2> myEach2s;
+
+    public MyEach2User(List<MyEach2> myEach2s) {
+        this.myEach2s = myEach2s;
+    }
+
+    public List<MyEach2> getAll() {
+        return myEach2s;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach3.java
@@ -3,7 +3,9 @@ package io.micronaut.inject.foreach.noqualifier;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.Qualifier;
 import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec", value = "EachBeanNoQualifierSpec")
 @EachBean(MyService.class)
 public class MyEach3 {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach3.java
@@ -1,0 +1,25 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.Qualifier;
+import io.micronaut.context.annotation.EachBean;
+
+@EachBean(MyService.class)
+public class MyEach3 {
+
+    private final BeanRegistration<MyService> myServiceBeanReg;
+    private final Qualifier<MyService> qualifier;
+
+    public MyEach3(BeanRegistration<MyService> myServiceBeanReg, Qualifier<MyService> qualifier) {
+        this.myServiceBeanReg = myServiceBeanReg;
+        this.qualifier = qualifier;
+    }
+
+    public BeanRegistration<MyService> getMyServiceBeanReg() {
+        return myServiceBeanReg;
+    }
+
+    public Qualifier<MyService> getQualifier() {
+        return qualifier;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach3User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach3User.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class MyEach3User {
+
+    private final List<MyEach3> beans;
+
+    public MyEach3User(List<MyEach3> beans) {
+        this.beans = beans;
+    }
+
+    public List<MyEach3> getAll() {
+        return beans;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach3User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyEach3User.java
@@ -1,9 +1,11 @@
 package io.micronaut.inject.foreach.noqualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 import java.util.List;
 
+@Requires(property = "spec", value = "EachBeanNoQualifierSpec")
 @Singleton
 public class MyEach3User {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyMapEachUser.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyMapEachUser.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+import java.util.Map;
+
+@Requires(property = "spec", value = "EachBeanNoQualifierSpec")
+@Singleton
+public class MyMapEachUser {
+
+    private final Map<String, MyEach1> allMap;
+
+    public MyMapEachUser(Map<String, MyEach1> allMap) {
+        this.allMap = allMap;
+    }
+
+    public Map<String, MyEach1> getAllMap() {
+        return allMap;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyService.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/noqualifier/MyService.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.foreach.noqualifier;
+
+public interface MyService {
+
+    String getName();
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/Bar.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/Bar.java
@@ -1,0 +1,13 @@
+package io.micronaut.inject.foreach.qualifier;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Named("Bar")
+@Singleton
+public class Bar implements MyService {
+    @Override
+    public String getName() {
+        return "bar";
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/Bar.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/Bar.java
@@ -1,8 +1,10 @@
 package io.micronaut.inject.foreach.qualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec", value = "EachBeanQualifierSpec")
 @Named("Bar")
 @Singleton
 public class Bar implements MyService {

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/EachBeanQualifierSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/EachBeanQualifierSpec.groovy
@@ -5,10 +5,24 @@ import spock.lang.Specification
 
 class EachBeanQualifierSpec extends Specification {
 
+    void "test returning a map of beans"() {
+        given:
+            ApplicationContext context = ApplicationContext.run([
+                    'spec': 'EachBeanQualifierSpec'
+            ])
+        when:
+            def bean = context.getBean(MyMapEachUser)
+        then:
+            bean.getAllMap().keySet().containsAll(["Foo", "Bar"])
+        cleanup:
+            context.close()
+    }
+
     void "test mapping each bean with qualifier"() {
         given:
-            ApplicationContext context = ApplicationContext.run()
-
+            ApplicationContext context = ApplicationContext.run([
+                    'spec': 'EachBeanQualifierSpec'
+            ])
         when:
             def myEach1Users = context.getBean(MyEach1User)
         then:

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/EachBeanQualifierSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/EachBeanQualifierSpec.groovy
@@ -1,0 +1,54 @@
+package io.micronaut.inject.foreach.qualifier
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class EachBeanQualifierSpec extends Specification {
+
+    void "test mapping each bean with qualifier"() {
+        given:
+            ApplicationContext context = ApplicationContext.run()
+
+        when:
+            def myEach1Users = context.getBean(MyEach1User)
+        then:
+            myEach1Users.getAll().size() == 2
+            myEach1Users.getAll().collect { it.myService.name }.containsAll("foo", "bar")
+        when:
+            def myEach1s = context.getBeansOfType(MyEach1)
+        then:
+            myEach1s.size() == 2
+            myEach1s.collect { it.myService.name }.containsAll("foo", "bar")
+
+        when:
+            def myEach2Users = context.getBean(MyEach2User)
+        then:
+            myEach2Users.getAll().size() == 2
+            myEach2Users.getAll().collect { it.myServiceBeanReg.bean().name }.containsAll("foo", "bar")
+            myEach2Users.getAll().collect { context.getBean(it.myServiceBeanReg.definition()).name }.containsAll("foo", "bar")
+        when:
+            def myEach2s = context.getBeansOfType(MyEach2)
+        then:
+            myEach2s.size() == 2
+            myEach2s.collect { it.myServiceBeanReg.bean().name }.containsAll("foo", "bar")
+            myEach2s.collect { context.getBean(it.myServiceBeanReg.definition()).name }.containsAll("foo", "bar")
+
+        when:
+            def myEach3Users = context.getBean(MyEach3User)
+        then:
+            myEach3Users.getAll().size() == 2
+            myEach3Users.getAll().collect { it.myServiceBeanReg.bean().name }.containsAll("foo", "bar")
+            myEach3Users.getAll().collect { context.getBean(it.myServiceBeanReg.definition()).name }.containsAll("foo", "bar")
+            myEach3Users.getAll().collect { it.qualifier.toString() }.containsAll("@Named('Foo')", "@Named('Bar')")
+        when:
+            def myEach3s = context.getBeansOfType(MyEach3)
+        then:
+            myEach3s.size() == 2
+            myEach3s.collect { it.myServiceBeanReg.bean().name }.containsAll("foo", "bar")
+            myEach3s.collect { context.getBean(it.myServiceBeanReg.definition()).name }.containsAll("foo", "bar")
+            myEach3s.collect { it.qualifier.toString() }.containsAll("@Named('Foo')", "@Named('Bar')")
+
+        cleanup:
+            context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/Foo.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/Foo.java
@@ -1,0 +1,13 @@
+package io.micronaut.inject.foreach.qualifier;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Named("Foo")
+@Singleton
+public class Foo implements MyService {
+    @Override
+    public String getName() {
+        return "foo";
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/Foo.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/Foo.java
@@ -1,8 +1,10 @@
 package io.micronaut.inject.foreach.qualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec", value = "EachBeanQualifierSpec")
 @Named("Foo")
 @Singleton
 public class Foo implements MyService {

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach1.java
@@ -1,7 +1,9 @@
 package io.micronaut.inject.foreach.qualifier;
 
 import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec", value = "EachBeanQualifierSpec")
 @EachBean(MyService.class)
 public class MyEach1 {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach1.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.foreach.qualifier;
+
+import io.micronaut.context.annotation.EachBean;
+
+@EachBean(MyService.class)
+public class MyEach1 {
+
+    private final MyService myService;
+
+    public MyEach1(MyService myService) {
+        this.myService = myService;
+    }
+
+    public MyService getMyService() {
+        return myService;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach1User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach1User.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.foreach.qualifier;
+
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class MyEach1User {
+
+    private final List<MyEach1> myEach1s;
+
+    public MyEach1User(List<MyEach1> myEach1s) {
+        this.myEach1s = myEach1s;
+    }
+
+    public List<MyEach1> getAll() {
+        return myEach1s;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach1User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach1User.java
@@ -1,9 +1,11 @@
 package io.micronaut.inject.foreach.qualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 import java.util.List;
 
+@Requires(property = "spec", value = "EachBeanQualifierSpec")
 @Singleton
 public class MyEach1User {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach2.java
@@ -2,7 +2,9 @@ package io.micronaut.inject.foreach.qualifier;
 
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec", value = "EachBeanQualifierSpec")
 @EachBean(MyService.class)
 public class MyEach2 {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach2.java
@@ -1,0 +1,18 @@
+package io.micronaut.inject.foreach.qualifier;
+
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.annotation.EachBean;
+
+@EachBean(MyService.class)
+public class MyEach2 {
+
+    private final BeanRegistration<MyService> myServiceBeanReg;
+
+    public MyEach2(BeanRegistration<MyService> myServiceBeanReg) {
+        this.myServiceBeanReg = myServiceBeanReg;
+    }
+
+    public BeanRegistration<MyService> getMyServiceBeanReg() {
+        return myServiceBeanReg;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach2User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach2User.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.foreach.qualifier;
+
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class MyEach2User {
+
+    private final List<MyEach2> myEach2s;
+
+    public MyEach2User(List<MyEach2> myEach2s) {
+        this.myEach2s = myEach2s;
+    }
+
+    public List<MyEach2> getAll() {
+        return myEach2s;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach2User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach2User.java
@@ -1,9 +1,11 @@
 package io.micronaut.inject.foreach.qualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 import java.util.List;
 
+@Requires(property = "spec", value = "EachBeanQualifierSpec")
 @Singleton
 public class MyEach2User {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach3.java
@@ -3,7 +3,9 @@ package io.micronaut.inject.foreach.qualifier;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.Qualifier;
 import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec", value = "EachBeanQualifierSpec")
 @EachBean(MyService.class)
 public class MyEach3 {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach3.java
@@ -1,0 +1,25 @@
+package io.micronaut.inject.foreach.qualifier;
+
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.Qualifier;
+import io.micronaut.context.annotation.EachBean;
+
+@EachBean(MyService.class)
+public class MyEach3 {
+
+    private final BeanRegistration<MyService> myServiceBeanReg;
+    private final Qualifier<MyService> qualifier;
+
+    public MyEach3(BeanRegistration<MyService> myServiceBeanReg, Qualifier<MyService> qualifier) {
+        this.myServiceBeanReg = myServiceBeanReg;
+        this.qualifier = qualifier;
+    }
+
+    public BeanRegistration<MyService> getMyServiceBeanReg() {
+        return myServiceBeanReg;
+    }
+
+    public Qualifier<MyService> getQualifier() {
+        return qualifier;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach3User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach3User.java
@@ -1,9 +1,11 @@
 package io.micronaut.inject.foreach.qualifier;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 import java.util.List;
 
+@Requires(property = "spec", value = "EachBeanQualifierSpec")
 @Singleton
 public class MyEach3User {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach3User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyEach3User.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.foreach.qualifier;
+
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class MyEach3User {
+
+    private final List<MyEach3> beans;
+
+    public MyEach3User(List<MyEach3> beans) {
+        this.beans = beans;
+    }
+
+    public List<MyEach3> getAll() {
+        return beans;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyMapEachUser.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyMapEachUser.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.foreach.qualifier;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+import java.util.Map;
+
+@Requires(property = "spec", value = "EachBeanQualifierSpec")
+@Singleton
+public class MyMapEachUser {
+
+    private final Map<String, MyEach1> allMap;
+
+    public MyMapEachUser(Map<String, MyEach1> allMap) {
+        this.allMap = allMap;
+    }
+
+    public Map<String, MyEach1> getAllMap() {
+        return allMap;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyService.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/qualifier/MyService.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.foreach.qualifier;
+
+public interface MyService {
+
+    String getName();
+
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -46,6 +46,7 @@ import io.micronaut.inject.BeanConfiguration;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
 import io.micronaut.inject.qualifiers.PrimaryQualifier;
+import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -559,10 +560,15 @@ public class DefaultApplicationContext extends DefaultBeanContext implements Con
                     createAndAddDelegate(resolutionContext, candidate, transformedCandidates, dependentPath);
                 } else {
                     Qualifier<?> qualifier = dependentCandidate.getDeclaredQualifier();
-                    if (qualifier == null && dependentCandidate.isPrimary()) {
-                        // Backwards compatibility, `getDeclaredQualifier` strips @Primary
-                        // This should be removed if @Primary is no longer qualifier
-                        qualifier = PrimaryQualifier.INSTANCE;
+                    if (qualifier == null) {
+                        if (dependentCandidate.isPrimary()) {
+                            // Backwards compatibility, `getDeclaredQualifier` strips @Primary
+                            // This should be removed if @Primary is no longer qualifier
+                            qualifier = PrimaryQualifier.INSTANCE;
+                        } else {
+                            // @EachBean needs to have something of qualifier to find its origin
+                            qualifier = Qualifiers.eachBeanOf(dependentCandidate);
+                        }
                     }
                     BeanDefinitionDelegate<?> delegate = BeanDefinitionDelegate.create(candidate, (Qualifier<T>) qualifier);
                     if (delegate.isEnabled(this, resolutionContext)) {

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -45,8 +45,8 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanConfiguration;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
+import io.micronaut.inject.qualifiers.EachBeanQualifier;
 import io.micronaut.inject.qualifiers.PrimaryQualifier;
-import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -567,7 +567,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements Con
                             qualifier = PrimaryQualifier.INSTANCE;
                         } else {
                             // @EachBean needs to have something of qualifier to find its origin
-                            qualifier = Qualifiers.eachBeanOf(dependentCandidate);
+                            qualifier = new EachBeanQualifier<>(dependentCandidate);
                         }
                     }
                     BeanDefinitionDelegate<?> delegate = BeanDefinitionDelegate.create(candidate, (Qualifier<T>) qualifier);

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/EachBeanQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/EachBeanQualifier.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.qualifiers;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanType;
+
+/**
+ * Qualifies the origin bean definition that was used to create an each bean.
+ *
+ * @param <T> The type
+ * @author Denis Stepanov
+ * @since 4.6
+ */
+@Internal
+final class EachBeanQualifier<T> extends FilteringQualifier<T> {
+
+    private final BeanDefinition<?> beanDefinition;
+
+    EachBeanQualifier(BeanDefinition<?> beanDefinition) {
+        this.beanDefinition = beanDefinition;
+    }
+
+    @Override
+    public boolean doesQualify(Class<T> beanType, BeanType<T> candidate) {
+        return candidate.equals(beanDefinition);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !EachBeanQualifier.class.isAssignableFrom(o.getClass())) {
+            return false;
+        }
+
+        EachBeanQualifier<?> that = (EachBeanQualifier<?>) o;
+
+        return beanDefinition.equals(that.beanDefinition);
+    }
+
+    @Override
+    public String toString() {
+        return "EachBeanQualifier('" + beanDefinition + "')";
+    }
+
+    @Override
+    public int hashCode() {
+        return beanDefinition.hashCode();
+    }
+
+}

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/EachBeanQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/EachBeanQualifier.java
@@ -27,11 +27,11 @@ import io.micronaut.inject.BeanType;
  * @since 4.6
  */
 @Internal
-final class EachBeanQualifier<T> extends FilteringQualifier<T> {
+public final class EachBeanQualifier<T> extends FilteringQualifier<T> {
 
     private final BeanDefinition<?> beanDefinition;
 
-    EachBeanQualifier(BeanDefinition<?> beanDefinition) {
+    public EachBeanQualifier(BeanDefinition<?> beanDefinition) {
         this.beanDefinition = beanDefinition;
     }
 

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
@@ -28,6 +28,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanType;
 import jakarta.inject.Named;
 
@@ -429,6 +430,18 @@ public class Qualifiers {
             }
         }
         return null;
+    }
+
+    /**
+     * Qualifies the origin bean definition that was used to create an each bean.
+     *
+     * @param beanDefinition The beanDefinition
+     * @param <T>            The component type
+     * @return The qualifier
+     * @since 4.6
+     */
+    public static <T> Qualifier<T> eachBeanOf(BeanDefinition<?> beanDefinition) {
+        return new EachBeanQualifier<>(beanDefinition);
     }
 
     private record PrefixQualifier<T>(String prefix) implements Qualifier<T> {

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
@@ -28,7 +28,6 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanType;
 import jakarta.inject.Named;
 
@@ -430,18 +429,6 @@ public class Qualifiers {
             }
         }
         return null;
-    }
-
-    /**
-     * Qualifies the origin bean definition that was used to create an each bean.
-     *
-     * @param beanDefinition The beanDefinition
-     * @param <T>            The component type
-     * @return The qualifier
-     * @since 4.6
-     */
-    public static <T> Qualifier<T> eachBeanOf(BeanDefinition<?> beanDefinition) {
-        return new EachBeanQualifier<>(beanDefinition);
     }
 
     private record PrefixQualifier<T>(String prefix) implements Qualifier<T> {


### PR DESCRIPTION
For each bean functionality, we require a qualifier to properly identify the origin bean, but there are use cases where the bean cannot be modified.

Previously, we would allow each bean without a qualifier, but that will fail when you want to inject an origin; this PR is allowing to inject it. 

Another solution for the qualifiers would be to add a qualifier that matches the bean type by the exact class, and maybe it can be reused elsewhere.

This should target 4.6 after it's created