### PR TITLE
Fix ByteBody stream writing for HTTP/2

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/StreamWriter.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/StreamWriter.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
 
 import java.util.function.Consumer;
@@ -99,7 +100,7 @@ final class StreamWriter extends ChannelInboundHandlerAdapter implements BufferC
         }
 
         int readable = buf.readableBytes();
-        ctx.writeAndFlush(buf).addListener((ChannelFutureListener) future -> {
+        ctx.writeAndFlush(new DefaultHttpContent(buf)).addListener((ChannelFutureListener) future -> {
             assert ctx.executor().inEventLoop();
             if (future.isSuccess()) {
                 if (ctx.channel().isWritable()) {
@@ -107,6 +108,8 @@ final class StreamWriter extends ChannelInboundHandlerAdapter implements BufferC
                 } else {
                     unwritten += readable;
                 }
+            } else {
+                error(future.cause());
             }
         });
     }

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/Http2Spec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/Http2Spec.groovy
@@ -1,14 +1,10 @@
-package io.micronaut.http.client.jdk
+package io.micronaut.http.client.netty
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Consumes
-import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Produces
+import io.micronaut.http.annotation.*
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.HttpVersionSelection
 import io.micronaut.http.client.annotation.Client
@@ -39,6 +35,7 @@ class Http2Spec extends Specification {
 
     def "test http2 post long string"() {
         when:
+        // Body must be >8096 bytes, according to io.netty.handler.codec.http.multipart.HttpPostBodyUtil#chunkSize
         def body = Map.of("q", "a" * 8097)
 
         def response = client.toBlocking().retrieve(HttpRequest.POST("/http2", body)
@@ -62,7 +59,7 @@ class Http2Spec extends Specification {
         @Post
         @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
         @Produces(MediaType.TEXT_PLAIN)
-        String post() {
+        String post(@Body Map<String, String> ignored) {
             "hello"
         }
     }


### PR DESCRIPTION
The writer wrote ByteBufs directly instead of HttpContent, which works for HTTP/1 but not HTTP/2. Also improved error handling.

Fixes #11260 

Draft until @asw12 signs the CLA for the test case