### PR TITLE
Add config options for form parsing limits

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
@@ -37,12 +37,12 @@ import io.micronaut.http.body.InternalByteBody;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.body.MessageBodyReader;
 import io.micronaut.http.codec.CodecException;
-import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.netty.FormDataHttpContentProcessor;
 import io.micronaut.http.server.netty.NettyHttpRequest;
 import io.micronaut.http.server.netty.body.AvailableNettyByteBody;
 import io.micronaut.http.server.netty.body.ImmediateMultiObjectBody;
 import io.micronaut.http.server.netty.body.ImmediateSingleObjectBody;
+import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
 import io.micronaut.web.router.RouteInfo;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
@@ -56,11 +56,11 @@ import java.util.Set;
 
 final class NettyBodyAnnotationBinder<T> extends DefaultBodyAnnotationBinder<T> {
     private static final Set<Class<?>> RAW_BODY_TYPES = CollectionUtils.setOf(String.class, byte[].class, ByteBuffer.class, InputStream.class);
-    final HttpServerConfiguration httpServerConfiguration;
+    final NettyHttpServerConfiguration httpServerConfiguration;
     final MessageBodyHandlerRegistry bodyHandlerRegistry;
 
     NettyBodyAnnotationBinder(ConversionService conversionService,
-                                     HttpServerConfiguration httpServerConfiguration,
+                              NettyHttpServerConfiguration httpServerConfiguration,
                                      MessageBodyHandlerRegistry bodyHandlerRegistry) {
         super(conversionService);
         this.httpServerConfiguration = httpServerConfiguration;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyServerRequestBinderRegistry.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyServerRequestBinderRegistry.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.server.netty.binders;
 
-import io.micronaut.context.BeanLocator;
 import io.micronaut.context.BeanProvider;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Order;
@@ -27,7 +26,7 @@ import io.micronaut.http.bind.DefaultRequestBinderRegistry;
 import io.micronaut.http.bind.RequestBinderRegistry;
 import io.micronaut.http.bind.binders.RequestArgumentBinder;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
-import io.micronaut.http.server.HttpServerConfiguration;
+import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
 import io.micronaut.http.server.netty.multipart.MultipartBodyArgumentBinder;
 import io.micronaut.http.server.netty.multipart.NettyStreamingFileUpload;
 import io.micronaut.scheduling.TaskExecutors;
@@ -53,8 +52,7 @@ public final class NettyServerRequestBinderRegistry implements RequestBinderRegi
 
     public NettyServerRequestBinderRegistry(ConversionService conversionService,
                                             List<RequestArgumentBinder> binders,
-                                            BeanLocator beanLocator,
-                                            BeanProvider<HttpServerConfiguration> httpServerConfiguration,
+                                            BeanProvider<NettyHttpServerConfiguration> httpServerConfiguration,
                                             @Named(TaskExecutors.BLOCKING)
                                             BeanProvider<ExecutorService> executorService,
                                             MessageBodyHandlerRegistry bodyHandlerRegistry) {
@@ -68,7 +66,6 @@ public final class NettyServerRequestBinderRegistry implements RequestBinderRegi
         internalRequestBinderRegistry.addArgumentBinder(new NettyPublisherBodyBinder(
             nettyBodyAnnotationBinder));
         internalRequestBinderRegistry.addArgumentBinder(new MultipartBodyArgumentBinder(
-            beanLocator,
             httpServerConfiguration
         ));
         internalRequestBinderRegistry.addArgumentBinder(new NettyInputStreamBodyBinder());

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -163,6 +163,20 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     @SuppressWarnings("WeakerAccess")
     public static final int DEFAULT_HTTP3_INITIAL_MAX_STREAMS_BIDIRECTIONAL = 100;
 
+    /**
+     * Default value for {@link #formMaxFields}.
+     *
+     * @since 4.6.0
+     */
+    public static final int DEFAULT_FORM_MAX_FIELDS = 128;
+
+    /**
+     * Default value for {@link #formMaxBufferedBytes}.
+     *
+     * @since 4.6.0
+     */
+    public static final int DEFAULT_FORM_MAX_BUFFERED_BYTES = 1024;
+
     private static final Logger LOG = LoggerFactory.getLogger(NettyHttpServerConfiguration.class);
 
     private final List<ChannelPipelineListener> pipelineCustomizers;
@@ -197,6 +211,8 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     private boolean eagerParsing = DEFAULT_EAGER_PARSING;
     private int jsonBufferMaxComponents = DEFAULT_JSON_BUFFER_MAX_COMPONENTS;
     private boolean legacyMultiplexHandlers = false;
+    private int formMaxFields = DEFAULT_FORM_MAX_FIELDS;
+    private int formMaxBufferedBytes = DEFAULT_FORM_MAX_BUFFERED_BYTES;
 
     /**
      * Default empty constructor.
@@ -762,6 +778,48 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public void setLegacyMultiplexHandlers(boolean legacyMultiplexHandlers) {
         this.legacyMultiplexHandlers = legacyMultiplexHandlers;
+    }
+
+    /**
+     * The maximum number of form fields permitted in a request.
+     *
+     * @return The maximum number of form fields
+     * @since 4.6.0
+     */
+    public int getFormMaxFields() {
+        return formMaxFields;
+    }
+
+    /**
+     * The maximum number of form fields permitted in a request.
+     *
+     * @param formMaxFields The maximum number of form fields
+     * @since 4.6.0
+     */
+    public void setFormMaxFields(int formMaxFields) {
+        this.formMaxFields = formMaxFields;
+    }
+
+    /**
+     * The maximum number of bytes the form / multipart decoders are allowed to buffer internally.
+     * This sets a limit on form field size.
+     *
+     * @return The maximum number of buffered bytes
+     * @since 4.6.0
+     */
+    public int getFormMaxBufferedBytes() {
+        return formMaxBufferedBytes;
+    }
+
+    /**
+     * The maximum number of bytes the form / multipart decoders are allowed to buffer internally.
+     * This sets a limit on form field size.
+     *
+     * @param formMaxBufferedBytes The maximum number of buffered bytes
+     * @since 4.6.0
+     */
+    public void setFormMaxBufferedBytes(int formMaxBufferedBytes) {
+        this.formMaxBufferedBytes = formMaxBufferedBytes;
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/MultipartBodyArgumentBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/MultipartBodyArgumentBinder.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.server.netty.multipart;
 
-import io.micronaut.context.BeanLocator;
 import io.micronaut.context.BeanProvider;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
@@ -24,12 +23,12 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.bind.binders.NonBlockingBodyArgumentBinder;
 import io.micronaut.http.multipart.CompletedPart;
-import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.multipart.MultipartBody;
 import io.micronaut.http.server.netty.FormDataHttpContentProcessor;
 import io.micronaut.http.server.netty.HttpContentProcessorAsReactiveProcessor;
 import io.micronaut.http.server.netty.NettyHttpRequest;
 import io.micronaut.http.server.netty.body.NettyByteBody;
+import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.FileUpload;
@@ -49,15 +48,14 @@ import java.util.Set;
  */
 @Internal
 public class MultipartBodyArgumentBinder implements NonBlockingBodyArgumentBinder<MultipartBody> {
-    private final BeanProvider<HttpServerConfiguration> httpServerConfiguration;
+    private final BeanProvider<NettyHttpServerConfiguration> httpServerConfiguration;
 
     /**
      * Default constructor.
      *
-     * @param beanLocator             The bean locator
      * @param httpServerConfiguration The server configuration
      */
-    public MultipartBodyArgumentBinder(BeanLocator beanLocator, BeanProvider<HttpServerConfiguration> httpServerConfiguration) {
+    public MultipartBodyArgumentBinder(BeanProvider<NettyHttpServerConfiguration> httpServerConfiguration) {
         this.httpServerConfiguration = httpServerConfiguration;
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/FormLimitSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/FormLimitSpec.groovy
@@ -1,0 +1,114 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.server.multipart.MultipartBody
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+
+class FormLimitSpec extends Specification {
+    def 'field count limit'(boolean multipart, int toSend, int limitToConfigure) {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name'                                      : 'FormLimitSpec',
+                'micronaut.server.port'                          : -1,
+                'micronaut.server.netty.form-max-fields'         : limitToConfigure,
+                'micronaut.http.client.exception-on-error-status': false
+        ])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI).toBlocking()
+
+        def body
+
+        if (multipart) {
+            def builder = io.micronaut.http.client.multipart.MultipartBody.builder()
+            for (int i = 0; i < toSend; i++) {
+                builder.addPart("f" + i, "val")
+            }
+            body = builder.build()
+        } else {
+            StringBuilder builder = new StringBuilder()
+            for (int i = 0; i < toSend; i++) {
+                if (builder.length() > 0) builder.append('&')
+                builder.append('f').append(i).append('=').append('val')
+            }
+            body = builder.toString()
+        }
+
+        when:
+        HttpResponse<String> response = client.exchange(HttpRequest.POST("/form-limit", body)
+                .contentType(multipart ? MediaType.MULTIPART_FORM_DATA_TYPE : MediaType.APPLICATION_FORM_URLENCODED_TYPE), Argument.STRING, Argument.STRING)
+        then:
+        if (toSend > limitToConfigure) {
+            assert response.status() == HttpStatus.REQUEST_ENTITY_TOO_LARGE
+        } else {
+            assert response.body() == "attributes: " + toSend
+        }
+
+        where:
+        multipart | toSend | limitToConfigure
+        false     | 100    | 128
+        false     | 100    | 64
+        true      | 100    | 128
+        true      | 100    | 64
+    }
+
+    def 'field name length limit'(boolean multipart, int toSend, int limitToConfigure) {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name'                                      : 'FormLimitSpec',
+                'micronaut.server.port'                          : -1,
+                'micronaut.server.netty.form-max-buffered-bytes' : limitToConfigure,
+                'micronaut.http.client.exception-on-error-status': false
+        ])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI).toBlocking()
+
+        def body = " " * toSend
+
+        when:
+        HttpResponse<String> response = client.exchange(HttpRequest.POST("/form-limit", body)
+                .contentType(multipart ? MediaType.MULTIPART_FORM_DATA + ";boundary=abcdef" : MediaType.APPLICATION_FORM_URLENCODED), Argument.STRING, Argument.STRING)
+        then:
+        if (toSend > limitToConfigure) {
+            assert response.status() == HttpStatus.REQUEST_ENTITY_TOO_LARGE
+        } else {
+            assert response.body() == "attributes: 0"
+        }
+
+        where:
+        multipart | toSend | limitToConfigure
+        false     | 100    | 128
+        false     | 100    | 64
+        /* client does not support raw multipart requests atm
+        true      | 100    | 128
+        true      | 100    | 64
+         */
+    }
+
+    @Controller("/form-limit")
+    @Requires(property = "spec.name", value = "FormLimitSpec")
+    static class MyCtrl {
+        @Post
+        @ExecuteOn(TaskExecutors.BLOCKING)
+        @Consumes([MediaType.APPLICATION_FORM_URLENCODED, MediaType.MULTIPART_FORM_DATA])
+        String post(@Body MultipartBody body) {
+            return "attributes: " + Flux.from(body).doOnNext { it.getBytes() }.count().block()
+        }
+    }
+}


### PR DESCRIPTION
For CVE-2024-29025, netty introduced form parsing limits with restrictive defaults. This PR adds config options for them.

Fixes #10825