### PR TITLE
Correct reading HTTP client response body without content type + `ByteBuffer` converters

### DIFF
--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBuffer.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBuffer.java
@@ -38,7 +38,7 @@ import java.util.Arrays;
  * @since 1.0
  */
 @Internal
-class NettyByteBuffer implements ByteBuffer<ByteBuf>, ReferenceCounted {
+final class NettyByteBuffer implements ByteBuffer<ByteBuf>, ReferenceCounted {
 
     private ByteBuf delegate;
 

--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferConverters.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferConverters.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.buffer.netty;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.MutableConversionService;
+import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.micronaut.core.io.buffer.ByteBuffer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+
+import java.util.Optional;
+
+/**
+ * Factory for {@link ByteBuf} and {@link NettyByteBuffer} related converters.
+ *
+ * @author Denis Stepanov
+ * @since 4.6
+ */
+@Internal
+public final class NettyByteBufferConverters implements TypeConverterRegistrar {
+    @Override
+    public void register(MutableConversionService conversionService) {
+
+        conversionService.addConverter(
+            NettyByteBuffer.class,
+            ByteBuf.class,
+            NettyByteBuffer::asNativeBuffer
+        );
+
+        conversionService.addConverter(
+            ByteBuf.class,
+            ByteBuffer.class,
+            NettyByteBuffer::new
+        );
+
+        conversionService.addConverter(
+            java.nio.ByteBuffer.class,
+            ByteBuf.class,
+            nioBuffer -> Unpooled.copiedBuffer(nioBuffer)
+        );
+
+        conversionService.addConverter(
+            ByteBuf.class,
+            CharSequence.class,
+            (byteBuf, target, context) -> Optional.of(byteBuf.toString(context.getCharset()))
+        );
+
+        conversionService.addConverter(
+            ByteBuf.class,
+            String.class,
+            (byteBuf, target, context) -> Optional.of(byteBuf.toString(context.getCharset()))
+        );
+
+        conversionService.addConverter(
+            CompositeByteBuf.class,
+            CharSequence.class,
+            (object, targetType, context) -> Optional.of(object.toString(context.getCharset()))
+        );
+
+        conversionService.addConverter(
+            ByteBuf.class,
+            byte[].class,
+            byteBuf -> ByteBufUtil.getBytes(byteBuf)
+        );
+
+        conversionService.addConverter(
+            byte[].class,
+            ByteBuf.class,
+            array -> Unpooled.wrappedBuffer(array)
+        );
+    }
+
+}

--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
@@ -17,8 +17,6 @@ package io.micronaut.buffer.netty;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.MutableConversionService;
-import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.netty.buffer.ByteBuf;
@@ -37,7 +35,7 @@ import java.util.function.Supplier;
 @Internal
 @Singleton
 @BootstrapContextCompatible
-public final class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocator, ByteBuf>, TypeConverterRegistrar {
+public final class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocator, ByteBuf> {
 
     /**
      * Default Netty ByteBuffer Factory.
@@ -58,17 +56,6 @@ public final class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAl
      */
     public NettyByteBufferFactory(ByteBufAllocator allocator) {
         this.allocatorSupplier = () -> allocator;
-    }
-
-    @Override
-    public void register(MutableConversionService conversionService) {
-        conversionService.addConverter(ByteBuf.class, ByteBuffer.class, DEFAULT::wrap);
-        conversionService.addConverter(ByteBuffer.class, ByteBuf.class, byteBuffer -> {
-            if (byteBuffer instanceof NettyByteBuffer) {
-                return (ByteBuf) byteBuffer.asNativeBuffer();
-            }
-            throw new IllegalArgumentException("Unconvertible buffer type " + byteBuffer);
-        });
     }
 
     @Override

--- a/buffer-netty/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
+++ b/buffer-netty/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
@@ -1,0 +1,1 @@
+io.micronaut.buffer.netty.NettyByteBufferConverters

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -381,7 +381,7 @@ public class DefaultHttpClient implements
                     new ClientFilterResolutionContext(null, AnnotationMetadata.EMPTY_METADATA)
             );
         }
-        this.webSocketRegistry = webSocketBeanRegistry != null ? webSocketBeanRegistry : WebSocketBeanRegistry.EMPTY;
+        this.webSocketRegistry = webSocketBeanRegistry;
         this.requestBinderRegistry = requestBinderRegistry;
         this.informationalServiceId = informationalServiceId;
         this.conversionService = conversionService;
@@ -562,18 +562,9 @@ public class DefaultHttpClient implements
                         here.""");
                 }
                 BlockHint blockHint = BlockHint.willBlockThisThread();
-                Flux<HttpResponse<O>> publisher = Flux.from(DefaultHttpClient.this.exchange(request, bodyType, errorType, blockHint));
-                return publisher.doOnNext(res -> {
-                    Optional<ByteBuf> byteBuf = res.getBody(ByteBuf.class);
-                    byteBuf.ifPresent(bb -> {
-                        if (bb.refCnt() > 0) {
-                            ReferenceCountUtil.safeRelease(bb);
-                        }
-                    });
-                    if (res instanceof FullNettyClientHttpResponse response) {
-                        response.onComplete();
-                    }
-                }).blockFirst();
+                return Flux.from(DefaultHttpClient.this.exchange(request, bodyType, errorType, blockHint))
+                    .blockFirst();
+                // We don't have to release client response buffer
             }
 
             @Override
@@ -585,7 +576,7 @@ public class DefaultHttpClient implements
                     return (O) response.getStatus();
                 } else {
                     Optional<O> body = response.getBody();
-                    if (!body.isPresent() && response.getBody(Argument.of(byte[].class)).isPresent()) {
+                    if (body.isEmpty() && response.getBody(Argument.of(byte[].class)).isPresent()) {
                         throw decorate(new HttpClientResponseException(
                         "Failed to decode the body for the given content type [%s]".formatted(response.getContentType().orElse(null)),
                             response
@@ -615,12 +606,12 @@ public class DefaultHttpClient implements
 
     private <I> Publisher<Event<ByteBuffer<?>>> eventStreamOrError(@NonNull io.micronaut.http.HttpRequest<I> request, @NonNull Argument<?> errorType) {
 
-        if (request instanceof MutableHttpRequest httpRequest) {
+        if (request instanceof MutableHttpRequest<?> httpRequest) {
             httpRequest.accept(MediaType.TEXT_EVENT_STREAM_TYPE);
         }
 
         return Flux.create(emitter ->
-                dataStream(request, errorType).subscribe(new Subscriber<ByteBuffer<?>>() {
+                dataStream(request, errorType).subscribe(new Subscriber<>() {
                     private Subscription dataSubscription;
                     private CurrentEvent currentEvent;
 
@@ -672,39 +663,33 @@ public class DefaultHttpClient implements
                                     if (fromIndex < len) {
                                         int toIndex = len - fromIndex;
                                         switch (type) {
-                                            case "data":
-                                                ByteBuffer content = buffer.slice(fromIndex, toIndex);
+                                            case "data" -> {
+                                                ByteBuffer<?> content = buffer.slice(fromIndex, toIndex);
                                                 byte[] d = currentEvent.data;
                                                 if (d == null) {
                                                     currentEvent.data = content.toByteArray();
                                                 } else {
                                                     currentEvent.data = ArrayUtils.concat(d, content.toByteArray());
                                                 }
-
-
-                                                break;
-                                            case "id":
-                                                ByteBuffer id = buffer.slice(fromIndex, toIndex);
+                                            }
+                                            case "id" -> {
+                                                ByteBuffer<?> id = buffer.slice(fromIndex, toIndex);
                                                 currentEvent.id = id.toString(StandardCharsets.UTF_8).trim();
-
-                                                break;
-                                            case "event":
-                                                ByteBuffer event = buffer.slice(fromIndex, toIndex);
+                                            }
+                                            case "event" -> {
+                                                ByteBuffer<?> event = buffer.slice(fromIndex, toIndex);
                                                 currentEvent.name = event.toString(StandardCharsets.UTF_8).trim();
-
-                                                break;
-                                            case "retry":
-                                                ByteBuffer retry = buffer.slice(fromIndex, toIndex);
+                                            }
+                                            case "retry" -> {
+                                                ByteBuffer<?> retry = buffer.slice(fromIndex, toIndex);
                                                 String text = retry.toString(StandardCharsets.UTF_8);
                                                 if (!StringUtils.isEmpty(text)) {
-                                                    Long millis = Long.valueOf(text);
-                                                    currentEvent.retry = Duration.ofMillis(millis);
+                                                    currentEvent.retry = Duration.ofMillis(Long.parseLong(text));
                                                 }
-
-                                                break;
-                                            default:
+                                            }
+                                            default -> {
                                                 // ignore message
-                                                break;
+                                            }
                                         }
                                     }
                                 }
@@ -853,7 +838,7 @@ public class DefaultHttpClient implements
                 return (O) response.getStatus();
             } else {
                 Optional<O> body = response.getBody();
-                if (!body.isPresent() && response.getBody(byte[].class).isPresent()) {
+                if (body.isEmpty() && response.getBody(byte[].class).isPresent()) {
                     throw decorate(new HttpClientResponseException(
                     "Failed to decode the body for the given content type [%s]".formatted(response.getContentType().orElse(null)),
                         response
@@ -1039,7 +1024,7 @@ public class DefaultHttpClient implements
                     AtomicReference<MutableHttpRequest<?>> requestWrapper = new AtomicReference<>(httpRequest);
                     Flux<HttpResponse<?>> proxyResponsePublisher = connectAndStream(request, request, requestURI, requestWrapper, true, false);
                     // apply filters
-                    //noinspection unchecked
+                    //noinspection
                     proxyResponsePublisher = Flux.from(
                             applyFilterToResponsePublisher(
                                     request,
@@ -1286,7 +1271,7 @@ public class DefaultHttpClient implements
      * @throws HttpPostRequestEncoder.ErrorDataEncoderException if there is an encoder exception
      */
     protected NettyRequestWriter buildNettyRequest(
-        MutableHttpRequest request,
+        MutableHttpRequest<?> request,
         URI requestURI,
         MediaType requestContentType,
         boolean permitsBody,
@@ -1308,7 +1293,7 @@ public class DefaultHttpClient implements
 
         HttpPostRequestEncoder postRequestEncoder = null;
         if (permitsBody) {
-            Optional body = request.getBody();
+            Optional<?> body = request.getBody();
             boolean hasBody = body.isPresent();
             if (requestContentType.equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE) && hasBody) {
                 Object bodyValue = body.get();
@@ -1326,7 +1311,7 @@ public class DefaultHttpClient implements
                 postRequestEncoder = buildMultipartRequest(request, bodyValue);
                 return postToWriter(newUri, postRequestEncoder);
             } else {
-                ByteBuf bodyContent = null;
+                ByteBuf bodyContent;
                 if (hasBody) {
                     Object bodyValue = body.get();
                     DynamicMessageBodyWriter dynamicWriter = new DynamicMessageBodyWriter(handlerRegistry, List.of(requestContentType));
@@ -1447,7 +1432,6 @@ public class DefaultHttpClient implements
                                     try {
                                         FullHttpResponse fullHttpResponse = new DefaultFullHttpResponse(nettyResponse.protocolVersion(), nettyResponse.status(), buffer, nettyResponse.headers(), new DefaultHttpHeaders(true));
                                         final FullNettyClientHttpResponse<Object> fullNettyClientHttpResponse = new FullNettyClientHttpResponse<>(fullHttpResponse, handlerRegistry, (Argument<Object>) errorType, true, conversionService);
-                                        fullNettyClientHttpResponse.onComplete();
                                         emitter.error(decorate(new HttpClientResponseException(
                                             fullHttpResponse.status().reasonPhrase(),
                                             null,
@@ -1481,7 +1465,7 @@ public class DefaultHttpClient implements
 
         return Flux.from(loadBalancer.select(getLoadBalancerDiscriminator())).map(server -> {
                     Optional<String> authInfo = server.getMetadata().get(io.micronaut.http.HttpHeaders.AUTHORIZATION_INFO, String.class);
-                    if (request instanceof MutableHttpRequest httpRequest && authInfo.isPresent()) {
+                    if (request instanceof MutableHttpRequest<?> httpRequest && authInfo.isPresent()) {
                         httpRequest.getHeaders().auth(authInfo.get());
                     }
 
@@ -1623,9 +1607,8 @@ public class DefaultHttpClient implements
     }
 
     private ByteBuf charSequenceToByteBuf(CharSequence bodyValue, MediaType requestContentType) {
-        CharSequence charSequence = bodyValue;
         return byteBufferFactory.copiedBuffer(
-                charSequence.toString().getBytes(
+                bodyValue.toString().getBytes(
                         requestContentType.getCharset().orElse(defaultCharset)
                 )
         ).asNativeBuffer();
@@ -1681,7 +1664,7 @@ public class DefaultHttpClient implements
         }
     }
 
-    private HttpPostRequestEncoder buildFormDataRequest(MutableHttpRequest clientHttpRequest, Object bodyValue) throws HttpPostRequestEncoder.ErrorDataEncoderException {
+    private HttpPostRequestEncoder buildFormDataRequest(MutableHttpRequest<?> clientHttpRequest, Object bodyValue) throws HttpPostRequestEncoder.ErrorDataEncoderException {
         HttpPostRequestEncoder postRequestEncoder = new HttpPostRequestEncoder(NettyHttpRequestBuilder.asBuilder(clientHttpRequest).toHttpRequestWithoutBody(), false);
 
         Map<String, Object> formData;
@@ -1693,7 +1676,7 @@ public class DefaultHttpClient implements
         for (Map.Entry<String, Object> entry : formData.entrySet()) {
             Object value = entry.getValue();
             if (value != null) {
-                if (value instanceof Collection collection) {
+                if (value instanceof Collection<?> collection) {
                     for (Object val : collection) {
                         addBodyAttribute(postRequestEncoder, entry.getKey(), val);
                     }
@@ -1712,7 +1695,7 @@ public class DefaultHttpClient implements
         }
     }
 
-    private HttpPostRequestEncoder buildMultipartRequest(MutableHttpRequest clientHttpRequest, Object bodyValue) throws HttpPostRequestEncoder.ErrorDataEncoderException {
+    private HttpPostRequestEncoder buildMultipartRequest(MutableHttpRequest<?> clientHttpRequest, Object bodyValue) throws HttpPostRequestEncoder.ErrorDataEncoderException {
         HttpDataFactory factory = new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE);
         io.netty.handler.codec.http.HttpRequest request = NettyHttpRequestBuilder.asBuilder(clientHttpRequest).toHttpRequestWithoutBody();
         HttpPostRequestEncoder postRequestEncoder = new HttpPostRequestEncoder(factory, request, true, CharsetUtil.UTF_8, HttpPostRequestEncoder.EncoderMode.HTML5);
@@ -1720,7 +1703,7 @@ public class DefaultHttpClient implements
             bodyValue = builder.build();
         }
         if (bodyValue instanceof MultipartBody multipartBody) {
-            postRequestEncoder.setBodyHttpDatas(multipartBody.getData(new MultipartDataFactory<InterfaceHttpData>() {
+            postRequestEncoder.setBodyHttpDatas(multipartBody.getData(new MultipartDataFactory<>() {
                 @NonNull
                 @Override
                 public InterfaceHttpData createFileUpload(@NonNull String name, @NonNull String filename, @NonNull MediaType contentType, @Nullable String encoding, @Nullable Charset charset, long length) {
@@ -2149,7 +2132,7 @@ public class DefaultHttpClient implements
         protected abstract Function<URI, Publisher<? extends O>> makeRedirectHandler(io.micronaut.http.HttpRequest<?> parentRequest, MutableHttpRequest<Object> redirectRequest);
     }
 
-    private class FullHttpResponseHandler<O> extends BaseHttpResponseHandler<HttpResponse<O>> {
+    private final class FullHttpResponseHandler<O> extends BaseHttpResponseHandler<HttpResponse<O>> {
         private final Argument<O> bodyType;
         private final Argument<?> errorType;
         private final ConnectionManager.PoolHandle poolHandle;
@@ -2209,16 +2192,12 @@ public class DefaultHttpClient implements
 
                 if (convertBodyWithBodyType) {
                     responsePromise.trySuccess(response);
-                    response.onComplete();
                 } else { // error flow
                     try {
                         responsePromise.tryFailure(makeErrorFromRequestBody(msg.status(), response));
-                        response.onComplete();
                     } catch (HttpClientResponseException t) {
                         responsePromise.tryFailure(t);
-                        response.onComplete();
                     } catch (Exception t) {
-                        response.onComplete();
                         responsePromise.tryFailure(makeErrorBodyParseError(msg, t));
                     }
                 }
@@ -2276,8 +2255,6 @@ public class DefaultHttpClient implements
                     false,
                     conversionService
             );
-            // this onComplete call disables further parsing by HttpClientResponseException
-            errorResponse.onComplete();
             return decorate(new HttpClientResponseException(
                 "Error decoding HTTP error response body: " + t.getMessage(),
                 t,
@@ -2305,11 +2282,7 @@ public class DefaultHttpClient implements
                     }
                 }
             ));
-            try {
-                forward.accept(clientResponseError);
-            } finally {
-                response.onComplete();
-            }
+            forward.accept(clientResponseError);
         }
 
         @Override
@@ -2326,7 +2299,7 @@ public class DefaultHttpClient implements
         }
     }
 
-    private class StreamHttpResponseHandler extends BaseHttpResponseHandler<MutableHttpResponse<?>> {
+    private final class StreamHttpResponseHandler extends BaseHttpResponseHandler<MutableHttpResponse<?>> {
         static final String NAME_FLOW_CONTROL = ChannelPipelineCustomizer.HANDLER_MICRONAUT_HTTP_RESPONSE + "-flow-control";
         static final String NAME_PUBLISHER = ChannelPipelineCustomizer.HANDLER_MICRONAUT_HTTP_RESPONSE + "-publisher";
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/FullNettyClientHttpResponse.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/FullNettyClientHttpResponse.java
@@ -18,7 +18,6 @@ package io.micronaut.http.client.netty;
 import io.micronaut.buffer.netty.NettyByteBufferFactory;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.async.subscriber.Completable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
@@ -55,7 +54,7 @@ import java.util.Optional;
  * @since 1.0
  */
 @Internal
-public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completable, NettyHttpResponseBuilder {
+public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, NettyHttpResponseBuilder {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultHttpClient.class);
 
@@ -67,7 +66,6 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
     private final Map<Argument, Optional> convertedBodies = new HashMap<>();
     private final MessageBodyHandlerRegistry handlerRegistry;
     private final B body;
-    private boolean complete;
     private final ConversionService conversionService;
 
     /**
@@ -89,8 +87,9 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
         this.nettyHttpResponse = fullHttpResponse;
         // this class doesn't really have lifecycle management (we don't make the user release()
         // it), so we have to copy the data to a non-refcounted buffer.
-        this.unpooledContent = Unpooled.buffer(fullHttpResponse.content().readableBytes());
-        unpooledContent.writeBytes(fullHttpResponse.content(), 0, fullHttpResponse.content().readableBytes());
+        ByteBuf buffer = Unpooled.buffer(fullHttpResponse.content().readableBytes());
+        buffer.writeBytes(fullHttpResponse.content(), 0, fullHttpResponse.content().readableBytes());
+        this.unpooledContent = Unpooled.unreleasableBuffer(buffer);
         this.handlerRegistry = handlerRegistry;
         this.nettyCookies = new NettyCookies(fullHttpResponse.headers(), conversionService);
         Class<?> rawBodyType = bodyType != null ? bodyType.getType() : null;
@@ -170,7 +169,7 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
             final Argument finalArgument = isOptional ? argument.getFirstTypeVariable().orElse(argument) : argument;
             Optional<T> converted;
             try {
-                converted = convertByteBuf(unpooledContent, finalArgument);
+                converted = convertByteBuf(finalArgument);
             } catch (RuntimeException e) {
                 if (code() < 400) {
                     throw e;
@@ -199,8 +198,8 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
         return CharSequence.class.isAssignableFrom(rawBodyType) || Map.class.isAssignableFrom(rawBodyType);
     }
 
-    private <T> Optional<T> convertByteBuf(ByteBuf content, Argument<T> type) {
-        if (content.refCnt() == 0 || content.readableBytes() == 0) {
+    private <T> Optional<T> convertByteBuf(Argument<T> type) {
+        if (unpooledContent.refCnt() == 0 || unpooledContent.readableBytes() == 0) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Full HTTP response received an empty body");
             }
@@ -221,19 +220,14 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
                 MessageBodyReader<T> r = reader.get();
                 MediaType ct = contentType.get();
                 if (r.isReadable(type, ct)) {
-                    return Optional.of(r.read(type, ct, headers, NettyByteBufferFactory.DEFAULT.wrap(content.retainedSlice())));
+                    return Optional.of(r.read(type, ct, headers, NettyByteBufferFactory.DEFAULT.wrap(unpooledContent)));
                 }
             }
         } else if (LOG.isTraceEnabled()) {
             LOG.trace("Missing or unknown Content-Type received from server.");
         }
         // last chance, try type conversion
-        return conversionService.convert(content, ByteBuf.class, type);
-    }
-
-    @Override
-    public void onComplete() {
-        this.complete = true;
+        return conversionService.convert(unpooledContent, ByteBuf.class, type);
     }
 
     @NonNull

--- a/http-client/src/test/groovy/io/micronaut/http/client/ResponseBodySpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ResponseBodySpec.groovy
@@ -2,6 +2,8 @@ package io.micronaut.http.client
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.io.buffer.ByteBuffer
 import io.micronaut.core.type.Argument
 import io.micronaut.core.type.MutableHeaders
 import io.micronaut.http.HttpRequest
@@ -64,6 +66,37 @@ class ResponseBodySpec extends Specification {
             buffer.release()
         then:
             response.getBody(String).get() == "Hello"
+    }
+
+    def "get a ByteBuffer"() {
+        when:
+            def response = httpClient.toBlocking().exchange(HttpRequest.GET("/response-body/string"))
+        then:
+            response.getContentType().isEmpty()
+            response.getBody(ByteBuffer).isPresent()
+    }
+
+    def "get a ByteBuffer 2"() {
+        when:
+            def response = httpClient.toBlocking().exchange(HttpRequest.GET("/response-body/string"))
+        then:
+            response.getContentType().isEmpty()
+        when:
+            def buffer = response.getBody(ByteBuf).get()
+            buffer.release()
+        then:
+            response.getBody(ByteBuffer).isPresent()
+    }
+
+    def "get a ByteBuffer 3"() {
+        when:
+            def response = httpClient.toBlocking().exchange(HttpRequest.GET("/response-body/string"))
+        then:
+            response.getContentType().isEmpty()
+        when:
+            def buffer = response.getBody(ByteBuf).get()
+        then:
+            ConversionService.SHARED.convert(buffer, ByteBuffer).isPresent()
     }
 
     @Requires(property = 'spec.name', value = 'ResponseBodySpec')

--- a/http-client/src/test/groovy/io/micronaut/http/client/ResponseBodySpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ResponseBodySpec.groovy
@@ -1,0 +1,117 @@
+package io.micronaut.http.client
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.MutableHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.body.MessageBodyWriter
+import io.micronaut.http.codec.CodecException
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.buffer.ByteBuf
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class ResponseBodySpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'ResponseBodySpec'
+    ])
+
+    @AutoCleanup
+    HttpClient httpClient = server.applicationContext.createBean(HttpClient, server.getURI())
+
+    def "get a string of empty content type response"() {
+        when:
+            def response = httpClient.toBlocking().exchange(HttpRequest.GET("/response-body/string"))
+
+        then:
+            response.getContentType().isEmpty()
+            response.getBody(String).get() == "Hello"
+    }
+
+    def "get a number of empty content type response"() {
+        when:
+            def response = httpClient.toBlocking().exchange(HttpRequest.GET("/response-body/number"))
+
+        then:
+            response.getContentType().isEmpty()
+            response.getBody(numberClass).get() == numberValue
+
+        where:
+            numberClass || numberValue
+            BigDecimal  || BigDecimal.valueOf(12345)
+            Integer     || Integer.valueOf(12345)
+            Double      || Double.valueOf(12345)
+    }
+
+    def "get a string after releasing ByteRef of empty content type response"() {
+        when:
+            def response = httpClient.toBlocking().exchange(HttpRequest.GET("/response-body/string"))
+        then:
+            response.getContentType().isEmpty()
+        when:
+            def buffer = response.getBody(ByteBuf).get()
+            buffer.release()
+        then:
+            response.getBody(String).get() == "Hello"
+    }
+
+    @Requires(property = 'spec.name', value = 'ResponseBodySpec')
+    @Controller("/response-body")
+    static class BodyController {
+
+        @Get("/string")
+        StringResponseNoContent string() {
+            return new StringResponseNoContent()
+        }
+
+        @Get("/number")
+        NumberResponseNoContent number() {
+            return new NumberResponseNoContent()
+        }
+    }
+
+    static class StringResponseNoContent {}
+
+    static class NumberResponseNoContent {}
+
+    @Requires(property = 'spec.name', value = 'ResponseBodySpec')
+    @Singleton
+    static class StringResponseNoContentWriter implements MessageBodyWriter<StringResponseNoContent> {
+
+        @Override
+        void writeTo(Argument<StringResponseNoContent> type,
+                     MediaType mediaType,
+                     StringResponseNoContent object,
+                     MutableHeaders outgoingHeaders,
+                     OutputStream outputStream) throws CodecException {
+            // Write response without content type
+            outputStream.write("Hello".getBytes(StandardCharsets.UTF_8))
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'ResponseBodySpec')
+    @Singleton
+    static class NumberResponseNoContentWriter implements MessageBodyWriter<NumberResponseNoContent> {
+
+        @Override
+        void writeTo(Argument<NumberResponseNoContent> type,
+                     MediaType mediaType,
+                     NumberResponseNoContent object,
+                     MutableHeaders outgoingHeaders,
+                     OutputStream outputStream) throws CodecException {
+            // Write response without content type
+            outputStream.write("12345".getBytes(StandardCharsets.UTF_8))
+        }
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
@@ -19,7 +19,6 @@ import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ArgumentConversionContext;
-import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
@@ -182,24 +181,6 @@ public final class NettyConverters implements TypeConverterRegistrar {
      */
     public static <T> Optional<T> refCountAwareConvert(ConversionService service, ReferenceCounted input, ArgumentConversionContext<T> context) {
         Optional<T> converted = service.convert(input, context);
-        postProcess(input, converted);
-        return converted;
-    }
-
-    /**
-     * This method converts a
-     * {@link io.netty.util.ReferenceCounted netty reference counted object} and transfers release
-     * ownership to the new object.
-     *
-     * @param service    The conversion service
-     * @param input      The object to convert
-     * @param targetType The type to convert to
-     * @param context    The context to convert with
-     * @param <T>        Target type
-     * @return The converted object
-     */
-    public static <T> Optional<T> refCountAwareConvert(ConversionService service, ReferenceCounted input, Class<T> targetType, ConversionContext context) {
-        Optional<T> converted = service.convert(input, targetType, context);
         postProcess(input, converted);
         return converted;
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
@@ -27,8 +27,6 @@ import io.micronaut.http.server.netty.multipart.NettyCompletedFileUpload;
 import io.micronaut.http.server.netty.multipart.NettyPartData;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.FileUpload;
@@ -55,35 +53,6 @@ public final class NettyConvertersSpi implements TypeConverterRegistrar {
                 CharSequence.class,
                 NettyHttpServerConfiguration.NettyListenerConfiguration.Family.class,
                 new CharSequenceToEnumConverter<>()
-        );
-        conversionService.addConverter(
-                ByteBuf.class,
-                CharSequence.class,
-                (byteBuf, target, context) -> Optional.of(byteBuf.toString(context.getCharset()))
-        );
-
-        conversionService.addConverter(
-                ByteBuf.class,
-                String.class,
-                (byteBuf, target, context) -> Optional.of(byteBuf.toString(context.getCharset()))
-        );
-
-        conversionService.addConverter(
-                CompositeByteBuf.class,
-                CharSequence.class,
-                (object, targetType, context) -> Optional.of(object.toString(context.getCharset()))
-        );
-
-        conversionService.addConverter(
-                ByteBuf.class,
-                byte[].class,
-                (object, targetType, context) -> Optional.of(ByteBufUtil.getBytes(object))
-        );
-
-        conversionService.addConverter(
-                byte[].class,
-                ByteBuf.class,
-                (object, targetType, context) -> Optional.of(Unpooled.wrappedBuffer(object))
         );
 
         conversionService.addConverter(


### PR DESCRIPTION
The buffer of the client response should be discarded 