### PR TITLE
RawHttpClient

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClient.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClient.java
@@ -1,0 +1,69 @@
+package io.micronaut.http.client;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.async.annotation.SingleResult;
+import io.micronaut.http.ByteBodyHttpResponse;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.body.ByteBody;
+import io.micronaut.http.body.CloseableByteBody;
+import org.reactivestreams.Publisher;
+
+import java.io.Closeable;
+import java.net.URI;
+
+/**
+ * HTTP client that allows sending "raw" requests with a {@link ByteBody} for the request and
+ * response body.
+ *
+ * @author Jonas Konrad
+ * @since 4.7.0
+ */
+@Experimental
+public interface RawHttpClient extends Closeable {
+    /**
+     * Send a raw request.
+     *
+     * @param request       The request metadata (method, URI, headers). The
+     *                      {@link HttpRequest#getBody() body} of this object is ignored
+     * @param requestBody   The request body bytes. {@code null} is equivalent to an empty body.
+     *                      The ownership of the body immediately transfers to the client, i.e. the
+     *                      client will always call {@link CloseableByteBody#close()} on the body
+     *                      even if there is an error before the request is sent.
+     * @param blockedThread The thread that is blocked waiting for this request. This is used for
+     *                      deadlock detection. Optional parameter.
+     * @return A mono that will contain the response to this request. This response will
+     * <i>usually</i> be a {@link ByteBodyHttpResponse}, unless a filter replaced it.
+     */
+    @NonNull
+    @SingleResult
+    Publisher<? extends HttpResponse<?>> exchange(@NonNull HttpRequest<?> request, @Nullable CloseableByteBody requestBody, @Nullable Thread blockedThread);
+
+    /**
+     * Create a new {@link RawHttpClient}.
+     * Note that this method should only be used outside the context of a Micronaut application.
+     * The returned {@link RawHttpClient} is not subject to dependency injection.
+     * The creator is responsible for closing the client to avoid leaking connections.
+     * Within a Micronaut application use {@link jakarta.inject.Inject} to inject a client instead.
+     *
+     * @param url The base URL
+     * @return The client
+     */
+    static RawHttpClient create(@Nullable URI url) {
+        return RawHttpClientFactoryResolver.getFactory().createRawClient(url);
+    }
+
+    /**
+     * Create a new {@link RawHttpClient} with the specified configuration. Note that this method should only be used
+     * outside the context of an application. Within Micronaut use {@link jakarta.inject.Inject} to inject a client instead
+     *
+     * @param url           The base URL
+     * @param configuration the client configuration
+     * @return The client
+     */
+    static RawHttpClient create(@Nullable URI url, @NonNull HttpClientConfiguration configuration) {
+        return RawHttpClientFactoryResolver.getFactory().createRawClient(url, configuration);
+    }
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClient.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client;
 
 import io.micronaut.core.annotation.Experimental;

--- a/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientFactory.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientFactory.java
@@ -1,0 +1,38 @@
+package io.micronaut.http.client;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+import java.net.URI;
+
+/**
+ * Factory for creating {@link RawHttpClient}s without an application context.
+ *
+ * @since 4.7.0
+ * @author Jonas Konrad
+ */
+@Experimental
+public interface RawHttpClientFactory {
+
+    /**
+     * Create a new {@link RawHttpClient}. Note that this method should only be used outside the context of an application. Within Micronaut use
+     * {@link jakarta.inject.Inject} to inject a client instead
+     *
+     * @param url The base URL
+     * @return The client
+     */
+    @NonNull
+    RawHttpClient createRawClient(@Nullable URI url);
+
+    /**
+     * Create a new {@link RawHttpClient} with the specified configuration. Note that this method should only be used
+     * outside the context of an application. Within Micronaut use {@link jakarta.inject.Inject} to inject a client instead
+     *
+     * @param url           The base URL
+     * @param configuration the client configuration
+     * @return The client
+     */
+    @NonNull
+    RawHttpClient createRawClient(@Nullable URI url, @NonNull HttpClientConfiguration configuration);
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientFactory.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client;
 
 import io.micronaut.core.annotation.Experimental;

--- a/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientFactoryResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientFactoryResolver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client;
 
 import io.micronaut.core.annotation.Internal;

--- a/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientFactoryResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientFactoryResolver.java
@@ -1,0 +1,30 @@
+package io.micronaut.http.client;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+@Internal
+final class RawHttpClientFactoryResolver {
+    private static volatile RawHttpClientFactory factory;
+
+    static RawHttpClientFactory getFactory() {
+        if (factory == null) {
+            synchronized (RawHttpClientFactoryResolver.class) { // double check
+                if (factory == null) {
+                    factory = resolveClientFactory();
+                }
+            }
+        }
+        return factory;
+    }
+
+    private static RawHttpClientFactory resolveClientFactory() {
+        final Iterator<RawHttpClientFactory> i = ServiceLoader.load(RawHttpClientFactory.class).iterator();
+        if (i.hasNext()) {
+            return i.next();
+        }
+        throw new IllegalStateException("No RawHttpClientFactory present on classpath, cannot create client");
+    }
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientRegistry.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientRegistry.java
@@ -1,0 +1,25 @@
+package io.micronaut.http.client;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Interface for managing the construction and lifecycle of instances of {@link RawHttpClient} clients.
+ *
+ * @author Jonas Konrad
+ * @since 4.7.0
+ */
+@Experimental
+public interface RawHttpClientRegistry {
+    /**
+     * Return the client for the client ID and path.
+     *
+     * @param httpVersion The HTTP version
+     * @param clientId    The client ID
+     * @param path        The path (Optional)
+     * @return The client
+     */
+    @NonNull
+    RawHttpClient getRawClient(@NonNull HttpVersionSelection httpVersion, @NonNull String clientId, @Nullable String path);
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientRegistry.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/RawHttpClientRegistry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client;
 
 import io.micronaut.core.annotation.Experimental;

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/RawTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/RawTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.tck.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.io.buffer.ByteArrayBufferFactory;
+import io.micronaut.http.ByteBodyHttpResponse;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.body.stream.AvailableByteArrayBody;
+import io.micronaut.http.client.RawHttpClient;
+import io.micronaut.http.tck.ServerUnderTest;
+import io.micronaut.http.tck.ServerUnderTestProviderUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.ThreadLocalRandom;
+
+@SuppressWarnings({
+    "java:S2259", // The tests will show if it's null
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "java:S1192", // It's more readable without the constant
+})
+class RawTest {
+    public static final String SPEC_NAME = "RawTest";
+
+    private static final byte[] LONG_PAYLOAD;
+
+    static {
+        LONG_PAYLOAD = new byte[1024 * 1024];
+        ThreadLocalRandom.current().nextBytes(LONG_PAYLOAD);
+    }
+
+    @Test
+    public void getLong() throws Exception {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME);
+             RawHttpClient client = server.getApplicationContext().createBean(RawHttpClient.class);
+             ByteBodyHttpResponse<?> response = Mono.from(client.exchange(HttpRequest.GET(server.getURL().get() + "/raw/get-long"), null, null))
+                 .cast(ByteBodyHttpResponse.class)
+                 .block()) {
+
+            Assertions.assertArrayEquals(
+                LONG_PAYLOAD,
+                response.byteBody().buffer().get().toByteArray()
+            );
+        }
+    }
+
+    @Test
+    public void echoLong() throws Exception {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME);
+             RawHttpClient client = server.getApplicationContext().createBean(RawHttpClient.class);
+             ByteBodyHttpResponse<?> response = Mono.from(client.exchange(
+                     HttpRequest.POST(server.getURL().get() + "/raw/echo", LONG_PAYLOAD),
+                     AvailableByteArrayBody.create(ByteArrayBufferFactory.INSTANCE, LONG_PAYLOAD),
+                     null
+                 ))
+                 .cast(ByteBodyHttpResponse.class)
+                 .block()) {
+
+            Assertions.assertArrayEquals(
+                LONG_PAYLOAD,
+                response.byteBody().buffer().get().toByteArray()
+            );
+        }
+    }
+
+    @Controller("/raw")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class RawController {
+        @Get("/get-long")
+        public InputStream getLong() {
+            return new ByteArrayInputStream(LONG_PAYLOAD);
+        }
+
+        @Post("/echo")
+        public InputStream echo(@Body InputStream body) throws IOException {
+            return body;
+        }
+    }
+}

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/RawTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/RawTest.java
@@ -85,6 +85,21 @@ class RawTest {
         }
     }
 
