### PR TITLE
Fix idle timeouts for websockets and streaming connections in 3.8.x

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -606,7 +606,7 @@ final class ConnectionManager {
                 if (readIdleTime.isPresent()) {
                     Duration duration = readIdleTime.get();
                     if (!duration.isNegative()) {
-                        pipeline.addLast(ChannelPipelineCustomizer.HANDLER_IDLE_STATE, new IdleStateHandler(duration.toMillis(), duration.toMillis(), duration.toMillis(), TimeUnit.MILLISECONDS));
+                        pipeline.addLast(ChannelPipelineCustomizer.HANDLER_IDLE_STATE, new IdleStateHandler(0, 0, duration.toMillis(), TimeUnit.MILLISECONDS));
                     }
                 }
 
@@ -1156,12 +1156,7 @@ final class ConnectionManager {
                         if (readIdleTime.isPresent()) {
                             Duration duration = readIdleTime.get();
                             if (!duration.isNegative()) {
-                                p.addLast(ChannelPipelineCustomizer.HANDLER_IDLE_STATE, new IdleStateHandler(
-                                        duration.toMillis(),
-                                        duration.toMillis(),
-                                        duration.toMillis(),
-                                        TimeUnit.MILLISECONDS
-                                ));
+                                p.addLast(ChannelPipelineCustomizer.HANDLER_IDLE_STATE, new IdleStateHandler(0, 0, duration.toMillis(), TimeUnit.MILLISECONDS));
                             }
                         }
                     }


### PR DESCRIPTION
Before this patch, the configured timeout would be applied for the read, write *and* combined streams. That means that if data was only sent in one direction on the connection, the timeout would trigger and the connection would close.

This patch changes the timeout to only apply when no data is sent in either direction.