### PR TITLE
Improve displaying of circular dependency error

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/ConstructorCircularDependencyFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/ConstructorCircularDependencyFailureSpec.groovy
@@ -31,36 +31,66 @@ class ConstructorCircularDependencyFailureSpec extends Specification {
         ApplicationContext context = ApplicationContext.run()
 
         when:"A bean is obtained that has a setter with @Inject"
-        B b =  context.getBean(B)
+        MyClassB b =  context.getBean(MyClassB)
 
         then:"The implementation is injected"
         def e = thrown(CircularDependencyException)
         e.message.normalize() == '''\
-Failed to inject value for field [a] of class: io.micronaut.inject.failures.ConstructorCircularDependencyFailureSpec$B
+Failed to inject value for field [propA] of class: io.micronaut.inject.failures.ConstructorCircularDependencyFailureSpec$MyClassB
 
 Message: Circular dependency detected
-Path Taken: 
-new B() --> B.a --> new A([C c]) --> new C([B b])
-^                                              |
-|                                              |
-|                                              |
-+----------------------------------------------+'''
+Path Taken:
+new MyClassB()
+      \\---> MyClassB.propA
+            ^  \\---> new MyClassA([MyClassC propC])
+            |        \\---> new MyClassC([MyClassB propB])
+            |              |
+            +--------------+'''
 
         cleanup:
         context.close()
     }
 
-    static class C {
-        @Inject C( B b ) {}
+    void "test another constructor circular dependency failure"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(["spec.name": getClass().simpleName])
+
+        when:"A bean is obtained that has a setter with @Inject"
+        context.getBean(MyClassD)
+
+        then:"The implementation is injected"
+        def e = thrown(CircularDependencyException)
+        e.message.normalize() == '''\
+Failed to inject value for field [propA] of class: io.micronaut.inject.failures.ConstructorCircularDependencyFailureSpec$MyClassB
+
+Message: Circular dependency detected
+Path Taken:
+new MyClassD(MyClassB propB)
+      \\---> new MyClassD([MyClassB propB])
+            \\---> MyClassB.propA
+                  ^  \\---> new MyClassA([MyClassC propC])
+                  |        \\---> new MyClassC([MyClassB propB])
+                  |              |
+                  +--------------+'''
+    }
+
+    static class MyClassC {
+        @Inject
+        MyClassC(MyClassB propB) {}
     }
     @Singleton
-    static class A {
-        A(C c) {}
+    static class MyClassA {
+        MyClassA(MyClassC propC) {}
     }
 
     @Singleton
-    static class B {
-        @Inject protected A a
+    static class MyClassB {
+        @Inject protected MyClassA propA
+    }
+
+    @Singleton
+    static class MyClassD {
+        MyClassD(MyClassB propB) {}
     }
 }
 

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/FactoryCircularDependencyFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/FactoryCircularDependencyFailureSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.failures
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.exceptions.CircularDependencyException
+import spock.lang.Specification
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+class FactoryCircularDependencyFailureSpec extends Specification {
+
+    void "test circular dependency with factory failure"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when:"A bean is obtained that has a setter with @Inject"
+        context.getBean(ElectricalGrid)
+
+        then:"The implementation is injected"
+        def e = thrown(CircularDependencyException)
+        e.message.normalize() == '''\
+Failed to inject value for parameter [stations] of class: io.micronaut.inject.failures.FactoryCircularDependencyFailureSpec$ElectricalGrid
+
+Message: Circular dependency detected
+Path Taken:
+new ElectricalGrid(List<ElectricStation E> stations)
+      \\---> new ElectricalGrid([List<ElectricStation E> stations])
+            ^  \\---> ElectricStationFactory.nuclearStation([MeasuringEquipment equipment])
+            |        \\---> MeasuringEquipment.grid
+            |              |
+            +--------------+'''
+
+        cleanup:
+        context.close()
+    }
+
+    static class ElectricalGrid {
+        @Inject
+        ElectricalGrid(List<ElectricStation> stations) {}
+    }
+
+    static class ElectricStation {
+        ElectricStation() {}
+    }
+
+    @Factory
+    static class ElectricStationFactory {
+
+        @Singleton
+        ElectricStation solarStation() {
+            return new ElectricStation()
+        }
+
+        @Singleton
+        ElectricStation nuclearStation(MeasuringEquipment equipment) {
+            return new ElectricStation()
+        }
+
+    }
+
+    @Singleton
+    static class MeasuringEquipment {
+        @Inject protected ElectricalGrid grid
+    }
+}
+

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/FieldCircularDependencyFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/FieldCircularDependencyFailureSpec.groovy
@@ -39,12 +39,13 @@ class FieldCircularDependencyFailureSpec extends Specification {
 Failed to inject value for field [a] of class: io.micronaut.inject.failures.FieldCircularDependencyFailureSpec$B
 
 Message: Circular dependency detected
-Path Taken: 
-new B() --> B.a --> new A([C c]) --> C.b
-^                                     |
-|                                     |
-|                                     |
-+-------------------------------------+'''
+Path Taken:
+new B()
+      \\---> B.a
+            ^  \\---> new A([C c])
+            |        \\---> C.b
+            |              |
+            +--------------+'''
         cleanup:
         context.close()
     }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyCircularDependencyFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyCircularDependencyFailureSpec.groovy
@@ -34,16 +34,17 @@ class PropertyCircularDependencyFailureSpec extends Specification {
 
         then:"The implementation is injected"
         CircularDependencyException e = thrown()
-        def lines = e.message.lines().toList()
-        lines[0] == 'Failed to inject value for parameter [a] of method [setA] of class: io.micronaut.inject.failures.PropertyCircularDependencyFailureSpec$B'
-        lines[1] == ''
-        lines[2] == 'Message: Circular dependency detected'
-        lines[3] == 'Path Taken: '
-        lines[4] == 'new B() --> B.setA([A a]) --> A.setB([B b])'
-        lines[5] == '^                                        |'
-        lines[6] == '|                                        |'
-        lines[7] == '|                                        |'
-        lines[8] == '+----------------------------------------+'
+        e.message == '''\
+Failed to inject value for parameter [a] of method [setA] of class: io.micronaut.inject.failures.PropertyCircularDependencyFailureSpec$B
+
+Message: Circular dependency detected
+Path Taken:
+new B()
+      \\---> B.setA([A a])
+            ^  \\---> A.setB([B b])
+            |        |
+            +--------+'''
+
         cleanup:
         context.close()
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/ConstructorCircularDependencyFailureSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/ConstructorCircularDependencyFailureSpec.groovy
@@ -16,13 +16,8 @@
 package io.micronaut.inject.failures.ctorcirculardependency
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.BeanContext
-import io.micronaut.context.DefaultBeanContext
-import io.micronaut.context.annotation.Property
 import io.micronaut.context.exceptions.CircularDependencyException
 import spock.lang.Specification
-
-import jakarta.inject.Singleton
 
 class ConstructorCircularDependencyFailureSpec extends Specification {
 
@@ -31,20 +26,21 @@ class ConstructorCircularDependencyFailureSpec extends Specification {
         ApplicationContext context = ApplicationContext.run(["spec.name": getClass().simpleName])
 
         when:"A bean is obtained that has a setter with @Inject"
-        B b =  context.getBean(B)
+        context.getBean(MyClassB)
 
         then:"The implementation is injected"
         def e = thrown(CircularDependencyException)
         e.message.normalize() == '''\
-Failed to inject value for field [a] of class: io.micronaut.inject.failures.ctorcirculardependency.B
+Failed to inject value for field [propA] of class: io.micronaut.inject.failures.ctorcirculardependency.MyClassB
 
 Message: Circular dependency detected
-Path Taken: 
-new B() --> B.a --> new A([C c]) --> new C([B b])
-^                                              |
-|                                              |
-|                                              |
-+----------------------------------------------+'''
+Path Taken:
+new MyClassB()
+^   \\---> MyClassB.propA
+|         \\---> new MyClassA([MyClassC propC])
+|               \\---> new MyClassC([MyClassB propB])
+|                           |
++---------------------------+'''
     }
 
     void "test multiple optionals do not cause a circular dependency exception"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/ConstructorCircularDependencyFailureSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/ConstructorCircularDependencyFailureSpec.groovy
