### PR TITLE
Add ability to disable normalization for property keys in EachProperty

### DIFF
--- a/core/src/main/java/io/micronaut/core/value/PropertyCatalog.java
+++ b/core/src/main/java/io/micronaut/core/value/PropertyCatalog.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.value;
+
+/**
+ * The property catalog to use.
+ *
+ * @since 4.7.0
+ */
+public enum PropertyCatalog {
+    /**
+     * The catalog that contains the raw keys.
+     */
+    RAW,
+    /**
+     * The catalog that contains normalized keys. A key is normalized into
+     * lower case hyphen separated form. For example an environment variable {@code FOO_BAR} would be
+     * normalized to {@code foo.bar}.
+     */
+    NORMALIZED,
+    /**
+     * The catalog that contains normalized keys and also generated keys. A synthetic key can be generated from
+     * an environment variable such as {@code FOO_BAR_BAZ} which will produce the following keys: {@code foo.bar.baz},
+     * {@code foo.bar-baz}, and {@code foo-bar.baz}.
+     */
+    GENERATED
+}

--- a/core/src/main/java/io/micronaut/core/value/PropertyResolver.java
+++ b/core/src/main/java/io/micronaut/core/value/PropertyResolver.java
@@ -90,6 +90,29 @@ public interface PropertyResolver extends ValueResolver<String> {
     }
 
     /**
+     * Returns a collection of properties entries under the given key, but .
+     * For example, if you set {@code PropertyCatalog.RAW} then the following keys:
+     *
+     * <pre>
+     * <code>datasource.MyDs-1.url=localhost
+     * datasource.MyDs-2.url=someother</code>
+     * </pre>
+     *
+     * Calling {@code getPropertyEntries(String)} with a value of {@code datasource} will result in a collection
+     * containing {@code MyDs-1} and {@code MyDs-2} (without normalization).
+     *
+     * @param name The name to resolve
+     * @param propertyCatalog property catalog to use
+     * @return The property entries.
+     *
+     * @since 4.7.0
+     */
+    @NonNull
+    default Collection<String> getPropertyEntries(@NonNull String name, @NonNull PropertyCatalog propertyCatalog) {
+        return Collections.emptySet();
+    }
+
+    /**
      * <p>Resolve the given property for the given name, type and generic type arguments.</p>
      *
      * <p>Implementers can choose to implement more intelligent type conversion by analyzing the typeArgument.</p>

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/eachbeanparameter/EachPropertyPropertiesDefault.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/eachbeanparameter/EachPropertyPropertiesDefault.java
@@ -1,0 +1,44 @@
+package io.micronaut.inject.configproperties.eachbeanparameter;
+
+import io.micronaut.context.annotation.ConfigurationInject;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+
+@Requires(property = "spec", value = "DisabledNormalizationSpec")
+@EachProperty(value = "app.default")
+public class EachPropertyPropertiesDefault {
+
+    private String name;
+    private String url;
+    private int serverPort;
+
+    @ConfigurationInject
+    public EachPropertyPropertiesDefault(@Parameter String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getServerPort() {
+        return serverPort;
+    }
+
+    public void setServerPort(int serverPort) {
+        this.serverPort = serverPort;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/eachbeanparameter/EachPropertyPropertiesGenerated.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/eachbeanparameter/EachPropertyPropertiesGenerated.java
@@ -1,0 +1,45 @@
+package io.micronaut.inject.configproperties.eachbeanparameter;
+
+import io.micronaut.context.annotation.ConfigurationInject;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.value.PropertyCatalog;
+
+@Requires(property = "spec", value = "DisabledNormalizationSpec")
+@EachProperty(value = "app.generated", catalog = PropertyCatalog.GENERATED)
+public class EachPropertyPropertiesGenerated {
+
+    private String name;
+    private String url;
+    private int serverPort;
+
+    @ConfigurationInject
+    public EachPropertyPropertiesGenerated(@Parameter String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getServerPort() {
+        return serverPort;
+    }
+
+    public void setServerPort(int serverPort) {
+        this.serverPort = serverPort;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/eachbeanparameter/EachPropertyPropertiesNormalized.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/eachbeanparameter/EachPropertyPropertiesNormalized.java
@@ -1,0 +1,45 @@
+package io.micronaut.inject.configproperties.eachbeanparameter;
+
+import io.micronaut.context.annotation.ConfigurationInject;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.value.PropertyCatalog;
+
+@Requires(property = "spec", value = "DisabledNormalizationSpec")
+@EachProperty(value = "app.normalized", catalog = PropertyCatalog.NORMALIZED)
+public class EachPropertyPropertiesNormalized {
+
+    private String name;
+    private String url;
+    private int serverPort;
+
+    @ConfigurationInject
+    public EachPropertyPropertiesNormalized(@Parameter String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getServerPort() {
+        return serverPort;
+    }
+
+    public void setServerPort(int serverPort) {
+        this.serverPort = serverPort;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/eachbeanparameter/EachPropertyPropertiesRaw.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/eachbeanparameter/EachPropertyPropertiesRaw.java
@@ -1,0 +1,45 @@
+package io.micronaut.inject.configproperties.eachbeanparameter;
+
+import io.micronaut.context.annotation.ConfigurationInject;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.value.PropertyCatalog;
+
+@Requires(property = "spec", value = "DisabledNormalizationSpec")
+@EachProperty(value = "app.raw", catalog = PropertyCatalog.RAW)
+public class EachPropertyPropertiesRaw {
+
+    private String name;
+    private String url;
+    private int serverPort;
+
+    @ConfigurationInject
+    public EachPropertyPropertiesRaw(@Parameter String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getServerPort() {
+        return serverPort;
+    }
+
+    public void setServerPort(int serverPort) {
+        this.serverPort = serverPort;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -43,6 +43,7 @@ import io.micronaut.core.naming.conventions.StringConvention;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.value.PropertyCatalog;
 import io.micronaut.inject.BeanConfiguration;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
@@ -251,6 +252,12 @@ public class DefaultApplicationContext extends DefaultBeanContext implements Con
     @Override
     public Collection<String> getPropertyEntries(@NonNull String name) {
         return getEnvironment().getPropertyEntries(name);
+    }
+
+    @NonNull
+    @Override
+    public Collection<String> getPropertyEntries(@NonNull String name, @NonNull PropertyCatalog propertyCatalog) {
+        return getEnvironment().getPropertyEntries(name, propertyCatalog);
     }
 
     @NonNull

--- a/inject/src/main/java/io/micronaut/context/annotation/EachProperty.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/EachProperty.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.context.annotation;
 
+import io.micronaut.core.value.PropertyCatalog;
 import jakarta.inject.Singleton;
 
 import java.lang.annotation.Documented;
@@ -91,6 +92,13 @@ public @interface EachProperty {
      */
     @AliasFor(annotation = ConfigurationReader.class, member = ConfigurationReader.PREFIX)
     String value();
