### PR TITLE
Uri template rewrite

### DIFF
--- a/http/src/main/java/io/micronaut/http/uri/DefaultUriMatchInfo.java
+++ b/http/src/main/java/io/micronaut/http/uri/DefaultUriMatchInfo.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.uri;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.ObjectUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The default {@link UriMatchInfo} implementation.
+ *
+ * @author Denis Stepanov
+ * @since 4.6.0
+ */
+@Internal
+final class DefaultUriMatchInfo implements UriMatchInfo {
+
+    private final String uri;
+    private final Map<String, Object> variableValues;
+    private final List<UriMatchVariable> variables;
+    private final Map<String, UriMatchVariable> variableMap;
+
+    /**
+     * @param uri            The URI
+     * @param variableValues The map of variable names with values
+     * @param variables      The variables
+     */
+    DefaultUriMatchInfo(String uri, Map<String, Object> variableValues, List<UriMatchVariable> variables) {
+        this.uri = uri;
+        this.variableValues = variableValues;
+        this.variables = variables;
+        LinkedHashMap<String, UriMatchVariable> vm = CollectionUtils.newLinkedHashMap(variables.size());
+        for (UriMatchVariable variable : variables) {
+            vm.put(variable.getName(), variable);
+        }
+        this.variableMap = Collections.unmodifiableMap(vm);
+    }
+
+    @Override
+    public String getUri() {
+        return uri;
+    }
+
+    @Override
+    public Map<String, Object> getVariableValues() {
+        return variableValues;
+    }
+
+    @Override
+    public List<UriMatchVariable> getVariables() {
+        return Collections.unmodifiableList(variables);
+    }
+
+    @Override
+    public Map<String, UriMatchVariable> getVariableMap() {
+        return variableMap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultUriMatchInfo that = (DefaultUriMatchInfo) o;
+        return uri.equals(that.uri) && variables.equals(that.variables);
+    }
+
+    @Override
+    public String toString() {
+        return getUri();
+    }
+
+    @Override
+    public int hashCode() {
+        return ObjectUtils.hash(uri, variableValues);
+    }
+}

--- a/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
@@ -162,6 +162,13 @@ public class UriTemplate implements Comparable<UriTemplate> {
     }
 
     /**
+     * @return The template string
+     */
+    public String getTemplateString() {
+        return templateString;
+    }
+
+    /**
      * @return The number of segments that are variable
      */
     public long getVariableSegmentCount() {

--- a/http/src/main/java/io/micronaut/http/uri/UriTemplateExpander.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplateExpander.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.uri;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.beans.BeanMap;
+import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Implementation of expanding for <a href="https://tools.ietf.org/html/rfc6570">rfc6570</a>.
+ *
+ * @author Denis Stepanov
+ * @since 4.6.0
+ */
+@Internal
+final class UriTemplateExpander implements UriTemplateParser.PartVisitor {
+
+    private final Map<String, Object> parameters;
+    private final StringBuilder builder = new StringBuilder();
+    private boolean queryStarted;
+    private boolean hashStarted;
+    private boolean needsSeparator;
+
+    UriTemplateExpander(Map<String, Object> parameters) {
+        this.parameters = parameters;
+    }
+
+    @Override
+    public void visitLiteral(String literal) {
+        builder.append(literal);
+    }
+
+    @Override
+    public void visitExpression(UriTemplateParser.ExpressionType type, List<UriTemplateParser.Variable> variables) {
+        for (UriTemplateParser.Variable variable : variables) {
+            appendValue(type, variable);
+        }
+        needsSeparator = false;
+    }
+
+    @Override
+    public String toString() {
+        return builder.toString();
+    }
+
+    private void appendValue(UriTemplateParser.ExpressionType type, UriTemplateParser.Variable variable) {
+        Object value = parameters.get(variable.name());
+        value = value instanceof Optional<?> optional ? optional.orElse(null) : value;
+        if (value == null) {
+            return;
+        }
+        if (value.getClass().isArray()) {
+            value = Arrays.asList((Object[]) value);
+        }
+        if (variable.explode()) {
+            value = expandPOJO(value);
+        }
+
+        if (value instanceof Iterable<?> iterable) {
+            List<String> values = asListOfString(iterable);
+            if (!values.isEmpty()) {
+                appendListValues(type, variable, values);
+            }
+
+        } else if (value instanceof Map<?, ?> map) {
+            if (map.isEmpty()) {
+                return;
+            }
+            List<Map.Entry<String, List<String>>> mapOfStrings = map.entrySet()
+                .stream()
+                .filter(e -> e.getValue() != null)
+                .map(e -> Map.entry(e.getKey().toString(), asListOfString(e.getValue())))
+                .filter(e -> !e.getValue().isEmpty())
+                .toList();
+            appendMapValues(type, variable, mapOfStrings);
+        } else {
+            appendValue(type, variable, value.toString());
+        }
+    }
+
+    private List<String> asListOfString(Object some) {
+        return some instanceof Iterable<?> i
+            ? CollectionUtils.iterableToList(i).stream().filter(Objects::nonNull).map(String::valueOf).toList()
+            : List.of(some.toString());
+    }
+
+    private void appendMapValues(UriTemplateParser.ExpressionType type, UriTemplateParser.Variable variable, List<Map.Entry<String, List<String>>> entries) {
+        if (variable.explode()) {
+            for (Map.Entry<String, List<String>> entry : entries) {
+                appendKeyValues(type, variable, entry.getKey(), entry.getValue());
+            }
+            return;
+        }
+        if (type.isQueryPart()) {
+            appendKeyValues(type, variable, variable.name(), aggregate(entries));
+        } else {
+            appendOperator(type);
+            appendValues(type, variable, aggregate(entries));
+        }
+    }
+
+    private List<String> aggregate(List<Map.Entry<String, List<String>>> entries) {
+        return entries
+            .stream()
+            .flatMap(e -> Stream.concat(Stream.of(e.getKey()), e.getValue().stream()))
+            .toList();
+    }
+
+    private void appendListValues(UriTemplateParser.ExpressionType type, UriTemplateParser.Variable variable, List<String> values) {
+        if (variable.explode()) {
+            for (String value : values) {
+                appendValue(type, variable, value);
+            }
+            return;
+        }
+        if (type.isQueryPart()) {
+            appendKeyValues(type, variable, variable.name(), values);
+        } else {
+            appendOperator(type);
+            appendValues(type, variable, values);
+        }
+    }
+
+    private void appendKeyValues(UriTemplateParser.ExpressionType type, UriTemplateParser.Variable variable, String key, List<String> values) {
+        appendOperator(type);
+        builder.append(key);
+        builder.append('=');
+        appendValues(type, variable, values);
+    }
+
+    private void appendValues(UriTemplateParser.ExpressionType type, UriTemplateParser.Variable variable, List<String> values) {
+        for (Iterator<String> iterator = values.iterator(); iterator.hasNext(); ) {
+            String value = iterator.next();
+            value = applyModifier(value, variable.modifier());
+            builder.append(type.isEncode() ? encode(value, type.isQueryPart()) : escape(value));
+            if (iterator.hasNext()) {
+                builder.append(',');
+            }
+        }
+    }
+
+    private void appendValue(UriTemplateParser.ExpressionType type, UriTemplateParser.Variable variable, String value) {
+        value = applyModifier(value, variable.modifier());
+        appendOperator(type);
+        if (type.isQueryPart()) {
+            builder.append(variable.name());
+            if (StringUtils.isNotEmpty(value) || type != UriTemplateParser.ExpressionType.PATH_STYLE_PARAMETER_EXPANSION) {
+                builder.append('=');
+                builder.append(encode(value, true));
+            }
+        } else {
+            builder.append(type.isEncode() ? encode(value, false) : escape(value));
+        }
+    }
+
+    private void appendOperator(UriTemplateParser.ExpressionType type) {
+        char separator = type.getSeparator();
+        if (type == UriTemplateParser.ExpressionType.NONE) {
+            appendSeparator(type, separator);
+        } else if (type == UriTemplateParser.ExpressionType.FORM_STYLE_PARAMETER_EXPANSION) {
+            builder.append(queryParamSeparator());
+        } else {
+            appendSeparator(type, separator);
+            if (type == UriTemplateParser.ExpressionType.FRAGMENT_EXPANSION) {
+                if (!hashStarted) {
+                    hashStarted = true;
+                    builder.append(type.getOperator());
+                }
+            } else if (type != UriTemplateParser.ExpressionType.RESERVED_EXPANSION) {
+                builder.append(type.getOperator());
+            }
+        }
+    }
+
+    private void appendSeparator(UriTemplateParser.ExpressionType type, char separator) {
+        // Append separator for previous value
+        if (!needsSeparator) {
+            needsSeparator = true;
+        } else if (separator != type.getOperator()) {
+            builder.append(separator);
+        }
+    }
+
+    private char queryParamSeparator() {
+        if (queryStarted) {
+            return '&';
+        }
+        queryStarted = true;
+        return '?';
+    }
+
+    private String applyModifier(String value, String modifier) {
+        if (modifier == null) {
+            return value;
+        }
+        try {
+            int limit = Integer.parseInt(modifier.trim(), 10);
+            if (limit < value.length()) {
+                return value.substring(0, limit);
+            }
+        } catch (NumberFormatException e) {
+            // Ignore
+        }
+        return value;
+    }
+
+    private String encode(String str, boolean query) {
+        String encoded = URLEncoder.encode(str, StandardCharsets.UTF_8);
+        return query ? encoded : encoded.replace("+", "%20");
+    }
+
+    private String escape(String v) {
+        return v.replace("%", "%25").replaceAll("\\s", "%20");
+    }
+
+    private Object expandPOJO(Object found) {
+        // Check for common expanded types, such as list or Map
+        if (found instanceof Iterable || found instanceof Map) {
+            return found;
+        }
+        // If a simple value, just use that
+        if (found == null || ClassUtils.isJavaLangType(found.getClass())) {
+            return found;
+        }
+        // Otherwise, expand the object into properties (after all, the user asked for an expanded parameter)
+        return BeanMap.of(found);
+    }
+
+}

--- a/http/src/main/java/io/micronaut/http/uri/UriTemplateMatcher.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplateMatcher.java
@@ -328,7 +328,7 @@ public final class UriTemplateMatcher implements UriMatcher, Comparable<UriTempl
                 default -> throw new IllegalStateException("Unsupported segment type: " + segment.type);
             }
         }
