### PR TITLE
Deprecate `MediaTypeCodec` and use Message Body Writer / Reader API for clients

### DIFF
--- a/config/checkstyle/custom-suppressions.xml
+++ b/config/checkstyle/custom-suppressions.xml
@@ -16,7 +16,7 @@
 
     <suppress checks=".*" files="FlowControlHandler.java" />
 
-    <suppress checks="ParameterNumber" files="DefaultHttpClient.java" />
+    <suppress checks="ParameterNumber" files="DefaultHttpClient.java|DefaultJdkHttpClient.java|JdkBlockingHttpClient.java" />
 
     <suppress checks="IllegalImport" files="JavaxProviderBeanDefinition.java" />
 

--- a/core/src/main/java/io/micronaut/core/io/buffer/ByteArrayBufferFactory.java
+++ b/core/src/main/java/io/micronaut/core/io/buffer/ByteArrayBufferFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.io.buffer;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * {@link ByteBufferFactory} implementation based on simple byte arrays.
+ *
+ * @author Jonas Konrad
+ * @since 4.7
+ */
+@Internal
+public class ByteArrayBufferFactory implements ByteBufferFactory<Void, byte[]> {
+    public static final ByteArrayBufferFactory INSTANCE = new ByteArrayBufferFactory();
+
+    private ByteArrayBufferFactory() {
+    }
+
+    @Override
+    public Void getNativeAllocator() {
+        throw new UnsupportedOperationException("No native allocator");
+    }
+
+    @Override
+    public ByteArrayByteBuffer buffer() {
+        return buffer(0);
+    }
+
+    @Override
+    public ByteArrayByteBuffer buffer(int initialCapacity) {
+        return new ByteArrayByteBuffer(new byte[initialCapacity]);
+    }
+
+    @Override
+    public ByteArrayByteBuffer buffer(int initialCapacity, int maxCapacity) {
+        return buffer(initialCapacity);
+    }
+
+    @Override
+    public ByteArrayByteBuffer copiedBuffer(byte[] bytes) {
+        return wrap(bytes.clone());
+    }
+
+    @Override
+    public ByteArrayByteBuffer copiedBuffer(java.nio.ByteBuffer nioBuffer) {
+        int pos = nioBuffer.position();
+        int lim = nioBuffer.limit();
+        byte[] arr = new byte[lim - pos];
+        nioBuffer.get(pos, arr, 0, arr.length);
+        return wrap(arr);
+    }
+
+    @Override
+    public ByteArrayByteBuffer wrap(byte[] existing) {
+        return new ByteArrayByteBuffer(existing);
+    }
+}

