### PR TITLE
KSP: Generate beans in the process method instead in the finish method

### DIFF
--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MyRepo3Spec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MyRepo3Spec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.kotlin.processing.aop.introduction
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.annotation.processing.test.KotlinCompiler
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.MethodElement
+import io.micronaut.inject.processing.ProcessingException
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+class MyRepo3Spec extends AbstractKotlinCompilerSpec {
+
+    void 'test my repo 3'() {
+        given:
+            def definition = KotlinCompiler.buildIntroducedBeanDefinition('test.MyRepo3', '''
+package test
+
+data class MyEntity(val id: Long, var name: String)
+
+@io.micronaut.kotlin.processing.aop.introduction.RepoDef
+interface MyRepoX : io.micronaut.kotlin.processing.aop.introduction.CrudRepo<MyEntity, Int>
+
+@io.micronaut.kotlin.processing.aop.introduction.RepoDef
+interface MyRepo3 : io.micronaut.kotlin.processing.aop.introduction.CoroutineCrudRepository<MyEntity, Int>
+
+''')
+        expect:
+            definition.getExecutableMethods().size() == 12
+            definition.getExecutableMethods().stream().allMatch { it.hasStereotype(Marker) }
+    }
+
+
+    static class MyRepositoryVisitor implements TypeElementVisitor<Object, Object> {
+
+        boolean enable
+
+        VisitorKind getVisitorKind() {
+            return VisitorKind.ISOLATING
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            enable = element.getSimpleName() == "MyRepo3"
+            if (enable) {
+                // Trigger a second round of BeanDefinitionProcessor
+                context.visitGeneratedSourceFile(
+                        "test",
+                        "HelloWorld",
+                        element
+                ).ifPresent(sourceFile -> {
+                    try {
+                        sourceFile.write(writer -> writer.write("data class HelloWorld"))
+                    } catch (Exception e) {
+                        throw new ProcessingException(element, "Failed to generate a builder: " + e.getMessage(), e);
+                    }
+                })
+            }
+        }
+
+        @Override
+        void visitMethod(MethodElement element, VisitorContext context) {
+            if (enable) {
+                element.annotate(Marker)
+            }
+        }
+    }
+}

--- a/inject-kotlin/src/test/kotlin/io/micronaut/kotlin/processing/aop/introduction/CoroutineCrudRepository.kt
+++ b/inject-kotlin/src/test/kotlin/io/micronaut/kotlin/processing/aop/introduction/CoroutineCrudRepository.kt
@@ -1,0 +1,30 @@
+package io.micronaut.kotlin.processing.aop.introduction
+
+import kotlinx.coroutines.flow.Flow
+
+interface CoroutineCrudRepository<E, ID> {
+
+    suspend fun <S : E> save(entity: S): S
+
+    suspend fun <S : E> update(entity: S): S
+
+    fun <S : E> updateAll(entities: Iterable<S>): Flow<S>
+
+    fun <S : E> saveAll(entities: Iterable<S>): Flow<S>
+
+    suspend fun findById(id: ID): E?
+
+    suspend fun existsById(id: ID): Boolean
+
+    fun findAll(): Flow<E>
+
+    suspend fun count(): Long
+
+    suspend fun deleteById(id: ID): Int
+
+    suspend fun delete(entity: E): Int
+
+    suspend fun deleteAll(entities: Iterable<E>): Int
+
+    suspend fun deleteAll(): Int
+}

--- a/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -11,3 +11,4 @@ io.micronaut.kotlin.processing.visitor.order.MyVisitor3
 io.micronaut.kotlin.processing.annotations.AddsRepeatableAnnotationSpec$AddRepeatableTypeElementVisitor
 io.micronaut.kotlin.processing.annotations.AddsUnseenInnerRepeatableAnnotationSpec$AddUnseenRepeatableTypeElementVisitor
 io.micronaut.kotlin.processing.annotations.AddsUnseenRepeatableAnnotationSpec$AddUnseenRepeatableTypeElementVisitor
+io.micronaut.kotlin.processing.aop.introduction.MyRepo3Spec$MyRepositoryVisitor


### PR DESCRIPTION
The resolver is changed if there is a second round making the caching fail

Fixes https://github.com/micronaut-projects/micronaut-core/issues/11040