+    @Test
+    public void httpClientFactory() throws Exception {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME);
+             RawHttpClient client = RawHttpClient.create(null);
+             ByteBodyHttpResponse<?> response = Mono.from(client.exchange(HttpRequest.GET(server.getURL().get() + "/raw/get-long"), null, null))
+                 .cast(ByteBodyHttpResponse.class)
+                 .block()) {
+
+            Assertions.assertArrayEquals(
+                LONG_PAYLOAD,
+                response.byteBody().buffer().get().toByteArray()
+            );
+        }
+    }
+
     @Controller("/raw")
     @Requires(property = "spec.name", value = SPEC_NAME)
     static class RawController {

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/RawTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/RawTest.java
@@ -19,14 +19,20 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.io.buffer.ByteArrayBufferFactory;
 import io.micronaut.http.ByteBodyHttpResponse;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.ClientFilter;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.body.stream.AvailableByteArrayBody;
 import io.micronaut.http.client.RawHttpClient;
 import io.micronaut.http.tck.ServerUnderTest;
 import io.micronaut.http.tck.ServerUnderTestProviderUtils;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -34,6 +40,8 @@ import reactor.core.publisher.Mono;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadLocalRandom;
 
 @SuppressWarnings({
@@ -71,7 +79,7 @@ class RawTest {
         try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME);
              RawHttpClient client = server.getApplicationContext().createBean(RawHttpClient.class);
              ByteBodyHttpResponse<?> response = Mono.from(client.exchange(
-                     HttpRequest.POST(server.getURL().get() + "/raw/echo", LONG_PAYLOAD),
+                     HttpRequest.POST(server.getURL().get() + "/raw/echo", null),
                      AvailableByteArrayBody.create(ByteArrayBufferFactory.INSTANCE, LONG_PAYLOAD),
                      null
                  ))
@@ -100,6 +108,53 @@ class RawTest {
         }
     }
 
+    @Test
+    public void filterRequestReplaceResponse() throws Exception {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME);
+             RawHttpClient client = server.getApplicationContext().createBean(RawHttpClient.class)) {
+            HttpResponse<?> response = Mono.from(client.exchange(
+                    HttpRequest.POST(server.getURL().get() + "/raw/filter-request-replace-response", null),
+                    AvailableByteArrayBody.create(ByteArrayBufferFactory.INSTANCE, "foo".getBytes(StandardCharsets.UTF_8)),
+                    null
+                ))
+                .block();
+
+            Assertions.assertFalse(response instanceof ByteBodyHttpResponse<?>);
+            Assertions.assertEquals("Replaced response. Request body: foo", response.getBody(String.class).get());
+        }
+    }
+
+    @Test
+    public void filterReplaceResponse() throws Exception {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME);
+             RawHttpClient client = server.getApplicationContext().createBean(RawHttpClient.class)) {
+            HttpResponse<?> response = Mono.from(client.exchange(
+                    HttpRequest.GET(server.getURL().get() + "/raw/filter-replace-response"),
+                    null,
+                    null
+                ))
+                .block();
+
+            Assertions.assertFalse(response instanceof ByteBodyHttpResponse<?>);
+            Assertions.assertEquals("Replaced response. Response body: bar", response.getBody(String.class).get());
+        }
+    }
+
+    @Test
+    public void redirect() throws Exception {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME);
+             RawHttpClient client = server.getApplicationContext().createBean(RawHttpClient.class);
+             ByteBodyHttpResponse<?> response = Mono.from(client.exchange(HttpRequest.GET(server.getURL().get() + "/raw/redirect-from"), null, null))
+                 .cast(ByteBodyHttpResponse.class)
+                 .block()) {
+
+            Assertions.assertEquals(
+                "redirect successful",
+                response.byteBody().buffer().get().toString(StandardCharsets.UTF_8)
+            );
+        }
+    }
+
     @Controller("/raw")
     @Requires(property = "spec.name", value = SPEC_NAME)
     static class RawController {
@@ -111,6 +166,39 @@ class RawTest {
         @Post("/echo")
         public InputStream echo(@Body InputStream body) throws IOException {
             return body;
+        }
+
+        @Get("/filter-replace-response")
+        public String filterReplaceResponse() {
+            return "bar";
+        }
+
+        @Get("/redirect-from")
+        public HttpResponse<?> redirectFrom() {
+            return HttpResponse.redirect(URI.create("/raw/redirect-to"));
+        }
+
+        @Get("/redirect-to")
+        public String redirectTo() {
+            return "redirect successful";
+        }
+    }
+
+    @ClientFilter("/raw")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class RawFilter {
+        @RequestFilter("/filter-request-replace-response")
+        public HttpResponse<?> filterRequestReplaceResponse(HttpRequest<?> request, @Body String body) throws Exception {
+            // @Body happens to work, but this should very much be considered experimental (and will only work for the raw client)
+            return HttpResponse.ok("Replaced response. Request body: " + body);
+        }
+
+        @ResponseFilter("/filter-replace-response")
+        @ExecuteOn(TaskExecutors.BLOCKING)
+        public HttpResponse<?> filterReplaceResponse(HttpResponse<?> response) throws Exception {
+            try (ByteBodyHttpResponse<?> r = (ByteBodyHttpResponse<?>) response) {
+                return HttpResponse.ok("Replaced response. Response body: " + r.byteBody().buffer().get().toString(StandardCharsets.UTF_8));
+            }
         }
     }
 }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
