### PR TITLE
Fix for service loader

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -257,7 +257,7 @@ public final class MicronautMetaServiceLoaderUtils {
                 List<S> collection = new ArrayList<>(serviceEntries.size());
                 for (String serviceEntry : serviceEntries) {
                     S val = instantiate(serviceEntry, classLoader);
-                    if (val != null && predicate.test(val)) {
+                    if (val != null && predicate != null && !predicate.test(val)) {
                         collection.add(val);
                     }
                 }


### PR DESCRIPTION
Fix for service loader, so that single-threaded `MicronautServiceCollector` implementation matches `ServiceInstanceLoader implementation`.

The `ServiceInstanceLoader` checks if predicate is null:
```java
@Override
        protected void compute() {
            try {
                result = instantiate(className, classLoader);
                if (result != null && predicate != null && !predicate.test(result)) {
                    result = null;
                }
            } catch (Throwable e) {
                throwable = e;
            }
        }
```
so `MicronautServiceCollector` must do that, too. I am getting null poineter error when I set `-Djava.util.concurrent.ForkJoinPool.common.parallelism=1` for Micronaut application.