### PR TITLE
Fix introspection for abstract classes (#10889)

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/ClassElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/ClassElement.java
@@ -269,6 +269,10 @@ public interface ClassElement extends TypedElement {
             // only static inner classes can be constructed
             return Optional.empty();
         }
+        if (isAbstract()) {
+            // abstract classes constructors are accessible only from their subtypes
+            return Optional.empty();
+        }
         List<ConstructorElement> constructors = getAccessibleConstructors()
                 .stream()
                 .filter(ctor -> ctor.getParameters().length == 0).toList();

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2216,6 +2216,14 @@ abstract class Test {
         expect:
         beanIntrospection != null
         beanIntrospection.getBeanProperties().size() == 2
+        !beanIntrospection.isBuildable()
+
+        when:
+        beanIntrospection.instantiate()
+
+        then:
+        def e = thrown(InstantiationException)
+        e.message == 'No default constructor exists'
     }
 
     void "test targeting abstract class with @Introspected(classes = "() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -4561,6 +4561,14 @@ abstract class Test {
         expect:
         beanIntrospection != null
         beanIntrospection.getBeanProperties().size() == 2
+        !beanIntrospection.isBuildable()
+
+        when:
+        beanIntrospection.instantiate()
+
+        then:
+        def e = thrown(InstantiationException)
+        e.message == 'No default constructor exists'
     }
 
     void "test introspection on abstract class with custom getter"() {

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -232,15 +232,19 @@ internal open class KotlinClassElement(
         if (defaultConstructor.isPresent) {
             defaultConstructor
         } else {
-            Optional.ofNullable(declaration.primaryConstructor)
-                .filter { !it.isPrivate() && it.parameters.isEmpty() }
-                .map {
-                    visitorContext.elementFactory.newConstructorElement(
-                        this,
-                        it,
-                        elementAnnotationMetadataFactory
-                    )
-                }
+            if (isAbstract) {
+                Optional.empty()
+            } else {
+                Optional.ofNullable(declaration.primaryConstructor)
+                    .filter { !it.isPrivate() && it.parameters.isEmpty() }
+                    .map {
+                        visitorContext.elementFactory.newConstructorElement(
+                            this,
+                            it,
+                            elementAnnotationMetadataFactory
+                        )
+                    }
+            }
         }
     }
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -2077,6 +2077,14 @@ abstract class Test {
         expect:
         beanIntrospection != null
         beanIntrospection.getBeanProperties().size() == 2
+        !beanIntrospection.isBuildable()
+
+        when:
+        beanIntrospection.instantiate()
+
+        then:
+        def e = thrown(InstantiationException)
+        e.message == 'No default constructor exists'
     }
 
     void "test targeting abstract class with @Introspected(classes = "() {


### PR DESCRIPTION
Ignore constructors for abstract classes, so the introspection is written as not buildable and the instantiation methods in the introspection are not overridden (trying to call a constructor for an abstract class).