+
+    /**
+     * @return property catalog to use. By default, uses NORMALIZATION catalog
+     *
+     * @since 4.7.0
+     */
+    PropertyCatalog catalog() default PropertyCatalog.NORMALIZED;
 
     /**
      * @return The name of the key returned by {@link #value()} that should be regarded as the {@link Primary} bean

--- a/inject/src/main/java/io/micronaut/context/env/ConfigurationPath.java
+++ b/inject/src/main/java/io/micronaut/context/env/ConfigurationPath.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.value.PropertyCatalog;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.qualifiers.Qualifiers;
@@ -119,6 +120,16 @@ public sealed interface ConfigurationPath
      * @return The current index or -1 if there is none
      */
     int index();
+
+    /**
+     * @return the current property catalog
+     *
+     * @since 4.7.0
+     */
+    @NonNull
+    default PropertyCatalog propertyCatalog() {
+        return PropertyCatalog.NORMALIZED;
+    }
 
     /**
      * @return The qualifier.

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -213,10 +213,16 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
     @NonNull
     @Override
     public Collection<String> getPropertyEntries(@NonNull String name) {
+        return getPropertyEntries(name, io.micronaut.core.value.PropertyCatalog.NORMALIZED);
+    }
+
+    @NonNull
+    @Override
+    public Collection<String> getPropertyEntries(@NonNull String name, @NonNull io.micronaut.core.value.PropertyCatalog propertyCatalog) {
         if (StringUtils.isEmpty(name)) {
             return Collections.emptySet();
         }
-        Map<String, Object> entries = resolveEntriesForKey(name, false, PropertyCatalog.NORMALIZED);
+        Map<String, Object> entries = resolveEntriesForKey(name, false, PropertyCatalog.valueOf(propertyCatalog.name()));
         if (entries == null) {
             return Collections.emptySet();
         }
@@ -835,10 +841,12 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
         }
     }
 
-
     /**
      * The property catalog to use.
+     *
+     * @deprecated Replaced by {@link io.micronaut.core.value.PropertyCatalog}
      */
+    @Deprecated(forRemoval = true)
     protected enum PropertyCatalog {
         /**
          * The catalog that contains the raw keys.


### PR DESCRIPTION
In my case I faced such a problem: I created a hierarchical structure for configuring several databases, each of which had settings for several tables. I used the `EachProperty` annotation and did not expect that the value injected into the Parameter variable would not be the one I set, but already normalized. Thus, the names of the databases and tables were converted, although I did not need this.

I realized that there is currently no way to disable normalization for such a case. This PR adds the `normalizePropertyKeys` flag to disable automatic key normalization for beans created using EachProperty