### PR TITLE
Add ByteBody.move

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/body/AvailableNettyByteBody.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/AvailableNettyByteBody.java
@@ -157,6 +157,11 @@ public final class AvailableNettyByteBody extends NettyByteBody implements Close
     }
 
     @Override
+    public @NonNull CloseableByteBody send() {
+        return new AvailableNettyByteBody(claim());
+    }
+
+    @Override
     public @NonNull String toString(Charset charset) {
         ByteBuf b = claim();
         try {

--- a/http-netty/src/main/java/io/micronaut/http/netty/body/AvailableNettyByteBody.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/AvailableNettyByteBody.java
@@ -157,7 +157,7 @@ public final class AvailableNettyByteBody extends NettyByteBody implements Close
     }
 
     @Override
-    public @NonNull CloseableByteBody send() {
+    public @NonNull CloseableByteBody move() {
         return new AvailableNettyByteBody(claim());
     }
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/body/StreamingNettyByteBody.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/StreamingNettyByteBody.java
@@ -182,7 +182,7 @@ public final class StreamingNettyByteBody extends NettyByteBody implements Close
     }
 
     @Override
-    public @NonNull CloseableByteBody send() {
+    public @NonNull CloseableByteBody move() {
         BufferConsumer.Upstream upstream = this.upstream;
         if (upstream == null) {
             failClaim();

--- a/http-netty/src/main/java/io/micronaut/http/netty/body/StreamingNettyByteBody.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/StreamingNettyByteBody.java
@@ -182,6 +182,16 @@ public final class StreamingNettyByteBody extends NettyByteBody implements Close
     }
 
     @Override
+    public @NonNull CloseableByteBody send() {
+        BufferConsumer.Upstream upstream = this.upstream;
+        if (upstream == null) {
+            failClaim();
+        }
+        this.upstream = null;
+        return new StreamingNettyByteBody(sharedBuffer, forceDelaySubscribe, upstream);
+    }
+
+    @Override
     public void close() {
         BufferConsumer.Upstream upstream = this.upstream;
         if (upstream == null) {

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/AvailableNettyByteBodySpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/AvailableNettyByteBodySpec.groovy
@@ -6,10 +6,10 @@ import spock.lang.Specification
 import java.nio.charset.StandardCharsets
 
 class AvailableNettyByteBodySpec extends Specification {
-    def 'send'() {
+    def move() {
         given:
         def a = new AvailableNettyByteBody(Unpooled.copiedBuffer("foo", StandardCharsets.UTF_8))
-        def b = a.send()
+        def b = a.move()
 
         when:
         a.close()

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/AvailableNettyByteBodySpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/AvailableNettyByteBodySpec.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.http.netty.body
+
+import io.netty.buffer.Unpooled
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class AvailableNettyByteBodySpec extends Specification {
+    def 'send'() {
+        given:
+        def a = new AvailableNettyByteBody(Unpooled.copiedBuffer("foo", StandardCharsets.UTF_8))
+        def b = a.send()
+
+        when:
+        a.close()
+        then:
+        b.buffer().get().toString(StandardCharsets.UTF_8) == "foo"
+    }
+}

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/StreamingNettyByteBodySpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/StreamingNettyByteBodySpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.http.netty.body
+
+import io.netty.buffer.Unpooled
+import io.netty.channel.embedded.EmbeddedChannel
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class StreamingNettyByteBodySpec extends Specification {
+    def 'send'() {
+        given:
+        def a = NettyBodyAdapter.adapt(Flux.just(Unpooled.copiedBuffer("foo", StandardCharsets.UTF_8)), new EmbeddedChannel().eventLoop())
+        def b = a.send()
+
+        when:
+        a.close()
+        then:
+        b.buffer().get().toString(StandardCharsets.UTF_8) == "foo"
+    }
+}

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/StreamingNettyByteBodySpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/StreamingNettyByteBodySpec.groovy
@@ -8,10 +8,10 @@ import spock.lang.Specification
 import java.nio.charset.StandardCharsets
 
 class StreamingNettyByteBodySpec extends Specification {
-    def 'send'() {
+    def move() {
         given:
         def a = NettyBodyAdapter.adapt(Flux.just(Unpooled.copiedBuffer("foo", StandardCharsets.UTF_8)), new EmbeddedChannel().eventLoop())
-        def b = a.send()
+        def b = a.move()
 
         when:
         a.close()

--- a/http/src/main/java/io/micronaut/http/body/ByteBody.java
+++ b/http/src/main/java/io/micronaut/http/body/ByteBody.java
@@ -146,7 +146,7 @@ public interface ByteBody {
      * claiming this body in the process.
      * <p>This is a primary operation. After this operation, no other primary operation or
      * {@link #split()} may be done.
-     * <p>The purpose of this method is to <i>send</i> the data to a different component in an
+     * <p>The purpose of this method is to <i>move</i> the data to a different component in an
      * application, making clear that the receiving component claims ownership of the body. If the
      * sending component then closes the original {@link ByteBody} for example, it will have no
      * impact on the new {@link CloseableByteBody} that the receiver is working with.
@@ -155,7 +155,7 @@ public interface ByteBody {
      * @since 4.8.0
      */
     @NonNull
-    CloseableByteBody send();
+    CloseableByteBody move();
 
     /**
      * This enum controls how backpressure should be handled if one of the two bodies

--- a/http/src/main/java/io/micronaut/http/body/ByteBody.java
+++ b/http/src/main/java/io/micronaut/http/body/ByteBody.java
@@ -138,7 +138,24 @@ public interface ByteBody {
      *
      * @return A future that completes when all bytes are available
      */
+    @NonNull
     CompletableFuture<? extends CloseableAvailableByteBody> buffer();
+
+    /**
+     * Create a new {@link CloseableByteBody} with the same content but an independent lifecycle,
+     * claiming this body in the process.
+     * <p>This is a primary operation. After this operation, no other primary operation or
+     * {@link #split()} may be done.
+     * <p>The purpose of this method is to <i>send</i> the data to a different component in an
+     * application, making clear that the receiving component claims ownership of the body. If the
+     * sending component then closes the original {@link ByteBody} for example, it will have no
+     * impact on the new {@link CloseableByteBody} that the receiver is working with.
+     *
+     * @return A new {@link CloseableByteBody} with the same content.
+     * @since 4.8.0
+     */
+    @NonNull
+    CloseableByteBody send();
 
     /**
      * This enum controls how backpressure should be handled if one of the two bodies

--- a/http/src/main/java/io/micronaut/http/body/stream/AvailableByteArrayBody.java
+++ b/http/src/main/java/io/micronaut/http/body/stream/AvailableByteArrayBody.java
@@ -90,7 +90,7 @@ public final class AvailableByteArrayBody implements CloseableAvailableByteBody,
     }
 
     @Override
-    public @NonNull CloseableByteBody send() {
+    public @NonNull CloseableByteBody move() {
         return new AvailableByteArrayBody(bufferFactory, toByteArray());
     }
 

--- a/http/src/main/java/io/micronaut/http/body/stream/AvailableByteArrayBody.java
+++ b/http/src/main/java/io/micronaut/http/body/stream/AvailableByteArrayBody.java
@@ -22,6 +22,7 @@ import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.http.body.CloseableAvailableByteBody;
+import io.micronaut.http.body.CloseableByteBody;
 import io.micronaut.http.body.InternalByteBody;
 
 import java.io.ByteArrayInputStream;
@@ -86,6 +87,11 @@ public final class AvailableByteArrayBody implements CloseableAvailableByteBody,
     @Override
     public @NonNull ByteBuffer<?> toByteBuffer() {
         return bufferFactory.wrap(toByteArray());
+    }
+
+    @Override
+    public @NonNull CloseableByteBody send() {
+        return new AvailableByteArrayBody(bufferFactory, toByteArray());
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/body/stream/InputStreamByteBody.java
+++ b/http/src/main/java/io/micronaut/http/body/stream/InputStreamByteBody.java
@@ -162,7 +162,7 @@ public final class InputStreamByteBody implements CloseableByteBody, InternalByt
     }
 
     @Override
-    public @NonNull CloseableByteBody send() {
+    public @NonNull CloseableByteBody move() {
         return new InputStreamByteBody(context, toInputStream());
     }
 

--- a/http/src/main/java/io/micronaut/http/body/stream/InputStreamByteBody.java
+++ b/http/src/main/java/io/micronaut/http/body/stream/InputStreamByteBody.java
@@ -161,6 +161,11 @@ public final class InputStreamByteBody implements CloseableByteBody, InternalByt
         });
     }
 
+    @Override
+    public @NonNull CloseableByteBody send() {
+        return new InputStreamByteBody(context, toInputStream());
+    }
+
     private record Context(
         OptionalLong expectedLength,
         Executor ioExecutor,

--- a/http/src/test/groovy/io/micronaut/http/body/stream/AvailableByteArrayBodySpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/body/stream/AvailableByteArrayBodySpec.groovy
@@ -6,10 +6,10 @@ import spock.lang.Specification
 import java.nio.charset.StandardCharsets
 
 class AvailableByteArrayBodySpec extends Specification {
-    def 'send'() {
+    def move() {
         given:
         def a = AvailableByteArrayBody.create(ByteArrayBufferFactory.INSTANCE, "foo".getBytes(StandardCharsets.UTF_8))
-        def b = a.send()
+        def b = a.move()
 
         when:
         a.close()

--- a/http/src/test/groovy/io/micronaut/http/body/stream/AvailableByteArrayBodySpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/body/stream/AvailableByteArrayBodySpec.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.http.body.stream
+
+import io.micronaut.core.io.buffer.ByteArrayBufferFactory
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class AvailableByteArrayBodySpec extends Specification {
+    def 'send'() {
+        given:
+        def a = AvailableByteArrayBody.create(ByteArrayBufferFactory.INSTANCE, "foo".getBytes(StandardCharsets.UTF_8))
+        def b = a.send()
+
+        when:
+        a.close()
+        then:
+        b.buffer().get().toString(StandardCharsets.UTF_8) == "foo"
+    }
+}

--- a/http/src/test/groovy/io/micronaut/http/body/stream/InputStreamByteBodySpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/body/stream/InputStreamByteBodySpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.http.body.stream
+
+import io.micronaut.core.io.buffer.ByteArrayBufferFactory
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.Executors
+
+class InputStreamByteBodySpec extends Specification {
+    def 'send'() {
+        given:
+        def pool = Executors.newCachedThreadPool()
+        def a = InputStreamByteBody.create(new ByteArrayInputStream("foo".getBytes(StandardCharsets.UTF_8)), OptionalLong.empty(), pool, ByteArrayBufferFactory.INSTANCE)
+        def b = a.send()
+
+        when:
+        a.close()
+        then:
+        b.buffer().get().toString(StandardCharsets.UTF_8) == "foo"
+
+        cleanup:
+        pool.shutdown()
+    }
+}

--- a/http/src/test/groovy/io/micronaut/http/body/stream/InputStreamByteBodySpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/body/stream/InputStreamByteBodySpec.groovy
@@ -7,11 +7,11 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.Executors
 
 class InputStreamByteBodySpec extends Specification {
-    def 'send'() {
+    def move() {
         given:
         def pool = Executors.newCachedThreadPool()
         def a = InputStreamByteBody.create(new ByteArrayInputStream("foo".getBytes(StandardCharsets.UTF_8)), OptionalLong.empty(), pool, ByteArrayBufferFactory.INSTANCE)
-        def b = a.send()
+        def b = a.move()
 
         when:
         a.close()


### PR DESCRIPTION
This method is a primary operation that transfers ownership. In particular this means it can convert a ByteBody (where the current code does not have exclusive ownership) to a CloseableByteBody (where it does).

The method cannot be implemented using existing methods. But that's okay since ByteBody is experimental, not implemented outside core (anymore), and this method is not used by core.