### PR TITLE
Cache Micronaut META-INF services

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/IOUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/IOUtils.java
@@ -37,12 +37,17 @@ import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.ProviderNotFoundException;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 /**
  * Utility methods for I/O operations.
@@ -98,7 +103,6 @@ public class IOUtils {
         try {
             Path myPath = resolvePath(uri, path, toClose, IOUtils::loadNestedJarUri);
             if (myPath != null) {
-                Path finalMyPath = myPath;
                 // use this method instead of Files#walk to eliminate the Stream overhead
                 Files.walkFileTree(myPath, Collections.emptySet(), 1, new FileVisitor<>() {
                     @Override
@@ -108,7 +112,7 @@ public class IOUtils {
 
                     @Override
                     public FileVisitResult visitFile(Path currentPath, BasicFileAttributes attrs) throws IOException {
-                        if (currentPath.equals(finalMyPath) || Files.isHidden(currentPath) || currentPath.getFileName().startsWith(".")) {
+                        if (currentPath.equals(myPath) || Files.isHidden(currentPath) || currentPath.getFileName().startsWith(".")) {
                             return FileVisitResult.CONTINUE;
                         }
                         consumer.accept(currentPath);
@@ -136,6 +140,23 @@ public class IOUtils {
                 }
             }
         }
+    }
+
+    /**
+     * Resolve the path in the URI.
+     *
+     * @param uri     The URI
+     * @param path    The path
+     * @param toClose to close hooks
+     * @return The path resolved
+     * @throws IOException
+     * @since 4.7
+     */
+    @Nullable
+    public static Path resolvePath(@NonNull URI uri,
+                                   @NonNull String path,
+                                   @NonNull List<Closeable> toClose) throws IOException {
+        return resolvePath(uri, path, toClose, IOUtils::loadNestedJarUri);
     }
 
     @Nullable
@@ -234,5 +255,83 @@ public class IOUtils {
             }
         }
         return answer.toString();