--- a/core/src/main/java/io/micronaut/core/io/buffer/ByteArrayByteBuffer.java
+++ b/core/src/main/java/io/micronaut/core/io/buffer/ByteArrayByteBuffer.java
@@ -42,7 +42,7 @@ public class ByteArrayByteBuffer implements ByteBuffer<byte[]> {
      *
      * @param underlyingBytes the bytes to wrap
      */
-    public ByteArrayByteBuffer(byte[] underlyingBytes) {
+    ByteArrayByteBuffer(byte[] underlyingBytes) {
         this(underlyingBytes, underlyingBytes.length);
     }
 
@@ -54,7 +54,7 @@ public class ByteArrayByteBuffer implements ByteBuffer<byte[]> {
      * @param underlyingBytes the bytes to wrap
      * @param capacity        the capacity of the buffer
      */
-    public ByteArrayByteBuffer(byte[] underlyingBytes, int capacity) {
+    ByteArrayByteBuffer(byte[] underlyingBytes, int capacity) {
         if (capacity < underlyingBytes.length) {
             this.underlyingBytes = Arrays.copyOf(underlyingBytes, capacity);
         } else if (capacity > underlyingBytes.length) {
@@ -97,7 +97,7 @@ public class ByteArrayByteBuffer implements ByteBuffer<byte[]> {
 
     @Override
     public ByteArrayByteBuffer readerIndex(int readPosition) {
-        this.readerIndex = Math.min(readPosition, underlyingBytes.length - 1);
+        this.readerIndex = Math.min(readPosition, underlyingBytes.length);
         return this;
     }
 
@@ -108,7 +108,7 @@ public class ByteArrayByteBuffer implements ByteBuffer<byte[]> {
 
     @Override
     public ByteArrayByteBuffer writerIndex(int position) {
-        this.writerIndex = Math.min(position, underlyingBytes.length - 1);
+        this.writerIndex = Math.min(position, underlyingBytes.length);
         return this;
     }
 

--- a/core/src/main/java/io/micronaut/core/io/buffer/ByteArrayByteBuffer.java
+++ b/core/src/main/java/io/micronaut/core/io/buffer/ByteArrayByteBuffer.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.io.buffer;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+/**
+ * A {@link ByteBuffer} implementation that is backed by a byte array.
+ *
+ * @since 4.7
+ */
+@Internal
+@Experimental
+public class ByteArrayByteBuffer implements ByteBuffer<byte[]> {
+
+    private final byte[] underlyingBytes;
+    private int readerIndex;
+    private int writerIndex;
+
+    /**
+     * Construct a new {@link ByteArrayByteBuffer} for the given bytes.
+     *
+     * @param underlyingBytes the bytes to wrap
+     */
+    public ByteArrayByteBuffer(byte[] underlyingBytes) {
+        this(underlyingBytes, underlyingBytes.length);
+    }
+
+    /**
+     * Construct a new {@link ByteArrayByteBuffer} for the given bytes and capacity.
+     * If capacity is greater than the length of the underlyingBytes, extra bytes will be zeroed out.
+     * If capacity is less than the length of the underlyingBytes, the underlyingBytes will be truncated.
+     *
+     * @param underlyingBytes the bytes to wrap
+     * @param capacity        the capacity of the buffer
+     */
+    public ByteArrayByteBuffer(byte[] underlyingBytes, int capacity) {
+        if (capacity < underlyingBytes.length) {
+            this.underlyingBytes = Arrays.copyOf(underlyingBytes, capacity);
+        } else if (capacity > underlyingBytes.length) {
+            this.underlyingBytes = new byte[capacity];
+            System.arraycopy(underlyingBytes, 0, this.underlyingBytes, 0, underlyingBytes.length);
+        } else {
+            this.underlyingBytes = underlyingBytes;
+        }
+    }
+
+    @Override
+    public byte[] asNativeBuffer() {
+        return underlyingBytes;
+    }
+
+    @Override
+    public int readableBytes() {
+        return underlyingBytes.length - readerIndex;
+    }
+
+    @Override
+    public int writableBytes() {
+        return underlyingBytes.length - writerIndex;
+    }
+
+    @Override
+    public int maxCapacity() {
+        return underlyingBytes.length;
+    }
+
+    @Override
+    public ByteArrayByteBuffer capacity(int capacity) {
+        return new ByteArrayByteBuffer(underlyingBytes, capacity);
+    }
+
+    @Override
+    public int readerIndex() {
+        return readerIndex;
+    }
+
+    @Override
+    public ByteArrayByteBuffer readerIndex(int readPosition) {
+        this.readerIndex = Math.min(readPosition, underlyingBytes.length - 1);
+        return this;
+    }
+
+    @Override
+    public int writerIndex() {
+        return writerIndex;
+    }
+
+    @Override
+    public ByteArrayByteBuffer writerIndex(int position) {
+        this.writerIndex = Math.min(position, underlyingBytes.length - 1);
+        return this;
+    }
+
+    @Override
+    public byte read() {
+        return underlyingBytes[readerIndex++];
+    }
+
+    @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        String s = new String(underlyingBytes, readerIndex, length, charset);
+        readerIndex += length;
+        return s;
+    }
+
+    @Override
+    public ByteArrayByteBuffer read(byte[] destination) {
+        int count = Math.min(readableBytes(), destination.length);
+        System.arraycopy(underlyingBytes, readerIndex, destination, 0, count);
+        readerIndex += count;
+        return this;
+    }
+
+    @Override
+    public ByteArrayByteBuffer read(byte[] destination, int offset, int length) {
+        int count = Math.min(readableBytes(), Math.min(destination.length - offset, length));
+        System.arraycopy(underlyingBytes, readerIndex, destination, offset, count);
+        readerIndex += count;
+        return this;
+    }
+
+    @Override
+    public ByteArrayByteBuffer write(byte b) {
+        underlyingBytes[writerIndex++] = b;
+        return this;
+    }
+
+    @Override
+    public ByteArrayByteBuffer write(byte[] source) {
+        int count = Math.min(writableBytes(), source.length);
+        System.arraycopy(source, 0, underlyingBytes, writerIndex, count);
+        writerIndex += count;
+        return this;
+    }
+
+    @Override
+    public ByteArrayByteBuffer write(CharSequence source, Charset charset) {
+        write(source.toString().getBytes(charset));
+        return this;
+    }
+
+    @Override
+    public ByteArrayByteBuffer write(byte[] source, int offset, int length) {
+        int count = Math.min(writableBytes(), length);
+        System.arraycopy(source, offset, underlyingBytes, writerIndex, count);
+        writerIndex += count;
+        return this;
+    }
+
+    @Override
+    public ByteArrayByteBuffer write(ByteBuffer... buffers) {
+        for (ByteBuffer<?> buffer : buffers) {
+            write(buffer.toByteArray());
+        }
+        return this;
+    }
+
+    @Override
+    public ByteArrayByteBuffer write(java.nio.ByteBuffer... buffers) {
+        for (java.nio.ByteBuffer buffer : buffers) {
+            write(buffer.array());
+        }
+        return this;
+    }
+
+    @Override
+    public ByteArrayByteBuffer slice(int index, int length) {
+        return new ByteArrayByteBuffer(Arrays.copyOfRange(underlyingBytes, index, index + length), length);
+    }
+
+    @Override
+    public java.nio.ByteBuffer asNioBuffer() {
+        return java.nio.ByteBuffer.wrap(underlyingBytes, readerIndex, readableBytes());
+    }
+
+    @Override
+    public java.nio.ByteBuffer asNioBuffer(int index, int length) {
+        return java.nio.ByteBuffer.wrap(underlyingBytes, index, length);
+    }
+
+    @Override
+    public InputStream toInputStream() {
+        return new ByteArrayInputStream(underlyingBytes, readerIndex, readableBytes());
+    }
+
+    @Override
+    public OutputStream toOutputStream() {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return Arrays.copyOfRange(underlyingBytes, readerIndex, readableBytes());
+    }
+
+    @Override
+    public String toString(Charset charset) {
+        return new String(underlyingBytes, readerIndex, readableBytes(), charset);
+    }
+
+    @Override
+    public int indexOf(byte b) {
+        for (int i = readerIndex; i < underlyingBytes.length; i++) {
+            if (underlyingBytes[i] == b) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public byte getByte(int index) {
+        return underlyingBytes[index];
+    }
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/AbstractHttpClientFactory.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/AbstractHttpClientFactory.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
 
 import java.net.URI;
@@ -36,13 +37,14 @@ import java.net.URL;
 public abstract class AbstractHttpClientFactory<T extends HttpClient> implements HttpClientFactory {
 
     protected final MediaTypeCodecRegistry mediaTypeCodecRegistry;
+    protected final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
     protected final ConversionService conversionService;
 
-    protected AbstractHttpClientFactory(
-        @Nullable MediaTypeCodecRegistry mediaTypeCodecRegistry,
-        ConversionService conversionService
-    ) {
+    protected AbstractHttpClientFactory(@Nullable MediaTypeCodecRegistry mediaTypeCodecRegistry,
+                                        MessageBodyHandlerRegistry messageBodyHandlerRegistry,
+                                        ConversionService conversionService) {
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
+        this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
         this.conversionService = conversionService;
     }
 

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
@@ -26,6 +26,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.bind.DefaultRequestBinderRegistry;
 import io.micronaut.http.bind.RequestBinderRegistry;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.DefaultHttpClientConfiguration;
 import io.micronaut.http.client.HttpClient;
@@ -66,6 +67,7 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
         @Nullable HttpClientFilterResolver<ClientFilterResolutionContext> filterResolver,
         @Nullable List<HttpFilterResolver.FilterEntry> clientFilterEntries,
         MediaTypeCodecRegistry mediaTypeCodecRegistry,
+        MessageBodyHandlerRegistry messageBodyHandlerRegistry,
         RequestBinderRegistry requestBinderRegistry,
         String clientId,
         ConversionService conversionService,
@@ -81,6 +83,7 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
             filterResolver,
             clientFilterEntries,
             mediaTypeCodecRegistry,
+            messageBodyHandlerRegistry,
             requestBinderRegistry,
             clientId,
             conversionService,
@@ -98,6 +101,7 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
             null,
             null,
             createDefaultMediaTypeRegistry(),
+            JdkHttpClientFactory.createDefaultMessageBodyHandlerRegistry(),
             new DefaultRequestBinderRegistry(conversionService),
             null,
             conversionService,
@@ -110,6 +114,7 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
         URI uri,
         HttpClientConfiguration configuration,
         MediaTypeCodecRegistry mediaTypeCodecRegistry,
+        MessageBodyHandlerRegistry messageBodyHandlerRegistry,
         ConversionService conversionService
     ) {
         this(
@@ -120,6 +125,7 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
             null,
             null,
             mediaTypeCodecRegistry,
+            messageBodyHandlerRegistry,
             new DefaultRequestBinderRegistry(conversionService),
             null,
             conversionService,
@@ -147,6 +153,7 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
             filterResolver,
             clientFilterEntries,
             mediaTypeCodecRegistry,
+            messageBodyHandlerRegistry,
             requestBinderRegistry,
             clientId,
             conversionService,

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
@@ -23,7 +23,7 @@ import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
-import io.micronaut.core.io.buffer.ByteArrayByteBuffer;
+import io.micronaut.core.io.buffer.ByteArrayBufferFactory;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
@@ -148,7 +148,7 @@ public class HttpResponseAdapter<O> implements HttpResponse<O> {
                         type,
                         contentType,
                         new SimpleHttpHeaders(),
-                        new ByteArrayByteBuffer(bytes)
+                        ByteArrayBufferFactory.INSTANCE.wrap(bytes)
                     );
                     return Optional.of(value);
                 } catch (CodecException e) {

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
@@ -23,14 +23,18 @@ import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
+import io.micronaut.core.io.buffer.ByteArrayByteBuffer;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.http.body.MessageBodyReader;
 import io.micronaut.http.codec.CodecException;
 import io.micronaut.http.codec.MediaTypeCodec;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
+import io.micronaut.http.simple.SimpleHttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,15 +61,18 @@ public class HttpResponseAdapter<O> implements HttpResponse<O> {
     private final MutableConvertibleValues<Object> attributes = new MutableConvertibleValuesMap<>();
 
     private final MediaTypeCodecRegistry mediaTypeCodecRegistry;
+    private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
 
     public HttpResponseAdapter(java.net.http.HttpResponse<byte[]> httpResponse,
-                               @NonNull Argument<O> bodyType,
+                               @Nullable Argument<O> bodyType,
                                ConversionService conversionService,
-                               MediaTypeCodecRegistry mediaTypeCodecRegistry) {
+                               MediaTypeCodecRegistry mediaTypeCodecRegistry,
+                               MessageBodyHandlerRegistry messageBodyHandlerRegistry) {
         this.httpResponse = httpResponse;
         this.bodyType = bodyType;
         this.conversionService = conversionService;
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
+        this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
     }
 
     @Override
@@ -95,53 +102,69 @@ public class HttpResponseAdapter<O> implements HttpResponse<O> {
 
     @Override
     public Optional<O> getBody() {
-        return convertBytes(getContentType().orElse(null), httpResponse.body(), bodyType);
+        return getBody(bodyType);
     }
 
     @Override
     public <T> Optional<T> getBody(Argument<T> type) {
-        return convertBytes(getContentType().orElse(null), httpResponse.body(), type);
+        final boolean isOptional = type.getType() == Optional.class;
+        final Argument<Object> theArgument = (Argument<Object>) (isOptional ? type.getFirstTypeVariable().orElse(type) : type);
+        Optional<?> optional = convertBytes(getContentType().orElse(null), httpResponse.body(), theArgument);
+        if (isOptional) {
+            // If the requested type is an Optional, then we need to wrap the result again
+            return Optional.of((T) optional);
+        }
+        return (Optional<T>) optional;
     }
 
-    private <T> Optional convertBytes(@Nullable MediaType contentType, byte[] bytes, Argument<T> type) {
+    private <T> Optional<T> convertBytes(@Nullable MediaType contentType, byte[] bytes, Argument<T> type) {
         if (bytes.length == 0) {
             return Optional.empty();
         }
-        final boolean isOptional = type.getType() == Optional.class;
-        final Argument finalArgument = isOptional ? type.getFirstTypeVariable().orElse(type) : type;
-
-        if (mediaTypeCodecRegistry != null && contentType != null) {
-            if (CharSequence.class.isAssignableFrom(finalArgument.getType())) {
+        if (type.getType().equals(byte[].class)) {
+            return Optional.of((T) bytes);
+        }
+        if (contentType != null) {
+            if (CharSequence.class.isAssignableFrom(type.getType())) {
                 Charset charset = contentType.getCharset().orElse(StandardCharsets.UTF_8);
-                var converted = Optional.of(new String(bytes, charset));
-                // If the requested type is an Optional, then we need to wrap the result again
-                return isOptional ? Optional.of(converted) : converted;
-            } else if (finalArgument.getType() == byte[].class) {
-                var converted = Optional.of(bytes);
-                // If the requested type is an Optional, then we need to wrap the result again
-                return isOptional ? Optional.of(converted) : converted;
-            } else {
-                Optional<MediaTypeCodec> foundCodec = mediaTypeCodecRegistry.findCodec(contentType);
-                if (foundCodec.isPresent()) {
-                    try {
-                        var converted = foundCodec.map(codec -> codec.decode(finalArgument, bytes));
-                        return isOptional ? Optional.of(converted) : converted;
-                    } catch (CodecException e) {
-                        if (LOG.isDebugEnabled()) {
-                            var message = e.getMessage();
-                            LOG.debug("Error decoding body for type [{}] from '{}'. Attempting fallback.", type, contentType);
-                            LOG.debug("CodecException Message was: {}", message == null ? "null" : message.replace("\n", ""));
-                        }
-                    }
+                return Optional.of((T) new String(bytes, charset));
+            }
+        }
+        if (mediaTypeCodecRegistry != null) {
+            Optional<MediaTypeCodec> foundCodec = mediaTypeCodecRegistry.findCodec(contentType);
+            if (foundCodec.isPresent()) {
+                try {
+                    return foundCodec.map(codec -> codec.decode(type, bytes));
+                } catch (CodecException e) {
+                    logCodecError(contentType, type, e);
+                }
+            }
+        }
+        if (messageBodyHandlerRegistry != null) {
+            MessageBodyReader<T> reader = messageBodyHandlerRegistry.findReader(type, contentType).orElse(null);
+            if (reader != null) {
+                try {
+                    T value = reader.read(
+                        type,
+                        contentType,
+                        new SimpleHttpHeaders(),
+                        new ByteArrayByteBuffer(bytes)
+                    );
+                    return Optional.of(value);
+                } catch (CodecException e) {
+                    logCodecError(contentType, type, e);
                 }
             }
         }
         // last chance, try type conversion
-        var converted = conversionService.convert(bytes, ConversionContext.of(finalArgument));
-        if (isOptional) {
-            return Optional.of(converted);
-        } else {
-            return converted;
+       return conversionService.convert(bytes, ConversionContext.of(type));
+    }
+
+    private <T> void logCodecError(MediaType contentType, Argument<T> type, CodecException e) {
+        if (LOG.isDebugEnabled()) {
+            var message = e.getMessage();
+            LOG.debug("Error decoding body for type [{}] from '{}'. Attempting fallback.", type, contentType);
+            LOG.debug("CodecException Message was: {}", message == null ? "null" : message.replace("\n", ""));
         }
     }
 }

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
@@ -34,7 +34,6 @@ import io.micronaut.http.body.MessageBodyReader;
 import io.micronaut.http.codec.CodecException;
 import io.micronaut.http.codec.MediaTypeCodec;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
-import io.micronaut.http.simple.SimpleHttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,7 +146,7 @@ public class HttpResponseAdapter<O> implements HttpResponse<O> {
                     T value = reader.read(
                         type,
                         contentType,
-                        new SimpleHttpHeaders(),
+                        getHeaders(),
                         ByteArrayBufferFactory.INSTANCE.wrap(bytes)
                     );
                     return Optional.of(value);

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/JdkBlockingHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/JdkBlockingHttpClient.java
@@ -17,10 +17,12 @@ package io.micronaut.http.client.jdk;
 
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.bind.RequestBinderRegistry;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.HttpVersionSelection;
@@ -52,6 +54,7 @@ public class JdkBlockingHttpClient extends AbstractJdkHttpClient implements Bloc
         @Nullable HttpClientFilterResolver<ClientFilterResolutionContext> filterResolver,
         @Nullable List<HttpFilterResolver.FilterEntry> clientFilterEntries,
         MediaTypeCodecRegistry mediaTypeCodecRegistry,
+        MessageBodyHandlerRegistry messageBodyHandlerRegistry,
         RequestBinderRegistry requestBinderRegistry,
         String clientId,
         ConversionService conversionService,
@@ -67,6 +70,7 @@ public class JdkBlockingHttpClient extends AbstractJdkHttpClient implements Bloc
             filterResolver,
             clientFilterEntries,
             mediaTypeCodecRegistry,
+            messageBodyHandlerRegistry,
             requestBinderRegistry,
             clientId,
             conversionService,
@@ -76,11 +80,10 @@ public class JdkBlockingHttpClient extends AbstractJdkHttpClient implements Bloc
     }
 
     @Override
-    public <I, O, E> io.micronaut.http.HttpResponse<O> exchange(io.micronaut.http.HttpRequest<I> request,
-                                              Argument<O> bodyType,
-                                              Argument<E> errorType) {
-        return exchangeImpl(request, bodyType)
-            .blockFirst();
+    public <I, O, E> io.micronaut.http.HttpResponse<O> exchange(@NonNull io.micronaut.http.HttpRequest<I> request,
+                                                                @Nullable Argument<O> bodyType,
+                                                                @Nullable Argument<E> errorType) {
+        return exchangeImpl(request, bodyType).blockFirst();
     }
 
     @Override

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -919,6 +919,7 @@ public class DefaultHttpClient implements
                 webSocketURL, protocolVersion, subprotocol, true, customHeaders, maxFramePayloadLength),
             requestBinderRegistry,
             mediaTypeCodecRegistry,
+            handlerRegistry,
             conversionService);
 
         return connectionManager.connectForWebsocket(requestKey, handler)

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -56,7 +56,6 @@ import io.micronaut.http.client.sse.SseClientRegistry;
 import io.micronaut.http.codec.MediaTypeCodec;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
 import io.micronaut.http.filter.HttpClientFilterResolver;
-import io.micronaut.http.netty.body.CustomizableNettyJsonHandler;
 import io.micronaut.http.netty.channel.ChannelPipelineCustomizer;
 import io.micronaut.http.netty.channel.ChannelPipelineListener;
 import io.micronaut.http.netty.channel.DefaultEventLoopGroupConfiguration;
@@ -69,6 +68,7 @@ import io.micronaut.inject.InjectionPoint;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.json.JsonFeatures;
 import io.micronaut.json.JsonMapper;
+import io.micronaut.json.body.CustomizableJsonHandler;
 import io.micronaut.json.codec.MapperMediaTypeCodec;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
 import io.micronaut.runtime.context.scope.refresh.RefreshEventListener;
@@ -408,7 +408,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
 
                     @SuppressWarnings("unchecked")
                     private <T> T customize(T handler) {
-                        if (handler instanceof CustomizableNettyJsonHandler cnjh) {
+                        if (handler instanceof CustomizableJsonHandler cnjh) {
                             return (T) cnjh.customize(jsonFeatures);
                         }
                         return handler;

--- a/http-netty/src/main/java/io/micronaut/http/netty/body/NettyJsonHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/NettyJsonHandler.java
@@ -36,6 +36,7 @@ import io.micronaut.http.codec.CodecException;
 import io.micronaut.http.netty.NettyHttpHeaders;
 import io.micronaut.json.JsonFeatures;
 import io.micronaut.json.JsonMapper;
+import io.micronaut.json.body.CustomizableJsonHandler;
 import io.micronaut.json.body.JsonMessageHandler;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
@@ -65,7 +66,7 @@ import java.io.OutputStream;
 @JsonMessageHandler.ConsumesJson
 @BootstrapContextCompatible
 @Requires(beans = JsonMapper.class)
-public final class NettyJsonHandler<T> implements MessageBodyHandler<T>, ChunkedMessageBodyReader<T>, CustomizableNettyJsonHandler, NettyBodyWriter<T> {
+public final class NettyJsonHandler<T> implements MessageBodyHandler<T>, ChunkedMessageBodyReader<T>, CustomizableJsonHandler, NettyBodyWriter<T> {
     private final JsonMessageHandler<T> jsonMessageHandler;
 
     public NettyJsonHandler(JsonMapper jsonMapper) {
@@ -77,7 +78,7 @@ public final class NettyJsonHandler<T> implements MessageBodyHandler<T>, Chunked
     }
 
     @Override
-    public CustomizableNettyJsonHandler customize(JsonFeatures jsonFeatures) {
+    public CustomizableJsonHandler customize(JsonFeatures jsonFeatures) {
         return new NettyJsonHandler<>(jsonMessageHandler.getJsonMapper().cloneWithFeatures(jsonFeatures));
     }
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/body/NettyJsonStreamHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/NettyJsonStreamHandler.java
@@ -29,6 +29,7 @@ import io.micronaut.http.body.MessageBodyHandler;
 import io.micronaut.http.codec.CodecException;
 import io.micronaut.json.JsonFeatures;
 import io.micronaut.json.JsonMapper;
+import io.micronaut.json.body.CustomizableJsonHandler;
 import io.micronaut.json.body.JsonMessageHandler;
 import io.netty.buffer.ByteBuf;
 import jakarta.inject.Singleton;
@@ -50,7 +51,7 @@ import java.util.List;
 @Singleton
 @Produces(MediaType.APPLICATION_JSON_STREAM)
 @Consumes(MediaType.APPLICATION_JSON_STREAM)
-public final class NettyJsonStreamHandler<T> implements MessageBodyHandler<T>, ChunkedMessageBodyReader<T>, CustomizableNettyJsonHandler {
+public final class NettyJsonStreamHandler<T> implements MessageBodyHandler<T>, ChunkedMessageBodyReader<T>, CustomizableJsonHandler {
     private final JsonMessageHandler<T> jsonMessageHandler;
 
     public NettyJsonStreamHandler(JsonMapper jsonMapper) {
@@ -62,7 +63,7 @@ public final class NettyJsonStreamHandler<T> implements MessageBodyHandler<T>, C
     }
 
     @Override
-    public CustomizableNettyJsonHandler customize(JsonFeatures jsonFeatures) {
+    public CustomizableJsonHandler customize(JsonFeatures jsonFeatures) {
         return new NettyJsonStreamHandler<>(jsonMessageHandler.getJsonMapper().cloneWithFeatures(jsonFeatures));
     }
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/AbstractNettyWebSocketHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/AbstractNettyWebSocketHandler.java
@@ -35,6 +35,7 @@ import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.body.MessageBodyReader;
 import io.micronaut.http.codec.CodecException;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
+import io.micronaut.http.simple.SimpleHttpHeaders;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.websocket.CloseReason;
@@ -364,7 +365,7 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
                             .orElse(null);
                         if (reader != null) {
                             ByteBuffer<ByteBuf> byteBuffer = new NettyByteBufferFactory(ctx.alloc()).wrap(msg.content().retain());
-                            data = reader.read((Argument) bodyArgument, mediaType, originatingRequest.getHeaders(), byteBuffer);
+                            data = reader.read((Argument) bodyArgument, mediaType, new SimpleHttpHeaders(), byteBuffer);
                         }
                     }
                 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/AbstractNettyWebSocketHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/AbstractNettyWebSocketHandler.java
@@ -24,12 +24,15 @@ import io.micronaut.core.bind.DefaultExecutableBinder;
 import io.micronaut.core.bind.ExecutableBinder;
 import io.micronaut.core.bind.exceptions.UnsatisfiedArgumentException;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.bind.RequestBinderRegistry;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.http.body.MessageBodyReader;
 import io.micronaut.http.codec.CodecException;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
 import io.micronaut.inject.ExecutableMethod;
@@ -92,6 +95,7 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
     protected final MethodExecutionHandle<?, ?> messageHandler;
     protected final MethodExecutionHandle<?, ?> pongHandler;
     protected final MediaTypeCodecRegistry mediaTypeCodecRegistry;
+    protected final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
     protected final WebSocketVersion webSocketVersion;
     protected final String subProtocol;
     protected final WebSocketSessionRepository webSocketSessionRepository;
@@ -102,9 +106,9 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
     /**
      * Default constructor.
      *
-     * @param ctx                        The channel handler context
      * @param binderRegistry             The request binder registry
      * @param mediaTypeCodecRegistry     The codec registry
+     * @param messageBodyHandlerRegistry The handler registry
      * @param webSocketBean              The websocket bean
      * @param request                    The originating request
      * @param uriVariables               The URI variables
@@ -114,9 +118,9 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
      * @param conversionService          The conversion service
      */
     protected AbstractNettyWebSocketHandler(
-            ChannelHandlerContext ctx,
             RequestBinderRegistry binderRegistry,
             MediaTypeCodecRegistry mediaTypeCodecRegistry,
+            MessageBodyHandlerRegistry messageBodyHandlerRegistry,
             WebSocketBean<?> webSocketBean,
             HttpRequest<?> request,
             Map<String, Object> uriVariables,
@@ -135,6 +139,7 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
         this.webSocketVersion = version;
         this.conversionService = conversionService;
+        this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
     }
 
     /**
@@ -335,10 +340,10 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
                 }
 
                 Argument<?> bodyArgument = this.getBodyArgument();
-                Optional<?> converted = conversionService.convert(content, ByteBuf.class, bodyArgument);
+                Object data = conversionService.convert(content, ByteBuf.class, bodyArgument).orElse(null);
                 content.release();
 
-                if (converted.isEmpty()) {
+                if (data == null) {
                     MediaType mediaType;
                     try {
                         mediaType = messageHandler.stringValue(Consumes.class).map(MediaType::of).orElse(MediaType.APPLICATION_JSON_TYPE);
@@ -347,19 +352,28 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
                         return;
                     }
                     try {
-                        converted = mediaTypeCodecRegistry.findCodec(mediaType).map(codec -> codec.decode(bodyArgument, new NettyByteBufferFactory(ctx.alloc()).wrap(msg.content())));
+                        data = mediaTypeCodecRegistry.findCodec(mediaType)
+                            .map(codec -> codec.decode(bodyArgument, new NettyByteBufferFactory(ctx.alloc()).wrap(msg.content())))
+                            .orElse(null);
                     } catch (CodecException e) {
                         messageProcessingException(ctx, e);
                         return;
                     }
+                    if (data == null) {
+                        MessageBodyReader<?> reader = messageBodyHandlerRegistry.findReader(bodyArgument, mediaType)
+                            .orElse(null);
+                        if (reader != null) {
+                            ByteBuffer<ByteBuf> byteBuffer = new NettyByteBufferFactory(ctx.alloc()).wrap(msg.content().retain());
+                            data = reader.read((Argument) bodyArgument, mediaType, originatingRequest.getHeaders(), byteBuffer);
+                        }
+                    }
                 }
 
-                if (converted.isPresent()) {
-                    Object v = converted.get();
+                if (data != null) {
 
                     NettyWebSocketSession currentSession = getSession();
                     ExecutableBinder<WebSocketState> executableBinder = new DefaultExecutableBinder<>(
-                            Collections.singletonMap(bodyArgument, v)
+                            Collections.singletonMap(bodyArgument, data)
                     );
 
                     try {
@@ -372,14 +386,15 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
                         Object result = invokeExecutable(boundExecutable, messageHandler);
                         if (Publishers.isConvertibleToPublisher(result)) {
                             Flux<?> flowable = Flux.from(instrumentPublisher(ctx, result));
+                            Object finalData = data;
                             flowable.subscribe(
                                     o -> {
                                     },
                                     error -> messageProcessingException(ctx, error),
-                                    () -> messageHandled(ctx, v)
+                                    () -> messageHandled(ctx, finalData)
                             );
                         } else {
-                            messageHandled(ctx, v);
+                            messageHandled(ctx, data);
                         }
                     } catch (Throwable e) {
                         messageProcessingException(ctx, e);
@@ -389,7 +404,7 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
                     writeCloseFrameAndTerminate(
                             ctx,
                             CloseReason.UNSUPPORTED_DATA.getCode(),
-                            CloseReason.UNSUPPORTED_DATA.getReason() + ": " + "Received data cannot be converted to target type: " + bodyArgument
+                            CloseReason.UNSUPPORTED_DATA.getReason() + ": " + "Received data cannot be data to target type: " + bodyArgument
                     );
                 }
             }

--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/NettyWebSocketSession.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/NettyWebSocketSession.java
@@ -24,6 +24,7 @@ import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
 import io.micronaut.websocket.CloseReason;
 import io.micronaut.websocket.WebSocketSession;
@@ -64,7 +65,6 @@ public class NettyWebSocketSession implements WebSocketSession {
     private final HttpRequest<?> request;
     private final String protocolVersion;
     private final boolean isSecure;
-    private final MediaTypeCodecRegistry codecRegistry;
     private final MutableConvertibleValues<Object> attributes;
     private final WebSocketMessageEncoder messageEncoder;
 
@@ -74,6 +74,7 @@ public class NettyWebSocketSession implements WebSocketSession {
      * @param channel The channel
      * @param request The original request used to create the session
      * @param codecRegistry The codec registry
+     * @param handlerRegistry The handlers registry
      * @param protocolVersion The protocol version
      * @param isSecure Whether the session is secure
      */
@@ -82,6 +83,7 @@ public class NettyWebSocketSession implements WebSocketSession {
             Channel channel,
             HttpRequest<?> request,
             MediaTypeCodecRegistry codecRegistry,
+            MessageBodyHandlerRegistry handlerRegistry,
             String protocolVersion,
             boolean isSecure) {
         this.id = id;
@@ -90,8 +92,7 @@ public class NettyWebSocketSession implements WebSocketSession {
         this.protocolVersion = protocolVersion;
         this.isSecure = isSecure;
         this.channel.attr(WEB_SOCKET_SESSION_KEY).set(this);
-        this.codecRegistry = codecRegistry;
-        this.messageEncoder = new WebSocketMessageEncoder(this.codecRegistry);
+        this.messageEncoder = new WebSocketMessageEncoder(codecRegistry, handlerRegistry);
         this.attributes = request.getAttribute("micronaut.SESSION", MutableConvertibleValues.class).orElseGet(MutableConvertibleValuesMap::new);
     }
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/WebSocketMessageEncoder.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/WebSocketMessageEncoder.java
@@ -17,10 +17,15 @@ package io.micronaut.http.netty.websocket;
 
 import io.micronaut.buffer.netty.NettyByteBufferFactory;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.type.Argument;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.http.body.MessageBodyWriter;
 import io.micronaut.http.codec.MediaTypeCodec;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
+import io.micronaut.http.simple.SimpleHttpHeaders;
 import io.micronaut.websocket.exceptions.WebSocketSessionException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -28,6 +33,7 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.nio.ByteBuffer;
@@ -44,12 +50,28 @@ import java.util.Optional;
 public class WebSocketMessageEncoder {
 
     private final MediaTypeCodecRegistry codecRegistry;
+    @Nullable
+    private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
 
     /**
      * @param codecRegistry The codec registry
+     * @deprecated Not used anymore
      */
+    @Deprecated(forRemoval = true, since = "4.7")
     public WebSocketMessageEncoder(MediaTypeCodecRegistry codecRegistry) {
         this.codecRegistry = codecRegistry;
+        this.messageBodyHandlerRegistry = null;
+    }
+
+    /**
+     * @param codecRegistry The codec registry
+     * @param messageBodyHandlerRegistry The message body handler registry
+     */
+    @Inject
+    public WebSocketMessageEncoder(MediaTypeCodecRegistry codecRegistry,
+                                   MessageBodyHandlerRegistry messageBodyHandlerRegistry) {
+        this.codecRegistry = codecRegistry;
+        this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
     }
 
     /**
@@ -69,10 +91,25 @@ public class WebSocketMessageEncoder {
         } else if (message instanceof ByteBuffer buffer) {
             return new BinaryWebSocketFrame(Unpooled.wrappedBuffer(buffer));
         } else {
-            Optional<MediaTypeCodec> codec = codecRegistry.findCodec(mediaType != null ? mediaType : MediaType.APPLICATION_JSON_TYPE);
+            MediaType theMediaType = mediaType != null ? mediaType : MediaType.APPLICATION_JSON_TYPE;
+            Optional<MediaTypeCodec> codec = codecRegistry.findCodec(theMediaType);
             if (codec.isPresent()) {
-                io.micronaut.core.io.buffer.ByteBuffer encoded = codec.get().encode(message, new NettyByteBufferFactory(UnpooledByteBufAllocator.DEFAULT));
+                io.micronaut.core.io.buffer.ByteBuffer<?> encoded = codec.get().encode(message, new NettyByteBufferFactory(UnpooledByteBufAllocator.DEFAULT));
                 return new TextWebSocketFrame((ByteBuf) encoded.asNativeBuffer());
+            }
+            if (messageBodyHandlerRegistry != null) {
+                Argument<Object> argument = Argument.ofInstance(message);
+                MessageBodyWriter<Object> messageBodyWriter = messageBodyHandlerRegistry.findWriter(argument, theMediaType).orElse(null);
+                if (messageBodyWriter != null) {
+                    io.micronaut.core.io.buffer.ByteBuffer<?> encoded = messageBodyWriter.writeTo(
+                        argument,
+                        theMediaType,
+                        message,
+                        new SimpleHttpHeaders(),
+                        new NettyByteBufferFactory(UnpooledByteBufAllocator.DEFAULT)
+                    );
+                    return new TextWebSocketFrame((ByteBuf) encoded.asNativeBuffer());
+                }
             }
         }
         throw new WebSocketSessionException("Unable to encode WebSocket message: " + message);

--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/WebSocketMessageEncoder.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/WebSocketMessageEncoder.java
@@ -29,7 +29,6 @@ import io.micronaut.http.simple.SimpleHttpHeaders;
 import io.micronaut.websocket.exceptions.WebSocketSessionException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
@@ -94,7 +93,7 @@ public class WebSocketMessageEncoder {
             MediaType theMediaType = mediaType != null ? mediaType : MediaType.APPLICATION_JSON_TYPE;
             Optional<MediaTypeCodec> codec = codecRegistry.findCodec(theMediaType);
             if (codec.isPresent()) {
-                io.micronaut.core.io.buffer.ByteBuffer<?> encoded = codec.get().encode(message, new NettyByteBufferFactory(UnpooledByteBufAllocator.DEFAULT));
+                io.micronaut.core.io.buffer.ByteBuffer<?> encoded = codec.get().encode(message, NettyByteBufferFactory.DEFAULT);
                 return new TextWebSocketFrame((ByteBuf) encoded.asNativeBuffer());
             }
             if (messageBodyHandlerRegistry != null) {
@@ -106,7 +105,7 @@ public class WebSocketMessageEncoder {
                         theMediaType,
                         message,
                         new SimpleHttpHeaders(),
-                        new NettyByteBufferFactory(UnpooledByteBufAllocator.DEFAULT)
+                        NettyByteBufferFactory.DEFAULT
                     );
                     return new TextWebSocketFrame((ByteBuf) encoded.asNativeBuffer());
                 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
@@ -123,9 +123,9 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
         ExecutorSelector executorSelector,
         @Nullable CoroutineHelper coroutineHelper) {
         super(
-                ctx,
                 nettyEmbeddedServices.getRequestArgumentSatisfier().getBinderRegistry(),
                 nettyEmbeddedServices.getMediaTypeCodecRegistry(),
+                nettyEmbeddedServices.getMessageBodyHandlerRegistry(),
                 webSocketBean,
                 request,
                 routeMatch.getVariableValues(),
@@ -243,6 +243,7 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
                 channel,
                 originatingRequest,
                 mediaTypeCodecRegistry,
+                messageBodyHandlerRegistry,
                 webSocketVersion.toHttpHeaderValue(),
                 ctx.pipeline().get(SslHandler.class) != null
         ) {

--- a/http-server/src/main/java/io/micronaut/http/server/codec/TextStreamCodec.java
+++ b/http-server/src/main/java/io/micronaut/http/server/codec/TextStreamCodec.java
@@ -50,11 +50,13 @@ import java.util.List;
  *
  * @author Graeme Rocher
  * @since 1.0
+ * @deprecated Replaced with message body writers / readers API
  */
 @Singleton
 @Internal
 @BootstrapContextCompatible
 @Requires(bean = ByteBufferFactory.class)
+@Deprecated(forRemoval = true, since = "4.7")
 public class TextStreamCodec implements MediaTypeCodec {
 
     public static final String CONFIGURATION_QUALIFIER = "text-stream";

--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -445,4 +445,24 @@ public interface HttpRequest<B> extends HttpMessage<B> {
         Objects.requireNonNull(httpMethodName, "Argument [httpMethodName] is required");
         return HttpRequestFactory.INSTANCE.create(httpMethod, uri, httpMethodName);
     }
+
+    /**
+     * Returns a mutable request based on this request.
+     * @return the mutable request
+     * @since 4.7
+     */
+    default MutableHttpRequest<B> toMutableRequest() {
+        if (this instanceof MutableHttpRequest<B> mutableHttpRequest) {
+            return mutableHttpRequest;
+        }
+        MutableHttpRequest<B> mutableHttpRequest = HttpRequest.create(getMethod(), getUri().toString());
+        getBody().ifPresent(mutableHttpRequest::body);
+        getHeaders().forEach((name, value) -> {
+            for (String val : value) {
+                mutableHttpRequest.header(name, val);
+            }
+        });
+        mutableHttpRequest.getAttributes().putAll(getAttributes());
+        return mutableHttpRequest;
+    }
 }

--- a/http/src/main/java/io/micronaut/http/MutableHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/MutableHttpRequest.java
@@ -160,4 +160,9 @@ public interface MutableHttpRequest<B> extends HttpRequest<B>, MutableHttpMessag
     default MutableHttpRequest<B> contentEncoding(CharSequence encoding) {
         return (MutableHttpRequest<B>) MutableHttpMessage.super.contentEncoding(encoding);
     }
+
+    @Override
+    default MutableHttpRequest<B> toMutableRequest() {
+        return this;
+    }
 }

--- a/http/src/main/java/io/micronaut/http/body/MessageBodyHandlerRegistry.java
+++ b/http/src/main/java/io/micronaut/http/body/MessageBodyHandlerRegistry.java
@@ -23,7 +23,6 @@ import io.micronaut.http.MediaType;
 import io.micronaut.http.codec.CodecException;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -68,9 +67,8 @@ public interface MessageBodyHandlerRegistry {
      * @since 4.6
      */
     default <T> Optional<MessageBodyReader<T>> findReader(@NonNull Argument<T> type,
-                                                          @NonNull MediaType mediaType) {
-        Objects.requireNonNull(mediaType);
-        return findReader(type, List.of(mediaType));
+                                                          @Nullable MediaType mediaType) {
+        return findReader(type, mediaType == null ? List.of() : List.of(mediaType));
     }
 
     /**
@@ -103,8 +101,8 @@ public interface MessageBodyHandlerRegistry {
      * @since 4.6
      */
     default <T> Optional<MessageBodyWriter<T>> findWriter(@NonNull Argument<T> type,
-                                                          @NonNull MediaType mediaType) {
-        return findWriter(type, List.of(mediaType));
+                                                          @Nullable MediaType mediaType) {
+        return findWriter(type, mediaType == null ? List.of() : List.of(mediaType));
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/codec/DefaultMediaTypeCodecRegistry.java
+++ b/http/src/main/java/io/micronaut/http/codec/DefaultMediaTypeCodecRegistry.java
@@ -30,7 +30,9 @@ import java.util.Optional;
  *
  * @author Graeme Rocher
  * @since 1.0
+ * @deprecated Replaced with {@link io.micronaut.http.body.MessageBodyHandlerRegistry}.
  */
+@Deprecated(forRemoval = true, since = "4.7")
 public class DefaultMediaTypeCodecRegistry implements MediaTypeCodecRegistry {
 
     Map<String, Optional<MediaTypeCodec>> decodersByExtension = new LinkedHashMap<>(3);

--- a/http/src/main/java/io/micronaut/http/codec/MediaTypeCodec.java
+++ b/http/src/main/java/io/micronaut/http/codec/MediaTypeCodec.java
@@ -33,7 +33,9 @@ import java.util.Collection;
  *
  * @author Graeme Rocher
  * @since 1.0
+ * @deprecated Replaced with {@link io.micronaut.http.body.MessageBodyHandler}
  */
+@Deprecated(since = "4.7")
 @Indexed(MediaTypeCodec.class)
 public interface MediaTypeCodec {
 

--- a/http/src/main/java/io/micronaut/http/codec/MediaTypeCodecRegistry.java
+++ b/http/src/main/java/io/micronaut/http/codec/MediaTypeCodecRegistry.java
@@ -26,7 +26,9 @@ import java.util.Optional;
  *
  * @author Graeme Rocher
  * @since 1.0
+ * @deprecated Replaced with {@link io.micronaut.http.body.MessageBodyHandlerRegistry}.
  */
+@Deprecated(since = "4.7")
 public interface MediaTypeCodecRegistry {
 
     /**

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
@@ -41,6 +41,13 @@ public class SimpleHttpHeaders implements MutableHttpHeaders {
 
     /**
      * Map-based implementation of {@link MutableHttpHeaders}.
+     */
+    public SimpleHttpHeaders() {
+        this(ConversionService.SHARED);
+    }
+
+    /**
+     * Map-based implementation of {@link MutableHttpHeaders}.
      *
      * @param headers           The headers
      * @param conversionService The conversion service

--- a/http/src/main/java/io/micronaut/runtime/http/codec/TextPlainCodec.java
+++ b/http/src/main/java/io/micronaut/runtime/http/codec/TextPlainCodec.java
@@ -50,9 +50,11 @@ import java.util.Optional;
  *
  * @author Graeme Rocher
  * @since 1.0
+ * @deprecated Replaced with message body writers / readers API
  */
 @Singleton
 @BootstrapContextCompatible
+@Deprecated(forRemoval = true, since = "4.7")
 public class TextPlainCodec implements MediaTypeCodec {
 
     public static final String CONFIGURATION_QUALIFIER = "text";

--- a/jackson-databind/src/main/java/io/micronaut/jackson/codec/JacksonMediaTypeCodec.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/codec/JacksonMediaTypeCodec.java
@@ -41,7 +41,9 @@ import java.io.IOException;
  *
  * @author Graeme Rocher
  * @since 1.0.0
+ * @deprecated Replaced with message body writers / readers API
  */
+@Deprecated(forRemoval = true, since = "4.7")
 public abstract class JacksonMediaTypeCodec extends MapperMediaTypeCodec {
 
     public static final String REGULAR_JSON_MEDIA_TYPE_CODEC_NAME = "json";

--- a/jackson-databind/src/main/java/io/micronaut/jackson/codec/JsonMediaTypeCodec.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/codec/JsonMediaTypeCodec.java
@@ -36,12 +36,14 @@ import jakarta.inject.Singleton;
  *
  * @author Graeme Rocher
  * @since 1.0.0
+ * @deprecated Replaced with message body writers / readers API
  */
 @Named("json")
 @Singleton
 @Secondary
 @BootstrapContextCompatible
 @Bean(typed = {JsonMediaTypeCodec.class, JacksonMediaTypeCodec.class}) // do not expose MapperMediaTypeCodec
+@Deprecated(forRemoval = true, since = "4.7")
 public class JsonMediaTypeCodec extends JacksonMediaTypeCodec {
 
     public static final String CONFIGURATION_QUALIFIER = "json";

--- a/jackson-databind/src/main/java/io/micronaut/jackson/codec/JsonStreamMediaTypeCodec.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/codec/JsonStreamMediaTypeCodec.java
@@ -41,11 +41,13 @@ import java.util.List;
  *
  * @author Graeme Rocher
  * @since 1.0
+ * @deprecated Replaced with message body writers / readers API
  */
 @Secondary
 @Singleton
 @BootstrapContextCompatible
 @Bean(typed = {JsonStreamMediaTypeCodec.class, JacksonMediaTypeCodec.class}) // do not expose MapperMediaTypeCodec
+@Deprecated(forRemoval = true, since = "4.7")
 public class JsonStreamMediaTypeCodec extends JsonMediaTypeCodec {
 
     public static final String CONFIGURATION_QUALIFIER = "json-stream";

--- a/json-core/src/main/java/io/micronaut/json/body/CustomizableJsonHandler.java
+++ b/json-core/src/main/java/io/micronaut/json/body/CustomizableJsonHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.http.netty.body;
+package io.micronaut.json.body;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
@@ -22,11 +22,11 @@ import io.micronaut.json.JsonFeatures;
 /**
  * {@link io.micronaut.http.body.MessageBodyHandler} that is customizable with {@link JsonFeatures}.
  *
- * @since 4.0.0
- * @author Jonas Konrad
+ * @since 4.7.0
+ * @author Denis Stepanov
  */
 @Internal
-public interface CustomizableNettyJsonHandler {
+public interface CustomizableJsonHandler {
     @NonNull
-    CustomizableNettyJsonHandler customize(@NonNull JsonFeatures jsonFeatures);
+    CustomizableJsonHandler customize(@NonNull JsonFeatures jsonFeatures);
 }

--- a/json-core/src/main/java/io/micronaut/json/body/JsonMessageHandler.java
+++ b/json-core/src/main/java/io/micronaut/json/body/JsonMessageHandler.java
@@ -31,6 +31,7 @@ import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.body.MessageBodyHandler;
 import io.micronaut.http.body.MessageBodyWriter;
 import io.micronaut.http.codec.CodecException;
+import io.micronaut.json.JsonFeatures;
 import io.micronaut.json.JsonMapper;
 import jakarta.inject.Singleton;
 
@@ -59,7 +60,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @JsonMessageHandler.ProducesJson
 @JsonMessageHandler.ConsumesJson
 @BootstrapContextCompatible
-public final class JsonMessageHandler<T> implements MessageBodyHandler<T> {
+public final class JsonMessageHandler<T> implements MessageBodyHandler<T>, CustomizableJsonHandler {
 
     /**
      * The JSON handler should be preferred if for any type.
@@ -140,6 +141,11 @@ public final class JsonMessageHandler<T> implements MessageBodyHandler<T> {
         } catch (IOException e) {
             throw decorateWrite(object, e);
         }
+    }
+
+    @Override
+    public CustomizableJsonHandler customize(JsonFeatures jsonFeatures) {
+        return new JsonMessageHandler<>(jsonMapper.cloneWithFeatures(jsonFeatures));
     }
 
     /**

--- a/json-core/src/main/java/io/micronaut/json/codec/JsonMediaTypeCodec.java
+++ b/json-core/src/main/java/io/micronaut/json/codec/JsonMediaTypeCodec.java
@@ -35,11 +35,13 @@ import java.util.List;
  *
  * @author Graeme Rocher
  * @since 1.0.0
+ * @deprecated Replaced with message body writers / readers API
  */
 @Experimental
 @Named(MapperMediaTypeCodec.REGULAR_JSON_MEDIA_TYPE_CODEC_NAME)
 @Singleton
 @BootstrapContextCompatible
+@Deprecated(forRemoval = true, since = "4.7")
 public class JsonMediaTypeCodec extends MapperMediaTypeCodec {
 
     public static final String CONFIGURATION_QUALIFIER = "json";

--- a/json-core/src/main/java/io/micronaut/json/codec/JsonStreamMediaTypeCodec.java
+++ b/json-core/src/main/java/io/micronaut/json/codec/JsonStreamMediaTypeCodec.java
@@ -37,10 +37,12 @@ import java.util.List;
  *
  * @author Graeme Rocher
  * @since 1.0
+ * @deprecated Replaced with message body writers / readers API
  */
 @Experimental
 @Singleton
 @BootstrapContextCompatible
+@Deprecated(forRemoval = true, since = "4.7")
 public class JsonStreamMediaTypeCodec extends JsonMediaTypeCodec {
 
     public static final String CONFIGURATION_QUALIFIER = "json-stream";

--- a/json-core/src/main/java/io/micronaut/json/codec/MapperMediaTypeCodec.java
+++ b/json-core/src/main/java/io/micronaut/json/codec/MapperMediaTypeCodec.java
@@ -47,7 +47,9 @@ import java.util.List;
  * @author Graeme Rocher
  * @author svishnyakov
  * @since 1.3.0
+ * @deprecated Replaced with message body writers / readers API
  */
+@Deprecated(since = "4.7")
 @Experimental
 public abstract class MapperMediaTypeCodec implements MediaTypeCodec {
     public static final String REGULAR_JSON_MEDIA_TYPE_CODEC_NAME = "json";


### PR DESCRIPTION
I tested it by disabling all codecs, and the tests passed.

Right now, we still don't use the message body API for functions. We should convert other modules: servlet, Oracle Cloud, Azure, and GCP. 