### PR TITLE
Replace the DefaultHttpClient constructors with a builder

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -539,7 +539,9 @@ public class DefaultHttpClient implements
 
     /**
      * @return The {@link MediaTypeCodecRegistry} used by this client
+     * @deprecated Use body handlers instead
      */
+    @Deprecated
     public MediaTypeCodecRegistry getMediaTypeCodecRegistry() {
         return mediaTypeCodecRegistry;
     }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -477,6 +477,12 @@ public class DefaultHttpClient implements
         );
     }
 
+    /**
+     * Create a new builder for a {@link DefaultHttpClient}.
+     *
+     * @return The builder
+     * @since 4.7.0
+     */
     @NonNull
     public static DefaultHttpClientBuilder builder() {
         return new DefaultHttpClientBuilder();

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -33,7 +33,6 @@ import io.micronaut.core.io.buffer.ReferenceCounted;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.type.Argument;
-import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.ObjectUtils;
 import io.micronaut.core.util.StringUtils;
@@ -69,7 +68,6 @@ import io.micronaut.http.client.exceptions.NoHostException;
 import io.micronaut.http.client.exceptions.ReadTimeoutException;
 import io.micronaut.http.client.exceptions.ResponseClosedException;
 import io.micronaut.http.client.filter.ClientFilterResolutionContext;
-import io.micronaut.http.client.filter.DefaultHttpClientFilterResolver;
 import io.micronaut.http.client.filters.ClientServerContextFilter;
 import io.micronaut.http.client.multipart.MultipartBody;
 import io.micronaut.http.client.multipart.MultipartDataFactory;
@@ -131,8 +129,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioDatagramChannel;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -190,7 +186,6 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -277,7 +272,9 @@ public class DefaultHttpClient implements
      * @param annotationMetadataResolver      The annotation metadata resolver
      * @param conversionService               The conversion service
      * @param filters                         The filters to use
+     * @deprecated Please go through the {@link #builder()} instead. If you need access to properties that are not public in the builder, make them public in core and document their usage.
      */
+    @Deprecated
     public DefaultHttpClient(@Nullable LoadBalancer loadBalancer,
                              @NonNull HttpClientConfiguration configuration,
                              @Nullable String contextPath,
@@ -288,25 +285,19 @@ public class DefaultHttpClient implements
                              @Nullable AnnotationMetadataResolver annotationMetadataResolver,
                              ConversionService conversionService,
                              HttpClientFilter... filters) {
-        this(loadBalancer,
-            null,
-            configuration,
-            contextPath,
-            new DefaultHttpClientFilterResolver(null, annotationMetadataResolver, Arrays.asList(filters)),
-            null,
-            threadFactory,
-            nettyClientSslBuilder,
-            codecRegistry,
-            handlerRegistry,
-            WebSocketBeanRegistry.EMPTY,
-            new DefaultRequestBinderRegistry(conversionService),
-            null,
-            NioSocketChannel::new,
-            NioDatagramChannel::new,
-            CompositeNettyClientCustomizer.EMPTY,
-            null,
-            conversionService,
-            null);
+        this(
+            builder()
+                .loadBalancer(loadBalancer)
+                .configuration(configuration)
+                .contextPath(contextPath)
+                .threadFactory(threadFactory)
+                .nettyClientSslBuilder(nettyClientSslBuilder)
+                .codecRegistry(codecRegistry)
+                .handlerRegistry(handlerRegistry)
+                .conversionService(conversionService)
+                .annotationMetadataResolver(annotationMetadataResolver)
+                .filters(filters)
+        );
     }
 
     /**
@@ -330,7 +321,9 @@ public class DefaultHttpClient implements
      * @param informationalServiceId          Optional service ID that will be passed to exceptions created by this client
      * @param conversionService               The conversion service
      * @param resolverGroup                   Optional predefined resolver group
+     * @deprecated Please go through the {@link #builder()} instead. If you need access to properties that are not public in the builder, make them public in core and document their usage.
      */
+    @Deprecated
     public DefaultHttpClient(@Nullable LoadBalancer loadBalancer,
                              @Nullable HttpVersionSelection explicitHttpVersion,
                              @NonNull HttpClientConfiguration configuration,
@@ -351,75 +344,105 @@ public class DefaultHttpClient implements
                              ConversionService conversionService,
                              @Nullable AddressResolverGroup<?> resolverGroup
     ) {
-        ArgumentUtils.requireNonNull("nettyClientSslBuilder", nettyClientSslBuilder);
-        ArgumentUtils.requireNonNull("codecRegistry", codecRegistry);
-        ArgumentUtils.requireNonNull("webSocketBeanRegistry", webSocketBeanRegistry);
-        ArgumentUtils.requireNonNull("requestBinderRegistry", requestBinderRegistry);
-        ArgumentUtils.requireNonNull("configuration", configuration);
-        ArgumentUtils.requireNonNull("filterResolver", filterResolver);
-        ArgumentUtils.requireNonNull("socketChannelFactory", socketChannelFactory);
-        this.loadBalancer = loadBalancer;
+        this(
+            builder()
+                .loadBalancer(loadBalancer)
+                .explicitHttpVersion(explicitHttpVersion)
+                .configuration(configuration)
+                .contextPath(contextPath)
+                .filterResolver(filterResolver)
+                .clientFilterEntries(clientFilterEntries)
+                .threadFactory(threadFactory)
+                .nettyClientSslBuilder(nettyClientSslBuilder)
+                .codecRegistry(codecRegistry)
+                .handlerRegistry(handlerRegistry)
+                .webSocketBeanRegistry(webSocketBeanRegistry)
+                .requestBinderRegistry(requestBinderRegistry)
+                .eventLoopGroup(eventLoopGroup)
+                .socketChannelFactory(socketChannelFactory)
+                .udpChannelFactory(udpChannelFactory)
+                .clientCustomizer(clientCustomizer)
+                .informationalServiceId(informationalServiceId)
+                .conversionService(conversionService)
+                .resolverGroup(resolverGroup)
+        );
+    }
+
+    DefaultHttpClient(DefaultHttpClientBuilder builder) {
+        this.loadBalancer = builder.loadBalancer;
+        this.configuration = builder.configuration == null ? new DefaultHttpClientConfiguration() : builder.configuration;
         this.defaultCharset = configuration.getDefaultCharset();
-        if (StringUtils.isNotEmpty(contextPath)) {
-            if (contextPath.charAt(0) != '/') {
-                contextPath = '/' + contextPath;
+        if (StringUtils.isNotEmpty(builder.contextPath)) {
+            if (builder.contextPath.charAt(0) != '/') {
+                builder.contextPath = '/' + builder.contextPath;
             }
-            this.contextPath = contextPath;
+            this.contextPath = builder.contextPath;
         } else {
             this.contextPath = null;
         }
-        this.configuration = configuration;
 
-        this.mediaTypeCodecRegistry = codecRegistry;
-        this.handlerRegistry = handlerRegistry;
+        this.mediaTypeCodecRegistry = builder.codecRegistry == null ? createDefaultMediaTypeRegistry() : builder.codecRegistry;
+        this.handlerRegistry = builder.handlerRegistry == null ? createDefaultMessageBodyHandlerRegistry() : builder.handlerRegistry;
         this.log = configuration.getLoggerName().map(LoggerFactory::getLogger).orElse(DEFAULT_LOG);
-        this.filterResolver = filterResolver;
-        if (clientFilterEntries != null) {
-            this.clientFilterEntries = clientFilterEntries;
+        if (builder.filterResolver == null) {
+            builder.filters();
+        }
+        this.filterResolver = builder.filterResolver;
+        if (builder.clientFilterEntries != null) {
+            this.clientFilterEntries = builder.clientFilterEntries;
         } else {
-            this.clientFilterEntries = filterResolver.resolveFilterEntries(
+            this.clientFilterEntries = builder.filterResolver.resolveFilterEntries(
                     new ClientFilterResolutionContext(null, AnnotationMetadata.EMPTY_METADATA)
             );
         }
-        this.webSocketRegistry = webSocketBeanRegistry;
-        this.requestBinderRegistry = requestBinderRegistry;
-        this.informationalServiceId = informationalServiceId;
-        this.conversionService = conversionService;
+        this.webSocketRegistry = builder.webSocketBeanRegistry;
+        this.conversionService = builder.conversionService;
+        this.requestBinderRegistry = builder.requestBinderRegistry == null ? new DefaultRequestBinderRegistry(conversionService) : builder.requestBinderRegistry;
+        this.informationalServiceId = builder.informationalServiceId;
 
         this.connectionManager = new ConnectionManager(
             log,
-            eventLoopGroup,
-            threadFactory,
+            builder.eventLoopGroup,
+            builder.threadFactory == null ? new DefaultThreadFactory(MultithreadEventLoopGroup.class) : builder.threadFactory,
             configuration,
-            explicitHttpVersion,
-            socketChannelFactory,
-            udpChannelFactory,
-            nettyClientSslBuilder,
-            clientCustomizer,
-            informationalServiceId,
-            resolverGroup);
+            builder.explicitHttpVersion,
+            builder.socketChannelFactory,
+            builder.udpChannelFactory,
+            builder.nettyClientSslBuilder == null ? new NettyClientSslBuilder(new ResourceResolver()) : builder.nettyClientSslBuilder,
+            builder.clientCustomizer,
+            builder.informationalServiceId,
+            builder.resolverGroup);
     }
 
     /**
      * @param uri The URL
+     * @deprecated Please go through the {@link #builder()} instead.
      */
+    @Deprecated
     public DefaultHttpClient(@Nullable URI uri) {
-        this(uri, new DefaultHttpClientConfiguration());
+        this(builder().uri(uri));
     }
 
     /**
-     *
+     * @deprecated Please go through the {@link #builder()} instead.
      */
+    @Deprecated
     public DefaultHttpClient() {
-        this((URI) null, new DefaultHttpClientConfiguration());
+        this(builder());
     }
 
     /**
      * @param uri           The URI
      * @param configuration The {@link HttpClientConfiguration} object
+     * @deprecated Please go through the {@link #builder()} instead.
      */
+    @Deprecated
     public DefaultHttpClient(@Nullable URI uri, @NonNull HttpClientConfiguration configuration) {
-        this(uri, configuration, new NettyClientSslBuilder(new ResourceResolver()));
+        this(
+            builder()
+                .uri(uri)
+                .configuration(configuration)
+        );
     }
 
     /**
@@ -428,29 +451,35 @@ public class DefaultHttpClient implements
      * @param uri           The URI
      * @param configuration The {@link HttpClientConfiguration} object
      * @param clientSslBuilder The SSL builder
+     * @deprecated Please go through the {@link #builder()} instead.
      */
+    @Deprecated
     public DefaultHttpClient(@Nullable URI uri, @NonNull HttpClientConfiguration configuration, @NonNull ClientSslBuilder clientSslBuilder) {
         this(
-            uri == null ? null : LoadBalancer.fixed(uri), configuration, null, new DefaultThreadFactory(MultithreadEventLoopGroup.class),
-            clientSslBuilder,
-            createDefaultMediaTypeRegistry(),
-            createDefaultMessageBodyHandlerRegistry(),
-            AnnotationMetadataResolver.DEFAULT,
-            ConversionService.SHARED);
+            builder()
+                .uri(uri)
+                .configuration(configuration)
+                .nettyClientSslBuilder(clientSslBuilder)
+        );
     }
 
     /**
      * @param loadBalancer  The {@link LoadBalancer} to use for selecting servers
      * @param configuration The {@link HttpClientConfiguration} object
+     * @deprecated Please go through the {@link #builder()} instead. If you need access to properties that are not public in the builder, make them public in core and document their usage.
      */
+    @Deprecated
     public DefaultHttpClient(@Nullable LoadBalancer loadBalancer, HttpClientConfiguration configuration) {
-        this(loadBalancer,
-            configuration, null, new DefaultThreadFactory(MultithreadEventLoopGroup.class),
-            new NettyClientSslBuilder(new ResourceResolver()),
-            createDefaultMediaTypeRegistry(),
-            createDefaultMessageBodyHandlerRegistry(),
-            AnnotationMetadataResolver.DEFAULT,
-            ConversionService.SHARED);
+        this(
+            builder()
+                .loadBalancer(loadBalancer)
+                .configuration(configuration)
+        );
+    }
+
+    @NonNull
+    public static DefaultHttpClientBuilder builder() {
+        return new DefaultHttpClientBuilder();
     }
 
     static boolean isAcceptEvents(io.micronaut.http.HttpRequest<?> request) {
@@ -513,8 +542,9 @@ public class DefaultHttpClient implements
      * Sets the {@link MediaTypeCodecRegistry} used by this client.
      *
      * @param mediaTypeCodecRegistry The registry to use. Should not be null
+     * @deprecated Use builder instead
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public void setMediaTypeCodecRegistry(MediaTypeCodecRegistry mediaTypeCodecRegistry) {
         if (mediaTypeCodecRegistry != null) {
             this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
@@ -535,7 +565,9 @@ public class DefaultHttpClient implements
      * Set the handler registry for this client.
      *
      * @param handlerRegistry The handler registry
+     * @deprecated Use builder instead
      */
+    @Deprecated(forRemoval = true)
     public final void setHandlerRegistry(@NonNull MessageBodyHandlerRegistry handlerRegistry) {
         this.handlerRegistry = handlerRegistry;
     }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClientBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClientBuilder.java
@@ -182,7 +182,15 @@ public final class DefaultHttpClientBuilder {
         return this;
     }
 
+    /**
+     * Set the codec registry. This has mostly been replaced by body handlers by now.
+     *
+     * @param codecRegistry The codec registry
+     * @return This builder
+     * @deprecated Use body handlers instead
+     */
     @NonNull
+    @Deprecated
     DefaultHttpClientBuilder codecRegistry(@NonNull MediaTypeCodecRegistry codecRegistry) {
         ArgumentUtils.requireNonNull("codecRegistry", codecRegistry);
         this.codecRegistry = codecRegistry;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClientBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClientBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client.netty;
 
 import io.micronaut.core.annotation.AnnotationMetadataResolver;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClientBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClientBuilder.java
@@ -1,0 +1,253 @@
+package io.micronaut.http.client.netty;
+
+import io.micronaut.core.annotation.AnnotationMetadataResolver;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.http.bind.RequestBinderRegistry;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.http.client.HttpClientConfiguration;
+import io.micronaut.http.client.HttpVersionSelection;
+import io.micronaut.http.client.LoadBalancer;
+import io.micronaut.http.client.filter.ClientFilterResolutionContext;
+import io.micronaut.http.client.filter.DefaultHttpClientFilterResolver;
+import io.micronaut.http.client.netty.ssl.ClientSslBuilder;
+import io.micronaut.http.codec.MediaTypeCodecRegistry;
+import io.micronaut.http.filter.HttpClientFilter;
+import io.micronaut.http.filter.HttpClientFilterResolver;
+import io.micronaut.http.filter.HttpFilterResolver;
+import io.micronaut.websocket.context.WebSocketBeanRegistry;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.resolver.AddressResolverGroup;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * While {@link DefaultHttpClient} is internal API, there are a few uses outside micronaut-core
+ * that use it directly, in particular micronaut-oracle-cloud. This builder acts as API for those
+ * users.
+ * <p>
+ * If you need to make a method of this builder public, please document the module that uses it.
+ *
+ * @author Jonas Konrad
+ * @since 4.7.0
+ */
+@Internal
+public final class DefaultHttpClientBuilder {
+    @Nullable
+    LoadBalancer loadBalancer = null;
+    @Nullable
+    HttpVersionSelection explicitHttpVersion = null;
+    HttpClientConfiguration configuration;
+    @Nullable
+    String contextPath = null;
+    @NonNull
+    AnnotationMetadataResolver annotationMetadataResolver = AnnotationMetadataResolver.DEFAULT;
+    HttpClientFilterResolver<ClientFilterResolutionContext> filterResolver;
+    List<HttpFilterResolver.FilterEntry> clientFilterEntries = null;
+    @Nullable
+    ThreadFactory threadFactory;
+    ClientSslBuilder nettyClientSslBuilder;
+    MediaTypeCodecRegistry codecRegistry;
+    MessageBodyHandlerRegistry handlerRegistry;
+    @NonNull
+    WebSocketBeanRegistry webSocketBeanRegistry = WebSocketBeanRegistry.EMPTY;
+    RequestBinderRegistry requestBinderRegistry;
+    @Nullable
+    EventLoopGroup eventLoopGroup = null;
+    @NonNull
+    ChannelFactory<? extends Channel> socketChannelFactory = NioSocketChannel::new;
+    @NonNull
+    ChannelFactory<? extends Channel> udpChannelFactory = NioDatagramChannel::new;
+    NettyClientCustomizer clientCustomizer = CompositeNettyClientCustomizer.EMPTY;
+    @Nullable
+    String informationalServiceId = null;
+    @NonNull
+    ConversionService conversionService = ConversionService.SHARED;
+    @Nullable
+    AddressResolverGroup<?> resolverGroup = null;
+
+    DefaultHttpClientBuilder() {
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder loadBalancer(@Nullable LoadBalancer loadBalancer) {
+        this.loadBalancer = loadBalancer;
+        return this;
+    }
+
+    /**
+     * Set the optional URI for this client to use as the root.
+     *
+     * @param uri The URI
+     * @return This builder
+     */
+    @NonNull
+    public DefaultHttpClientBuilder uri(@Nullable URI uri) {
+        return loadBalancer(uri == null ? null : LoadBalancer.fixed(uri));
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder explicitHttpVersion(@Nullable HttpVersionSelection explicitHttpVersion) {
+        this.explicitHttpVersion = explicitHttpVersion;
+        return this;
+    }
+
+    /**
+     * Set the configuration.
+     *
+     * @param configuration The client configuration
+     * @return This builder
+     */
+    @NonNull
+    public DefaultHttpClientBuilder configuration(@NonNull HttpClientConfiguration configuration) {
+        ArgumentUtils.requireNonNull("configuration", configuration);
+        this.configuration = configuration;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder contextPath(@Nullable String contextPath) {
+        this.contextPath = contextPath;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder filterResolver(@NonNull HttpClientFilterResolver<ClientFilterResolutionContext> filterResolver) {
+        ArgumentUtils.requireNonNull("filterResolver", filterResolver);
+        this.filterResolver = filterResolver;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder annotationMetadataResolver(@Nullable AnnotationMetadataResolver annotationMetadataResolver) {
+        if (annotationMetadataResolver != null) {
+            this.annotationMetadataResolver = annotationMetadataResolver;
+        }
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder filters(HttpClientFilter... filters) {
+        return filterResolver(new DefaultHttpClientFilterResolver(null, annotationMetadataResolver, Arrays.asList(filters)));
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder clientFilterEntries(@Nullable List<HttpFilterResolver.FilterEntry> clientFilterEntries) {
+        this.clientFilterEntries = clientFilterEntries;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder threadFactory(@Nullable ThreadFactory threadFactory) {
+        this.threadFactory = threadFactory;
+        return this;
+    }
+
+    /**
+     * The netty SSL context builder. Used by the micronaut-oracle-cloud OKE workload identity
+     * client.
+     *
+     * @param nettyClientSslBuilder The SSL context builder
+     * @return This builder
+     */
+    @NonNull
+    public DefaultHttpClientBuilder nettyClientSslBuilder(@NonNull ClientSslBuilder nettyClientSslBuilder) {
+        ArgumentUtils.requireNonNull("nettyClientSslBuilder", nettyClientSslBuilder);
+        this.nettyClientSslBuilder = nettyClientSslBuilder;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder codecRegistry(@NonNull MediaTypeCodecRegistry codecRegistry) {
+        ArgumentUtils.requireNonNull("codecRegistry", codecRegistry);
+        this.codecRegistry = codecRegistry;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder handlerRegistry(@NonNull MessageBodyHandlerRegistry handlerRegistry) {
+        ArgumentUtils.requireNonNull("handlerRegistry", handlerRegistry);
+        this.handlerRegistry = handlerRegistry;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder webSocketBeanRegistry(@NonNull WebSocketBeanRegistry webSocketBeanRegistry) {
+        ArgumentUtils.requireNonNull("webSocketBeanRegistry", webSocketBeanRegistry);
+        this.webSocketBeanRegistry = webSocketBeanRegistry;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder requestBinderRegistry(@NonNull RequestBinderRegistry requestBinderRegistry) {
+        ArgumentUtils.requireNonNull("requestBinderRegistry", requestBinderRegistry);
+        this.requestBinderRegistry = requestBinderRegistry;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder eventLoopGroup(@Nullable EventLoopGroup eventLoopGroup) {
+        this.eventLoopGroup = eventLoopGroup;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder socketChannelFactory(@NonNull ChannelFactory<? extends Channel> socketChannelFactory) {
+        ArgumentUtils.requireNonNull("socketChannelFactory", socketChannelFactory);
+        this.socketChannelFactory = socketChannelFactory;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder udpChannelFactory(@NonNull ChannelFactory<? extends Channel> udpChannelFactory) {
+        ArgumentUtils.requireNonNull("udpChannelFactory", udpChannelFactory);
+        this.udpChannelFactory = udpChannelFactory;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder clientCustomizer(@NonNull NettyClientCustomizer clientCustomizer) {
+        ArgumentUtils.requireNonNull("clientCustomizer", clientCustomizer);
+        this.clientCustomizer = clientCustomizer;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder informationalServiceId(@Nullable String informationalServiceId) {
+        this.informationalServiceId = informationalServiceId;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder conversionService(@NonNull ConversionService conversionService) {
+        ArgumentUtils.requireNonNull("conversionService", conversionService);
+        this.conversionService = conversionService;
+        return this;
+    }
+
+    @NonNull
+    DefaultHttpClientBuilder resolverGroup(@Nullable AddressResolverGroup<?> resolverGroup) {
+        this.resolverGroup = resolverGroup;
+        return this;
+    }
+
+    /**
+     * Build the final HTTP client. This method may only be called once.
+     *
+     * @return The client
+     */
+    @NonNull
+    public DefaultHttpClient build() {
+        return new DefaultHttpClient(this);
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -77,8 +77,6 @@ import io.micronaut.websocket.context.WebSocketBeanRegistry;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.socket.DatagramChannel;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.resolver.AddressResolverGroup;
 import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
@@ -449,8 +447,8 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
             .handlerRegistry(handlerRegistry)
             .webSocketBeanRegistry(WebSocketBeanRegistry.forClient(beanContext))
             .eventLoopGroup(resolveEventLoopGroup(configuration, beanContext))
-            .socketChannelFactory(resolveSocketChannelFactory(NettyChannelType.CLIENT_SOCKET, SocketChannel.class, configuration, beanContext))
-            .udpChannelFactory(resolveSocketChannelFactory(NettyChannelType.DATAGRAM_SOCKET, DatagramChannel.class, configuration, beanContext))
+            .socketChannelFactory(resolveSocketChannelFactory(NettyChannelType.CLIENT_SOCKET, configuration, beanContext))
+            .udpChannelFactory(resolveSocketChannelFactory(NettyChannelType.DATAGRAM_SOCKET, configuration, beanContext))
             .clientCustomizer(clientCustomizer)
             .informationalServiceId(clientId)
             .conversionService(beanContext.getBean(ConversionService.class))
@@ -494,7 +492,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
         }
     }
 
-    private <C extends Channel> ChannelFactory<? extends C> resolveSocketChannelFactory(NettyChannelType type, Class<C> channelClass, HttpClientConfiguration configuration, BeanContext beanContext) {
+    private ChannelFactory<? extends Channel> resolveSocketChannelFactory(NettyChannelType type, HttpClientConfiguration configuration, BeanContext beanContext) {
         final String eventLoopGroup = configuration.getEventLoopGroup();
 
         final EventLoopGroupConfiguration eventLoopGroupConfiguration = beanContext.findBean(EventLoopGroupConfiguration.class, Qualifiers.byName(eventLoopGroup))
@@ -506,7 +504,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                     }
                 });
 
-        return () -> channelClass.cast(eventLoopGroupFactory.channelInstance(type, eventLoopGroupConfiguration));
+        return () -> eventLoopGroupFactory.channelInstance(type, eventLoopGroupConfiguration);
     }
 
     private ClientKey getClientKey(AnnotationMetadata metadata) {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -30,7 +30,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.FilterMatcher;
-import io.micronaut.http.bind.DefaultRequestBinderRegistry;
 import io.micronaut.http.bind.RequestBinderRegistry;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.body.MessageBodyReader;
@@ -378,19 +377,19 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
             }
 
 
-            final DefaultHttpClient client = buildClient(
-                    loadBalancer,
-                    clientKey.httpVersion,
+            final DefaultHttpClientBuilder builder = clientBuilder(
                     configuration,
                     clientId,
-                    contextPath,
                     beanContext,
                     annotationMetadata
-            );
+            )
+                .loadBalancer(loadBalancer)
+                .explicitHttpVersion(clientKey.httpVersion)
+                .contextPath(contextPath);
             final JsonFeatures jsonFeatures = clientKey.jsonFeatures;
             if (jsonFeatures != null) {
                 List<MediaTypeCodec> codecs = new ArrayList<>(2);
-                MediaTypeCodecRegistry codecRegistry = client.getMediaTypeCodecRegistry();
+                MediaTypeCodecRegistry codecRegistry = builder.codecRegistry;
                 for (MediaTypeCodec codec : codecRegistry.getCodecs()) {
                     if (codec instanceof MapperMediaTypeCodec typeCodec) {
                         codecs.add(typeCodec.cloneWithFeatures(jsonFeatures));
@@ -401,10 +400,9 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                 if (!codecRegistry.findCodec(MediaType.APPLICATION_JSON_TYPE).isPresent()) {
                     codecs.add(createNewJsonCodec(this.beanContext, jsonFeatures));
                 }
-                client.setMediaTypeCodecRegistry(MediaTypeCodecRegistry.of(codecs));
-
-                client.setHandlerRegistry(new MessageBodyHandlerRegistry() {
-                    final MessageBodyHandlerRegistry delegate = client.getHandlerRegistry();
+                builder.codecRegistry(MediaTypeCodecRegistry.of(codecs));
+                builder.handlerRegistry(new MessageBodyHandlerRegistry() {
+                    final MessageBodyHandlerRegistry delegate = builder.handlerRegistry;
 
                     @SuppressWarnings("unchecked")
                     private <T> T customize(T handler) {
@@ -425,49 +423,38 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                     }
                 });
             }
-            return client;
+            return builder.build();
         });
     }
 
-    private DefaultHttpClient buildClient(
-            LoadBalancer loadBalancer,
-            HttpVersionSelection httpVersion,
+    private DefaultHttpClientBuilder clientBuilder(
             HttpClientConfiguration configuration,
             String clientId,
-            String contextPath,
             BeanContext beanContext,
             AnnotationMetadata annotationMetadata) {
 
-        EventLoopGroup eventLoopGroup = resolveEventLoopGroup(configuration, beanContext);
-        ConversionService conversionService = beanContext.getBean(ConversionService.class);
         String addressResolverGroupName = configuration.getAddressResolverGroupName();
-        AddressResolverGroup<?> resolverGroup = addressResolverGroupName == null ? null : beanContext.getBean(AddressResolverGroup.class, Qualifiers.byName(addressResolverGroupName));
-        return new DefaultHttpClient(
-                loadBalancer,
-                httpVersion,
-                configuration,
-                contextPath,
-                clientFilterResolver,
-                clientFilterResolver.resolveFilterEntries(new ClientFilterResolutionContext(
-                        clientId == null ? null : Collections.singletonList(clientId),
-                        annotationMetadata
-                )),
-                threadFactory,
-                nettyClientSslBuilder,
-                codecRegistry,
-                handlerRegistry,
-                WebSocketBeanRegistry.forClient(beanContext),
-                beanContext.findBean(RequestBinderRegistry.class).orElseGet(() ->
-                        new DefaultRequestBinderRegistry(conversionService)
-                ),
-                eventLoopGroup,
-                resolveSocketChannelFactory(NettyChannelType.CLIENT_SOCKET, SocketChannel.class, configuration, beanContext),
-                resolveSocketChannelFactory(NettyChannelType.DATAGRAM_SOCKET, DatagramChannel.class, configuration, beanContext),
-                clientCustomizer,
-                clientId,
-                conversionService,
-                resolverGroup
-        );
+        DefaultHttpClientBuilder builder = DefaultHttpClient.builder();
+        beanContext.findBean(RequestBinderRegistry.class).ifPresent(builder::requestBinderRegistry);
+        return builder
+            .configuration(configuration)
+            .filterResolver(clientFilterResolver)
+            .clientFilterEntries(clientFilterResolver.resolveFilterEntries(new ClientFilterResolutionContext(
+                clientId == null ? null : Collections.singletonList(clientId),
+                annotationMetadata
+            )))
+            .threadFactory(threadFactory)
+            .nettyClientSslBuilder(nettyClientSslBuilder)
+            .codecRegistry(codecRegistry)
+            .handlerRegistry(handlerRegistry)
+            .webSocketBeanRegistry(WebSocketBeanRegistry.forClient(beanContext))
+            .eventLoopGroup(resolveEventLoopGroup(configuration, beanContext))
+            .socketChannelFactory(resolveSocketChannelFactory(NettyChannelType.CLIENT_SOCKET, SocketChannel.class, configuration, beanContext))
+            .udpChannelFactory(resolveSocketChannelFactory(NettyChannelType.DATAGRAM_SOCKET, DatagramChannel.class, configuration, beanContext))
+            .clientCustomizer(clientCustomizer)
+            .informationalServiceId(clientId)
+            .conversionService(beanContext.getBean(ConversionService.class))
+            .resolverGroup(addressResolverGroupName == null ? null : beanContext.getBean(AddressResolverGroup.class, Qualifiers.byName(addressResolverGroupName)));
     }
 
     private EventLoopGroup resolveEventLoopGroup(HttpClientConfiguration configuration, BeanContext beanContext) {
@@ -491,15 +478,15 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
             if (configuration == null) {
                 configuration = defaultHttpClientConfiguration;
             }
-            DefaultHttpClient c = buildClient(
-                loadBalancer,
-                null,
+            DefaultHttpClient c = clientBuilder(
                 configuration,
                 null,
-                loadBalancer.getContextPath().orElse(null),
                 beanContext,
                 AnnotationMetadata.EMPTY_METADATA
-            );
+            )
+                .loadBalancer(loadBalancer)
+                .contextPath(loadBalancer.getContextPath().orElse(null))
+                .build();
             balancedClients.add(c);
             return c;
         } else {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClientFactory.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClientFactory.java
@@ -30,9 +30,9 @@ import io.micronaut.http.client.sse.SseClientFactory;
 import io.micronaut.websocket.WebSocketClient;
 import io.micronaut.websocket.WebSocketClientFactory;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URI;
 
 /**
  * A factory to create Netty HTTP clients.
@@ -125,10 +125,10 @@ public class NettyHttpClientFactory implements
     }
 
     private DefaultHttpClient createNettyClient(URI uri) {
-        return new DefaultHttpClient(uri);
+        return DefaultHttpClient.builder().uri(uri).build();
     }
 
     private DefaultHttpClient createNettyClient(URI uri, HttpClientConfiguration configuration) {
-        return new DefaultHttpClient(uri, configuration);
+        return DefaultHttpClient.builder().uri(uri).configuration(configuration).build();
     }
 }

--- a/http-client/src/test/groovy/io/micronaut/http/body/BodyReadersSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/body/BodyReadersSpec.groovy
@@ -11,7 +11,7 @@ import spock.lang.Unroll
 class BodyReadersSpec extends Specification {
 
     @AutoCleanup
-    DefaultHttpClient httpClient = new DefaultHttpClient((URI) null)
+    DefaultHttpClient httpClient = DefaultHttpClient.builder().build()
 
     @Unroll
     void "test type handlers"() {

--- a/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
@@ -22,8 +22,8 @@ import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Put
-import io.micronaut.http.client.HttpClientConfiguration
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.HttpClientConfiguration
 import io.micronaut.http.client.ServiceHttpClientConfiguration
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.netty.DefaultHttpClient
@@ -35,7 +35,6 @@ import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.handler.ssl.SslHandler
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
-import reactor.core.publisher.Flux
 import spock.lang.Specification
 
 import java.security.cert.X509Certificate
@@ -213,7 +212,7 @@ class ManualHttpServiceDefinitionSpec extends Specification {
 
 
         when:
-        def client = new DefaultHttpClient(embeddedServer.getURI(), ctx.getBean(HttpClientConfiguration, Qualifiers.byName("client1")))
+        def client = DefaultHttpClient.builder().uri(embeddedServer.getURI()).configuration(ctx.getBean(HttpClientConfiguration, Qualifiers.byName("client1"))).build()
 
         then:
         client.toBlocking().retrieve(HttpRequest.GET("/ssl-test"), String) == DN

--- a/test-suite/src/test/groovy/io/micronaut/docs/http/client/proxy/ProxyRequestSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/docs/http/client/proxy/ProxyRequestSpec.groovy
@@ -42,7 +42,7 @@ class ProxyRequestSpec extends Specification {
         given:"A client with no read timeout"
         def configuration = new DefaultHttpClientConfiguration()
         configuration.setReadTimeout(Duration.ofSeconds(-1))
-        def client = new DefaultHttpClient(embeddedServer.URI, configuration)
+        def client = DefaultHttpClient.builder().uri(embeddedServer.URI).configuration(configuration).build()
 
         when:"A GET request is proxied"
         client.exchange("/proxy/timeout", String).blockFirst()


### PR DESCRIPTION
Unfortunately we have a bit of a mess in micronaut-oracle-cloud with dependencies on DefaultHttpClient. oke identity depended on internal classes that broke in 4.6, requiring a change downstream.

This patch replaces the DefaultHttpClient constructors with a builder. The defaults are now unified between constructors, and we can limit exposure to only those settings that micronaut-oracle-cloud actually needs.