@@ -54,12 +54,6 @@ public record BlockHint(Thread blockedThread, @Nullable BlockHint next) {
         }
     }
 
-    void checkIsNotBlocked(EventLoop eventLoop) {
-        if (blocks(eventLoop)) {
-            throw createException();
-        }
-    }
-
     @NonNull
     static HttpClientException createException() {
         return new HttpClientException(

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -43,6 +43,8 @@ import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.http.client.LoadBalancerResolver;
 import io.micronaut.http.client.ProxyHttpClient;
 import io.micronaut.http.client.ProxyHttpClientRegistry;
+import io.micronaut.http.client.RawHttpClient;
+import io.micronaut.http.client.RawHttpClientRegistry;
 import io.micronaut.http.client.ServiceHttpClientConfiguration;
 import io.micronaut.http.client.StreamingHttpClient;
 import io.micronaut.http.client.StreamingHttpClientRegistry;
@@ -113,6 +115,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
         StreamingHttpClientRegistry<StreamingHttpClient>,
         WebSocketClientRegistry<WebSocketClient>,
         ProxyHttpClientRegistry<ProxyHttpClient>,
+        RawHttpClientRegistry,
         ChannelPipelineCustomizer,
         NettyClientCustomizer.Registry,
         RefreshEventListener {
@@ -181,7 +184,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
 
     @NonNull
     @Override
-    public HttpClient getClient(@NonNull HttpVersionSelection httpVersion, @NonNull String clientId, @Nullable String path) {
+    public DefaultHttpClient getClient(@NonNull HttpVersionSelection httpVersion, @NonNull String clientId, @Nullable String path) {
         final ClientKey key = new ClientKey(
                 httpVersion,
                 clientId,
@@ -191,6 +194,11 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                 null
         );
         return getClient(key, beanContext, AnnotationMetadata.EMPTY_METADATA);
+    }
+
+    @Override
+    public @NonNull RawHttpClient getRawClient(@NonNull HttpVersionSelection httpVersion, @NonNull String clientId, @Nullable String path) {
+        return getClient(httpVersion, clientId, path);
     }
 
     @Override

--- a/http-client/src/main/java/io/micronaut/http/client/netty/MutableHttpRequestWrapper.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/MutableHttpRequestWrapper.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  * @since 4.0.0
  */
 @Internal
-final class MutableHttpRequestWrapper<B> extends HttpRequestWrapper<B> implements MutableHttpRequest<B> {
+class MutableHttpRequestWrapper<B> extends HttpRequestWrapper<B> implements MutableHttpRequest<B> {
     private ConversionService conversionService;
 
     @Nullable

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClientFactory.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClientFactory.java
@@ -23,6 +23,8 @@ import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.HttpClientFactory;
 import io.micronaut.http.client.ProxyHttpClient;
 import io.micronaut.http.client.ProxyHttpClientFactory;
+import io.micronaut.http.client.RawHttpClient;
+import io.micronaut.http.client.RawHttpClientFactory;
 import io.micronaut.http.client.StreamingHttpClient;
 import io.micronaut.http.client.StreamingHttpClientFactory;
 import io.micronaut.http.client.sse.SseClient;
@@ -46,7 +48,8 @@ public class NettyHttpClientFactory implements
         SseClientFactory,
         ProxyHttpClientFactory,
         StreamingHttpClientFactory,
-        WebSocketClientFactory {
+        WebSocketClientFactory,
+        RawHttpClientFactory {
 
     @NonNull
     @Override
@@ -106,6 +109,16 @@ public class NettyHttpClientFactory implements
     @Override
     public WebSocketClient createWebSocketClient(URI uri, @NonNull HttpClientConfiguration configuration) {
         return createNettyClient(uri, configuration);
+    }
+
+    @Override
+    public @NonNull RawHttpClient createRawClient(@Nullable URI url) {
+        return createNettyClient(url);
+    }
+
+    @Override
+    public @NonNull RawHttpClient createRawClient(@Nullable URI url, @NonNull HttpClientConfiguration configuration) {
+        return createNettyClient(url, configuration);
     }
 
     private DefaultHttpClient createNettyClient(URL url) {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/RawHttpRequestWrapper.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/RawHttpRequestWrapper.java
@@ -1,0 +1,58 @@
+package io.micronaut.http.client.netty;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.ServerHttpRequest;
+import io.micronaut.http.body.ByteBody;
+import io.micronaut.http.body.CloseableByteBody;
+import io.micronaut.http.netty.NettyHttpRequestBuilder;
+import io.netty.handler.codec.http.HttpRequest;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * This is a combination of a {@link HttpRequest} with a {@link ByteBody}. It implements
+ * {@link MutableHttpRequest} so that it can be used unchanged in the client,
+ * {@link NettyHttpRequestBuilder} so that the bytes are
+ *
+ * @param <B> The body type, mostly unused
+ * @since 4.7.0
+ */
+@Internal
+final class RawHttpRequestWrapper<B> extends MutableHttpRequestWrapper<B> implements MutableHttpRequest<B>, NettyHttpRequestBuilder, ServerHttpRequest<B>, Closeable {
+    private final CloseableByteBody byteBody;
+
+    public RawHttpRequestWrapper(ConversionService conversionService, MutableHttpRequest<B> delegate, CloseableByteBody byteBody) {
+        super(conversionService, delegate);
+        this.byteBody = byteBody;
+    }
+
+    @Override
+    public @NonNull ByteBody byteBody() {
+        return byteBody;
+    }
+
+    @Override
+    public @Nullable ByteBody byteBodyDirect() {
+        return byteBody;
+    }
+
+    @Override
+    public <T> MutableHttpRequest<T> body(T body) {
+        throw new UnsupportedOperationException("Changing the body of raw requests is currently not supported");
+    }
+
+    @Override
+    public @NonNull HttpRequest toHttpRequestWithoutBody() {
+        return NettyHttpRequestBuilder.asBuilder(getDelegate()).toHttpRequestWithoutBody();
+    }
+
+    @Override
+    public void close() throws IOException {
+        byteBody.close();
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/RawHttpRequestWrapper.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/RawHttpRequestWrapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client.netty;
 
 import io.micronaut.core.annotation.Internal;

--- a/http-client/src/main/resources/META-INF/services/io.micronaut.http.client.RawHttpClientFactory
+++ b/http-client/src/main/resources/META-INF/services/io.micronaut.http.client.RawHttpClientFactory
@@ -1,0 +1,1 @@
+io.micronaut.http.client.netty.NettyHttpClientFactory

--- a/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
+++ b/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
@@ -17,6 +17,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SuppressWarnings("java:S2187") // This runs a suite of tests, but has no tests of its own
 @ExcludeClassNamePatterns({
     "io.micronaut.http.client.tck.tests.ContinueTest", // Unsupported body type errors
+    "io.micronaut.http.client.tck.tests.RawTest", // There's no raw client for the JDK client
 })
 public class JdkHttpMethodTests {
 }


### PR DESCRIPTION
Add a new HTTP client variant for making raw requests. The main purpose of this is to allow implementing the micronaut-oraclecloud HTTP client without direct access to ConnectionManager.

This client is a fairly thin wrapper around #11182. It gives direct access to the request/response body bytes, but still runs filters and follows redirects.

The fact that filters are run and redirects are followed creates some limitations for this new client:

- If a filter replaces the response, it is possible that the client returns a non-ByteBody response. This means that the client has to return `Publisher<? extends HttpResponse<?>>` instead of `Publisher<? extends ByteBodyHttpResponse<?>>`, even though `ByteBodyHttpResponse` is almost always what users of this API want. Nonetheless I've decided to leave handling this up to the user.
- Unfortunately it is *not* possible to implement the other HttpClients using this RawHttpClient. The reason is that filters for other clients see the "bean" form of the body, not the bytes. As a consequence, my medium-term goal of sharing more code between the JDK and netty HTTP clients will have to use an abstract class with an even lower level API than what is introduced in this PR.

Nonetheless, I think it is better to follow redirects and run filters. It would be odd to have a HttpClient that completely ignores the configured follow-redirects behavior, and I think it would also be unexpected for users to have a (non-internal) client that does not run client filters – we already had problems with this in micronaut-oraclecloud.