### PR TITLE
fix: escape `+` to fix rendering in docs

### DIFF
--- a/src/main/docs/guide/httpServer/routing.adoc
+++ b/src/main/docs/guide/httpServer/routing.adoc
@@ -91,7 +91,7 @@ By default, URI variables as defined by the https://tools.ietf.org/html/rfc6570[
 
 This can be problematic if you wish to match or expand entire paths. As per https://tools.ietf.org/html/rfc6570#section-3.2.3[section 3.2.3 of the specification], you can use reserved expansion or matching using the `+` operator.
 
-For example the URI `/books/{+path}` matches both `/books/foo` and `/books/foo/bar` since the `+` indicates that the variable `path` should include reserved characters (in this case `/`).
+For example the URI `/books/{\+path}` matches both `/books/foo` and `/books/foo/bar` since the `+` indicates that the variable `path` should include reserved characters (in this case `/`).
 
 == Routing Annotations
 


### PR DESCRIPTION
before:

<img width="778" alt="Screenshot 2024-07-10 at 22 47 53" src="https://github.com/micronaut-projects/micronaut-core/assets/7002833/92c58781-08d5-4422-aec9-f3cfb86a948c">

after:

<img width="806" alt="Screenshot 2024-07-10 at 22 48 06" src="https://github.com/micronaut-projects/micronaut-core/assets/7002833/53f54b9a-f64e-4529-bc72-c27e2cf38aa8">