-        return true;
+        return uri.isEmpty();
     }
 
     private static int readText(String input, boolean requiresSlash) {

--- a/http/src/main/java/io/micronaut/http/uri/UriTemplateMatcher.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplateMatcher.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.uri;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Implementation of the paths matching <a href="https://tools.ietf.org/html/rfc6570">rfc6570</a>.
+ *
+ * @author Denis Stepanov
+ * @since 4.6.0
+ */
+@Internal
+public final class UriTemplateMatcher implements UriMatcher, Comparable<UriTemplateMatcher> {
+
+    private final String templateString;
+    private final List<UriTemplateParser.Part> parts;
+    private final List<UriMatchVariable> variables;
+    private final Segment[] segments;
+    private final boolean isRoot;
+
+    // Matches cache
+    private UriMatchInfo rootMatchInfo;
+    private UriMatchInfo exactMatchInfo;
+
+    /**
+     * Construct a new URI template for the given template.
+     *
+     * @param templateString The template string
+     */
+    public UriTemplateMatcher(String templateString) {
+        this(templateString, UriTemplateParser.parse(templateString));
+    }
+
+    /**
+     * Construct a new URI template for the given template.
+     *
+     * @param parts The parsed parts
+     */
+    private UriTemplateMatcher(String templateString, List<UriTemplateParser.Part> parts) {
+        this.templateString = templateString;
+        this.parts = parts;
+        List<UriMatchVariable> variables = new ArrayList<>();
+        this.segments = provideMatchSegments(parts, variables);
+        this.isRoot = segments.length == 0 || segments[0].type == SegmentType.LITERAL && isRoot(segments[0].value);
+        this.variables = Collections.unmodifiableList(variables);
+    }
+
+    private static Segment[] provideMatchSegments(List<UriTemplateParser.Part> parts, List<UriMatchVariable> variables) {
+        List<Segment> segments = new ArrayList<>();
+        List<String> regexpVariables = new ArrayList<>();
+        StringBuilder regexp = null;
+        for (int i = 0; i < parts.size(); i++) {
+            UriTemplateParser.Part part = parts.get(i);
+            if (part instanceof UriTemplateParser.Literal literal) {
+                if (regexp == null) {
+                    segments.add(new Segment(SegmentType.LITERAL, literal.text(), null, null));
+                } else {
+                    regexp.append(Pattern.quote(literal.text()));
+                }
+            } else if (part instanceof UriTemplateParser.Expression expression) {
+                if (regexp == null && allowPathSegment(expression, parts, i)) {
+                    for (UriTemplateParser.Variable variable : expression.variables()) {
+                        variables.add(new UriMatchVariable(
+                                variable.name(),
+                                variable.explode() ? '*' : '0',
+                                expression.type().getOperator()
+                            )
+                        );
+                        segments.add(new Segment(SegmentType.PATH, variable.name(), null, null));
+                    }
+                    continue;
+                }
+                if (regexp == null) {
+                    regexp = new StringBuilder();
+                }
+                for (UriTemplateParser.Variable variable : expression.variables()) {
+                    variables.add(new UriMatchVariable(
+                            variable.name(),
+                            variable.explode() ? '*' : '0',
+                            expression.type().getOperator()
+                        )
+                    );
+                    appendRegexp(regexp, expression.type(), variable, regexpVariables);
+                }
+            }
+        }
+        if (regexp != null) {
+            segments.add(new Segment(SegmentType.REGEXP, null, Pattern.compile(regexp.toString()), regexpVariables.toArray(String[]::new)));
+        }
+
+        return segments.toArray(Segment[]::new);
+    }
+
+    private static boolean allowPathSegment(UriTemplateParser.Expression expression,
+                                     List<UriTemplateParser.Part> parts,
+                                     int index) {
+        if (expression.type() != UriTemplateParser.ExpressionType.NONE) {
+            return false; // Only this on is supported
+        }
+        if (!expression.variables().stream().allMatch(v -> v.modifier() == null)) {
+            return false; // Cannot have any kind of pattern
+        }
+        if (parts.size() == index + 1) {
+            return true; // Last path
+        }
+        if (parts.get(index + 1) instanceof UriTemplateParser.Literal literal && literal.text().startsWith("/")) {
+            return true; // It can absorb everything till the next one
+        }
+        return false;
+    }
+
+    @SuppressWarnings("MissingSwitchDefault")
+    private static void appendRegexp(StringBuilder regexpBuilder,
+                                     UriTemplateParser.ExpressionType type,
+                                     UriTemplateParser.Variable variable,
+                                     List<String> variables) {
+
+        switch (type) {
+            case PATH_STYLE_PARAMETER_EXPANSION:
+            case FORM_STYLE_PARAMETER_EXPANSION:
+            case FORM_STYLE_QUERY_CONTINUATION:
+            case FRAGMENT_EXPANSION:
+                return; // Unsupported types
+        }
+
+        Integer limit = null;
+        String pattern = null;
+        String modifier = variable.modifier();
+        if (StringUtils.isNotEmpty(modifier)) {
+            try {
+                limit = Integer.parseInt(modifier);
+            } catch (Exception ignore) {
+                // Ignore
+            }
+            if (limit == null) {
+                pattern = modifier;
+            }
+        }
+
+        // Code originally from UriMatchTemplate
+
+        String operatorPrefix = "";
+        String operatorQuantifier = "";
+        String variableQuantifier = "+?)";
+        String variablePattern = null;
+        if (pattern != null) {
+            char firstChar = pattern.charAt(0);
+            if (firstChar == '?') {
+                operatorQuantifier = "";
+            } else {
+                int patternLength = pattern.length();
+                char lastChar = pattern.charAt(patternLength - 1);
+                if (lastChar == '*' ||
+                    (patternLength > 1 && lastChar == '?'
+                        && (pattern.charAt(patternLength - 2) == '*' || pattern.charAt(patternLength - 2) == '+'))) {
+                    operatorQuantifier = "?";
+                }
+                String s = (firstChar == '^') ? pattern.substring(1) : pattern;
+                char operator = type.getOperator();
+                if (operator == '/' || operator == '.') {
+                    variablePattern = "(" + s + ")";
+                } else {
+                    operatorPrefix = "(";
+                    variablePattern = s + ")";
+                }
+                variableQuantifier = "";
+            }
+        } else if (limit != null) {
+            variableQuantifier = "{1," + limit + "})";
+        }
+
+        variables.add(variable.name());
+
+        boolean operatorAppended = false;
+        switch (type) {
+            case LABEL_EXPANSION:
+            case PATH_SEGMENT_EXPANSION:
+                regexpBuilder
+                    .append("(")
+                    .append(operatorPrefix)
+                    .append("\\")
+                    .append(type.getOperator())
+                    .append(operatorQuantifier);
+                operatorAppended = true;
+                // fall through
+            case RESERVED_EXPANSION:
+            case NONE:
+                if (!operatorAppended) {
+                    regexpBuilder.append("(").append(operatorPrefix);
+                }
+                if (variablePattern == null) {
+                    if (type == UriTemplateParser.ExpressionType.RESERVED_EXPANSION) {
+                        // Allow reserved characters. See https://tools.ietf.org/html/rfc6570#section-3.2.3
+                        variablePattern = "([\\S]";
+                    } else {
+                        variablePattern = "([^/?#(!{)&;+]";
+                    }
+                }
+                regexpBuilder
+                    .append(variablePattern)
+                    .append(variableQuantifier)
+                    .append(")");
+                break;
+            default:
+                throw new IllegalStateException("Unsupported regexp expression type: " + type);
+        }
+        if (type == UriTemplateParser.ExpressionType.PATH_SEGMENT_EXPANSION || pattern != null && pattern.equals("?")) {
+            regexpBuilder.append("?");
+        }
+    }
+
+    /**
+     * Match the given URI string.
+     *
+     * @param uri The uRI
+     * @return an optional match
+     */
+    @Override
+    public Optional<UriMatchInfo> match(String uri) {
+        return Optional.ofNullable(tryMatch(uri));
+    }
+
+    /**
+     * Match the given URI string.
+     *
+     * @param uri The uRI
+     * @return a match or null
+     */
+    @Nullable
+    public UriMatchInfo tryMatch(@NonNull String uri) {
+        int length = uri.length();
+        if (length > 1 && uri.charAt(length - 1) == '/') {
+            uri = uri.substring(0, length - 1);
+        }
+        if (isRoot && isRoot(uri)) {
+            if (rootMatchInfo == null) {
+                rootMatchInfo = new DefaultUriMatchInfo(uri, Collections.emptyMap(), variables);
+            }
+            return rootMatchInfo;
+        }
+        // Remove any url parameters before matching
+        int parameterIndex = uri.indexOf('?');
+        if (parameterIndex > -1) {
+            uri = uri.substring(0, parameterIndex);
+        }
+        if (uri.endsWith("/")) {
+            uri = uri.substring(0, uri.length() - 1);
+        }
+        if (variables.isEmpty()) {
+            if (uri.equals(templateString)) {
+                if (exactMatchInfo == null) {
+                    exactMatchInfo = new UriMatchTemplate.DefaultUriMatchInfo(uri, Collections.emptyMap(), variables);
+                }
+                return exactMatchInfo;
+            }
+            return null;
+        }
+        Map<String, Object> variableMap = CollectionUtils.newLinkedHashMap(variables.size());
+        if (match(uri, variableMap)) {
+            return new DefaultUriMatchInfo(uri, variableMap, variables);
+        }
+        return null;
+    }
+
+    private boolean match(String uri, Map<String, Object> variableMap) {
+        for (int i = 0; i < segments.length; i++) {
+            Segment segment = segments[i];
+            switch (segment.type) {
+                case LITERAL -> {
+                    if (uri.startsWith(segment.value)) {
+                        uri = uri.substring(segment.value.length());
+                    } else {
+                        return false;
+                    }
+                }
+                case PATH -> {
+                    boolean requiresSlash = i + 1 != segments.length;
+                    int index = readText(uri, requiresSlash);
+                    if (index > 0) { // Deny empty path
+                        String path = uri.substring(0, index);
+                        variableMap.put(segment.value, path);
+                        uri = uri.substring(index);
+                    } else {
+                        return false;
+                    }
+                }
+                case REGEXP -> {
+                    Matcher matcher = segment.pattern.matcher(uri);
+                    if (matcher.matches()) {
+                        int groupInx = 2;
+                        for (String matchingVariable : segment.regexpVariables) {
+                            String group = matcher.group(groupInx);
+                            variableMap.put(matchingVariable, group);
+                            groupInx += 2;
+                        }
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
+                default -> throw new IllegalStateException("Unsupported segment type: " + segment.type);
+            }
+        }
+        return true;
+    }
+
+    private static int readText(String input, boolean requiresSlash) {
+        // NOTE: Micronaut doesn't allow some of the character in the path value
+        int length = input.length();
+        for (int i = 0; i < length; i++) {
+            char c = input.charAt(i);
+            if (requiresSlash && c == '/') {
+                return i;
+            }
+            if (rejectCharacter(c, input, i)) {
+                return -1;
+            }
+        }
+        return length;
+    }
+
+    private static boolean rejectCharacter(char c, String input, int i) {
+        switch (c) {
+            case '/':
+            case '?':
+            case '{':
+            case '}':
+            case '&':
+            case ';':
+            case '+':
+                return true;
+            case '#':
+                if (i + 1 < input.length()) {
+                    c = input.charAt(i + 1);
+                    if (c != '{') {
+                        return true;
+                    }
+                }
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Nests another URI template with this template.
+     *
+     * @param uriTemplate The URI template. If it does not begin with forward slash it will automatically be appended with forward slash
+     * @return The new URI template
+     */
+    public UriTemplateMatcher nest(CharSequence uriTemplate) {
+        List<UriTemplateParser.Part> newParts = UriTemplateParser.parse(uriTemplate.toString());
+        return new UriTemplateMatcher(templateString + uriTemplate, UriTemplateParser.concat(parts, newParts));
+    }
+
+    /**
+     * Returns the path string excluding any query variables.
+     *
+     * @return The path string
+     */
+    public String toPathString() {
+        StringBuilder builder = new StringBuilder();
+        visitParts(parts, new UriTemplateParser.PartVisitor() {
+            @Override
+            public void visitLiteral(String literal) {
+                builder.append(literal);
+            }
+
+            @Override
+            public void visitExpression(UriTemplateParser.ExpressionType type, List<UriTemplateParser.Variable> variables) {
+                builder.append('{');
+                if (type != UriTemplateParser.ExpressionType.NONE) {
+                    builder.append(type.getOperator());
+                }
+                for (Iterator<UriTemplateParser.Variable> iterator = variables.iterator(); iterator.hasNext(); ) {
+                    UriTemplateParser.Variable variable = iterator.next();
+                    builder.append(variable.name());
+                    if (variable.explode()) {
+                        builder.append('*');
+                    }
+                    if (variable.modifier() != null) {
+                        builder.append(':');
+                        builder.append(variable.modifier());
+                    }
+                    if (iterator.hasNext()) {
+                        builder.append(',');
+                    }
+                }
+                builder.append('}');
+            }
+        });
+        return builder.toString();
+    }
+
+    /**
+     * Expand the string with the given parameters.
+     *
+     * @param parameters The parameters
+     * @return The expanded URI
+     */
+    public String expand(Map<String, Object> parameters) {
+        UriTemplateExpander uriTemplateExpander = new UriTemplateExpander(parameters);
+        visitParts(parts, uriTemplateExpander);
+        return uriTemplateExpander.toString();
+    }
+
+    @Override
+    public int compareTo(UriTemplateMatcher o) {
+        if (this == o) {
+            return 0;
+        }
+
+        PathEvaluator thisEvaluator = new PathEvaluator();
+        PathEvaluator thatEvaluator = new PathEvaluator();
+
+        visitParts(parts, thisEvaluator);
+        visitParts(o.parts, thatEvaluator);
+
+        // using that.compareTo because more raw length should have higher precedence
+        int rawCompare = Integer.compare(thatEvaluator.rawLength, thisEvaluator.rawLength);
+        if (rawCompare == 0) {
+            return Integer.compare(thisEvaluator.variableCount, thatEvaluator.variableCount);
+        }
+        return rawCompare;
+    }
+
+    @Override
+    public String toString() {
+        return toPathString();
+    }
+
+    private static void visitParts(List<UriTemplateParser.Part> parts, UriTemplateParser.PartVisitor visitor) {
+        for (UriTemplateParser.Part part : parts) {
+            part.visit(visitor);
+        }
+    }
+
+    private boolean isRoot(String uri) {
+        int length = uri.length();
+        return length == 0 || length == 1 && uri.charAt(0) == '/';
+    }
+
+    /**
+     * /**
+     * Create a new {@link UriTemplate} for the given URI.
+     *
+     * @param uri The URI
+     * @return The template
+     */
+    public static UriTemplateMatcher of(String uri) {
+        return new UriTemplateMatcher(uri);
+    }
+
+    private static final class PathEvaluator implements UriTemplateParser.PartVisitor {
+
+        int variableCount = 0;
+        int rawLength = 0;
+
+        @Override
+        public void visitLiteral(String literal) {
+            rawLength += literal.length();
+        }
+
+        @Override
+        public void visitExpression(UriTemplateParser.ExpressionType type, List<UriTemplateParser.Variable> variables) {
+            if (!type.isQueryPart()) {
+                variableCount += variables.size();
+            }
+        }
+    }
+
+    private record Segment(SegmentType type, String value,
+                           Pattern pattern, String[] regexpVariables) {
+    }
+
+    private enum SegmentType {
+        LITERAL, PATH, REGEXP
+    }
+
+}

--- a/http/src/main/java/io/micronaut/http/uri/UriTemplateMatcher.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplateMatcher.java
@@ -276,7 +276,7 @@ public final class UriTemplateMatcher implements UriMatcher, Comparable<UriTempl
         if (variables.isEmpty()) {
             if (uri.equals(templateString)) {
                 if (exactMatchInfo == null) {
-                    exactMatchInfo = new UriMatchTemplate.DefaultUriMatchInfo(uri, Collections.emptyMap(), variables);
+                    exactMatchInfo = new DefaultUriMatchInfo(uri, Collections.emptyMap(), variables);
                 }
                 return exactMatchInfo;
             }

--- a/http/src/main/java/io/micronaut/http/uri/UriTemplateParser.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplateParser.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.uri;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * The URI template parser <a href="https://tools.ietf.org/html/rfc6570">rfc6570</a>.
+ *
+ * @author Denis Stepanov
+ * @since 4.6.0
+ */
+@Internal
+final class UriTemplateParser {
+
+    private UriTemplateParser() {
+    }
+
+    /**
+     * Parse the template according to the spec.
+     *
+     * @param template The template
+     * @return The parts of the template
+     */
+    public static List<Part> parse(String template) {
+        List<Part> parts = new ArrayList<>(10);
+        int expressionStartIndex = -1;
+        char[] input = template.toCharArray();
+        StringBuilder literal = new StringBuilder();
+        boolean isText = true;
+        for (int i = 0; i < input.length; i++) {
+            char c = input[i];
+            if (c == '{') {
+                isText = false;
+                if (!literal.isEmpty()) {
+                    parts.add(new Literal(literal.toString()));
+                    literal.setLength(0);
+                }
+                expressionStartIndex = i;
+            } else if (c == '}' && expressionStartIndex != -1) {
+                Expression expression = parseExpression(input, expressionStartIndex + 1, i);
+                parts.add(expression);
+                isText = true;
+            } else if (isText) {
+                if (Character.isISOControl(c) || Character.isWhitespace(c) || isAllowedCharacter(c) || c == '%') {
+                    literal.append(c);
+                } else {
+                    throw new IllegalStateException("Unexpected character '" + c + "' at position " + i + " in " + template);
+                }
+            }
+        }
+        if (!literal.isEmpty()) {
+            parts.add(new Literal(literal.toString()));
+            literal.setLength(0);
+        }
+        return parts;
+    }
+
+    /**
+     * Concat two collections of parts. Properly merging `/`.
+     *
+     * @param parts1 The first collection
+     * @param parts2 The second collection
+     * @return the merged collection
+     */
+    public static List<UriTemplateParser.Part> concat(List<UriTemplateParser.Part> parts1, List<UriTemplateParser.Part> parts2) {
+        parts1 = new ArrayList<>(parts1);
+        parts2 = new ArrayList<>(parts2);
+        List<UriTemplateParser.Part> queryParams = new ArrayList<>();
+        List<UriTemplateParser.Part> fragmentParams = new ArrayList<>();
+        // Query params should be last
+        removeQueryParams(parts1, queryParams);
+        removeQueryParams(parts2, queryParams);
+        // Fragment params should be before query params
+        removeFragmentParams(parts1, fragmentParams);
+        removeFragmentParams(parts2, fragmentParams);
+        if (parts1.isEmpty()) {
+            return CollectionUtils.concat(parts2, CollectionUtils.concat(fragmentParams, queryParams));
+        }
+        if (parts2.isEmpty()) {
+            return CollectionUtils.concat(parts1, CollectionUtils.concat(fragmentParams, queryParams));
+        }
+
+        if (parts2.get(0) instanceof UriTemplateParser.Expression expression
+            && expression.type() == UriTemplateParser.ExpressionType.NONE) {
+            parts2.add(0, new UriTemplateParser.Literal("/"));
+        }
+        List<UriTemplateParser.Part> concat = new ArrayList<>(parts1.size() + parts2.size());
+        UriTemplateParser.Part parts1Last = parts1.get(parts1.size() - 1);
+        UriTemplateParser.Part parts2First = parts2.get(0);
+        concat.addAll(parts1.subList(0, parts1.size() - 1));
+        if (parts1Last instanceof UriTemplateParser.Literal literalPart1) {
+            String literal1 = literalPart1.text();
+            boolean literal1EndsWithSlash = literal1.endsWith("/");
+            if (literal1EndsWithSlash
+                && parts2First instanceof UriTemplateParser.Expression expression
+                && expression.type() == UriTemplateParser.ExpressionType.PATH_SEGMENT_EXPANSION) {
+                // Strip / from the last part of parts1, because it's needed for the new part
+                parts1Last = new UriTemplateParser.Literal(literal1.substring(0, literal1.length() - 1));
+            }
+            if (parts2First instanceof UriTemplateParser.Literal literalPart2) {
+                String literal2 = literalPart2.text();
+                boolean literal2StartsWithSlash = literal2.startsWith("/");
+                if (literal1EndsWithSlash && literal2StartsWithSlash) {
+                    literal1 = literal1.substring(0, literal1.length() - 1);
+                } else if (!literal1EndsWithSlash && !literal2StartsWithSlash) {
+                    literal1 += "/";
+                } else if (literal2.equals("/") && parts2.size() == 1 && queryParams.isEmpty() && fragmentParams.isEmpty()) {
+                    literal2 = "";
+                }
+                parts1Last = new UriTemplateParser.Literal(literal1.concat(literal2));
+                parts2First = null;
+            }
+        }
+        concat.add(parts1Last);
+        if (parts2First != null) {
+            concat.add(parts2First);
+        }
+        concat.addAll(parts2.subList(1, parts2.size()));
+        concat.addAll(fragmentParams);
+        concat.addAll(queryParams);
+        return concat;
+    }
+
+    private static void removeQueryParams(List<UriTemplateParser.Part> parts1, List<UriTemplateParser.Part> params) {
+        for (Iterator<Part> iterator = parts1.iterator(); iterator.hasNext(); ) {
+            UriTemplateParser.Part part = iterator.next();
+            if (part instanceof UriTemplateParser.Expression expression && expression.type().isQueryPart()) {
+                params.add(expression);
+                iterator.remove();
+            }
+        }
+    }
+
+    private static void removeFragmentParams(List<UriTemplateParser.Part> parts1, List<UriTemplateParser.Part> params) {
+        for (Iterator<UriTemplateParser.Part> iterator = parts1.iterator(); iterator.hasNext(); ) {
+            UriTemplateParser.Part part = iterator.next();
+            if (part instanceof UriTemplateParser.Expression expression && expression.type() == UriTemplateParser.ExpressionType.FRAGMENT_EXPANSION) {
+                params.add(expression);
+                iterator.remove();
+            }
+        }
+    }
+
+    private static boolean isAllowedCharacter(char c) {
+        return switch (c) {
+            case '<', '>', '\\', '^', '`', '{', '|', '}' -> false;
+            default -> true;
+        };
+    }
+
+    private static Expression parseExpression(char[] input, int fromIndex, int toIndex) {
+        List<Variable> variables = new ArrayList<>(2);
+        ExpressionType expressionType = parseOperator(input[fromIndex]);
+        int variableNameStartIndex = expressionType == ExpressionType.NONE ? fromIndex : fromIndex + 1;
+        int variableNameEndIndex = -1;
+        int variableModifierStartIndex = -1;
+        int variableModifierEndIndex = -1;
+        for (int i = variableNameStartIndex; i < toIndex; i++) {
+            char c = input[i];
+            if (c == ',') {
+                if (variableModifierStartIndex != -1) {
+                    variableModifierEndIndex = i;
+                } else {
+                    variableNameEndIndex = i;
+                }
+                variables.add(createVariable(
+                    input,
+                    variableNameStartIndex,
+                    variableNameEndIndex,
+                    variableModifierStartIndex,
+                    variableModifierEndIndex
+                ));
+                variableNameStartIndex = i + 1;
+                variableNameEndIndex = -1;
+                variableModifierStartIndex = -1;
+                variableModifierEndIndex = -1;
+            } else if (c == ':') {
+                variableNameEndIndex = i;
+                variableModifierStartIndex = i + 1;
+            } else {
+                if (variableModifierStartIndex != -1) {
+                    variableModifierEndIndex = i;
+                } else {
+                    variableNameEndIndex = i;
+                }
+            }
+        }
+        if (variableModifierStartIndex != -1) {
+            variableModifierEndIndex = toIndex;
+        } else {
+            variableNameEndIndex = toIndex;
+        }
+        variables.add(createVariable(
+            input,
+            variableNameStartIndex,
+            variableNameEndIndex,
+            variableModifierStartIndex,
+            variableModifierEndIndex
+        ));
+        return new Expression(expressionType, variables);
+    }
+
+    private static Variable createVariable(char[] input,
+                                           int variableNameStartIndex,
+                                           int variableNameEndIndex,
+                                           int variableModifierStartIndex,
+                                           int variableModifierEndIndex) {
+        boolean explore = false;
+        if (input[variableNameEndIndex - 1] == '*') {
+            explore = true;
+            variableNameEndIndex--;
+        }
+        String modifier = null;
+        if (variableModifierStartIndex != -1) {
+            modifier = new String(input, variableModifierStartIndex, variableModifierEndIndex - variableModifierStartIndex);
+        }
+        return new Variable(
+            new String(input, variableNameStartIndex, variableNameEndIndex - variableNameStartIndex),
+            modifier,
+            explore
+        );
+    }
+
+    private static ExpressionType parseOperator(char c) {
+        return switch (c) {
+            case '+' -> ExpressionType.RESERVED_EXPANSION;
+            case '#' -> ExpressionType.FRAGMENT_EXPANSION;
+            case '.' -> ExpressionType.LABEL_EXPANSION;
+            case '/' -> ExpressionType.PATH_SEGMENT_EXPANSION;
+            case ';' -> ExpressionType.PATH_STYLE_PARAMETER_EXPANSION;
+            case '?' -> ExpressionType.FORM_STYLE_PARAMETER_EXPANSION;
+            case '&' -> ExpressionType.FORM_STYLE_QUERY_CONTINUATION;
+            default -> ExpressionType.NONE;
+        };
+    }
+
+    /**
+     * The variable.
+     *
+     * @param name     The name
+     * @param modifier The modifier
+     * @param explode  Is exploded
+     */
+    public record Variable(String name, String modifier, boolean explode) {
+    }
+
+    /**
+     * The expression part.
+     *
+     * @param type      The type
+     * @param variables The variables
+     */
+    public record Expression(ExpressionType type, List<Variable> variables) implements Part {
+        @Override
+        public void visit(PartVisitor visitor) {
+            visitor.visitExpression(type, variables);
+        }
+    }
+
+    /**
+     * The literal part.
+     *
+     * @param text The text
+     */
+    public record Literal(String text) implements Part {
+        @Override
+        public void visit(PartVisitor visitor) {
+            visitor.visitLiteral(text);
+        }
+    }
+
+    /**
+     * The interface representing a template part.
+     */
+    public interface Part {
+
+        /**
+         * Visit parts using a visitor.
+         *
+         * @param visitor The visitor
+         */
+        void visit(PartVisitor visitor);
+
+    }
+
+    /**
+     * The parts visitor.
+     */
+    public interface PartVisitor {
+
+        /**
+         * Visits a literal.
+         *
+         * @param literal The literal value
+         */
+        void visitLiteral(String literal);
+
+        /**
+         * Visits and expression.
+         *
+         * @param type      The type
+         * @param variables The variables
+         */
+        void visitExpression(ExpressionType type, List<Variable> variables);
+
+    }
+
+    /**
+     * The expression type.
+     */
+    public enum ExpressionType {
+        NONE('0', ',', false, true),
+        RESERVED_EXPANSION('+', ',', false, false),
+        FRAGMENT_EXPANSION('#', ',', false, false),
+        LABEL_EXPANSION('.', '.', false, true),
+        PATH_SEGMENT_EXPANSION('/', '/', false, true),
+        PATH_STYLE_PARAMETER_EXPANSION(';', ';', true, true),
+        FORM_STYLE_PARAMETER_EXPANSION('?', '&', true, true),
+        FORM_STYLE_QUERY_CONTINUATION('&', '&', true, true);
+
+        private final char separator;
+        private final char operator;
+        private final boolean isQueryPart;
+        private final boolean encode;
+
+        ExpressionType(char operator, char separator, boolean isQueryPart, boolean encode) {
+            this.separator = separator;
+            this.operator = operator;
+            this.isQueryPart = isQueryPart;
+            this.encode = encode;
+        }
+
+        /**
+         * @return Teh query part
+         */
+        public boolean isQueryPart() {
+            return isQueryPart;
+        }
+
+        /**
+         * @return The operator
+         */
+        public char getOperator() {
+            return operator;
+        }
+
+        /**
+         * @return The separator
+         */
+        public char getSeparator() {
+            return separator;
+        }
+
+        /**
+         * @return Is encoded
+         */
+        public boolean isEncode() {
+            return encode;
+        }
+    }
+
+}

--- a/http/src/test/groovy/io/micronaut/http/uri/UriTemplateExpanderSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriTemplateExpanderSpec.groovy
@@ -1,0 +1,606 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.uri
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * @author Denis Stepanov
+ */
+class UriTemplateExpanderSpec extends Specification {
+
+    @Unroll
+    void "Test nest template #template with path #nested and #arguments"() {
+        given:
+        UriTemplateMatcher uriTemplate = new UriTemplateMatcher(template)
+
+        expect:
+        uriTemplate.nest(nested).expand(arguments) == result
+
+        where:
+        template       | nested               | arguments                               | result
+        '/city'        | 'country/{name}'     | [name: 'Fred']                          | '/city/country/Fred'
+        '/city/'       | 'country/{name}'     | [name: 'Fred']                          | '/city/country/Fred'
+        '/city/'       | '/country/{name}'    | [name: 'Fred']                          | '/city/country/Fred'
+        '/city'        | '/country/{name}'    | [name: 'Fred']                          | '/city/country/Fred'
+        '/poetry'      | '/{?max}'            | [max: '10']                             | '/poetry/?max=10'
+        '/poetry'      | '{?max}'             | [max: '10']                             | '/poetry?max=10'
+        '/'            | '/hello/{name}'      | [name: 'Fred']                          | '/hello/Fred'
+        ''             | '/hello/{name}'      | [name: 'Fred']                          | '/hello/Fred'
+        '/test/'       | '/hello/{name}'      | [name: 'Fred']                          | '/test/hello/Fred'
+        '{var}'        | '{var2}'             | [var: 'foo', var2: 'bar']               | 'foo/bar'
+        '/book{/id}'   | '/author{/authorId}' | [id: 'foo', authorId: 'bar']            | '/book/foo/author/bar'
+        '{var}/'       | '{var2}'             | [var: 'foo', var2: 'bar']               | 'foo/bar'
+        '{var}'        | '/{var2}'            | [var: 'foo', var2: 'bar']               | 'foo/bar'
+        '{var}{?q}'    | '/{var2}'            | [var: 'foo', var2: 'bar', q: 'test']    | 'foo/bar?q=test'
+        '{var}{?q}'    | '{var2}'             | [var: 'foo', var2: 'bar', q: 'test']    | 'foo/bar?q=test'
+        '{var}{#hash}' | '{var2}'             | [var: 'foo', var2: 'bar', hash: 'test'] | 'foo/bar#test'
+        '/'            | '{?req*}'            | [req: [var: 'foo', var2: null]]         | '/?var=foo'
+        '/'            | '{?keys*}{?keys2*}'  | [keys: [var: 'foo', var2: null]]          | '/?var=foo'
+        '/'            | '{?keys*}{?keys2*}'  | [keys: [var: null], keys2: [var2: null]]  | '/'
+        '/'            | '{?keys*}{?keys2*}'  | [keys: [var: 'foo'], keys2: [var2: null]] | '/?var=foo'
+        '/'            | '{?keys*}{?keys2*}'  | [keys: [var: 'foo'], keys2: [var2: 'bar']]| '/?var=foo&var2=bar'
+        '/'            | '{?keys*}{?keys2*}'  | [keys: [var: null], keys2: [var2: 'bar']] | '/?var2=bar'
+        '/'            | '{?keys*}{&keys2*}'  | [keys: [var: null], keys2: [var2: null]]  | '/'
+        '/'            | '{?keys*}{&keys2*}'  | [keys: [var: 'foo'], keys2: [var2: null]] | '/?var=foo'
+        '/'            | '{?keys*}{&keys2*}'  | [keys: [var: 'foo'], keys2: [var2: 'bar']]| '/?var=foo&var2=bar'
+        '/'            | '{?keys*}{&keys2*}'  | [keys: [var: null], keys2: [var2: 'bar']] | '/&var2=bar'
+    }
+
+    @Unroll
+    void "Test nest template #template toPathString() with path #nested"() {
+        given:
+        UriTemplateMatcher uriTemplate = new UriTemplateMatcher(template)
+
+        expect:
+        uriTemplate.nest(nested).toPathString() == result
+
+        where:
+        template       | nested                         | result
+        '/city'        | '/'                            | '/city'
+        '/city'        | ''                             | '/city'
+        '/city'        | 'country/{name}'               | '/city/country/{name}'
+//        '/foo'         | '/find?{x,empty}'              | '/foo/find' TODO: Not yet implemented. Probably should work
+        '/foo'         | '/find{?x,empty}'              | '/foo/find{?x,empty}'
+        '/foo'         | '{/list*,path:4}'              | '/foo{/list*,path:4}'
+        '/person'      | '/{fred}'                      | '/person/{fred}'
+        '/books'       | '{/id}'                        | '/books{/id}'
+        '/books/'      | '{/id}'                        | '/books{/id}'
+        ""             | '/authors{/authorId}'          | '/authors{/authorId}'
+        '/'            | '/regex/{color:^blue|orange$}' | '/regex/{color:^blue|orange$}'
+        '/poetry'      | '/{?max}'                      | '/poetry/{?max}'
+        '/poetry'      | '{?max}'                       | '/poetry{?max}'
+        '/'            | '/hello/{name}'                | '/hello/{name}'
+        ''             | '/hello/{name}'                | '/hello/{name}'
+        '/test/'       | '/hello/{name}'                | '/test/hello/{name}'
+        '{var}'        | '{var2}'                       | '{var}/{var2}'
+        '/book{/id}'   | '/author{/authorId}'           | '/book{/id}/author{/authorId}'
+        '{var}/'       | '{var2}'                       | '{var}/{var2}'
+        '{var}'        | '/{var2}'                      | '{var}/{var2}'
+        '{var}{?q}'    | '/{var2}'                      | '{var}/{var2}{?q}'
+        '{var}{#hash}' | '{var2}'                       | '{var}/{var2}{#hash}'
+        '/foo'         | '/find{?year*}'                | '/foo/find{?year*}'
+        '/foo'         | '/find{?bar*}{?baz*}'          | '/foo/find{?bar*}{?baz*}'
+        '/foo'         | '/find{?bar*}{&baz*}'          | '/foo/find{?bar*}{&baz*}'
+    }
+
+    @Unroll
+    void "Test nest template #template toString() with path #nested"() {
+        given:
+        UriTemplateMatcher uriTemplate = new UriTemplateMatcher(template)
+
+        expect:
+        uriTemplate.nest(nested).toString() == result
+
+        where:
+        template       | nested                         | result
+        '/city'        | '/'                            | '/city'
+        '/city'        | ''                             | '/city'
+        '/city'        | 'country/{name}'               | '/city/country/{name}'
+        '/city/'       | 'country/{name}'               | '/city/country/{name}'
+        '/city/'       | '/country/{name}'              | '/city/country/{name}'
+        '/city'        | '/country/{name}'              | '/city/country/{name}'
+        '/foo'         | '/find?{x,empty}'              | '/foo/find?{x,empty}'
+        '/foo'         | '/find{?x,empty}'              | '/foo/find{?x,empty}'
+        '/foo'         | '{/list*,path:4}'              | '/foo{/list*,path:4}'
+        '/person'      | '/{fred}'                      | '/person/{fred}'
+        '/books'       | '{/id}'                        | '/books{/id}'
+        '/books/'      | '{/id}'                        | '/books{/id}'
+        ""             | '/authors{/authorId}'          | '/authors{/authorId}'
+        '/'            | '/regex/{color:^blue|orange$}' | '/regex/{color:^blue|orange$}'
+        '/poetry'      | '/{?max}'                      | '/poetry/{?max}'
+        '/poetry'      | '{?max}'                       | '/poetry{?max}'
+        '/'            | '/hello/{name}'                | '/hello/{name}'
+        ''             | '/hello/{name}'                | '/hello/{name}'
+        '/test/'       | '/hello/{name}'                | '/test/hello/{name}'
+        '{var}'        | '{var2}'                       | '{var}/{var2}'
+        '/book{/id}'   | '/author{/authorId}'           | '/book{/id}/author{/authorId}'
+        '{var}/'       | '{var2}'                       | '{var}/{var2}'
+        '{var}'        | '/{var2}'                      | '{var}/{var2}'
+        '{var}{?q}'    | '/{var2}'                      | '{var}/{var2}{?q}'
+        '{var}{#hash}' | '{var2}'                       | '{var}/{var2}{#hash}'
+        '/foo'         | '/find{?year*}'                | '/foo/find{?year*}'
+        '/foo'         | '/find{?keys1*}{?keys2*}'      | '/foo/find{?keys1*}{?keys2*}'
+        '/foo'         | '/find{?keys1*}{&keys2*}'      | '/foo/find{?keys1*}{&keys2*}'
+    }
+
+    @Unroll
+    void "Test expand URI template #template with arguments #arguments for path"() {
+        given:
+        UriTemplateMatcher uriTemplate = new UriTemplateMatcher(template)
+
+        expect: 'See https://tools.ietf.org/html/rfc6570#section-2.4.1'
+        uriTemplate.expand(arguments) == result
+
+        where:
+        template              | arguments                                          | result
+        ''                    | [:]                                                | ''
+        '/'                   | [:]                                                | '/'
+        '{var}'               | [var: 'value']                                     | 'value' // Section 2.4.1 - Prefix Values
+        '{var:20}'            | [var: 'value']                                     | 'value'
+        '{var:3}'             | [var: 'value']                                     | 'val'
+        '{semi}'              | [semi: ';']                                        | '%3B'
+        '{semi:2}'            | [semi: ';']                                        | '%3B'
+        'find{?year*}'        | [year: ["1965", "2000", "2012"]]                   | 'find?year=1965&year=2000&year=2012' // Section 2.4.2.  Composite Values
+        'find{?year*}'        | [:]                                                | 'find' // Section 2.4.2.  Composite Values
+        'www{.dom*}'          | [dom: ["example", "com"]]                          | 'www.example.com'
+        '{count}'             | [count: ['one', 'two', 'three']]                   | 'one,two,three' // Section 3.2.1  Variable Expansion
+        '{count*}'            | [count: ['one', 'two', 'three']]                   | 'one,two,three'
+        '{/count}'            | [count: ['one', 'two', 'three']]                   | '/one,two,three'
+        '{/count*}'           | [count: ['one', 'two', 'three']]                   | '/one/two/three'
+        '{;count}'            | [count: ['one', 'two', 'three']]                   | ';count=one,two,three'
+        '{;count*}'           | [count: ['one', 'two', 'three']]                   | ';count=one;count=two;count=three'
+        '{?count}'            | [count: ['one', 'two', 'three']]                   | '?count=one,two,three'
+        '{?count*}'           | [count: ['one', 'two', 'three']]                   | '?count=one&count=two&count=three'
+        '{&count*}'           | [count: ['one', 'two', 'three']]                   | '&count=one&count=two&count=three'
+        '{var}'               | [var: ['value']]                                   | 'value' // Section 3.2.2 - Level 1 - Simple String Expansion: {var}
+        '{hello}'             | [hello: "Hello World!"]                            | 'Hello%20World%21'
+        '{half}'              | [half: '50%']                                      | '50%25'
+        'O{empty}X'           | [empty: '']                                        | 'OX'
+        'O{undef}X'           | [:]                                                | 'OX'
+        '{x,y}'               | [x: 1024, y: 768]                                  | '1024,768'
+        '?{x,empty}'          | [x: 1024, empty: '']                               | '?1024,'
+        '?{x,undef}'          | [x: 1024, empty: '']                               | '?1024'
+        '?{undef,y}'          | [y: 768]                                           | '?768'
+        'map?{x,y}'           | [x: 1024, y: 768]                                  | 'map?1024,768' // Section 3.2.2 - Simple String Expansion: {var}
+        '{x,hello,y}'         | [x: 1024, y: 768, hello: "Hello World!"]           | '1024,Hello%20World%21,768'
+        '{var:30}'            | [var: 'value']                                     | 'value' // Section 3.2.2 - Level 4 - Simple String Expansion: {var}
+        '{list}'              | [list: ['red', 'green', 'blue']]                   | 'red,green,blue'
+        '{list*}'             | [list: ['red', 'green', 'blue']]                   | 'red,green,blue'
+        '{keys}'              | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'semi,%3B,dot,.,comma,%2C'
+        '{keys*}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'semi=%3B,dot=.,comma=%2C'
+        '{+var}'              | [var: 'value']                                     | 'value' // Section 3.2.3 - Level 2 - Reserved Expansion: {+var}
+        '{+hello}'            | [hello: "Hello World!"]                            | 'Hello%20World!'
+        '{+half}'             | [half: '50%']                                      | '50%25'
+        '{base}index'         | [base: 'http://example.com/home/']                 | 'http%3A%2F%2Fexample.com%2Fhome%2Findex'
+        '{+base}index'        | [base: 'http://example.com/home/']                 | 'http://example.com/home/index'
+        '{+base}{hello}'      | [base: 'http://example.com/home/', hello: "Hello World!"] | 'http://example.com/home/Hello%20World%21'
+        'O{+empty}X'          | [empty: '']                                        | 'OX'
+        'O{+undef}X'          | [:]                                                | 'OX'
+        '{+path}/here'        | [path: "/foo/bar"]                                 | '/foo/bar/here'
+        'here?ref={+path}'    | [path: "/foo/bar"]                                 | 'here?ref=/foo/bar'
+        'up{+path}{var}/here' | [path: "/foo/bar", var: 'value']                   | 'up/foo/barvalue/here'
+        '{+x,hello,y}'        | [x: 1024, y: 768, hello: "Hello World!"]           | '1024,Hello%20World!,768'
+        '{+path,x}/here'      | [path: "/foo/bar", x: 1024]                        | '/foo/bar,1024/here'
+        '{+path:6}/here'      | [path: "/foo/bar"]                                 | '/foo/b/here' // Section 3.2.3 - Level 4 - Reserved expansion with value modifiers
+        '{+list}'             | [list: ['red', 'green', 'blue']]                   | 'red,green,blue'
+        '{+list*}'            | [list: ['red', 'green', 'blue']]                   | 'red,green,blue'
+        '{+keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'semi,;,dot,.,comma,,'
+        '{+keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'semi=;,dot=.,comma=,'
+        '{#var}'              | [var: 'value']                                     | '#value' // Section 3.2.4 - Level 2 - Fragment Expansion: {#var}
+        '{#hello}'            | [hello: "Hello World!"]                            | '#Hello%20World!'
+        '{#half}'             | [half: '50%']                                      | '#50%25'
+        'foo{#empty}'         | [empty: '']                                        | 'foo#'
+        'foo{#undef}'         | [:]                                                | 'foo'
+        'X{#var}'             | [var: 'value']                                     | 'X#value'
+        'X{#hello}'           | [hello: "Hello World!", var: 'value']              | 'X#Hello%20World!'
+        '{#x,hello,y}'        | [x: 1024, y: 768, hello: "Hello World!"]           | '#1024,Hello%20World!,768' // Section 3.2.4 - Level 3 - Fragment Expansion: {#var}
+        '{#path,x}/here'      | [path: "/foo/bar", x: 1024]                        | '#/foo/bar,1024/here'
+        '{#path:6}/here'      | [path: "/foo/bar"]                                 | '#/foo/b/here' // Section 3.2.4 - Level 4 - Fragment expansion with value modifiers
+        '{#list}'             | [list: ['red', 'green', 'blue']]                   | '#red,green,blue'
+        '{#list*}'            | [list: ['red', 'green', 'blue']]                   | '#red,green,blue'
+        '{#keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | '#semi,;,dot,.,comma,,'
+        '{#keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | '#semi=;,dot=.,comma=,'
+        'X{.var}'             | [var: 'value']                                     | 'X.value' // Section 3.2.5 - Level 3 - Label Expansion with Dot-Prefix: {.var}
+        'X{.empty}'           | [empty: '']                                        | 'X.'
+        'X{.undef}'           | [:]                                                | 'X'
+        'X{.x,y}'             | [x: 1024, y: 768]                                  | 'X.1024.768'
+        '{.who}'              | [who: 'fred']                                      | '.fred'
+        '{.who,who}'          | [who: 'fred']                                      | '.fred.fred'
+        '{.half,who}'         | [half: '50%', who: 'fred']                         | '.50%25.fred'
+        'www{.dom*}'          | [dom: ["example", "com"]]                          | 'www.example.com'
+        'X{.var:3}'           | [var: 'value']                                     | 'X.val' // Section 3.2.5 - Level 4 - Label expansion, dot-prefixed
+        'X{.list*}'           | [list: ['red', 'green', 'blue']]                   | 'X.red.green.blue'
+        'X{.list}'            | [list: ['red', 'green', 'blue']]                   | 'X.red,green,blue'
+        'X{.keys}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'X.semi,%3B,dot,.,comma,%2C'
+        'X{.keys*}'           | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'X.semi=%3B.dot=..comma=%2C'
+        'X{.empty_keys}'      | [empty_keys: [:]]                                  | 'X'
+        'X{.empty_keys}'      | [empty_keys: []]                                   | 'X'
+        '{/who}'              | [who: 'fred']                                      | '/fred' // Section 3.2.6 - Level 3 - Path Segment Expansion: {/var}
+        '{/who,who}'          | [who: 'fred']                                      | '/fred/fred'
+        '{/var,empty,empty}'  | [var: 'fred']                                      | '/fred'
+        '{/half,who}'         | [half: '50%', who: 'fred']                         | '/50%25/fred'
+        '{/who,dub}'          | [who: 'fred', dub: 'me/too']                       | '/fred/me%2Ftoo'
+        '{/var}'              | [var: 'value']                                     | '/value'
+        '{/var,undef}'        | [var: 'value']                                     | '/value'
+        '{/var,empty}'        | [var: 'value', empty: '']                          | '/value/'
+        '{/var,x}/here'       | [var: 'value', x: 1024]                            | '/value/1024/here'
+        '{/var:1,var}'        | [var: 'value']                                     | '/v/value' // Section 3.2.6 - Level 4 - Path Segment Expansion: {/var}
+        '{/list}'             | [list: ['red', 'green', 'blue']]                   | '/red,green,blue'
+        '{/list*}'            | [list: ['red', 'green', 'blue']]                   | '/red/green/blue'
+        '{/list*,path:4}'     | [list: ['red', 'green', 'blue'], path: "/foo/bar"] | '/red/green/blue/%2Ffoo'
+        '/files/content{/path*}{/name}' | [name: "value"]                                                 | '/files/content/value'
+        '{/keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | '/semi,%3B,dot,.,comma,%2C'
+        '{/keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | '/semi=%3B/dot=./comma=%2C'
+        '{;who}'              | [who: 'fred']                                      | ';who=fred' // Section 3.2.7 - Level 3 - Path-Style Parameter Expansion: {;var}
+        '{;half}'             | [half: '50%']                                      | ';half=50%25'
+        '{;empty}'            | [empty: '']                                        | ';empty'
+        '{;v,empty,who}'      | [v: 6, empty: '', who: 'fred']                     | ';v=6;empty;who=fred'
+        '{;v,undef,who}'      | [v: 6, who: 'fred']                                | ';v=6;who=fred'
+        '{;x,y}'              | [x: 1024, y: 768]                                  | ';x=1024;y=768'
+        '{;x,y,empty}'        | [x: 1024, y: 768, empty: '']                       | ';x=1024;y=768;empty'
+        '{;x,y,undef}'        | [x: 1024, y: 768, empty: '']                       | ';x=1024;y=768'
+        '{;hello:5}'          | [hello: "Hello World!"]                            | ';hello=Hello' // Section 3.2.7 - Level 4 - Path-Style Parameter Expansion: {;var}
+        '{;list}'             | [list: ['red', 'green', 'blue']]                   | ';list=red,green,blue'
+        '{;list*}'            | [list: ['red', 'green', 'blue']]                   | ';list=red;list=green;list=blue'
+        '{;keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | ';keys=semi,%3B,dot,.,comma,%2C'
+        '{;keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | ';semi=%3B;dot=.;comma=%2C'
+        '{?who}'              | [who: 'fred']                                      | '?who=fred' // Section 3.2.8 - Level 3 - Form-Style Query Expansion: {?var}
+        '{?half}'             | [half: '50%']                                      | '?half=50%25'
+        '{?x,y}'              | [x: 1024, y: 768, empty: '']                       | '?x=1024&y=768'
+        '{?x,y,empty}'        | [x: 1024, y: 768, empty: '']                       | '?x=1024&y=768&empty='
+        '{?x,y,undef}'        | [x: 1024, y: 768, empty: '']                       | '?x=1024&y=768'
+        '{?var:3}'            | [var: 'value']                                     | '?var=val' // Section 3.2.8 - Level 4 - Form-Style Query Expansion: {?var}
+        '{?list}'             | [list: ['red', 'green', 'blue']]                   | '?list=red,green,blue'
+        '{?list*}'            | [list: ['red', 'green', 'blue']]                   | '?list=red&list=green&list=blue'
+        '{?keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | '?keys=semi,%3B,dot,.,comma,%2C'
+        '{?keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | '?semi=%3B&dot=.&comma=%2C'
+        '{?hello}'            | [hello: "Hello World!"]                            | '?hello=Hello+World%21'
+        '?fixed=yes{&x}'      | [x: 1024]                                          | '?fixed=yes&x=1024' // Section 3.2.9 - Level 3 - Form-style query continuation
+        '{&x,y,empty}'        | [x: 1024, y: 768, empty: '']                       | '&x=1024&y=768&empty='
+        '{&x,y,empty}'        | [x: 1024, y: 768, empty: null]                     | '&x=1024&y=768'
+        '{&var:3}'            | [var: 'value']                                     | '&var=val' // Section 3.2.9 - Level 4 - Form-style query continuation
+        '{&list}'             | [list: ['red', 'green', 'blue']]                   | '&list=red,green,blue'
+        '{&list*}'            | [list: ['red', 'green', 'blue']]                   | '&list=red&list=green&list=blue'
+        '{&keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | '&keys=semi,%3B,dot,.,comma,%2C'
+        '{&keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | '&semi=%3B&dot=.&comma=%2C'
+        '{?list*,locale,currency}' | [list: ['red', 'green', 'blue'], locale: null, currency: 'USD'] | '?list=red&list=green&list=blue&currency=USD'
+        '{?param[]*}'         | ['param[]': ['a', 'b', 'c']]                       | '?param[]=a&param[]=b&param[]=c'
+        '{?keys*}{?keys2*}'   | [keys: [var: 'foo', var2: null]]                   | '?var=foo'
+        '{?keys*}{?keys2*}'   | [keys: [var: null], keys2: [var2: null]]           | ''
+        '{?keys*}{?keys2*}'   | [keys: [var: 'foo'], keys2: [var2: null]]          | '?var=foo'
+        '{?keys*}{?keys2*}'   | [keys: [var: 'foo'], keys2: [var2: 'bar']]         | '?var=foo&var2=bar'
+        '{?keys*}{?keys2*}'   | [keys: [var: null], keys2: [var2: 'bar']]          | '?var2=bar'
+        '{?keys*}{&keys2*}'   | [keys: [var: null], keys2: [var2: null]]           | ''
+        '{?keys*}{&keys2*}'   | [keys: [var: 'foo'], keys2: [var2: null]]          | '?var=foo'
+        '{?keys*}{&keys2*}'   | [keys: [var: 'foo'], keys2: [var2: 'bar']]         | '?var=foo&var2=bar'
+        '{?keys*}{&keys2*}'   | [keys: [var: null], keys2: [var2: 'bar']]          | '&var2=bar'
+    }
+
+
+    @Unroll
+    void "Test expand URI template #template with arguments #arguments for full URL"() {
+        given:
+        UriTemplateMatcher uriTemplate = new UriTemplateMatcher(template)
+
+        expect: 'See https://tools.ietf.org/html/rfc6570#section-2.4.1'
+        uriTemplate.expand(arguments) == result
+
+        where:
+        template                                 | arguments                                          | result
+        'http://example.com/v/{v}/p{?o,m,s}'     | [v: 'value']                                       | 'http://example.com/v/value/p'
+        'http://example.com/v/{v}/p{?o,m,s}'     | [v: 'value', o: 'val']                             | 'http://example.com/v/value/p?o=val'
+        'http://example.com/v/{v}/p{?o,m,s}'     | [v: 'value', m: 'val']                             | 'http://example.com/v/value/p?m=val'
+        'http://example.com/v/{v}/p{?o,m,s}'     | [v: 'value', s: 'val']                             | 'http://example.com/v/value/p?s=val'
+        'http://example.com/v/{v}/p{?o,m,s}'     | [v: 'value', o: 'val1', m: 'val2', s: 'val3']      | 'http://example.com/v/value/p?o=val1&m=val2&s=val3'
+        'http://example.com/v/{v}/p{?o,m,s}'     | [v: 'value', m: 'val2', s: 'val3']                 | 'http://example.com/v/value/p?m=val2&s=val3'
+        'http://example.com/v/{v}/p{?o,m,s}'     | [v: 'value', o: 'val1', s: 'val3']                 | 'http://example.com/v/value/p?o=val1&s=val3'
+        'http://example.com/v/{v}/p{?o,m,s}'     | [v: 'value', o: 'val1', m: 'val2'           ]      | 'http://example.com/v/value/p?o=val1&m=val2'
+        'http://example.com/{var}'               | [var: 'value']                                     | 'http://example.com/value' // Section 2.4.1 - Prefix Values
+        'http://example.com/{var:20}'            | [var: 'value']                                     | 'http://example.com/value'
+        'http://example.com/{var:3}'             | [var: 'value']                                     | 'http://example.com/val'
+        'http://example.com/{semi}'              | [semi: ';']                                        | 'http://example.com/%3B'
+        'http://example.com/{semi:2}'            | [semi: ';']                                        | 'http://example.com/%3B'
+        'http://example.com/find{?year*}'        | [year: ["1965", "2000", "2012"]]                   | 'http://example.com/find?year=1965&year=2000&year=2012' // Section 2.4.2.  Composite Values
+        'http://example.com/www{.dom*}'          | [dom: ["example", "com"]]                          | 'http://example.com/www.example.com'
+        'http://example.com/{count}'             | [count: ['one', 'two', 'three']]                   | 'http://example.com/one,two,three' // Section 3.2.1  Variable Expansion
+        'http://example.com/{count*}'            | [count: ['one', 'two', 'three']]                   | 'http://example.com/one,two,three'
+        'http://example.com/{/count}'            | [count: ['one', 'two', 'three']]                   | 'http://example.com//one,two,three'
+        'http://example.com/{/count*}'           | [count: ['one', 'two', 'three']]                   | 'http://example.com//one/two/three'
+        'http://example.com/{;count}'            | [count: ['one', 'two', 'three']]                   | 'http://example.com/;count=one,two,three'
+        'http://example.com/{;count*}'           | [count: ['one', 'two', 'three']]                   | 'http://example.com/;count=one;count=two;count=three'
+        'http://example.com/{?count}'            | [count: ['one', 'two', 'three']]                   | 'http://example.com/?count=one,two,three'
+        'http://example.com/{?count*}'           | [count: ['one', 'two', 'three']]                   | 'http://example.com/?count=one&count=two&count=three'
+        'http://example.com/{&count*}'           | [count: ['one', 'two', 'three']]                   | 'http://example.com/&count=one&count=two&count=three'
+        'http://example.com/{var}'               | [var: ['value']]                                   | 'http://example.com/value' // Section 3.2.2 - Level 1 - Simple String Expansion: {var}
+        'http://example.com/{hello}'             | [hello: "Hello World!"]                            | 'http://example.com/Hello%20World%21'
+        'http://example.com/{half}'              | [half: '50%']                                      | 'http://example.com/50%25'
+        'http://example.com/O{empty}X'           | [empty: '']                                        | 'http://example.com/OX'
+        'http://example.com/O{undef}X'           | [:]                                                | 'http://example.com/OX'
+        'http://example.com/{x,y}'               | [x: 1024, y: 768]                                  | 'http://example.com/1024,768'
+        'http://example.com/?{x,empty}'          | [x: 1024, empty: '']                               | 'http://example.com/?1024,'
+        'http://example.com/?{x,undef}'          | [x: 1024, empty: '']                               | 'http://example.com/?1024'
+        'http://example.com/?{undef,y}'          | [y: 768]                                           | 'http://example.com/?768'
+        'http://example.com/map?{x,y}'           | [x: 1024, y: 768]                                  | 'http://example.com/map?1024,768' // Section 3.2.2 - Simple String Expansion: {var}
+        'http://example.com/{x,hello,y}'         | [x: 1024, y: 768, hello: "Hello World!"]           | 'http://example.com/1024,Hello%20World%21,768'
+        'http://example.com/{var:30}'            | [var: 'value']                                     | 'http://example.com/value' // Section 3.2.2 - Level 4 - Simple String Expansion: {var}
+        'http://example.com/{list}'              | [list: ['red', 'green', 'blue']]                   | 'http://example.com/red,green,blue'
+        'http://example.com/{list*}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com/red,green,blue'
+        'http://example.com/{keys}'              | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/semi,%3B,dot,.,comma,%2C'
+        'http://example.com/{keys*}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/semi=%3B,dot=.,comma=%2C'
+        'http://example.com/{+var}'              | [var: 'value']                                     | 'http://example.com/value' // Section 3.2.3 - Level 2 - Reserved Expansion: {+var}
+        'http://example.com/{+hello}'            | [hello: "Hello World!"]                            | 'http://example.com/Hello%20World!'
+        'http://example.com/{+hello}'            | [hello: "foo/bar"]                                 | 'http://example.com/foo/bar'
+        'http://example.com/{+hello}'            | [hello: ""]                                        | 'http://example.com/'
+        'http://example.com/{+half}'             | [half: '50%']                                      | 'http://example.com/50%25'
+        'http://example.com/{base}index'         | [base: 'http://example.com/home/']                 | 'http://example.com/http%3A%2F%2Fexample.com%2Fhome%2Findex'
+        'http://example.com/{+base}index'        | [base: 'http://example.com/home/']                 | 'http://example.com/http://example.com/home/index'
+        'http://example.com/O{+empty}X'          | [empty: '']                                        | 'http://example.com/OX'
+        'http://example.com/O{+undef}X'          | [:]                                                | 'http://example.com/OX'
+        'http://example.com{+path}/here'         | [path: "/foo/bar"]                                 | 'http://example.com/foo/bar/here'
+        'http://example.com/here?ref={+path}'    | [path: "/foo/bar"]                                 | 'http://example.com/here?ref=/foo/bar'
+        'http://example.com/up{+path}{var}/here' | [path: "/foo/bar", var: 'value']                   | 'http://example.com/up/foo/barvalue/here'
+        'http://example.com/{+x,hello,y}'        | [x: 1024, y: 768, hello: "Hello World!"]           | 'http://example.com/1024,Hello%20World!,768'
+        'http://example.com{+path,x}/here'       | [path: "/foo/bar", x: 1024]                        | 'http://example.com/foo/bar,1024/here'
+        'http://example.com{+path:6}/here'       | [path: "/foo/bar"]                                 | 'http://example.com/foo/b/here' // Section 3.2.3 - Level 4 - Reserved expansion with value modifiers
+        'http://example.com/{+list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com/red,green,blue'
+        'http://example.com/{+list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com/red,green,blue'
+        'http://example.com/{+keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/semi,;,dot,.,comma,,'
+        'http://example.com/{+keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/semi=;,dot=.,comma=,'
+        'http://example.com/{#var}'              | [var: 'value']                                     | 'http://example.com/#value' // Section 3.2.4 - Level 2 - Fragment Expansion: {#var}
+        'http://example.com/{#hello}'            | [hello: "Hello World!"]                            | 'http://example.com/#Hello%20World!'
+        'http://example.com/{#half}'             | [half: '50%']                                      | 'http://example.com/#50%25'
+        'http://example.com/foo{#empty}'         | [empty: '']                                        | 'http://example.com/foo#'
+        'http://example.com/foo{#undef}'         | [:]                                                | 'http://example.com/foo'
+        'http://example.com/X{#var}'             | [var: 'value']                                     | 'http://example.com/X#value'
+        'http://example.com/X{#hello}'           | [hello: "Hello World!", var: 'value']              | 'http://example.com/X#Hello%20World!'
+        'http://example.com/{#x,hello,y}'        | [x: 1024, y: 768, hello: "Hello World!"]           | 'http://example.com/#1024,Hello%20World!,768' // Section 3.2.4 - Level 3 - Fragment Expansion: {#var}
+        'http://example.com/{#path,x}/here'      | [path: "/foo/bar", x: 1024]                        | 'http://example.com/#/foo/bar,1024/here'
+        'http://example.com/{#path:6}/here'      | [path: "/foo/bar"]                                 | 'http://example.com/#/foo/b/here' // Section 3.2.4 - Level 4 - Fragment expansion with value modifiers
+        'http://example.com/{#list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com/#red,green,blue'
+        'http://example.com/{#list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com/#red,green,blue'
+        'http://example.com/{#keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/#semi,;,dot,.,comma,,'
+        'http://example.com/{#keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/#semi=;,dot=.,comma=,'
+        'http://example.com/X{.var}'             | [var: 'value']                                     | 'http://example.com/X.value' // Section 3.2.5 - Level 3 - Label Expansion with Dot-Prefix: {.var}
+        'http://example.com/X{.empty}'           | [empty: '']                                        | 'http://example.com/X.'
+        'http://example.com/X{.undef}'           | [:]                                                | 'http://example.com/X'
+        'http://example.com/X{.x,y}'             | [x: 1024, y: 768]                                  | 'http://example.com/X.1024.768'
+        'http://example.com/{.who}'              | [who: 'fred']                                      | 'http://example.com/.fred'
+        'http://example.com/{.who,who}'          | [who: 'fred']                                      | 'http://example.com/.fred.fred'
+        'http://example.com/{.half,who}'         | [half: '50%', who: 'fred']                         | 'http://example.com/.50%25.fred'
+        'http://example.com/www{.dom*}'          | [dom: ["example", "com"]]                          | 'http://example.com/www.example.com'
+        'http://example.com/X{.var:3}'           | [var: 'value']                                     | 'http://example.com/X.val' // Section 3.2.5 - Level 4 - Label expansion, dot-prefixed
+        'http://example.com/X{.list*}'           | [list: ['red', 'green', 'blue']]                   | 'http://example.com/X.red.green.blue'
+        'http://example.com/X{.list}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com/X.red,green,blue'
+        'http://example.com/X{.keys}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/X.semi,%3B,dot,.,comma,%2C'
+        'http://example.com/X{.keys*}'           | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/X.semi=%3B.dot=..comma=%2C'
+        'http://example.com/X{.empty_keys}'      | [empty_keys: [:]]                                  | 'http://example.com/X'
+        'http://example.com/X{.empty_keys}'      | [empty_keys: []]                                   | 'http://example.com/X'
+        'http://example.com{/who}'               | [who: 'fred']                                      | 'http://example.com/fred' // Section 3.2.6 - Level 3 - Path Segment Expansion: {/var}
+        'http://example.com{/who,who}'           | [who: 'fred']                                      | 'http://example.com/fred/fred'
+        'http://example.com{/half,who}'          | [half: '50%', who: 'fred']                         | 'http://example.com/50%25/fred'
+        'http://example.com{/who,dub}'           | [who: 'fred', dub: 'me/too']                       | 'http://example.com/fred/me%2Ftoo'
+        'http://example.com{/var}'               | [var: 'value']                                     | 'http://example.com/value'
+        'http://example.com{/var,undef}'         | [var: 'value']                                     | 'http://example.com/value'
+        'http://example.com{/var,empty}'         | [var: 'value', empty: '']                          | 'http://example.com/value/'
+        'http://example.com{/var,x}/here'        | [var: 'value', x: 1024]                            | 'http://example.com/value/1024/here'
+        'http://example.com{/var:1,var}'         | [var: 'value']                                     | 'http://example.com/v/value' // Section 3.2.6 - Level 4 - Path Segment Expansion: {/var}
+        'http://example.com{/list}'              | [list: ['red', 'green', 'blue']]                   | 'http://example.com/red,green,blue'
+        'http://example.com{/list*}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com/red/green/blue'
+        'http://example.com{/list*,path:4}'      | [list: ['red', 'green', 'blue'], path: "/foo/bar"] | 'http://example.com/red/green/blue/%2Ffoo'
+        'http://example.com{/keys}'              | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/semi,%3B,dot,.,comma,%2C'
+        'http://example.com{/keys*}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/semi=%3B/dot=./comma=%2C'
+        'http://example.com/{;who}'              | [who: 'fred']                                      | 'http://example.com/;who=fred' // Section 3.2.7 - Level 3 - Path-Style Parameter Expansion: {;var}
+        'http://example.com/{;half}'             | [half: '50%']                                      | 'http://example.com/;half=50%25'
+        'http://example.com/{;empty}'            | [empty: '']                                        | 'http://example.com/;empty'
+        'http://example.com/{;v,empty,who}'      | [v: 6, empty: '', who: 'fred']                     | 'http://example.com/;v=6;empty;who=fred'
+        'http://example.com/{;v,undef,who}'      | [v: 6, who: 'fred']                                | 'http://example.com/;v=6;who=fred'
+        'http://example.com/{;x,y}'              | [x: 1024, y: 768]                                  | 'http://example.com/;x=1024;y=768'
+        'http://example.com/{;x,y,empty}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com/;x=1024;y=768;empty'
+        'http://example.com/{;x,y,undef}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com/;x=1024;y=768'
+        'http://example.com/{;hello:5}'          | [hello: "Hello World!"]                            | 'http://example.com/;hello=Hello' // Section 3.2.7 - Level 4 - Path-Style Parameter Expansion: {;var}
+        'http://example.com/{;list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com/;list=red,green,blue'
+        'http://example.com/{;list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com/;list=red;list=green;list=blue'
+        'http://example.com/{;keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/;keys=semi,%3B,dot,.,comma,%2C'
+        'http://example.com/{;keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/;semi=%3B;dot=.;comma=%2C'
+        'http://example.com/{?who}'              | [who: 'fred']                                      | 'http://example.com/?who=fred' // Section 3.2.8 - Level 3 - Form-Style Query Expansion: {?var}
+        'http://example.com/{?half}'             | [half: '50%']                                      | 'http://example.com/?half=50%25'
+        'http://example.com/{?x,y}'              | [x: 1024, y: 768, empty: '']                       | 'http://example.com/?x=1024&y=768'
+        'http://example.com/{?x,y,empty}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com/?x=1024&y=768&empty='
+        'http://example.com/{?x,y,undef}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com/?x=1024&y=768'
+        'http://example.com/{?var:3}'            | [var: 'value']                                     | 'http://example.com/?var=val' // Section 3.2.8 - Level 4 - Form-Style Query Expansion: {?var}
+        'http://example.com/{?list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com/?list=red,green,blue'
+        'http://example.com/{?list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com/?list=red&list=green&list=blue'
+        'http://example.com/{?keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/?keys=semi,%3B,dot,.,comma,%2C'
+        'http://example.com/{?keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/?semi=%3B&dot=.&comma=%2C'
+        'http://example.com/?fixed=yes{&x}'      | [x: 1024]                                          | 'http://example.com/?fixed=yes&x=1024' // Section 3.2.9 - Level 3 - Form-style query continuation
+        'http://example.com/{&x,y,empty}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com/&x=1024&y=768&empty='
+        'http://example.com/{&var:3}'            | [var: 'value']                                     | 'http://example.com/&var=val' // Section 3.2.9 - Level 4 - Form-style query continuation
+        'http://example.com/{&list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com/&list=red,green,blue'
+        'http://example.com/{&list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com/&list=red&list=green&list=blue'
+        'http://example.com/{&keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/&keys=semi,%3B,dot,.,comma,%2C'
+        'http://example.com/{&keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com/&semi=%3B&dot=.&comma=%2C'
+        'http://example.com/foo{?query,number}'  | [query: 'mycelium', number: 100]                   | 'http://example.com/foo?query=mycelium&number=100'
+        'http://example.com/foo{?query,number}'  | [number: 100]                                      | 'http://example.com/foo?number=100'
+        'http://example.com/foo{?req*}'          | [req: [number: 100, name: null]]                   | 'http://example.com/foo?number=100'
+        'http://example.com/foo{?keys*}{?keys2*}'| [keys: [var: 'foo', var2: null]]                   | 'http://example.com/foo?var=foo'
+        'http://example.com/foo{?keys*}{?keys2*}'| [keys: [var: null], keys2: [var2: null]]           | 'http://example.com/foo'
+        'http://example.com/foo{?keys*}{?keys2*}'| [keys: [var: 'foo'], keys2: [var2: null]]          | 'http://example.com/foo?var=foo'
+        'http://example.com/foo{?keys*}{?keys2*}'| [keys: [var: 'foo'], keys2: [var2: 'bar']]         | 'http://example.com/foo?var=foo&var2=bar'
+        'http://example.com/foo{?keys*}{?keys2*}'| [keys: [var: null], keys2: [var2: 'bar']]          | 'http://example.com/foo?var2=bar'
+        'http://example.com/foo{?keys*}{&keys2*}'| [keys: [var: null], keys2: [var2: null]]           | 'http://example.com/foo'
+        'http://example.com/foo{?keys*}{&keys2*}'| [keys: [var: 'foo'], keys2: [var2: null]]          | 'http://example.com/foo?var=foo'
+        'http://example.com/foo{?keys*}{&keys2*}'| [keys: [var: 'foo'], keys2: [var2: 'bar']]         | 'http://example.com/foo?var=foo&var2=bar'
+        'http://example.com/foo{?keys*}{&keys2*}'| [keys: [var: null], keys2: [var2: 'bar']]          | 'http://example.com/foo&var2=bar'
+    }
+
+
+    @Unroll
+    void "Test expand URI template #template with arguments #arguments for full URL and port"() {
+        given:
+        UriTemplateMatcher uriTemplate = new UriTemplateMatcher(template)
+
+        expect: 'See https://tools.ietf.org/html/rfc6570#section-2.4.1'
+        uriTemplate.expand(arguments) == result
+
+        where:
+        template                                      | arguments                                          | result
+        'http://example.com:8080/v/{v}/p{?o,m,s}'     | [v: 'value']                                       | 'http://example.com:8080/v/value/p'
+        'http://example.com:8080/v/{v}/p{?o,m,s}'     | [v: 'val100', m: 'value']                          | 'http://example.com:8080/v/val100/p?m=value'
+        'http://example.com:8080/v/{v}/p{?o,m,s}'     | [v: 'value', o: 'val']                             | 'http://example.com:8080/v/value/p?o=val'
+        'http://example.com:8080/v/{v}/p{?o,m,s}'     | [v: 'value', m: 'val']                             | 'http://example.com:8080/v/value/p?m=val'
+        'http://example.com:8080/v/{v}/p{?o,m,s}'     | [v: 'value', s: 'val']                             | 'http://example.com:8080/v/value/p?s=val'
+        'http://example.com:8080/v/{v}/p{?o,m,s}'     | [v: 'value', o: 'val1', m: 'val2', s: 'val3']      | 'http://example.com:8080/v/value/p?o=val1&m=val2&s=val3'
+        'http://example.com:8080/v/{v}/p{?o,m,s}'     | [v: 'value', m: 'val2', s: 'val3']                 | 'http://example.com:8080/v/value/p?m=val2&s=val3'
+        'http://example.com:8080/v/{v}/p{?o,m,s}'     | [v: 'value', o: 'val1', s: 'val3']                 | 'http://example.com:8080/v/value/p?o=val1&s=val3'
+        'http://example.com:8080/v/{v}/p{?o,m,s}'     | [v: 'value', o: 'val1', m: 'val2'           ]      | 'http://example.com:8080/v/value/p?o=val1&m=val2'
+        'http://example.com:8080{+path,x}/here'       | [path: "/foo/bar", x: 1024]                        | 'http://example.com:8080/foo/bar,1024/here'
+        'http://example.com:8080/{var}'               | [var: 'value']                                     | 'http://example.com:8080/value' // Section 2.4.1 - Prefix Values
+        'http://example.com:8080/{var:20}'            | [var: 'value']                                     | 'http://example.com:8080/value'
+        'http://example.com:8080/{var:3}'             | [var: 'value']                                     | 'http://example.com:8080/val'
+        'http://example.com:8080/{semi}'              | [semi: ';']                                        | 'http://example.com:8080/%3B'
+        'http://example.com:8080/{semi:2}'            | [semi: ';']                                        | 'http://example.com:8080/%3B'
+        'http://example.com:8080/find{?year*}'        | [year: ["1965", "2000", "2012"]]                   | 'http://example.com:8080/find?year=1965&year=2000&year=2012' // Section 2.4.2.  Composite Values
+        'http://example.com:8080/www{.dom*}'          | [dom: ["example", "com"]]                          | 'http://example.com:8080/www.example.com'
+        'http://example.com:8080/{count}'             | [count: ['one', 'two', 'three']]                   | 'http://example.com:8080/one,two,three' // Section 3.2.1  Variable Expansion
+        'http://example.com:8080/{count*}'            | [count: ['one', 'two', 'three']]                   | 'http://example.com:8080/one,two,three'
+        'http://example.com:8080/{/count}'            | [count: ['one', 'two', 'three']]                   | 'http://example.com:8080//one,two,three'
+        'http://example.com:8080/{/count*}'           | [count: ['one', 'two', 'three']]                   | 'http://example.com:8080//one/two/three'
+        'http://example.com:8080/{;count}'            | [count: ['one', 'two', 'three']]                   | 'http://example.com:8080/;count=one,two,three'
+        'http://example.com:8080/{;count*}'           | [count: ['one', 'two', 'three']]                   | 'http://example.com:8080/;count=one;count=two;count=three'
+        'http://example.com:8080/{?count}'            | [count: ['one', 'two', 'three']]                   | 'http://example.com:8080/?count=one,two,three'
+        'http://example.com:8080/{?count*}'           | [count: ['one', 'two', 'three']]                   | 'http://example.com:8080/?count=one&count=two&count=three'
+        'http://example.com:8080/{&count*}'           | [count: ['one', 'two', 'three']]                   | 'http://example.com:8080/&count=one&count=two&count=three'
+        'http://example.com:8080/{var}'               | [var: ['value']]                                   | 'http://example.com:8080/value' // Section 3.2.2 - Level 1 - Simple String Expansion: {var}
+        'http://example.com:8080/{hello}'             | [hello: "Hello World!"]                            | 'http://example.com:8080/Hello%20World%21'
+        'http://example.com:8080/{half}'              | [half: '50%']                                      | 'http://example.com:8080/50%25'
+        'http://example.com:8080/O{empty}X'           | [empty: '']                                        | 'http://example.com:8080/OX'
+        'http://example.com:8080/O{undef}X'           | [:]                                                | 'http://example.com:8080/OX'
+        'http://example.com:8080/{x,y}'               | [x: 1024, y: 768]                                  | 'http://example.com:8080/1024,768'
+        'http://example.com:8080/?{x,empty}'          | [x: 1024, empty: '']                               | 'http://example.com:8080/?1024,'
+        'http://example.com:8080/?{x,undef}'          | [x: 1024, empty: '']                               | 'http://example.com:8080/?1024'
+        'http://example.com:8080/?{undef,y}'          | [y: 768]                                           | 'http://example.com:8080/?768'
+        'http://example.com:8080/map?{x,y}'           | [x: 1024, y: 768]                                  | 'http://example.com:8080/map?1024,768' // Section 3.2.2 - Simple String Expansion: {var}
+        'http://example.com:8080/{x,hello,y}'         | [x: 1024, y: 768, hello: "Hello World!"]           | 'http://example.com:8080/1024,Hello%20World%21,768'
+        'http://example.com:8080/{var:30}'            | [var: 'value']                                     | 'http://example.com:8080/value' // Section 3.2.2 - Level 4 - Simple String Expansion: {var}
+        'http://example.com:8080/{list}'              | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/red,green,blue'
+        'http://example.com:8080/{list*}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/red,green,blue'
+        'http://example.com:8080/{keys}'              | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/semi,%3B,dot,.,comma,%2C'
+        'http://example.com:8080/{keys*}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/semi=%3B,dot=.,comma=%2C'
+        'http://example.com:8080/{+var}'              | [var: 'value']                                     | 'http://example.com:8080/value' // Section 3.2.3 - Level 2 - Reserved Expansion: {+var}
+        'http://example.com:8080/{+hello}'            | [hello: "Hello World!"]                            | 'http://example.com:8080/Hello%20World!'
+        'http://example.com:8080/{+half}'             | [half: '50%']                                      | 'http://example.com:8080/50%25'
+        'http://example.com:8080/{base}index'         | [base: 'http://example.com/home/']                 | 'http://example.com:8080/http%3A%2F%2Fexample.com%2Fhome%2Findex'
+        'http://example.com:8080/{+base}index'        | [base: 'http://example.com/home/']                 | 'http://example.com:8080/http://example.com/home/index'
+        'http://example.com:8080/O{+empty}X'          | [empty: '']                                        | 'http://example.com:8080/OX'
+        'http://example.com:8080/O{+undef}X'          | [:]                                                | 'http://example.com:8080/OX'
+        'http://example.com:8080{+path}/here'         | [path: "/foo/bar"]                                 | 'http://example.com:8080/foo/bar/here'
+        'http://example.com:8080/here?ref={+path}'    | [path: "/foo/bar"]                                 | 'http://example.com:8080/here?ref=/foo/bar'
+        'http://example.com:8080/up{+path}{var}/here' | [path: "/foo/bar", var: 'value']                   | 'http://example.com:8080/up/foo/barvalue/here'
+        'http://example.com:8080/{+x,hello,y}'        | [x: 1024, y: 768, hello: "Hello World!"]           | 'http://example.com:8080/1024,Hello%20World!,768'
+        'http://example.com:8080{+path,x}/here'       | [path: "/foo/bar", x: 1024]                        | 'http://example.com:8080/foo/bar,1024/here'
+        'http://example.com:8080{+path:6}/here'       | [path: "/foo/bar"]                                 | 'http://example.com:8080/foo/b/here' // Section 3.2.3 - Level 4 - Reserved expansion with value modifiers
+        'http://example.com:8080/{+list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/red,green,blue'
+        'http://example.com:8080/{+list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/red,green,blue'
+        'http://example.com:8080/{+keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/semi,;,dot,.,comma,,'
+        'http://example.com:8080/{+keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/semi=;,dot=.,comma=,'
+        'http://example.com:8080/{#var}'              | [var: 'value']                                     | 'http://example.com:8080/#value' // Section 3.2.4 - Level 2 - Fragment Expansion: {#var}
+        'http://example.com:8080/{#hello}'            | [hello: "Hello World!"]                            | 'http://example.com:8080/#Hello%20World!'
+        'http://example.com:8080/{#half}'             | [half: '50%']                                      | 'http://example.com:8080/#50%25'
+        'http://example.com:8080/foo{#empty}'         | [empty: '']                                        | 'http://example.com:8080/foo#'
+        'http://example.com:8080/foo{#undef}'         | [:]                                                | 'http://example.com:8080/foo'
+        'http://example.com:8080/X{#var}'             | [var: 'value']                                     | 'http://example.com:8080/X#value'
+        'http://example.com:8080/X{#hello}'           | [hello: "Hello World!", var: 'value']              | 'http://example.com:8080/X#Hello%20World!'
+        'http://example.com:8080/{#x,hello,y}'        | [x: 1024, y: 768, hello: "Hello World!"]           | 'http://example.com:8080/#1024,Hello%20World!,768' // Section 3.2.4 - Level 3 - Fragment Expansion: {#var}
+        'http://example.com:8080/{#path,x}/here'      | [path: "/foo/bar", x: 1024]                        | 'http://example.com:8080/#/foo/bar,1024/here'
+        'http://example.com:8080/{#path:6}/here'      | [path: "/foo/bar"]                                 | 'http://example.com:8080/#/foo/b/here' // Section 3.2.4 - Level 4 - Fragment expansion with value modifiers
+        'http://example.com:8080/{#list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/#red,green,blue'
+        'http://example.com:8080/{#list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/#red,green,blue'
+        'http://example.com:8080/{#keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/#semi,;,dot,.,comma,,'
+        'http://example.com:8080/{#keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/#semi=;,dot=.,comma=,'
+        'http://example.com:8080/X{.var}'             | [var: 'value']                                     | 'http://example.com:8080/X.value' // Section 3.2.5 - Level 3 - Label Expansion with Dot-Prefix: {.var}
+        'http://example.com:8080/X{.empty}'           | [empty: '']                                        | 'http://example.com:8080/X.'
+        'http://example.com:8080/X{.undef}'           | [:]                                                | 'http://example.com:8080/X'
+        'http://example.com:8080/X{.x,y}'             | [x: 1024, y: 768]                                  | 'http://example.com:8080/X.1024.768'
+        'http://example.com:8080/{.who}'              | [who: 'fred']                                      | 'http://example.com:8080/.fred'
+        'http://example.com:8080/{.who,who}'          | [who: 'fred']                                      | 'http://example.com:8080/.fred.fred'
+        'http://example.com:8080/{.half,who}'         | [half: '50%', who: 'fred']                         | 'http://example.com:8080/.50%25.fred'
+        'http://example.com:8080/www{.dom*}'          | [dom: ["example", "com"]]                          | 'http://example.com:8080/www.example.com'
+        'http://example.com:8080/X{.var:3}'           | [var: 'value']                                     | 'http://example.com:8080/X.val' // Section 3.2.5 - Level 4 - Label expansion, dot-prefixed
+        'http://example.com:8080/X{.list*}'           | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/X.red.green.blue'
+        'http://example.com:8080/X{.list}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/X.red,green,blue'
+        'http://example.com:8080/X{.keys}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/X.semi,%3B,dot,.,comma,%2C'
+        'http://example.com:8080/X{.keys*}'           | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/X.semi=%3B.dot=..comma=%2C'
+        'http://example.com:8080/X{.empty_keys}'      | [empty_keys: [:]]                                  | 'http://example.com:8080/X'
+        'http://example.com:8080/X{.empty_keys}'      | [empty_keys: []]                                   | 'http://example.com:8080/X'
+        'http://example.com:8080{/who}'               | [who: 'fred']                                      | 'http://example.com:8080/fred' // Section 3.2.6 - Level 3 - Path Segment Expansion: {/var}
+        'http://example.com:8080{/who,who}'           | [who: 'fred']                                      | 'http://example.com:8080/fred/fred'
+        'http://example.com:8080{/half,who}'          | [half: '50%', who: 'fred']                         | 'http://example.com:8080/50%25/fred'
+        'http://example.com:8080{/who,dub}'           | [who: 'fred', dub: 'me/too']                       | 'http://example.com:8080/fred/me%2Ftoo'
+        'http://example.com:8080{/var}'               | [var: 'value']                                     | 'http://example.com:8080/value'
+        'http://example.com:8080{/var,undef}'         | [var: 'value']                                     | 'http://example.com:8080/value'
+        'http://example.com:8080{/var,empty}'         | [var: 'value', empty: '']                          | 'http://example.com:8080/value/'
+        'http://example.com:8080{/var,x}/here'        | [var: 'value', x: 1024]                            | 'http://example.com:8080/value/1024/here'
+        'http://example.com:8080{/var:1,var}'         | [var: 'value']                                     | 'http://example.com:8080/v/value' // Section 3.2.6 - Level 4 - Path Segment Expansion: {/var}
+        'http://example.com:8080{/list}'              | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/red,green,blue'
+        'http://example.com:8080{/list*}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/red/green/blue'
+        'http://example.com:8080{/list*,path:4}'      | [list: ['red', 'green', 'blue'], path: "/foo/bar"] | 'http://example.com:8080/red/green/blue/%2Ffoo'
+        'http://example.com:8080{/keys}'              | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/semi,%3B,dot,.,comma,%2C'
+        'http://example.com:8080{/keys*}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/semi=%3B/dot=./comma=%2C'
+        'http://example.com:8080/{;who}'              | [who: 'fred']                                      | 'http://example.com:8080/;who=fred' // Section 3.2.7 - Level 3 - Path-Style Parameter Expansion: {;var}
+        'http://example.com:8080/{;half}'             | [half: '50%']                                      | 'http://example.com:8080/;half=50%25'
+        'http://example.com:8080/{;empty}'            | [empty: '']                                        | 'http://example.com:8080/;empty'
+        'http://example.com:8080/{;v,empty,who}'      | [v: 6, empty: '', who: 'fred']                     | 'http://example.com:8080/;v=6;empty;who=fred'
+        'http://example.com:8080/{;v,undef,who}'      | [v: 6, who: 'fred']                                | 'http://example.com:8080/;v=6;who=fred'
+        'http://example.com:8080/{;x,y}'              | [x: 1024, y: 768]                                  | 'http://example.com:8080/;x=1024;y=768'
+        'http://example.com:8080/{;x,y,empty}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com:8080/;x=1024;y=768;empty'
+        'http://example.com:8080/{;x,y,undef}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com:8080/;x=1024;y=768'
+        'http://example.com:8080/{;hello:5}'          | [hello: "Hello World!"]                            | 'http://example.com:8080/;hello=Hello' // Section 3.2.7 - Level 4 - Path-Style Parameter Expansion: {;var}
+        'http://example.com:8080/{;list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/;list=red,green,blue'
+        'http://example.com:8080/{;list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/;list=red;list=green;list=blue'
+        'http://example.com:8080/{;keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/;keys=semi,%3B,dot,.,comma,%2C'
+        'http://example.com:8080/{;keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/;semi=%3B;dot=.;comma=%2C'
+        'http://example.com:8080/{?who}'              | [who: 'fred']                                      | 'http://example.com:8080/?who=fred' // Section 3.2.8 - Level 3 - Form-Style Query Expansion: {?var}
+        'http://example.com:8080/{?half}'             | [half: '50%']                                      | 'http://example.com:8080/?half=50%25'
+        'http://example.com:8080/{?x,y}'              | [x: 1024, y: 768, empty: '']                       | 'http://example.com:8080/?x=1024&y=768'
+        'http://example.com:8080/{?x,y,empty}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com:8080/?x=1024&y=768&empty='
+        'http://example.com:8080/{?x,y,undef}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com:8080/?x=1024&y=768'
+        'http://example.com:8080/{?var:3}'            | [var: 'value']                                     | 'http://example.com:8080/?var=val' // Section 3.2.8 - Level 4 - Form-Style Query Expansion: {?var}
+        'http://example.com:8080/{?list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/?list=red,green,blue'
+        'http://example.com:8080/{?list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/?list=red&list=green&list=blue'
+        'http://example.com:8080/{?keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/?keys=semi,%3B,dot,.,comma,%2C'
+        'http://example.com:8080/{?keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/?semi=%3B&dot=.&comma=%2C'
+        'http://example.com:8080/?fixed=yes{&x}'      | [x: 1024]                                          | 'http://example.com:8080/?fixed=yes&x=1024' // Section 3.2.9 - Level 3 - Form-style query continuation
+        'http://example.com:8080/{&x,y,empty}'        | [x: 1024, y: 768, empty: '']                       | 'http://example.com:8080/&x=1024&y=768&empty='
+        'http://example.com:8080/{&var:3}'            | [var: 'value']                                     | 'http://example.com:8080/&var=val' // Section 3.2.9 - Level 4 - Form-style query continuation
+        'http://example.com:8080/{&list}'             | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/&list=red,green,blue'
+        'http://example.com:8080/{&list*}'            | [list: ['red', 'green', 'blue']]                   | 'http://example.com:8080/&list=red&list=green&list=blue'
+        'http://example.com:8080/{&keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/&keys=semi,%3B,dot,.,comma,%2C'
+        'http://example.com:8080/{&keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/&semi=%3B&dot=.&comma=%2C'
+        'http://example.com:8080/{&keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: null]]     | 'http://example.com:8080/&semi=%3B&dot=.'
+        'http://example.com:8080/{?keys*}{?keys2*}'   | [keys: [var: 'foo', var2: null]]                   | 'http://example.com:8080/?var=foo'
+        'http://example.com:8080/{?keys*}{?keys2*}'   | [keys: [var: null], keys2: [var2: null]]           | 'http://example.com:8080/'
+        'http://example.com:8080/{?keys*}{?keys2*}'   | [keys: [var: 'foo'], keys2: [var2: null]]          | 'http://example.com:8080/?var=foo'
+        'http://example.com:8080/{?keys*}{?keys2*}'   | [keys: [var: 'foo'], keys2: [var2: 'bar']]         | 'http://example.com:8080/?var=foo&var2=bar'
+        'http://example.com:8080/{?keys*}{?keys2*}'   | [keys: [var: null], keys2: [var2: 'bar']]          | 'http://example.com:8080/?var2=bar'
+        'http://example.com:8080/{?keys*}{&keys2*}'   | [keys: [var: null], keys2: [var2: null]]           | 'http://example.com:8080/'
+        'http://example.com:8080/{?keys*}{&keys2*}'   | [keys: [var: 'foo'], keys2: [var2: null]]          | 'http://example.com:8080/?var=foo'
+        'http://example.com:8080/{?keys*}{&keys2*}'   | [keys: [var: 'foo'], keys2: [var2: 'bar']]         | 'http://example.com:8080/?var=foo&var2=bar'
+        'http://example.com:8080/{?keys*}{&keys2*}'   | [keys: [var: null], keys2: [var2: 'bar']]          | 'http://example.com:8080/&var2=bar'
+    }
+
+}

--- a/http/src/test/groovy/io/micronaut/http/uri/UriTemplateMatcherSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriTemplateMatcherSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2014 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,16 +20,15 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 /**
- * @author Graeme Rocher
- * @since 1.0
+ * @author Denis Stepanov
  */
-class UriMatchTemplateSpec extends Specification {
+class UriTemplateMatcherSpec extends Specification {
 
     @Unroll
     void "test compareTo for #left and #right"() {
         given:
-        UriMatchTemplate leftTemplate = new UriMatchTemplate(left)
-        UriMatchTemplate rightTemplate = new UriMatchTemplate(right)
+        UriTemplateMatcher leftTemplate = new UriTemplateMatcher(left)
+        UriTemplateMatcher rightTemplate = new UriTemplateMatcher(right)
 
         expect:
         leftTemplate.compareTo(rightTemplate) == result
@@ -49,7 +48,7 @@ class UriMatchTemplateSpec extends Specification {
     @Unroll
     void "Test URI template #template matches #uri when nested with #nested"() {
         given:
-        UriMatchTemplate matchTemplate = new UriMatchTemplate(template)
+        UriTemplateMatcher matchTemplate = new UriTemplateMatcher(template)
         Optional<UriMatchInfo> info = matchTemplate.nest(nested).match(uri)
 
         expect:
@@ -71,7 +70,7 @@ class UriMatchTemplateSpec extends Specification {
     @Unroll
     void "Test URI template #template matches #uri"() {
         given:
-        UriMatchTemplate matchTemplate = new UriMatchTemplate(template)
+        UriTemplateMatcher matchTemplate = new UriTemplateMatcher(template)
         Optional<UriMatchInfo> info = matchTemplate.match(uri)
 
         expect:
@@ -81,6 +80,9 @@ class UriMatchTemplateSpec extends Specification {
         where:
         template                         | uri                        | matches | variables
         // raw unencoded paths
+        "/books{/id:.*}{/chapter:.*}"    | '/books/1/ch22'            | true    | [id: '1/ch22', chapter:'']
+        "/books{/id:\\d+}{/chapter:.*}"  | '/books/1/ch22'            | true    | [id: '1', chapter:'ch22']
+    "/books{/id:\\d+}{/chapter:.*}/file{.ext:?}" | '/books/1/ch22/file.xml' | true    | [id: '1', chapter:'ch22', ext: 'xml']
         "/id/{id}.csv"                   |'/id/{id}'                  | false   | null
         "https://www.domain.com/{+path}" |'https://www.domain.com/abc'| true    | [path:'abc']
         "https://www.domain.com/       " |'https://www.domain.com    '| false   | null
@@ -90,9 +92,6 @@ class UriMatchTemplateSpec extends Specification {
         "/books/{+path}/test"            | '/books/foo/bar/test'      | true    | [path: 'foo/bar']
         "/books{/id}{.ext:?}"            | '/books/1.xml'             | true    | [id: '1', ext: 'xml']
         "/books{/id}{.ext:?}"            | '/books/1'                 | true    | [id: '1', ext: null]
-        "/books{/id:.*}{/chapter:.*}"    | '/books/1/ch22'            | true    | [id: '1/ch22', chapter:'']
-        "/books{/id:\\d+}{/chapter:.*}"  | '/books/1/ch22'            | true    | [id: '1', chapter:'ch22']
-"/books{/id:\\d+}{/chapter:.*}/file{.ext:?}" | '/books/1/ch22/file.xml' | true    | [id: '1', chapter:'ch22', ext: 'xml']
         "/books{/path:.*?}{.ext:?}"      | '/books/foo/bar.xml'       | true    | [path: 'foo/bar', ext: 'xml']
         ""                               | ""                         | true    | [:]
         "/"                              | "/"                        | true    | [:]
@@ -108,7 +107,7 @@ class UriMatchTemplateSpec extends Specification {
         "/books{/path:.*}"               | '/books/foo/bar'           | true    | [path: 'foo/bar']
         "/books{/path:.*}{.ext}"         | '/books/foo/bar.xml'       | true    | [path: 'foo/bar', ext: 'xml']
         "/books{/path:.*}{.ext:?}"       | '/books/foo/bar'           | true    | [path: 'foo/bar', ext: null]
-        "/books/{id}"                    | '/books'                   | false   | null
+        "/books/{id}/{chapter}"          | '/books/123/ch1'           | true    | [id: '123', chapter: 'ch1']
         "/books/{id}"                    | '/books/1'                 | true    | [id: '1']
         "/books/{id}"                    | '/books/test'              | true    | [id: 'test']
         "/books/{id:2}"                  | '/books/1'                 | true    | [id: '1']
@@ -146,7 +145,7 @@ class UriMatchTemplateSpec extends Specification {
     @Unroll
     void "Test URI template #template matches #uri with trailing slash"() {
         given:
-        UriMatchTemplate matchTemplate = new UriMatchTemplate(template)
+        UriTemplateMatcher matchTemplate = new UriTemplateMatcher(template)
         Optional<UriMatchInfo> info = matchTemplate.match(uri)
 
         expect:
@@ -194,7 +193,7 @@ class UriMatchTemplateSpec extends Specification {
     @Unroll
     void "Test URI template #template matches uri with encoded characters: #uri"() {
         given:
-        UriMatchTemplate matchTemplate = new UriMatchTemplate(template)
+        UriTemplateMatcher matchTemplate = new UriTemplateMatcher(template)
         Optional<UriMatchInfo> info = matchTemplate.match(uri)
 
         expect:

--- a/router/src/main/java/io/micronaut/web/router/DefaultUrlRouteInfo.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultUrlRouteInfo.java
@@ -25,6 +25,7 @@ import io.micronaut.http.MediaType;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.uri.UriMatchInfo;
 import io.micronaut.http.uri.UriMatchTemplate;
+import io.micronaut.http.uri.UriTemplateMatcher;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.scheduling.executor.ExecutorSelector;
 import io.micronaut.scheduling.executor.ThreadSelection;
@@ -48,6 +49,7 @@ public final class DefaultUrlRouteInfo<T, R> extends DefaultRequestMatcher<T, R>
 
     private final HttpMethod httpMethod;
     private final UriMatchTemplate uriMatchTemplate;
+    private final UriTemplateMatcher uriTemplateMatcher;
     private final Charset defaultCharset;
     private final Integer port;
     private final ConversionService conversionService;
@@ -71,6 +73,7 @@ public final class DefaultUrlRouteInfo<T, R> extends DefaultRequestMatcher<T, R>
         super(targetMethod, bodyArgument, bodyArgumentName, consumesMediaTypes, producesMediaTypes, httpMethod.permitsRequestBody(), false, predicates, messageBodyHandlerRegistry);
         this.httpMethod = httpMethod;
         this.uriMatchTemplate = uriMatchTemplate;
+        this.uriTemplateMatcher = new UriTemplateMatcher(uriMatchTemplate.getTemplateString());
         this.defaultCharset = defaultCharset;
         this.port = port;
         this.conversionService = conversionService;
@@ -94,7 +97,7 @@ public final class DefaultUrlRouteInfo<T, R> extends DefaultRequestMatcher<T, R>
 
     @Override
     public UriRouteMatch<T, R> tryMatch(String uri) {
-        UriMatchInfo matchInfo = uriMatchTemplate.tryMatch(uri);
+        UriMatchInfo matchInfo = uriTemplateMatcher.tryMatch(uri);
         if (matchInfo != null) {
             return new DefaultUriRouteMatch<>(matchInfo, this, defaultCharset, conversionService);
         }
@@ -108,7 +111,7 @@ public final class DefaultUrlRouteInfo<T, R> extends DefaultRequestMatcher<T, R>
 
     @Override
     public int compareTo(UriRouteInfo o) {
-        return uriMatchTemplate.compareTo(o.getUriMatchTemplate());
+        return uriTemplateMatcher.compareTo(((DefaultUrlRouteInfo) o).uriTemplateMatcher);
     }
 
     @Override


### PR DESCRIPTION
This is an attempt to get rid of the old `UriTemplate`, `UriMatchTemplate`, and `UriTypeMatchTemplate` (not used in Core). The implementation of matching/expanding is very confusing and hard to understand, with all the things being changed in the inherited constructor methods, etc. It does not allow adding any changes that we might need.

The new implementation is split into a parser, an expander, and an alternative URI template matcher. The matcher now matches segments of the path, allowing to match without always using the regexp; this should improve the performance of matching basic `/hello` or `/hello/{world}.` In the future, we can implement routing, which will combine similar segments into one, reducing the complexity for N to something better, considering most routes share the same prefix.

The new matcher passes previous tests and is now used to match the routes. However, there are still some cases where the old template is used: resolving conflicts and the URI builder. Next, I will investigate what needs to be aligned with the JAX-RS implementation.

Unfortunately, the classes are public and cannot be removed or changed, so we have a new implementation until v5.