@@ -36,11 +36,34 @@ Failed to inject value for field [propA] of class: io.micronaut.inject.failures.
 Message: Circular dependency detected
 Path Taken:
 new MyClassB()
-^   \\---> MyClassB.propA
-|         \\---> new MyClassA([MyClassC propC])
-|               \\---> new MyClassC([MyClassB propB])
-|                           |
-+---------------------------+'''
+      \\---> MyClassB.propA
+            ^  \\---> new MyClassA([MyClassC propC])
+            |        \\---> new MyClassC([MyClassB propB])
+            |              |
+            +--------------+'''
+    }
+
+    void "test another constructor circular dependency failure"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(["spec.name": getClass().simpleName])
+
+        when:"A bean is obtained that has a setter with @Inject"
+        context.getBean(MyClassD)
+
+        then:"The implementation is injected"
+        def e = thrown(CircularDependencyException)
+        e.message.normalize() == '''\
+Failed to inject value for field [propA] of class: io.micronaut.inject.failures.ctorcirculardependency.MyClassB
+
+Message: Circular dependency detected
+Path Taken:
+new MyClassD(MyClassB propB)
+      \\---> new MyClassD([MyClassB propB])
+            \\---> MyClassB.propA
+                  ^  \\---> new MyClassA([MyClassC propC])
+                  |        \\---> new MyClassC([MyClassB propB])
+                  |              |
+                  +--------------+'''
     }
 
     void "test multiple optionals do not cause a circular dependency exception"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/MyClassA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/MyClassA.java
