### PR TITLE
don’t capture such a generic exception as RuntimeException

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/NettyCorsSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/NettyCorsSpec.groovy
@@ -365,7 +365,7 @@ class NettyCorsSpec extends AbstractMicronautSpec {
 
         @Get("/error")
         String error() {
-            throw new RuntimeException("error")
+            throw new CustomRuntimeException("error")
         }
 
         @Get("/error-checked")
@@ -378,9 +378,15 @@ class NettyCorsSpec extends AbstractMicronautSpec {
             HttpResponse.badRequest()
         }
 
-        @Error(exception = RuntimeException)
+        @Error(exception = CustomRuntimeException)
         HttpResponse onError() {
             HttpResponse.badRequest()
+        }
+    }
+
+    static class CustomRuntimeException extends RuntimeException {
+        CustomRuntimeException(String message) {
+            super(message);
         }
     }
 }


### PR DESCRIPTION
This pull request rewrites the test to avoid capturing such a generic exception as `RuntimeException`