### PR TITLE
deprecate HttpResponse::getStatus

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
@@ -83,7 +83,7 @@ public class HttpClientResponseException extends HttpClientException implements 
 
     /**
      * @return The {@link io.micronaut.http.HttpStatus} returned
-     * @deprecated To support custom status codes. Use {@link #code()} instead of {@link #getStatus()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #getStatus()} and {@link HttpStatus#getReason()}
+     * To support custom status codes. Use {@link #code()} instead of {@link #getStatus()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #getStatus()} and {@link HttpStatus#getReason()}.
      */
     @Deprecated(since = "4.7.2")
     public HttpStatus getStatus() {

--- a/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
@@ -85,7 +85,6 @@ public class HttpClientResponseException extends HttpClientException implements 
      * @return The {@link io.micronaut.http.HttpStatus} returned
      * To support custom status codes. Use {@link #code()} instead of {@link #getStatus()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #getStatus()} and {@link HttpStatus#getReason()}.
      */
-    @Deprecated(since = "4.7.2")
     public HttpStatus getStatus() {
         return getResponse().getStatus();
     }

--- a/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
@@ -83,9 +83,25 @@ public class HttpClientResponseException extends HttpClientException implements 
 
     /**
      * @return The {@link io.micronaut.http.HttpStatus} returned
+     * @deprecated To support custom status codes. Use {@link #code()} instead of {@link #getStatus()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #getStatus()} and {@link HttpStatus#getReason()}
      */
+    @Deprecated(since = "4.7.2")
     public HttpStatus getStatus() {
         return getResponse().getStatus();
+    }
+
+    /**
+     * @return The response status code
+     */
+    public int code() {
+        return getResponse().code();
+    }
+
+    /**
+     * @return The HTTP status reason phrase
+     */
+    public String reason() {
+        return getResponse().reason();
     }
 
     @SuppressWarnings("MagicNumber")

--- a/http-client/src/test/groovy/io/micronaut/http/client/docs/httpstatus/HttpStatusSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/docs/httpstatus/HttpStatusSpec.groovy
@@ -91,6 +91,8 @@ class HttpStatusSpec extends Specification {
         HttpClientResponseException e = thrown()
         e.message == "success"
         e.status == HttpStatus.NOT_FOUND
+        HttpStatus.NOT_FOUND.code == e.code()
+        HttpStatus.NOT_FOUND.reason == e.reason()
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/5348")

--- a/http/src/main/java/io/micronaut/http/HttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponse.java
@@ -36,7 +36,7 @@ public interface HttpResponse<B> extends HttpMessage<B> {
 
     /**
      * @return The current status
-     * @deprecated To support custom status codes. Use {@link #code()} instead of {@link #getStatus()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #getStatus()} and {@link HttpStatus#getReason()}
+     * To support custom status codes. Use {@link #code()} instead of {@link #getStatus()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #getStatus()} and {@link HttpStatus#getReason()}
      */
     default HttpStatus getStatus() {
         return HttpStatus.valueOf(code());

--- a/http/src/main/java/io/micronaut/http/HttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponse.java
@@ -71,7 +71,6 @@ public interface HttpResponse<B> extends HttpMessage<B> {
      * @return The HTTP status
      * @deprecated To support custom status codes. Use {@link #code()} instead of {@link #status()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #status()} and {@link HttpStatus#getReason()}
      */
-    @Deprecated(since = "4.7.2")
     default HttpStatus status() {
         return getStatus();
     }

--- a/http/src/main/java/io/micronaut/http/HttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponse.java
@@ -69,7 +69,7 @@ public interface HttpResponse<B> extends HttpMessage<B> {
 
     /**
      * @return The HTTP status
-     * @deprecated To support custom status codes. Use {@link #code()} instead of {@link #status()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #status()} and {@link HttpStatus#getReason()}
+     * To support custom status codes. Use {@link #code()} instead of {@link #status()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #status()} and {@link HttpStatus#getReason()}
      */
     default HttpStatus status() {
         return getStatus();

--- a/http/src/main/java/io/micronaut/http/HttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponse.java
@@ -36,7 +36,9 @@ public interface HttpResponse<B> extends HttpMessage<B> {
 
     /**
      * @return The current status
+     * @deprecated To support custom status codes. Use {@link #code()} instead of {@link #getStatus()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #getStatus()} and {@link HttpStatus#getReason()}
      */
+    @Deprecated(since = "4.7.2")
     default HttpStatus getStatus() {
         return HttpStatus.valueOf(code());
     }
@@ -68,7 +70,9 @@ public interface HttpResponse<B> extends HttpMessage<B> {
 
     /**
      * @return The HTTP status
+     * @deprecated To support custom status codes. Use {@link #code()} instead of {@link #status()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #status()} and {@link HttpStatus#getReason()}
      */
+    @Deprecated(since = "4.7.2")
     default HttpStatus status() {
         return getStatus();
     }

--- a/http/src/main/java/io/micronaut/http/HttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponse.java
@@ -38,7 +38,6 @@ public interface HttpResponse<B> extends HttpMessage<B> {
      * @return The current status
      * @deprecated To support custom status codes. Use {@link #code()} instead of {@link #getStatus()} and {@link HttpStatus#getCode()}  and {@link #reason()} instead of {@link #getStatus()} and {@link HttpStatus#getReason()}
      */
-    @Deprecated(since = "4.7.2")
     default HttpStatus getStatus() {
         return HttpStatus.valueOf(code());
     }


### PR DESCRIPTION
This pull-request deprecates `HttpResponse::getStatus` and `HttpClientResponseException::getStatus`. It adds `HttpClientResponseException::code`, and `HttpClientResponseException::reason` methods.

In order to be custom status codes compatible is better for people to use `HttpResponse::code` instead of `HttpResponse::getStatus`.

For example, we hit an issue in Micrometer https://github.com/micronaut-projects/micronaut-micrometer/pull/857

I have annotated the method as deprecated but not for removal. I don’t think we should remove it as it will break a lot of apps and tests.