### PR TITLE
Fix stream backpressure when compressing

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/InputStreamBodyWriter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/InputStreamBodyWriter.java
@@ -31,6 +31,7 @@ import io.micronaut.http.netty.body.NettyWriteContext;
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
 import io.micronaut.scheduling.TaskExecutors;
 import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
@@ -58,6 +59,7 @@ public final class InputStreamBodyWriter extends AbstractFileBodyWriter implemen
 
     @Override
     public void writeTo(HttpRequest<?> request, MutableHttpResponse<InputStream> outgoingResponse, Argument<InputStream> type, MediaType mediaType, InputStream object, NettyWriteContext nettyContext) throws CodecException {
+        outgoingResponse.getHeaders().setIfMissing(HttpHeaderNames.CONTENT_TYPE, mediaType);
         if (outgoingResponse instanceof NettyMutableHttpResponse<?> nettyResponse) {
             final DefaultHttpResponse finalResponse = new DefaultHttpResponse(
                 nettyResponse.getNettyHttpVersion(),

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
@@ -298,9 +298,11 @@ abstract class MultiplexedServerHandler {
                     }
 
                     private void complete0() {
-                        if (finish()) {
+                        if (!responseDone) {
                             writeData(Unpooled.EMPTY_BUFFER, true, ctx.voidPromise());
-                            flush();
+                            if (finish()) {
+                                flush();
+                            }
                         }
                     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -1108,8 +1108,9 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
             }
 
             if (!removed) {
+                int n = buf.readableBytes();
                 writeCompressing(new DefaultHttpContent(buf), true, false);
-                incompleteWrittenBytes += buf.readableBytes();
+                incompleteWrittenBytes += n;
                 if (ctx.channel().isWritable()) {
                     writeSome();
                 }


### PR DESCRIPTION
When compression is on, writeCompressing will immediately advance the buffer position, so `buf.readableBytes()` would be 0 and backpressure would not be relieved properly.

Fixes #11114