+    }
+
+    /**
+     * Find all the resources starting with the path.
+     *
+     * @param classLoader The classloader
+     * @param path        The path
+     * @return the resources as URIs
+     * @throws IOException
+     * @since 4.7
+     */
+    public static List<URI> getResources(ClassLoader classLoader, final String path) throws IOException {
+        final Enumeration<URL> micronautResources = classLoader.getResources(path);
+        Set<URI> uniqueURIs = new LinkedHashSet<>();
+        while (micronautResources.hasMoreElements()) {
+            URL url = micronautResources.nextElement();
+            try {
+                uniqueURIs.add(url.toURI());
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (uniqueURIs.isEmpty()) {
+            FileSystem fs = null;
+            try {
+                fs = FileSystems.getFileSystem(URI.create("jrt:/"));
+            } catch (FileSystemNotFoundException | ProviderNotFoundException e) {
+                //no-op
+            }
+            if (fs == null || !fs.isOpen()) {
+                try {
+                    fs = FileSystems.newFileSystem(URI.create("jrt:/"), Collections.emptyMap(), classLoader);
+                } catch (IOException | ProviderNotFoundException e) {
+                    // not available, probably running in Native Image.
+                }
+            }
+            if (fs != null) {
+                Path modulesPath = fs.getPath("modules");
+                try (Stream<Path> stream = Files.list(modulesPath)) {
+                    stream
+                        .filter(p -> !p.getFileName().toString().startsWith("jdk.")) // filter out JDK internal modules
+                        .filter(p -> !p.getFileName().toString().startsWith("java.")) // filter out JDK public modules
+                        .map(p -> p.resolve(path))
+                        .filter(Files::exists)
+                        .map(modulesPath::resolve)
+                        .map(Path::toUri)
+                        .forEach(uniqueURIs::add);
+                }
+
+                // uri will be jrt:/modules/<module>/META-INF/micronaut/<service>, so we can walk through its files as if it was a directory
+            }
+        }
+        List<URI> uris = new ArrayList<>(uniqueURIs.size());
+        for (URI uri : uniqueURIs) {
+            String scheme = uri.getScheme();
+            if ("file".equals(scheme)) {
+                uri = normalizeFilePath(path, uri);
+            }
+            // on GraalVM there are spurious extra resources that end with # and then a number
+            // we ignore this extra ones
+            if (!("resource".equals(scheme) && uri.toString().contains("#"))) {
+                uris.add(uri);
+            }
+        }
+        return uris;
+    }
+
+    private static URI normalizeFilePath(String path, URI uri) {
+        Path p = Paths.get(uri);
+        if (p.endsWith(path)) {
+            Path subpath = Paths.get(path);
+            for (int i = 0; i < subpath.getNameCount(); i++) {
+                p = p.getParent();
+            }
+            uri = p.toUri();
+        }
+        return uri;
     }
 }

--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -93,9 +93,10 @@ public final class MicronautMetaServiceLoaderUtils {
                                                               @NonNull String serviceName) throws IOException {
         CacheEntry ce = cacheEntry;
         if (ce == null || ce.classLoader != classLoader) {
-            cacheEntry = new CacheEntry(classLoader, findAllMicronautMetaServices(classLoader));
+            ce = new CacheEntry(classLoader, findAllMicronautMetaServices(classLoader));
+            cacheEntry = ce;
         }
-        return cacheEntry.services.getOrDefault(serviceName, Set.of());
+        return ce.services.getOrDefault(serviceName, Set.of());
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -59,8 +59,8 @@ public final class MicronautMetaServiceLoaderUtils {
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
     private static final MethodType VOID_TYPE = MethodType.methodType(void.class);
 
-    private static ClassLoader CACHED_SERVICES_CLASSLOADER;
-    private static Map<String, Set<String>> CACHED_SERVICES;
+    private static ClassLoader cachedServicesClassloader;
+    private static Map<String, Set<String>> cachedServices;
 
     /**
      * Find all instantiated Micronaut service entries.
@@ -96,11 +96,11 @@ public final class MicronautMetaServiceLoaderUtils {
     @NonNull
     public static Set<String> findMicronautMetaServiceEntries(@NonNull ClassLoader classLoader,
                                                               @NonNull String serviceName) throws IOException {
-        if (CACHED_SERVICES == null || CACHED_SERVICES_CLASSLOADER != classLoader) {
-            CACHED_SERVICES = findAllMicronautMetaServices(classLoader);
-            CACHED_SERVICES_CLASSLOADER = classLoader;
+        if (cachedServices == null || cachedServicesClassloader != classLoader) {
+            cachedServices = findAllMicronautMetaServices(classLoader);
+            cachedServicesClassloader = classLoader;
         }
-        return CACHED_SERVICES.getOrDefault(serviceName, Set.of());
+        return cachedServices.getOrDefault(serviceName, Set.of());
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -93,9 +93,9 @@ public final class MicronautMetaServiceLoaderUtils {
                                                               @NonNull String serviceName) throws IOException {
         CacheEntry ce = cacheEntry;
         if (ce == null || ce.classLoader != classLoader) {
-            cacheEntry = new CacheEntry(classLoader, findAllMicronautMetaServices(classLoader));
+            cacheEntry = ce = new CacheEntry(classLoader, findAllMicronautMetaServices(classLoader));
         }
-        return cacheEntry.services.getOrDefault(serviceName, Set.of());
+        return ce.services.getOrDefault(serviceName, Set.of());
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -91,7 +91,8 @@ public final class MicronautMetaServiceLoaderUtils {
     @NonNull
     public static Set<String> findMicronautMetaServiceEntries(@NonNull ClassLoader classLoader,
                                                               @NonNull String serviceName) throws IOException {
-        if (cacheEntry == null || cacheEntry.classLoader != classLoader) {
+        CacheEntry ce = cacheEntry;
+        if (ce == null || ce.classLoader != classLoader) {
             cacheEntry = new CacheEntry(classLoader, findAllMicronautMetaServices(classLoader));
         }
         return cacheEntry.services.getOrDefault(serviceName, Set.of());

--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.io.service;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.io.IOUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URI;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RecursiveAction;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * The loader of Micronaut services under META-INF/micronaut/.
+ *
+ * @author Denis Stepanov
+ * @since 4.7
+ */
+@Internal
+public final class MicronautMetaServiceLoaderUtils {
+
+    private static final String MICRONAUT_SERVICES_PATH = "META-INF/micronaut/";
+
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
+    private static final MethodType VOID_TYPE = MethodType.methodType(void.class);
+
+    private static Map<String, Set<String>> services;
+
+    /**
+     * Find all instantiated Micronaut service entries.
+     *
+     * @param constructor  The final collection constructor by size
+     * @param classLoader  The classloader
+     * @param serviceClass The service class
+     * @param predicate    The predicate
+     * @param <S>          The service type
+     * @return the result
+     */
+    @NonNull
+    public static <S> List<S> findMetaMicronautServiceEntries(@NonNull Function<Integer, List<S>> constructor,
+                                                              @NonNull ClassLoader classLoader,
+                                                              @NonNull Class<S> serviceClass,
+                                                              @Nullable Predicate<S> predicate) {
+        SoftServiceLoader.StaticServiceLoader<S> staticServiceLoader = (SoftServiceLoader.StaticServiceLoader<S>) SoftServiceLoader.STATIC_SERVICES.get(serviceClass.getName());
+        if (staticServiceLoader != null) {
+            return staticServiceLoader.load(predicate);
+        }
+        return new MicronautServiceCollector<>(classLoader, serviceClass.getName(), predicate)
+            .collect(constructor, true);
+    }
+
+    /**
+     * Find Micronaut service entries.
+     *
+     * @param classLoader The classloader
+     * @param serviceName The service name
+     * @return The entries
+     * @throws IOException
+     */
+    @NonNull
+    public static Set<String> findMicronautMetaServiceEntries(@NonNull ClassLoader classLoader,
+                                                              @NonNull String serviceName) throws IOException {
+        if (services == null) {
+            // Should we cache based on the classloader?
+            services = findAllMicronautMetaServices(classLoader);
+        }
+        return services.getOrDefault(serviceName, Set.of());
+    }
+
+    /**
+     * Find all Micronaut services.
+     *
+     * @param classLoader The classloader
+     * @return the all entries
+     * @throws IOException
+     */
+    @NonNull
+    public static Map<String, Set<String>> findAllMicronautMetaServices(@NonNull ClassLoader classLoader) throws IOException {
+        final ServiceScanner.StaticServiceDefinitions ssd = ServiceScanner.findStaticServiceDefinitions();
+        if (ssd != null) {
+            return ssd.serviceTypeMap();
+        }
+        List<URI> resourceDefs = IOUtils.getResources(classLoader, MICRONAUT_SERVICES_PATH);
+        if (resourceDefs.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, Set<String>> services = new LinkedHashMap<>();
+
+        FileVisitor<Path> visitor = new FileVisitor<>() {
+
+            private Set<String> definitions;
+
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                if (dir.endsWith(MICRONAUT_SERVICES_PATH)) {
+                    return FileVisitResult.CONTINUE;
+                }
+                String serviceName = dir.getFileName().toString();
+                definitions = services.get(serviceName);
+                if (definitions == null) {
+                    definitions = new LinkedHashSet<>();
+                    services.put(serviceName, definitions);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path currentPath, BasicFileAttributes attrs) throws IOException {
+                if (Files.isHidden(currentPath)) {
+                    return FileVisitResult.CONTINUE;
+                }
+                Path fileName = currentPath.getFileName();
+                if (fileName.startsWith(".")) {
+                    return FileVisitResult.CONTINUE;
+                }
+                definitions.add(fileName.toString());
+                return FileVisitResult.SKIP_SUBTREE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+                return FileVisitResult.CONTINUE;
+            }
+        };
+
+        List<Closeable> toClose = new ArrayList<>();
+        try {
+            for (URI uri : resourceDefs) {
+                Path myPath = IOUtils.resolvePath(uri, MICRONAUT_SERVICES_PATH, toClose);
+                if (myPath != null) {
+                    Files.walkFileTree(myPath, Collections.emptySet(), 2, visitor);
+                }
+            }
+        } catch (IOException e) {
+            // ignore, can't do anything here and can't log because class used in compiler
+        } finally {
+            for (Closeable closeable : toClose) {
+                try {
+                    closeable.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
+        return services;
+    }
+
+    private static <S> S instantiate(String className, ClassLoader classLoader) {
+        try {
+            @SuppressWarnings("unchecked") final Class<S> loadedClass =
+                (Class<S>) Class.forName(className, false, classLoader);
+            // MethodHandler should more performant than the basic reflection
+            return (S) LOOKUP.findConstructor(loadedClass, VOID_TYPE).invoke();
+        } catch (NoClassDefFoundError | ClassNotFoundException | NoSuchMethodException |
+                 IllegalAccessException e) {
+            // Ignore
+            return null;
+        } catch (Throwable e) {
+            return sneakyThrow(e);
+        }
+    }
+
+    private static <T extends Throwable, R> R sneakyThrow(Throwable t) throws T {
+        throw (T) t;
+    }
+
+    /**
+     * Fork-join recursive services loader.
+     *
+     * @param <S> The service type
+     */
+    @SuppressWarnings("java:S1948")
+    private static final class MicronautServiceCollector<S> extends RecursiveActionValuesCollector<S> {
+
+        private final ClassLoader classLoader;
+        private final String serviceName;
+        private final Predicate<S> predicate;
+        private final List<RecursiveActionValuesCollector<S>> tasks = new ArrayList<>();
+        private final AtomicInteger size = new AtomicInteger();
+
+        MicronautServiceCollector(ClassLoader classLoader, String serviceName, Predicate<S> predicate) {
+            this.classLoader = classLoader;
+            this.serviceName = serviceName;
+            this.predicate = predicate;
+        }
+
+        @Override
+        protected void compute() {
+            try {
+                Set<String> serviceEntries = MicronautMetaServiceLoaderUtils.findMicronautMetaServiceEntries(classLoader, serviceName);
+                size.set(serviceEntries.size());
+                for (String serviceEntry : serviceEntries) {
+                    final ServiceInstanceLoader<S> task = new ServiceInstanceLoader<>(classLoader, serviceEntry, predicate);
+                    tasks.add(task);
+                    task.fork();
+                }
+            } catch (IOException e) {
+                throw new ServiceConfigurationError("Failed to load resources for service: " + serviceName, e);
+            }
+        }
+
+        public List<S> collect(Function<Integer, List<S>> constructor, boolean allowFork) {
+            if (allowFork && ForkJoinPool.getCommonPoolParallelism() > 1) {
+                ForkJoinPool.commonPool().invoke(this);
+                List<S> collection = null;
+                for (RecursiveActionValuesCollector<S> task : tasks) {
+                    task.join();
+                    if (collection == null) {
+                        collection = constructor.apply(size.get());
+                    }
+                    task.collect(collection);
+                }
+                return collection;
+            }
+            try {
+                Set<String> serviceEntries = MicronautMetaServiceLoaderUtils.findMicronautMetaServiceEntries(classLoader, serviceName);
+                List<S> collection = constructor.apply(serviceEntries.size());
+                for (String serviceEntry : serviceEntries) {
+                    S val = instantiate(serviceEntry, classLoader);
+                    if (val != null && predicate.test(val)) {
+                        collection.add(val);
+                    }
+                }
+                return collection;
+            } catch (IOException e) {
+                throw new ServiceConfigurationError("Failed to load resources for service: " + serviceName, e);
+            }
+        }
+
+        @Override
+        public void collect(Collection<S> values) {
+            throw new IllegalStateException("Only constructor method is supported!");
+        }
+    }
+
+    /**
+     * Initializes and filters the entry.
+     *
+     * @param <S> The service type
+     */
+    private static final class ServiceInstanceLoader<S> extends RecursiveActionValuesCollector<S> {
+
+        private final ClassLoader classLoader;
+        private final String className;
+        private final Predicate<S> predicate;
+        private S result;
+        private Throwable throwable;
+
+        public ServiceInstanceLoader(ClassLoader classLoader, String className, Predicate<S> predicate) {
+            this.classLoader = classLoader;
+            this.className = className;
+            this.predicate = predicate;
+        }
+
+        @Override
+        protected void compute() {
+            try {
+                result = instantiate(className, classLoader);
+                if (result != null && predicate != null && !predicate.test(result)) {
+                    result = null;
+                }
+            } catch (Throwable e) {
+                throwable = e;
+            }
+        }
+
+        @Override
+        public void collect(Collection<S> values) {
+            if (throwable != null) {
+                throw new SoftServiceLoader.ServiceLoadingException("Failed to load a service: " + throwable.getMessage(), throwable);
+            }
+            if (result != null && !values.contains(result)) {
+                values.add(result);
+            }
+        }
+    }
+
+    /**
+     * Abstract recursive action class.
+     *
+     * @param <S> The type
+     */
+    private abstract static class RecursiveActionValuesCollector<S> extends RecursiveAction {
+
+        /**
+         * Collects loaded values.
+         *
+         * @param values The values
+         */
+        public abstract void collect(Collection<S> values);
+
+    }
+
+}

--- a/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
@@ -17,39 +17,24 @@ package io.micronaut.core.io.service;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.io.IOUtils;
-import java.nio.file.FileSystemNotFoundException;
-import java.nio.file.ProviderNotFoundException;
-import java.util.stream.Stream;
 import org.graalvm.nativeimage.ImageSingletons;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceConfigurationError;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveAction;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -72,49 +57,8 @@ final class ServiceScanner<S> {
         this.transformer = transformer;
     }
 
-    private static URI normalizeFilePath(String path, URI uri) {
-        Path p = Paths.get(uri);
-        if (p.endsWith(path)) {
-            Path subpath = Paths.get(path);
-            for (int i = 0; i < subpath.getNameCount(); i++) {
-                p = p.getParent();
-            }
-            uri = p.toUri();
-        }
-        return uri;
-    }
-
-    /**
-     * Note: referenced by {@code io.micronaut.core.graal.ServiceLoaderInitialization}.
-     */
-    @SuppressWarnings("java:S3398")
-    private static Set<String> computeMicronautServiceTypeNames(URI uri, String path) {
-        final StaticServiceDefinitions ssd = findStaticServiceDefinitions();
-        if (ssd != null) {
-            return ssd.serviceTypeMap.getOrDefault(
-                path,
-                Collections.emptySet()
-            );
-        } else {
-            Set<String> typeNames = new HashSet<>();
-            // Keep the anonymous class instead of Lambda to reduce the Lambda invocation overhead during the startup
-            @SuppressWarnings({"Convert2Lambda", "java:S1604"}) Consumer<Path> consumer = new Consumer<>() {
-
-                @Override
-                public void accept(Path currentPath) {
-                    if (Files.isRegularFile(currentPath)) {
-                        final String typeName = currentPath.getFileName().toString();
-                        typeNames.add(typeName);
-                    }
-                }
-            };
-            IOUtils.eachFile(uri, path, consumer);
-            return typeNames;
-        }
-    }
-
     @Nullable
-    private static StaticServiceDefinitions findStaticServiceDefinitions() {
+    static StaticServiceDefinitions findStaticServiceDefinitions() {
         if (hasImageSingletons()) {
             return ImageSingletons.contains(StaticServiceDefinitions.class) ? ImageSingletons.lookup(StaticServiceDefinitions.class) : null;
         } else {
@@ -143,7 +87,7 @@ final class ServiceScanner<S> {
                     if (line == null) {
                         break;
                     }
-                    if (line.length() == 0 || line.charAt(0) == '#') {
+                    if (line.isEmpty() || line.charAt(0) == '#') {
                         continue;
                     }
                     if (!lineCondition.test(line)) {
@@ -162,78 +106,8 @@ final class ServiceScanner<S> {
         return typeNames;
     }
 
-    private boolean isWebSphereClassLoader() {
-        return classLoader.getClass().getName().startsWith("com.ibm.ws.classloader");
-    }
-
-    private String buildResourceSearchPath() {
-        String path = "META-INF/micronaut/" + serviceName;
-
-        if (isWebSphereClassLoader()) {
-            // Special case WebSphere classloader
-            // https://github.com/micronaut-projects/micronaut-core/issues/9905
-            return path + "/";
-        }
-
-        return path;
-    }
-
     private Enumeration<URL> findStandardServiceConfigs() throws IOException {
         return classLoader.getResources(SoftServiceLoader.META_INF_SERVICES + '/' + serviceName);
-    }
-
-    private void findMicronautMetaServiceConfigs(BiConsumer<URI, String> consumer) throws IOException, URISyntaxException {
-        String path = buildResourceSearchPath();
-        final Enumeration<URL> micronautResources = classLoader.getResources(path);
-        Set<URI> uniqueURIs = new LinkedHashSet<>();
-        while (micronautResources.hasMoreElements()) {
-            URL url = micronautResources.nextElement();
-            final URI uri = url.toURI();
-            uniqueURIs.add(uri);
-        }
-
-        if (uniqueURIs.isEmpty()) {
-            FileSystem fs = null;
-            try {
-                fs = FileSystems.getFileSystem(URI.create("jrt:/"));
-            } catch (FileSystemNotFoundException | ProviderNotFoundException e) {
-                //no-op
-            }
-            if (fs == null || !fs.isOpen()) {
-                try {
-                    fs = FileSystems.newFileSystem(URI.create("jrt:/"), Collections.emptyMap(), classLoader);
-                } catch (IOException | ProviderNotFoundException e) {
-                    // not available, probably running in Native Image.
-                }
-            }
-            if (fs != null) {
-                Path modulesPath = fs.getPath("modules");
-                try (Stream<Path> stream = Files.list(modulesPath)) {
-                    stream
-                        .filter(p -> !p.getFileName().toString().startsWith("jdk.")) // filter out JDK internal modules
-                        .filter(p -> !p.getFileName().toString().startsWith("java.")) // filter out JDK public modules
-                        .map(p -> p.resolve(path))
-                        .filter(Files::exists)
-                        .map(modulesPath::resolve)
-                        .map(Path::toUri)
-                        .forEach(uniqueURIs::add);
-                }
-
-                // uri will be jrt:/modules/<module>/META-INF/micronaut/<service>, so we can walk through its files as if it was a directory
-            }
-        }
-
-        for (URI uri : uniqueURIs) {
-            String scheme = uri.getScheme();
-            if ("file".equals(scheme)) {
-                uri = normalizeFilePath(path, uri);
-            }
-            // on GraalVM there are spurious extra resources that end with # and then a number
-            // we ignore this extra ones
-            if (!("resource".equals(scheme) && uri.toString().contains("#"))) {
-                consumer.accept(uri, path);
-            }
-        }
     }
 
     /**
@@ -254,12 +128,13 @@ final class ServiceScanner<S> {
                     tasks.add(task);
                     task.fork();
                 }
-                findMicronautMetaServiceConfigs((uri, path) -> {
-                    final MicronautMetaServicesLoader task = new MicronautMetaServicesLoader(uri, path);
+                Set<String> serviceEntries = MicronautMetaServiceLoaderUtils.findMicronautMetaServiceEntries(classLoader, serviceName);
+                for (String serviceEntry : serviceEntries) {
+                    final ServiceInstanceLoader task = new ServiceInstanceLoader(serviceEntry);
                     tasks.add(task);
                     task.fork();
-                });
-            } catch (IOException | URISyntaxException e) {
+                }
+            } catch (IOException e) {
                 throw new ServiceConfigurationError("Failed to load resources for service: " + serviceName, e);
             }
         }
@@ -293,47 +168,16 @@ final class ServiceScanner<S> {
                             }
                         }
                     }
-                    findMicronautMetaServiceConfigs((uri, path) -> {
-                        for (String typeName : computeMicronautServiceTypeNames(uri, path)) {
-                            S val = transformer.apply(typeName);
-                            if (val != null) {
-                                values.add(val);
-                            }
+                    Set<String> serviceEntries = MicronautMetaServiceLoaderUtils.findMicronautMetaServiceEntries(classLoader, serviceName);
+                    for (String serviceEntry : serviceEntries) {
+                        S val = transformer.apply(serviceEntry);
+                        if (val != null) {
+                            values.add(val);
                         }
-                    });
-                } catch (IOException | URISyntaxException e) {
+                    }
+                } catch (IOException e) {
                     throw new ServiceConfigurationError("Failed to load resources for service: " + serviceName, e);
                 }
-            }
-        }
-    }
-
-    private final class MicronautMetaServicesLoader extends RecursiveActionValuesCollector<S> {
-        private final URI uri;
-        private final List<ServiceInstanceLoader> tasks = new ArrayList<>();
-        private final String path;
-
-        private MicronautMetaServicesLoader(URI uri, String path) {
-            this.uri = uri;
-            this.path = path;
-        }
-
-        @Override
-        public void collect(Collection<S> values) {
-            for (ServiceInstanceLoader task : tasks) {
-                task.join();
-                task.collect(values);
-            }
-        }
-
-        @Override
-        @SuppressWarnings("java:S2095")
-        protected void compute() {
-            Set<String> typeNames = computeMicronautServiceTypeNames(uri, path);
-            for (String typeName : typeNames) {
-                ServiceInstanceLoader task = new ServiceInstanceLoader(typeName);
-                tasks.add(task);
-                task.fork();
             }
         }
     }

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -49,7 +49,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
     private static final MethodType VOID_TYPE = MethodType.methodType(void.class);
 
-    private static final Map<String, SoftServiceLoader.StaticServiceLoader<?>> STATIC_SERVICES =
+    static final Map<String, SoftServiceLoader.StaticServiceLoader<?>> STATIC_SERVICES =
             StaticOptimizations.get(Optimizations.class)
                     .map(Optimizations::getServiceLoaders)
                     .orElse(Collections.emptyMap());

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1877,7 +1877,6 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
         if (beanDefinitionReferences == null) {
             beanDefinitionReferences = MicronautMetaServiceLoaderUtils.findMetaMicronautServiceEntries(
-                ArrayList::new,
                 classLoader,
                 BeanDefinitionReference.class,
                 BeanDefinitionReference::isPresent
@@ -1917,7 +1916,6 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     protected Iterable<BeanConfiguration> resolveBeanConfigurations() {
         if (beanConfigurationsList == null) {
             beanConfigurationsList = MicronautMetaServiceLoaderUtils.findMetaMicronautServiceEntries(
-                ArrayList::new,
                 classLoader,
                 BeanConfiguration.class,
                 null

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -72,7 +72,7 @@ import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
-import io.micronaut.core.io.service.SoftServiceLoader;
+import io.micronaut.core.io.service.MicronautMetaServiceLoaderUtils;
 import io.micronaut.core.naming.NameResolver;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.naming.Named;
@@ -1876,9 +1876,12 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     @NonNull
     protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
         if (beanDefinitionReferences == null) {
-            final SoftServiceLoader<BeanDefinitionReference> definitions = SoftServiceLoader.load(BeanDefinitionReference.class, classLoader);
-            beanDefinitionReferences = new ArrayList<>(300);
-            definitions.collectAll(beanDefinitionReferences, BeanDefinitionReference::isPresent);
+            beanDefinitionReferences = MicronautMetaServiceLoaderUtils.findMetaMicronautServiceEntries(
+                ArrayList::new,
+                classLoader,
+                BeanDefinitionReference.class,
+                BeanDefinitionReference::isPresent
+            );
         }
         return beanDefinitionReferences;
     }
@@ -1913,9 +1916,12 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     @NonNull
     protected Iterable<BeanConfiguration> resolveBeanConfigurations() {
         if (beanConfigurationsList == null) {
-            final SoftServiceLoader<BeanConfiguration> definitions = SoftServiceLoader.load(BeanConfiguration.class, classLoader);
-            beanConfigurationsList = new ArrayList<>(300);
-            definitions.collectAll(beanConfigurationsList, null);
+            beanConfigurationsList = MicronautMetaServiceLoaderUtils.findMetaMicronautServiceEntries(
+                ArrayList::new,
+                classLoader,
+                BeanConfiguration.class,
+                null
+            );
         }
         return beanConfigurationsList;
     }


### PR DESCRIPTION
I noticed some time ago that we loaded the Miconaut META-INF service multiple times. Now, it should be cached and loaded only once. Also, for Micronaut services, we can avoid previous text file entries. That should improve some startup time.