### PR TITLE
Fix build with JCenter removal

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,10 +8,10 @@ repositories {
 }
 
 dependencies {
-    implementation "org.aim42:htmlSanityCheck:1.1.6"
-    implementation "io.micronaut.build.internal:micronaut-gradle-plugins:6.7.1"
+    implementation libs.htmlsanitycheck
+    implementation libs.micronaut.build.plugins
 
-    implementation "org.tomlj:tomlj:1.1.1"
-    implementation "me.champeau.gradle:japicmp-gradle-plugin:0.4.3"
-    implementation "org.graalvm.buildtools.native:org.graalvm.buildtools.native.gradle.plugin:0.10.2"
+    implementation libs.tomlj
+    implementation libs.japicmp.gradle.plugin
+    implementation libs.native.gradle.plugin
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-geb-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-geb-base.gradle
@@ -1,6 +1,4 @@
 if (System.getProperty('geb.env')) {
-    apply plugin:"com.energizedwork.webdriver-binaries"
-
     webdriverBinaries {
         chromedriver "${chromedriverVersion}"
         geckodriver "${geckodriverVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,10 +43,6 @@ rsapi=http://www.reactive-streams.org/reactive-streams-1.0.3-javadoc
 projectUrl=https://micronaut.io
 developers=Graeme Rocher
 
-# Dependency Versions
-chromedriverVersion=79.0.3945.36
-geckodriverVersion=0.26.0
-webdriverBinariesVersion=1.4
 kotlin.stdlib.default.dependency=false
 
 # For the docs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ graal-svm = "23.1.4"
 h2 = "2.2.224"
 hibernate = "5.5.9.Final"
 htmlunit = "2.70.0"
+htmlsanitycheck = "1.1.6"
 httpcomponents-client = "4.5.14"
 jakarta-inject-api = "2.0.1"
 jakarta-inject-tck = "2.0.1"
@@ -27,6 +28,7 @@ jsr107 = "1.1.1"
 jsr305 = "3.0.2"
 jakarta-el = "5.0.1"
 jakarta-el-impl = "5.0.0-M1"
+japicmp-gradle-plugin="0.4.3"
 jazzer = "0.22.1"
 jcache = "1.1.1"
 junit5 = "5.10.3"
@@ -35,6 +37,7 @@ logback = "1.5.6"
 logbook-netty = "2.16.0"
 log4j = "2.23.1"
 micronaut-aws = "4.5.0"
+micronaut-build-plugins="7.2.0"
 micronaut-groovy = "4.3.0"
 micronaut-session = "4.3.0"
 micronaut-sql = "5.3.0"
@@ -43,6 +46,7 @@ micronaut-validation = "4.6.1"
 micronaut-rxjava2 = "2.3.0"
 micronaut-rxjava3 = "3.3.0"
 micronaut-reactor = "3.3.0"
+native-gradle-plugin = "0.10.2"
 neo4j-java-driver = "5.17.0"
 selenium = "4.9.1"
 slf4j = "2.0.13"
@@ -51,6 +55,7 @@ spock = "2.3-groovy-4.0"
 spotbugs = "4.7.1"
 systemlambda = "1.2.1"
 testcontainers = "1.19.8"
+tomlj="1.1.1"
 vertx = "4.5.8"
 wiremock = "2.33.2"
 
@@ -184,6 +189,7 @@ h2 = { module = "com.h2database:h2", version.ref = "h2" }
 hibernate = { module = "org.hibernate:hibernate-core", version.ref = "hibernate" }
 
 htmlunit = { module = "net.sourceforge.htmlunit:htmlunit", version.ref = "htmlunit" }
+htmlsanitycheck = { module = "org.aim42:htmlSanityCheck", version.ref = "htmlsanitycheck"}
 
 jakarta-inject-api = { module = "jakarta.inject:jakarta.inject-api", version.ref = "jakarta-inject-api" }
 jakarta-inject-tck = { module = "jakarta.inject:jakarta.inject-tck", version.ref = "jakarta-inject-tck" }
@@ -194,7 +200,7 @@ jakarta-el-impl = { module = "org.glassfish:jakarta.el", version.ref = "jakarta-
 javax-inject = { module = "javax.inject:javax.inject", version.ref = "javax-inject" }
 javax-persistence = { module = "javax.persistence:javax.persistence-api", version.ref = "javax-persistence" }
 jakarta-persistence = { module = "jakarta.persistence:jakarta.persistence-api", version.ref = "jakarta-persistence" }
-
+japicmp-gradle-plugin = { module = "me.champeau.gradle:japicmp-gradle-plugin", version.ref = "japicmp-gradle-plugin"}
 jcache = { module = "javax.cache:cache-api", version.ref = "jcache" }
 
 jetty-alpn-openjdk8-client = { module = "org.eclipse.jetty:jetty-alpn-openjdk8-client", version.ref = "jetty" }
@@ -225,6 +231,7 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 logbook-netty = { module = "org.zalando:logbook-netty", version.ref = "logbook-netty" }
 
 micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
+micronaut-build-plugins = { module = "io.micronaut.build.internal:micronaut-gradle-plugins", version.ref="micronaut-build-plugins"}
 micronaut-runtime-groovy = { module = "io.micronaut.groovy:micronaut-runtime-groovy", version.ref = "micronaut-groovy" }
 micronaut-session = { module = "io.micronaut.session:micronaut-session", version.ref = "micronaut-session" }
 micronaut-test-bom = { module = "io.micronaut.test:micronaut-test-bom", version.ref = "micronaut-test" }
@@ -236,6 +243,8 @@ micronaut-test-spock = { module = "io.micronaut.test:micronaut-test-spock", vers
 micronaut-sql-jdbc = { module = "io.micronaut.sql:micronaut-jdbc", version.ref = "micronaut-sql" }
 micronaut-sql-jdbc-tomcat = { module = "io.micronaut.sql:micronaut-jdbc-tomcat", version.ref = "micronaut-sql" }
 mysql-driver = { module = "mysql:mysql-connector-java" }
+
+native-gradle-plugin = { module = "org.graalvm.buildtools.native:org.graalvm.buildtools.native.gradle.plugin", version.ref = "native-gradle-plugin"}
 
 neo4j-bolt = { module = "org.neo4j.driver:neo4j-java-driver", version.ref = "neo4j-java-driver" }
 
@@ -257,6 +266,7 @@ spotbugs = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = 
 
 systemlambda = { module = "com.github.stefanbirkner:system-lambda", version.ref = "systemlambda" }
 
+tomlj = { module = "org.tomlj:tomlj", version.ref="tomlj"}
 micronaut-tracing-jaeger = { module = "io.micronaut.tracing:micronaut-tracing-jaeger" }
 micronaut-tracing-brave = { module = "io.micronaut.tracing:micronaut-tracing-brave" }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.7.1'
+    id 'io.micronaut.build.shared.settings' version '7.2.0'
 }
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
@@ -65,7 +65,6 @@ include "websocket"
 
 // test suites
 include "test-suite"
-include "test-suite-geb"
 include "test-suite-helper"
 include "test-suite-http-client-jdk-ssl"
 include "test-suite-http-client-tck-netty"

--- a/test-suite-geb/build.gradle
+++ b/test-suite-geb/build.gradle
@@ -1,18 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
-
-buildscript {
-    repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-    }
-    dependencies {
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
-    }
-}
-
 plugins {
     id "io.micronaut.build.internal.convention-test-library"
     id 'io.micronaut.build.internal.functional-test'
     id 'java-test-fixtures'
+    alias(libs.plugins.webdriver)
     id 'io.micronaut.build.internal.convention-geb-base'
 }
 


### PR DESCRIPTION
JCenter is now redirecting to Maven Central, so it doesn't serve artifacts which were only in JCenter anymore. Of course, our build had such an artifact. It was brought through the "webdrivers" plugin, which depends on a grolifant version which is not on Maven Central.

Unfortunately, upgrading that plugin is not straightforward. While there is an alternative, there is actually no version which is compatible with Gradle 8.7:

https://github.com/erdi/webdriver-binaries-gradle-plugin/issues/43

At the same time, the `test-geb` module was actually not tested on CI. The only way to run the tests was locally, and the instructions to do so were wrong, so it's unlikely that it gave any useful signal anywhere recently.

As such, this commit removes the `test-suite-geb` module, at least until we have a proper replacement.

Fixes #10988