### PR TITLE
Add new `definitionType` parameter for `@Client` annotation

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/annotation/Client.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/annotation/Client.java
@@ -17,8 +17,11 @@ package io.micronaut.http.client.annotation;
 
 import io.micronaut.aop.Introduction;
 import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.HttpVersion;
+import io.micronaut.http.annotation.Consumes;
+import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.HttpVersionSelection;
 import io.micronaut.http.hateoas.JsonError;
@@ -54,6 +57,28 @@ public @interface Client {
     @AliasFor(member = "value") // <2>
     String id() default "";
 // end::value[]
+
+    /**
+     * The interface definition type. When set to {@link DefinitionType.SERVER} the {@link Produces} and {@link Consumes}
+     * definition evaluated for each method of the interface will be reversed .
+     *
+     * <p>Whilst not necessarily recommended, there are scenarios like testing where it is useful to share a common interface between client and server and use the
+     * interface to create a new client declarative client. The client typically needs to produce the content type accepted by the server and consume the content type
+     * produced by the server. In this arrangement using the interface directly will not result in the correct behaviour.</p>
+     *
+     * <p>In this scenario you can set {@link DefinitionType} to {@link DefinitionType.SERVER} which will ensure the requests sent by the client use the content type declared by the {@link Consumes}
+     *  annotation of the interface and that responses use the content type declared by the {@link Produces}.</p>
+     *
+     * <p>The default behaviour is to use {@link DefinitionType.CLIENT} where the inverse of the above is true.</p>
+     *
+     * @return The interface definition type
+     * @since 4.8.0
+     * @see Consumes
+     * @see Produces
+     */
+    @Experimental
+    @NonNull
+    DefinitionType definitionType() default DefinitionType.CLIENT;
 
     /**
      * The base URI for the client. Only to be used in
@@ -109,4 +134,39 @@ public @interface Client {
         HttpVersionSelection.ALPN_HTTP_2,
         HttpVersionSelection.ALPN_HTTP_1
     };
+
+    /**
+     * The interface definition type.
+     *
+     * @since 4.8.0
+     */
+    @Experimental
+    enum DefinitionType {
+        /**
+         * Client interface definition type.
+         */
+        CLIENT,
+        /**
+         * Server (controller) interface definition type.
+         */
+        SERVER;
+
+        /**
+         * Returns true, if this definition type is {@link DefinitionType.CLIENT}.
+         *
+         * @return true, if this definition type is {@link DefinitionType.CLIENT}.
+         */
+        public boolean isClient() {
+            return this == CLIENT;
+        }
+
+        /**
+         * Returns true, if this definition type is {@link DefinitionType.SERVER}.
+         *
+         * @return true, if this definition type is {@link DefinitionType.SERVER}.
+         */
+        public boolean isServer() {
+            return this == SERVER;
+        }
+    }
 }

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -401,8 +401,10 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
 
         final MediaType[] acceptTypes;
         Collection<MediaType> accept = request.accept();
+        var definitionType = annotationMetadata.enumValue(Client.class, "definitionType", Client.DefinitionType.class)
+            .orElse(Client.DefinitionType.CLIENT);
         if (accept.isEmpty()) {
-            String[] consumesMediaType = context.stringValues(Consumes.class);
+            String[] consumesMediaType = context.stringValues(definitionType.isClient() ? Consumes.class : Produces.class);
             if (ArrayUtils.isEmpty(consumesMediaType)) {
                 acceptTypes = DEFAULT_ACCEPT_TYPES;
             } else {
@@ -411,8 +413,8 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
             request.accept(acceptTypes);
         }
 
-        if (body != null && !request.getContentType().isPresent()) {
-            MediaType[] contentTypes = MediaType.of(context.stringValues(Produces.class));
+        if (body != null && request.getContentType().isEmpty()) {
+            MediaType[] contentTypes = MediaType.of(context.stringValues(definitionType.isClient() ? Produces.class : Consumes.class));
             if (ArrayUtils.isEmpty(contentTypes)) {
                 contentTypes = DEFAULT_ACCEPT_TYPES;
             }


### PR DESCRIPTION
This was asked in the Discord, and I was also interested in this question earlier: is it possible to use a single interface to describe the client and the controller? The feign library was invented for Spring (8-9 years ago), which later became part of Spring Cloud. And so, when I saw that Micronaut has built-in support for a single interface, I was happy, but it turned out that the client and controller do not support the single interface mode.

So, for now, the main problem, in my opinion, is the opposite perception of the Consumes and Produces annotations for the client and the controller. I added the `definitionType` parameter, which can be one of two values - `CLIENT` (default) and `SERVER`. `SERVER` value means that you use server (controller) interface to describe http client endpoints.

Perhaps there are some other significant differences between the interface for the controller and the client, but I do not know about them.

Why is this important: in general, it is quite common practice to make a microservice with 2 submodules - API and business logic, so that you can write all the endpoints and DTOs in the API module, and then simply inherit from the interface and thus get a ready-made HTTP client.

@graemerocher @yawkat @sdelamo @dstepanov 