### PR TITLE
Skip classes from introspection generation that are postponed

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -256,13 +256,16 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
     public void finish(VisitorContext visitorContext) {
         try {
             if (!writers.isEmpty()) {
-                for (BeanIntrospectionWriter writer : writers.values()) {
-                    try {
-                        writer.accept(visitorContext);
-                    } catch (IOException e) {
-                        throw new ClassGenerationException("I/O error occurred during class generation: " + e.getMessage(), e);
+                writers.forEach((className, writer) ->{
+                    if (!visitorContext.isPostponedToNextRound(className)) {
+                        try {
+                            writer.accept(visitorContext);
+                        } catch (IOException e) {
+                            throw new ClassGenerationException("I/O error occurred during class generation: " + e.getMessage(), e);
+                        }
                     }
-                }
+                });
+
             }
         } finally {
             writers.clear();

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -256,7 +256,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
     public void finish(VisitorContext visitorContext) {
         try {
             if (!writers.isEmpty()) {
-                writers.forEach((className, writer) ->{
+                writers.forEach((className, writer) -> {
                     if (!visitorContext.isPostponedToNextRound(className)) {
                         try {
                             writer.accept(visitorContext);

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -33,6 +33,7 @@ import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.ast.PropertyElementQuery;
+import io.micronaut.inject.visitor.ElementPostponedToNextRoundException;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.ClassGenerationException;
@@ -257,12 +258,12 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         try {
             if (!writers.isEmpty()) {
                 writers.forEach((className, writer) -> {
-                    if (!visitorContext.isPostponedToNextRound(className)) {
-                        try {
-                            writer.accept(visitorContext);
-                        } catch (IOException e) {
-                            throw new ClassGenerationException("I/O error occurred during class generation: " + e.getMessage(), e);
-                        }
+                    try {
+                        writer.accept(visitorContext);
+                    } catch (ElementPostponedToNextRoundException ignore) {
+                        // Ignore, next round will redo
+                    } catch (IOException e) {
+                        throw new ClassGenerationException("I/O error occurred during class generation: " + e.getMessage(), e);
                     }
                 });
 

--- a/core-processor/src/main/java/io/micronaut/inject/visitor/ElementPostponedToNextRoundException.java
+++ b/core-processor/src/main/java/io/micronaut/inject/visitor/ElementPostponedToNextRoundException.java
@@ -34,6 +34,7 @@ public final class ElementPostponedToNextRoundException extends RuntimeException
      * @param originatingElement The originating element
      */
     public ElementPostponedToNextRoundException(@NonNull Element originatingElement) {
+        super("Original element: " + originatingElement.getName() + " is postponed to the next round!");
         this.originatingElement = originatingElement;
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/visitor/ElementPostponedToNextRoundException.java
+++ b/core-processor/src/main/java/io/micronaut/inject/visitor/ElementPostponedToNextRoundException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.visitor;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.ast.Element;
+
+/**
+ * Exception is thrown when the visitor is attempted to create a new file but the originated element is postponed to the next round.
+ *
+ * @author Denis Stepanov
+ * @since 4.7
+ */
+@Internal
+public final class ElementPostponedToNextRoundException extends RuntimeException {
+
+    private final Element originatingElement;
+
+    /**
+     * @param originatingElement The originating element
+     */
+    public ElementPostponedToNextRoundException(@NonNull Element originatingElement) {
+        this.originatingElement = originatingElement;
+    }
+
+    @NonNull
+    public Element getOriginatingElement() {
+        return originatingElement;
+    }
+
+}

--- a/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
+++ b/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
@@ -281,6 +281,17 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
     }
 
     /**
+     * Whether processing is delayed to a later stage
+     * @param className The class name
+     * @return True it is
+     * @since 4.6.5
+     */
+    @Experimental
+    default boolean isPostponedToNextRound(String className) {
+        return false;
+    }
+
+    /**
      * The annotation processor environment custom options.
      * <p><b>All options names MUST start with {@link VisitorContext#MICRONAUT_BASE_OPTION_NAME}</b></p>
      *

--- a/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
+++ b/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
@@ -281,18 +281,6 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
     }
 
     /**
-     * Whether processing is delayed to a later stage.
-     *
-     * @param className The class name
-     * @return True it is
-     * @since 4.6.5
-     */
-    @Experimental
-    default boolean isPostponedToNextRound(String className) {
-        return false;
-    }
-
-    /**
      * The annotation processor environment custom options.
      * <p><b>All options names MUST start with {@link VisitorContext#MICRONAUT_BASE_OPTION_NAME}</b></p>
      *

--- a/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
+++ b/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
@@ -281,7 +281,8 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
     }
 
     /**
-     * Whether processing is delayed to a later stage
+     * Whether processing is delayed to a later stage.
+     *
      * @param className The class name
      * @return True it is
      * @since 4.6.5

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -19,12 +19,10 @@ import io.micronaut.annotation.processing.visitor.JavaVisitorContext;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
-import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 
-import java.util.LinkedHashSet;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
@@ -38,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -79,11 +78,7 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
     private final Set<String> supportedAnnotationTypes = new HashSet<>(5);
     private final Map<String, Boolean> isProcessedCache = new HashMap<>(30);
     private Set<String> processedTypes;
-    private Set<String> postponedTypes = new LinkedHashSet<>();
-
-    {
-        visitorAttributes.put(JavaVisitorContext.POSTPONED, postponedTypes);
-    }
+    protected Set<String> postponedTypes = new LinkedHashSet<>();
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
@@ -104,14 +99,6 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
         }
         options.addAll(super.getSupportedOptions());
         return options;
-    }
-
-    /**
-     * A list of types that are still pending.
-     * @return The pending types
-     */
-    protected Set<String> getPostponedTypes() {
-        return postponedTypes;
     }
 
     /**
@@ -231,7 +218,8 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
             modelUtils,
             filer,
             visitorAttributes,
-            getVisitorKind()
+            getVisitorKind(),
+            postponedTypes
         );
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -19,10 +19,12 @@ import io.micronaut.annotation.processing.visitor.JavaVisitorContext;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 
+import java.util.LinkedHashSet;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
@@ -77,6 +79,11 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
     private final Set<String> supportedAnnotationTypes = new HashSet<>(5);
     private final Map<String, Boolean> isProcessedCache = new HashMap<>(30);
     private Set<String> processedTypes;
+    private Set<String> postponedTypes = new LinkedHashSet<>();
+
+    {
+        visitorAttributes.put(JavaVisitorContext.POSTPONED, postponedTypes);
+    }
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
@@ -97,6 +104,14 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
         }
         options.addAll(super.getSupportedOptions());
         return options;
+    }
+
+    /**
+     * A list of types that are still pending.
+     * @return The pending types
+     */
+    protected Set<String> getPostponedTypes() {
+        return postponedTypes;
     }
 
     /**

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
@@ -29,6 +29,7 @@ import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+import java.util.Set;
 
 /**
  * Utility methods for annotations.
@@ -143,7 +144,8 @@ public class AnnotationUtils {
             modelUtils,
             filer,
             visitorAttributes,
-            TypeElementVisitor.VisitorKind.ISOLATING
+            TypeElementVisitor.VisitorKind.ISOLATING,
+            Set.of()
         );
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -240,10 +240,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                 roundEnv.getRootElements()
             ).filter(notGroovyObject).forEach(elements::add);
 
-            Set<String> postponedTypes = getPostponedTypes();
-            postponedTypes.stream().map(elementUtils::getTypeElement)
-                .filter(Objects::nonNull)
-                .forEach(elements::add);
+            postponedTypes.stream().map(elementUtils::getTypeElement).filter(Objects::nonNull).forEach(elements::add);
             postponedTypes.clear();
 
             if (!elements.isEmpty()) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -107,7 +107,6 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
 
     private List<LoadedVisitor> loadedVisitors;
     private Collection<? extends TypeElementVisitor<?, ?>> typeElementVisitors;
-    private final Set<String> pendingTypes = new LinkedHashSet<>();
 
     /**
      * The visited annotation names.
@@ -241,8 +240,11 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                 roundEnv.getRootElements()
             ).filter(notGroovyObject).forEach(elements::add);
 
-            pendingTypes.stream().map(elementUtils::getTypeElement).filter(Objects::nonNull).forEach(elements::add);
-            pendingTypes.clear();
+            Set<String> postponedTypes = getPostponedTypes();
+            postponedTypes.stream().map(elementUtils::getTypeElement)
+                .filter(Objects::nonNull)
+                .forEach(elements::add);
+            postponedTypes.clear();
 
             if (!elements.isEmpty()) {
 
@@ -272,7 +274,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                             }
                             error(originatingElement.element(), e.getMessage());
                         } catch (PostponeToNextRoundException e) {
-                            pendingTypes.add(javaClassElement.getName());
+                            postponedTypes.add(javaClassElement.getName());
                         }
                     }
                 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -52,6 +52,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 import java.lang.annotation.Annotation;
@@ -265,9 +266,13 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     @Override
     public Collection<ClassElement> getInterfaces() {
         if (resolvedInterfaces == null) {
-            resolvedInterfaces = classElement.getInterfaces().stream().map(mirror -> newClassElement(mirror, getTypeArguments())).toList();
+            resolvedInterfaces = classElement.getInterfaces().stream().filter(this::onlyAvailable).map(mirror -> newClassElement(mirror, getTypeArguments())).toList();
         }
         return resolvedInterfaces;
+    }
+
+    private boolean onlyAvailable(TypeMirror mirror) {
+        return !(mirror instanceof DeclaredType declaredType) || declaredType.getKind() != TypeKind.ERROR;
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
@@ -171,6 +171,7 @@ public final class JavaVisitorContext implements VisitorContext, BeanElementVisi
      * @param filer The filer
      * @param visitorAttributes The attributes
      * @param visitorKind The visitor kind
+     * @param postponedTypes The postponed types
      */
     public JavaVisitorContext(
         ProcessingEnvironment processingEnv,

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
@@ -82,6 +82,7 @@ import java.util.stream.Stream;
 @Internal
 public final class JavaVisitorContext implements VisitorContext, BeanElementVisitorContext {
 
+    public static final String POSTPONED = "io.micronaut.POSTPONED";
     private final Messager messager;
     private final Elements elements;
     private final Types types;
@@ -166,6 +167,15 @@ public final class JavaVisitorContext implements VisitorContext, BeanElementVisi
         this.elementAnnotationMetadataFactory = new JavaElementAnnotationMetadataFactory(false, this.annotationMetadataBuilder);
         this.expressionCompilationContextFactory = new DefaultExpressionCompilationContextFactory(this);
         this.filer = filer;
+    }
+
+    @Override
+    public boolean isPostponedToNextRound(String className) {
+        return visitorAttributes.get(
+            JavaVisitorContext.POSTPONED,
+            Set.class,
+            Set.of()
+        ).contains(className);
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.visitors
+
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class PostponedVisitorsSpec extends AbstractTypeElementSpec {
+
+    void 'test'() {
+        when:
+            def definition = buildBeanIntrospection('test.Walrus', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.visitors.Wither;
+
+@Introspected
+@Wither
+public record Walrus (
+    @NonNull
+    String name,
+    int age,
+    byte[] chipInfo
+) implements WalrusWither  {
+}
+
+''')
+        then:
+            definition
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/Wither.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/Wither.java
@@ -1,0 +1,8 @@
+package io.micronaut.visitors;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Wither {
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/WitherVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/WitherVisitor.java
@@ -1,0 +1,47 @@
+package io.micronaut.visitors;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class WitherVisitor implements TypeElementVisitor<Wither, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+            context.visitGeneratedSourceFile(
+                "test",
+                "WalrusWither",
+                element
+            ).ifPresent(sourceFile -> {
+                try {
+                    sourceFile.write(writer -> writer.write("""
+                        package test;
+
+                        public interface WalrusWither {
+                            String name();
+
+                            int age();
+
+                            byte[] chipInfo();
+
+                            default Walrus withName(String name) {
+                                return new Walrus(name, this.age(), this.chipInfo());
+                            }
+
+                            default Walrus withAge(int age) {
+                                return new Walrus(this.name(), age, this.chipInfo());
+                            }
+
+                            default Walrus withChipInfo(byte[] chipInfo) {
+                                return new Walrus(this.name(), this.age(), chipInfo);
+                            }
+                        }
+                        """));
+                } catch (Exception e) {
+                    throw new ProcessingException(element, "Failed to generate a Wither: " + e.getMessage(), e);
+                }
+            });
+    }
+
+}

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -19,3 +19,4 @@ io.micronaut.annotation.AnnotatePropertySpec$AnnotatePropertyVisitor
 io.micronaut.annotation.AnnotateClassSpec$AnnotateClassVisitor
 io.micronaut.annotation.AnnotateTypeArgSpec$AnnotateTypeArgVisitor
 io.micronaut.aop.introduction.beans.MyRepoVisitor2
+io.micronaut.visitors.WitherVisitor


### PR DESCRIPTION
Currently if a class is postponed the introspection is still generated. This means that in the next round the introspection is recreated and an exception is thrown because there was an attempt to rewrite the some class.

Without this change it is impossible to use `@Wither` and `@Introspected` together.

Unclear how to create a test for it here. Will have to upgrade SourceGen and add a test there.