@@ -17,12 +17,10 @@ package io.micronaut.inject.failures.ctorcirculardependency;
 
 import io.micronaut.context.annotation.Requires;
 
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 @Requires(property = "spec.name", value = "ConstructorCircularDependencyFailureSpec")
 @Singleton
-public class B {
-    @Inject
-    protected A a;
+public class MyClassA {
+    public MyClassA(MyClassC propC) {}
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/MyClassB.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/MyClassB.java
@@ -17,10 +17,12 @@ package io.micronaut.inject.failures.ctorcirculardependency;
 
 import io.micronaut.context.annotation.Requires;
 
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 @Requires(property = "spec.name", value = "ConstructorCircularDependencyFailureSpec")
 @Singleton
-public class A {
-    public A(C c) {}
+public class MyClassB {
+    @Inject
+    protected MyClassA propA;
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/MyClassC.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/MyClassC.java
@@ -17,7 +17,7 @@ package io.micronaut.inject.failures.ctorcirculardependency;
 
 import jakarta.inject.Inject;
 
-public class C {
+public class MyClassC {
     @Inject
-    public C(B b ) {}
+    public MyClassC(MyClassB propB) {}
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/MyClassD.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/ctorcirculardependency/MyClassD.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.failures.ctorcirculardependency;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Requires(property = "spec.name", value = "ConstructorCircularDependencyFailureSpec")
+@Singleton
+public class MyClassD {
+
+    @Inject
+    public MyClassD(MyClassB propB) {}
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/fieldcirculardependency/FieldCircularDependencyFailureSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/fieldcirculardependency/FieldCircularDependencyFailureSpec.groovy
@@ -36,12 +36,13 @@ class FieldCircularDependencyFailureSpec extends Specification {
 Failed to inject value for field [a] of class: io.micronaut.inject.failures.fieldcirculardependency.B
 
 Message: Circular dependency detected
-Path Taken: 
-new B() --> B.a --> new A([C c]) --> C.b
-^                                     |
-|                                     |
-|                                     |
-+-------------------------------------+'''
+Path Taken:
+new B()
+      \\---> B.a
+            ^  \\---> new A([C c])
+            |        \\---> C.b
+            |              |
+            +--------------+'''
 
         cleanup:
         context.close()

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -329,7 +329,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
 
             // Try finding an actual cycle, cycleI is index where the cycle starts
             int cycleIndex = lastIndexOf(iterator().next());
-            if (cycleIndex >= 0) {
+            if (cycleIndex > 0) {
                 cycleIndex = size() - cycleIndex;
             } else {
                 cycleIndex = 0;
@@ -489,12 +489,14 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
                                 push(constructorSegment);
                             }
                         } else {
+                            push(constructorSegment);
                             throw new CircularDependencyException(AbstractBeanResolutionContext.this, argument, CIRCULAR_ERROR_MSG);
                         }
                     } else {
                         push(constructorSegment);
                     }
                 } else {
+                    push(constructorSegment);
                     throw new CircularDependencyException(AbstractBeanResolutionContext.this, argument, CIRCULAR_ERROR_MSG);
                 }
             } else {

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -326,28 +326,26 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
             Iterator<Segment<?, ?>> i = descendingIterator();
             StringBuilder pathString = new StringBuilder();
             String ls = CachedEnvironment.getProperty("line.separator");
+
+            boolean first = true;
+            String spaces = "   ";
+
             while (i.hasNext()) {
                 String segmentString = i.next().toString();
                 pathString.append(segmentString);
                 if (i.hasNext()) {
-                    pathString.append(RIGHT_ARROW);
-                } else {
-                    int totalLength = pathString.length() - 3;
-                    String spaces = String.join("", Collections.nCopies(totalLength, " "));
-                    pathString.append(ls)
-                            .append("^")
-                            .append(spaces)
-                            .append("|")
-                            .append(ls)
-                            .append("|")
-                            .append(spaces)
-                            .append("|").append(ls)
-                            .append("|")
-                            .append(spaces)
-                            .append("|").append(ls).append('+');
-                    pathString.append(String.join("", Collections.nCopies(totalLength, "-"))).append('+');
+                    pathString
+                        .append(ls).append(first ? "^" : "|").append(spaces).append("\\---> ");
                 }
+                spaces = spaces + "      ";
+                first = false;
             }
+
+            String dashes = String.join("", Collections.nCopies(spaces.length(), "-"));
+            pathString
+                .append(ls).append("|").append(spaces).append("|")
+                .append(ls).append("+").append(dashes).append("+");
+
             return pathString.toString();
         }
 

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -327,24 +327,36 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
             StringBuilder pathString = new StringBuilder();
             String ls = CachedEnvironment.getProperty("line.separator");
 
-            boolean first = true;
-            String spaces = "   ";
-
-            while (i.hasNext()) {
-                String segmentString = i.next().toString();
-                pathString.append(segmentString);
-                if (i.hasNext()) {
-                    pathString
-                        .append(ls).append(first ? "^" : "|").append(spaces).append("\\---> ");
-                }
-                spaces = spaces + "      ";
-                first = false;
+            // Try finding an actual cycle, cycleI is index where the cycle starts
+            int cycleIndex = lastIndexOf(iterator().next());
+            if (cycleIndex >= 0) {
+                cycleIndex = size() - cycleIndex;
+            } else {
+                cycleIndex = 0;
             }
 
-            String dashes = String.join("", Collections.nCopies(spaces.length(), "-"));
+            String spaces = "";
+            int index = 0;
+            // The last element ends the cycle and is repeated in the path, so we skip it
+            // and point to an already present element instead
+            while (i.hasNext() && index < size() - 1) {
+                String segmentString = i.next().toString();
+                if (index == cycleIndex) {
+                    pathString.append(ls).append(spaces).append("^").append("  \\---> ");
+                    spaces = spaces + "|  ";
+                } else if (index != 0) {
+                    pathString.append(ls).append(spaces).append("\\---> ");
+                }
+                pathString.append(segmentString);
+                spaces = spaces + "      ";
+                ++index;
+            }
+
+            String dashes = String.join("", Collections.nCopies(spaces.length() - spaces.indexOf("|") - 1, "-"));
             pathString
-                .append(ls).append("|").append(spaces).append("|")
-                .append(ls).append("+").append(dashes).append("+");
+                .append(ls).append(spaces).append("|")
+                .append(ls).append(spaces, 0, spaces.indexOf("|"))
+                .append("+").append(dashes).append("+");
 
             return pathString.toString();
         }
@@ -372,6 +384,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
                 Segment<?, ?> previous = peek();
                 MethodSegment<?, ?> methodSegment = new MethodArgumentSegment(declaringType, (Qualifier<Object>) getCurrentQualifier(), methodName, argument, arguments, previous instanceof MethodSegment ms ? ms : null);
                 if (contains(methodSegment)) {
+                    push(methodSegment);
                     throw new CircularDependencyException(AbstractBeanResolutionContext.this, argument, CIRCULAR_ERROR_MSG);
                 } else {
                     push(methodSegment);
@@ -391,6 +404,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
             MethodSegment<?, ?> methodSegment = new MethodArgumentSegment(declaringType, (Qualifier<Object>) getCurrentQualifier(), methodInjectionPoint.getName(), argument,
                     methodInjectionPoint.getArguments(), previous instanceof MethodSegment ms ? ms : null);
             if (contains(methodSegment)) {
+                push(methodSegment);
                 throw new CircularDependencyException(AbstractBeanResolutionContext.this, methodInjectionPoint, argument, CIRCULAR_ERROR_MSG);
             } else {
                 push(methodSegment);
@@ -404,6 +418,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
             Segment<?, ?> previous = peek();
             MethodSegment<?, ?> methodSegment = new MethodArgumentSegment(declaringType, (Qualifier<Object>) getCurrentQualifier(), methodName, argument, arguments, previous instanceof MethodSegment ms ? ms : null);
             if (contains(methodSegment)) {
+                push(methodSegment);
                 throw new CircularDependencyException(AbstractBeanResolutionContext.this, declaringType, methodName, argument, CIRCULAR_ERROR_MSG);
             } else {
                 push(methodSegment);
@@ -416,6 +431,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         public Path pushFieldResolve(BeanDefinition declaringType, FieldInjectionPoint fieldInjectionPoint) {
             FieldSegment<?, ?> fieldSegment = new FieldSegment<>(declaringType, getCurrentQualifier(), fieldInjectionPoint.asArgument());
             if (contains(fieldSegment)) {
+                push(fieldSegment);
                 throw new CircularDependencyException(AbstractBeanResolutionContext.this, fieldInjectionPoint, CIRCULAR_ERROR_MSG);
             } else {
                 push(fieldSegment);
@@ -427,6 +443,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         public Path pushFieldResolve(BeanDefinition declaringType, Argument fieldAsArgument) {
             FieldSegment<?, ?> fieldSegment = new FieldSegment<>(declaringType, getCurrentQualifier(), fieldAsArgument);
             if (contains(fieldSegment)) {
+                push(fieldSegment);
                 throw new CircularDependencyException(AbstractBeanResolutionContext.this, declaringType, fieldAsArgument.getName(), CIRCULAR_ERROR_MSG);
             } else {
                 push(fieldSegment);
@@ -438,6 +455,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         public Path pushAnnotationResolve(BeanDefinition beanDefinition, Argument annotationMemberBeanAsArgument) {
             AnnotationSegment annotationSegment = new AnnotationSegment(beanDefinition, getCurrentQualifier(), annotationMemberBeanAsArgument);
             if (contains(annotationSegment)) {
+                push(annotationSegment);
                 throw new CircularDependencyException(AbstractBeanResolutionContext.this, beanDefinition, annotationMemberBeanAsArgument.getName(), CIRCULAR_ERROR_MSG);
             } else {
                 push(annotationSegment);
@@ -457,6 +475,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
                         if (declaringType instanceof ProxyBeanDefinition<?> proxyBeanDefinition) {
                             // take into account proxies
                             if (!proxyBeanDefinition.getTargetDefinitionType().equals(declaringBean.getClass())) {
+                                push(constructorSegment);
                                 throw new CircularDependencyException(AbstractBeanResolutionContext.this, argument, CIRCULAR_ERROR_MSG);
                             } else {
                                 push(constructorSegment);
@@ -464,6 +483,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
                         } else if (declaringBean instanceof ProxyBeanDefinition<?> proxyBeanDefinition) {
                             // take into account proxies
                             if (!proxyBeanDefinition.getTargetDefinitionType().equals(declaringType.getClass())) {
+                                push(constructorSegment);
                                 throw new CircularDependencyException(AbstractBeanResolutionContext.this, argument, CIRCULAR_ERROR_MSG);
                             } else {
                                 push(constructorSegment);

--- a/inject/src/main/java/io/micronaut/context/exceptions/MessageUtils.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/MessageUtils.java
@@ -174,11 +174,11 @@ class MessageUtils {
     }
 
     private static void appendPath(boolean circular, StringBuilder builder, String ls, BeanResolutionContext.Path path) {
-        String pathString = circular ? path.toCircularString() : path.toString();
-        builder.append("Path Taken: ");
+        builder.append("Path Taken:");
         if (circular) {
-            builder.append(ls);
+            builder.append(ls).append(path.toCircularString());
+        } else {
+            builder.append(" ").append(path);
         }
-        builder.append(pathString);
     }
 }


### PR DESCRIPTION
For some classes `ClassA`, `ClassB`, `ClassC` and `ClassD` that have a dependency cycle, the current message is:
```
Failed to inject value for field [propA] of class: io.micronaut.inject.failures.ctorcirculardependency.MyClassB
 
Message: Circular dependency detected
Path Taken: 
new MyClassD(MyClassB propB) --> new MyClassD([MyClassB propB]) --> MyClassB.propA --> new MyClassA([MyClassC propC]) --> new MyClassC([MyClassB propB])
^                                                                                                                                                     |
|                                                                                                                                                     |
|                                                                                                                                                     |
+-----------------------------------------------------------------------------------------------------------------------------------------------------+
```

After the change it would be:
```
Failed to inject value for field [propA] of class: io.micronaut.inject.failures.ctorcirculardependency.MyClassB
 
Message: Circular dependency detected
Path Taken: 
new MyClassD(MyClassB propB)
      \---> new MyClassD([MyClassB propB])
            \---> MyClassB.propA
                  ^  \---> new MyClassA([MyClassC propC])
                  |        \---> new MyClassC([MyClassB propB])
                  |              |
                  +--------------+
```

This improves it by:
* Showing the actual cycle, as the cycle does not always include the first element in the path. In this case it is `ClassB->ClassA->ClassC->ClassB`, so `ClassD` is ommitted
* Displaying each entry on a new line to improve readability. This is important for classes with long class names and multiple injection parameters. I changed the test class names to longer, as `A`, `B`, `C` did not seem realistic.