### PR TITLE
Allow customization of the Bootstrap in NettyClientCustomizer

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/CompositeNettyClientCustomizer.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/CompositeNettyClientCustomizer.java
@@ -16,7 +16,9 @@
 package io.micronaut.http.client.netty;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.netty.AbstractCompositeCustomizer;
+import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 
 import java.util.Collections;
@@ -40,6 +42,11 @@ final class CompositeNettyClientCustomizer
     @Override
     protected NettyClientCustomizer specializeForChannel(NettyClientCustomizer member, Channel channel, ChannelRole role) {
         return member.specializeForChannel(channel, role);
+    }
+
+    @Override
+    public @NonNull NettyClientCustomizer specializeForBootstrap(@NonNull Bootstrap bootstrap) {
+        return specialize(ch -> ch.specializeForBootstrap(bootstrap));
     }
 
     @Override

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -438,7 +438,7 @@ public class ConnectionManager {
      * @param channelInitializer The initializer to use
      * @return Future that terminates when the TCP connection is established.
      */
-    ChannelFuture doConnect(DefaultHttpClient.RequestKey requestKey, ChannelInitializer<?> channelInitializer) {
+    ChannelFuture doConnect(DefaultHttpClient.RequestKey requestKey, CustomizerAwareInitializer channelInitializer) {
         String host = requestKey.getHost();
         int port = requestKey.getPort();
         Bootstrap localBootstrap = bootstrap.clone();
@@ -446,8 +446,10 @@ public class ConnectionManager {
         if (proxy.type() != Proxy.Type.DIRECT) {
             localBootstrap.resolver(NoopAddressResolverGroup.INSTANCE);
         }
-        localBootstrap.handler(channelInitializer);
-        return localBootstrap.connect(host, port);
+        localBootstrap.handler(channelInitializer)
+            .remoteAddress(host, port);
+        channelInitializer.bootstrappedCustomizer = clientCustomizer.specializeForBootstrap(localBootstrap);
+        return localBootstrap.connect();
     }
 
     /**
@@ -518,7 +520,7 @@ public class ConnectionManager {
     final Mono<?> connectForWebsocket(DefaultHttpClient.RequestKey requestKey, ChannelHandler handler) {
         Sinks.Empty<Object> initial = new CancellableMonoSink<>(null);
 
-        ChannelFuture connectFuture = doConnect(requestKey, new ChannelInitializer<Channel>() {
+        ChannelFuture connectFuture = doConnect(requestKey, new CustomizerAwareInitializer() {
             @Override
             protected void initChannel(@NonNull Channel ch) {
                 addLogHandler(ch);
@@ -546,7 +548,7 @@ public class ConnectionManager {
                         ch.pipeline().addLast(WebSocketClientCompressionHandler.INSTANCE);
                     }
                     ch.pipeline().addLast(ChannelPipelineCustomizer.HANDLER_MICRONAUT_WEBSOCKET_CLIENT, handler);
-                    clientCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION).onInitialPipelineBuilt();
+                    bootstrappedCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION).onInitialPipelineBuilt();
                     if (initial.tryEmitEmpty().isSuccess()) {
                         return;
                     }
@@ -741,11 +743,15 @@ public class ConnectionManager {
         return HttpClientExceptionUtils.populateServiceId(exc, informationalServiceId, configuration);
     }
 
+    private static abstract class CustomizerAwareInitializer extends ChannelInitializer<Channel> {
+        NettyClientCustomizer bootstrappedCustomizer;
+    }
+
     /**
      * Initializer for TLS channels. After ALPN we will proceed either with
      * {@link #initHttp1(Channel)} or {@link #initHttp2(Pool, Channel, NettyClientCustomizer)}.
      */
-    private final class AdaptiveAlpnChannelInitializer extends ChannelInitializer<Channel> {
+    private final class AdaptiveAlpnChannelInitializer extends CustomizerAwareInitializer {
         private final Pool pool;
 
         private final SslContext sslContext;
@@ -767,7 +773,7 @@ public class ConnectionManager {
          */
         @Override
         protected void initChannel(@NonNull Channel ch) {
-            NettyClientCustomizer channelCustomizer = clientCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
+            NettyClientCustomizer channelCustomizer = bootstrappedCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
 
             configureProxy(ch.pipeline(), true, host, port);
 
@@ -822,7 +828,7 @@ public class ConnectionManager {
      * Initializer for H2C connections. Will proceed with
      * {@link #initHttp2(Pool, Channel, NettyClientCustomizer)} when the upgrade is done.
      */
-    private final class Http2UpgradeInitializer extends ChannelInitializer<Channel> {
+    private final class Http2UpgradeInitializer extends CustomizerAwareInitializer {
         private final Pool pool;
 
         Http2UpgradeInitializer(Pool pool) {
@@ -831,7 +837,7 @@ public class ConnectionManager {
 
         @Override
         protected void initChannel(@NonNull Channel ch) throws Exception {
-            NettyClientCustomizer connectionCustomizer = clientCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
+            NettyClientCustomizer connectionCustomizer = bootstrappedCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
 
             Http2FrameCodec frameCodec = makeFrameCodec();
 
@@ -877,6 +883,8 @@ public class ConnectionManager {
         private final String host;
         private final int port;
 
+        private NettyClientCustomizer bootstrappedCustomizer;
+
         Http3ChannelInitializer(Pool pool, String host, int port) {
             this.pool = pool;
             this.host = host;
@@ -905,7 +913,7 @@ public class ConnectionManager {
         }
 
         private void initChannel(Channel ch) {
-            NettyClientCustomizer channelCustomizer = clientCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
+            NettyClientCustomizer channelCustomizer = bootstrappedCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
 
             ch.pipeline()
                 .addLast(Http3.newQuicClientCodecBuilder()
@@ -1099,12 +1107,15 @@ public class ConnectionManager {
         }
 
         private ChannelFuture openConnectionFuture() {
-            ChannelInitializer<?> initializer;
+            CustomizerAwareInitializer initializer;
             if (requestKey.isSecure()) {
                 if (httpVersion.isHttp3()) {
-                    return udpBootstrap.clone()
-                        .handler(new Http3ChannelInitializer(this, requestKey.getHost(), requestKey.getPort()))
-                        .bind(0);
+                    Http3ChannelInitializer channelInitializer = new Http3ChannelInitializer(this, requestKey.getHost(), requestKey.getPort());
+                    Bootstrap localBootstrap = udpBootstrap.clone()
+                        .handler(channelInitializer)
+                        .localAddress(0);
+                    channelInitializer.bootstrappedCustomizer = clientCustomizer.specializeForBootstrap(localBootstrap);
+                    return localBootstrap.bind();
                 }
 
                 initializer = new AdaptiveAlpnChannelInitializer(
@@ -1115,7 +1126,7 @@ public class ConnectionManager {
                 );
             } else {
                 initializer = switch (httpVersion.getPlaintextMode()) {
-                    case HTTP_1 -> new ChannelInitializer<>() {
+                    case HTTP_1 -> new CustomizerAwareInitializer() {
                         @Override
                         protected void initChannel(@NonNull Channel ch) throws Exception {
                             configureProxy(ch.pipeline(), false, requestKey.getHost(), requestKey.getPort());
@@ -1125,7 +1136,7 @@ public class ConnectionManager {
                                 public void channelActive(@NonNull ChannelHandlerContext ctx) throws Exception {
                                     super.channelActive(ctx);
                                     ctx.pipeline().remove(this);
-                                    NettyClientCustomizer channelCustomizer = clientCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
+                                    NettyClientCustomizer channelCustomizer = bootstrappedCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
                                     new Http1ConnectionHolder(ch, channelCustomizer).init(true);
                                 }
                             });

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -743,7 +743,7 @@ public class ConnectionManager {
         return HttpClientExceptionUtils.populateServiceId(exc, informationalServiceId, configuration);
     }
 
-    private static abstract class CustomizerAwareInitializer extends ChannelInitializer<Channel> {
+    static abstract class CustomizerAwareInitializer extends ChannelInitializer<Channel> {
         NettyClientCustomizer bootstrappedCustomizer;
     }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -161,8 +161,9 @@ public class ConnectionManager {
     private volatile SslContext sslContext;
     private volatile /* QuicSslContext */ Object http3SslContext;
     private volatile SslContext websocketSslContext;
-    private final NettyClientCustomizer clientCustomizer;
     private final String informationalServiceId;
+
+    final NettyClientCustomizer clientCustomizer;
 
     /**
      * Copy constructor used by the test suite to patch this manager.

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -141,6 +141,8 @@ import java.util.function.Supplier;
 @Internal
 public class ConnectionManager {
 
+    final NettyClientCustomizer clientCustomizer;
+
     private final HttpVersionSelection httpVersion;
     private final Logger log;
     private final Map<DefaultHttpClient.RequestKey, Pool> pools = new ConcurrentHashMap<>();
@@ -162,8 +164,6 @@ public class ConnectionManager {
     private volatile /* QuicSslContext */ Object http3SslContext;
     private volatile SslContext websocketSslContext;
     private final String informationalServiceId;
-
-    final NettyClientCustomizer clientCustomizer;
 
     /**
      * Copy constructor used by the test suite to patch this manager.
@@ -744,7 +744,7 @@ public class ConnectionManager {
         return HttpClientExceptionUtils.populateServiceId(exc, informationalServiceId, configuration);
     }
 
-    static abstract class CustomizerAwareInitializer extends ChannelInitializer<Channel> {
+    abstract static class CustomizerAwareInitializer extends ChannelInitializer<Channel> {
         NettyClientCustomizer bootstrappedCustomizer;
     }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientCustomizer.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientCustomizer.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.http.client.netty;
 
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
+import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 
 /**
@@ -44,6 +46,16 @@ public interface NettyClientCustomizer {
      */
     @NonNull
     default NettyClientCustomizer specializeForChannel(@NonNull Channel channel, @NonNull ChannelRole role) {
+        return this;
+    }
+
+    /**
+     * @param bootstrap The bootstrap that will be used to connect
+     * @return The new customizer, or {@code this} if no specialization needs to take place.
+     */
+    @Experimental
+    @NonNull
+    default NettyClientCustomizer specializeForBootstrap(@NonNull Bootstrap bootstrap) {
         return this;
     }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientCustomizer.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientCustomizer.java
@@ -52,6 +52,7 @@ public interface NettyClientCustomizer {
     /**
      * @param bootstrap The bootstrap that will be used to connect
      * @return The new customizer, or {@code this} if no specialization needs to take place.
+     * @since 4.7.0
      */
     @Experimental
     @NonNull

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
@@ -94,7 +94,7 @@ class ConnectionManagerSpec extends Specification {
             int i = 0
 
             @Override
-            protected ChannelFuture doConnect(DefaultHttpClient.RequestKey requestKey, ChannelInitializer<? extends Channel> channelInitializer) {
+            protected ChannelFuture doConnect(DefaultHttpClient.RequestKey requestKey, ConnectionManager.CustomizerAwareInitializer channelInitializer) {
                 try {
                     def connection = connections[i++]
                     connection.clientChannel = new EmbeddedChannel(new DummyChannelId('client' + i), connection.clientInitializer, channelInitializer) {

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
@@ -96,6 +96,7 @@ class ConnectionManagerSpec extends Specification {
             @Override
             protected ChannelFuture doConnect(DefaultHttpClient.RequestKey requestKey, ConnectionManager.CustomizerAwareInitializer channelInitializer) {
                 try {
+                    channelInitializer.bootstrappedCustomizer = clientCustomizer
                     def connection = connections[i++]
                     connection.clientChannel = new EmbeddedChannel(new DummyChannelId('client' + i), connection.clientInitializer, channelInitializer) {
                         def loop


### PR DESCRIPTION
This change allows access to the Bootstrap before the client connects. This can change e.g. the remoteAddress.

I use this for unix domain socket support for micronaut-oracle-cloud. Though I'm not yet 100% sure if it's necessary, there.