### PR TITLE
[Fix #10585] Add http-client error log for non-CompletableFuture responses

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -217,6 +217,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
         Class<?> javaReturnType = returnType.getType();
         BlockingHttpClient blockingHttpClient = httpClient.toBlocking();
         RequestBinderResult binderResult = bindRequest(context, httpMethod, httpMethodName, uriToBind, interceptedMethod, annotationMetadata);
+        String clientName = declaringType.getName();
 
         if (binderResult.isError()) {
             return binderResult.errorResult;
@@ -228,25 +229,18 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
             request.getHeaders().remove(HttpHeaders.ACCEPT);
         }
 
-        try {
-            if (HttpResponse.class.isAssignableFrom(javaReturnType)) {
-                return handleBlockingCall(javaReturnType, () ->
+        if (HttpResponse.class.isAssignableFrom(javaReturnType)) {
+            return handleBlockingCall(
+                clientName, javaReturnType, () ->
                     blockingHttpClient.exchange(request,
-                        returnType.asArgument().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT),
-                        errorType
-                    ));
-            } else if (void.class == javaReturnType) {
-                return handleBlockingCall(javaReturnType, () ->
-                    blockingHttpClient.exchange(request, null, errorType));
-            } else {
-                return handleBlockingCall(javaReturnType, () ->
-                    blockingHttpClient.retrieve(request, returnType.asArgument(), errorType));
-            }
-        } catch (Exception e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Client [{}] received HTTP error response: {}", declaringType.getName(), e.getMessage(), e);
-            }
-            throw e;
+                    returnType.asArgument().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT),
+                    errorType
+                ));
+        } else if (void.class == javaReturnType) {
+            return handleBlockingCall(clientName, javaReturnType, () -> blockingHttpClient.exchange(request, null, errorType));
+        } else {
+            return handleBlockingCall(clientName, javaReturnType,
+                () -> blockingHttpClient.retrieve(request, returnType.asArgument(), errorType));
         }
     }
 
@@ -289,6 +283,10 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
 
             @Override
             protected void doOnError(Throwable t) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Client [{}] received HTTP error response: {}", declaringType.getName(), t.getMessage(), t);
+                }
+
                 if (t instanceof HttpClientResponseException e) {
                     if (e.getStatus() == HttpStatus.NOT_FOUND) {
                         if (reactiveValueType == Optional.class) {
@@ -301,9 +299,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                         return;
                     }
                 }
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Client [{}] received HTTP error response: {}", declaringType.getName(), t.getMessage(), t);
-                }
+
                 future.completeExceptionally(t);
             }
 
@@ -627,7 +623,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
         }
     }
 
-    private Object handleBlockingCall(Class returnType, Supplier<Object> supplier) {
+    private Object handleBlockingCall(String clientName, Class returnType, Supplier<Object> supplier) {
         try {
             if (void.class == returnType) {
                 supplier.get();
@@ -636,6 +632,10 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                 return supplier.get();
             }
         } catch (RuntimeException t) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Client [{}] received HTTP error response: {}", clientName, t.getMessage(), t);
+            }
+
             if (t instanceof HttpClientResponseException exception && exception.getStatus() == HttpStatus.NOT_FOUND) {
                 if (returnType == Optional.class) {
                     return Optional.empty();

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -186,13 +186,13 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                 return switch (interceptedMethod.resultType()) {
                     case PUBLISHER ->
                             handlePublisher(context, returnType, reactiveValueType, httpMethod, httpMethodName,
-                                uri, interceptedMethod, annotationMetadata, httpClient, errorType, valueType);
+                                uri, interceptedMethod, annotationMetadata, httpClient, errorType, valueType, declaringType);
                     case COMPLETION_STAGE ->
                             handleCompletionStage(context, httpMethod, httpMethodName, uri, interceptedMethod,
                                 annotationMetadata, httpClient, returnType, errorType, valueType, reactiveValueType, declaringType);
                     case SYNCHRONOUS ->
                             handleSynchronous(context, returnType, httpClient, httpMethod, httpMethodName, uri,
-                                interceptedMethod, annotationMetadata, errorType);
+                                interceptedMethod, annotationMetadata, errorType, declaringType);
                 };
             } catch (Exception e) {
                 return interceptedMethod.handleException(e);
@@ -211,7 +211,8 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                                      String uriToBind,
                                      InterceptedMethod interceptedMethod,
                                      AnnotationMetadata annotationMetadata,
-                                     Argument<?> errorType) {
+                                     Argument<?> errorType,
+                                     Class<?> declaringType) {
 
         Class<?> javaReturnType = returnType.getType();
         BlockingHttpClient blockingHttpClient = httpClient.toBlocking();
@@ -227,18 +228,25 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
             request.getHeaders().remove(HttpHeaders.ACCEPT);
         }
 
-        if (HttpResponse.class.isAssignableFrom(javaReturnType)) {
-            return handleBlockingCall(javaReturnType, () ->
-                blockingHttpClient.exchange(request,
-                    returnType.asArgument().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT),
-                    errorType
-                ));
-        } else if (void.class == javaReturnType) {
-            return handleBlockingCall(javaReturnType, () ->
-                blockingHttpClient.exchange(request, null, errorType));
-        } else {
-            return handleBlockingCall(javaReturnType, () ->
-                blockingHttpClient.retrieve(request, returnType.asArgument(), errorType));
+        try {
+            if (HttpResponse.class.isAssignableFrom(javaReturnType)) {
+                return handleBlockingCall(javaReturnType, () ->
+                    blockingHttpClient.exchange(request,
+                        returnType.asArgument().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT),
+                        errorType
+                    ));
+            } else if (void.class == javaReturnType) {
+                return handleBlockingCall(javaReturnType, () ->
+                    blockingHttpClient.exchange(request, null, errorType));
+            } else {
+                return handleBlockingCall(javaReturnType, () ->
+                    blockingHttpClient.retrieve(request, returnType.asArgument(), errorType));
+            }
+        } catch (Exception e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Client [{}] received HTTP error response: {}", declaringType.getName(), e.getMessage(), e);
+            }
+            throw e;
         }
     }
 
@@ -318,7 +326,8 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                                    AnnotationMetadata annotationMetadata,
                                    HttpClient httpClient,
                                    Argument<?> errorType,
-                                   Argument<?> valueType) {
+                                   Argument<?> valueType,
+                                   Class<?> declaringType) {
         boolean isSingle = returnType.isSingleResult() ||
                 returnType.isCompletable() ||
                 HttpResponse.class.isAssignableFrom(reactiveValueType) ||
@@ -332,6 +341,14 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
         } else {
             publisher = httpClientResponsePublisher(httpClient, requestPublisher, returnType, errorType, valueType);
         }
+
+        publisher = Flux.from(publisher)
+            .doOnError(t -> {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Client [{}] received HTTP error response: {}", declaringType.getName(), t.getMessage(), t);
+                }
+            });
+
         Object finalPublisher = interceptedMethod.handleResult(publisher);
         for (ReactiveClientResultTransformer transformer : transformers) {
             finalPublisher = transformer.transform(finalPublisher);

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -338,12 +338,11 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
             publisher = httpClientResponsePublisher(httpClient, requestPublisher, returnType, errorType, valueType);
         }
 
-        publisher = Flux.from(publisher)
-            .doOnError(t -> {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Client [{}] received HTTP error response: {}", declaringType.getName(), t.getMessage(), t);
-                }
-            });
+        if (LOG.isDebugEnabled()) {
+            publisher = Flux.from(publisher).doOnError(t ->
+                LOG.debug("Client [{}] received HTTP error response: {}", declaringType.getName(), t.getMessage(), t)
+            );
+        }
 
         Object finalPublisher = interceptedMethod.handleResult(publisher);
         for (ReactiveClientResultTransformer transformer : transformers) {

--- a/test-suite-logback/build.gradle
+++ b/test-suite-logback/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation(projects.injectGroovy)
     testImplementation(libs.logback.classic)
+    testImplementation(libs.managed.reactor.test);
 
     testImplementation(projects.management)
     testImplementation(projects.httpClient)

--- a/test-suite-logback/src/test/groovy/io/micronaut/logback/LoggerClientExceptionSpec.groovy
+++ b/test-suite-logback/src/test/groovy/io/micronaut/logback/LoggerClientExceptionSpec.groovy
@@ -1,0 +1,88 @@
+package io.micronaut.logback
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.interceptor.HttpClientIntroductionAdvice
+import io.micronaut.logback.clients.TeapotClient
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.slf4j.LoggerFactory
+import reactor.test.StepVerifier
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.concurrent.CompletionException
+
+@MicronautTest
+@Issue("https://github.com/micronaut-projects/micronaut-core/issues/10585")
+class LoggerClientExceptionSpec extends Specification {
+    public static final String LOG_MESSAGE = "Client [io.micronaut.logback.clients.TeapotClient] received HTTP error response: Client '/teapot': Client Error (418)"
+
+    @Inject
+    TeapotClient client
+
+    @Shared
+    Logger log = (Logger) LoggerFactory.getLogger(HttpClientIntroductionAdvice)
+
+    @Shared
+    ListAppender<ILoggingEvent> appender = new ListAppender<>()
+
+    void setupSpec() {
+        log.setLevel(Level.TRACE)
+        appender.start()
+        log.addAppender(appender)
+    }
+
+    void cleanup() {
+        appender.list.clear()
+    }
+
+    private void assertLogMessage() {
+        assert appender.list.size() == 1
+        assert appender.list[0].formattedMessage == LOG_MESSAGE
+        assert appender.list[0].level == Level.DEBUG
+    }
+
+    void "client synchronous response type should log received error"() {
+        when:
+        def response = client.syncTeapot()
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.I_AM_A_TEAPOT
+        response == null
+        assertLogMessage()
+    }
+
+    void "client with completable future response type should log received error"() {
+        given:
+        def response = client.asyncTeapot()
+
+        when:
+        response.join()
+
+        then:
+        thrown(CompletionException)
+        response.isCompletedExceptionally()
+        assertLogMessage()
+    }
+
+    void "client with reactive response type should log received error"() {
+        given:
+        def response = client.reactiveTeapot()
+
+        when:
+        StepVerifier.create(response)
+                .expectErrorMatches { it instanceof HttpClientResponseException &&
+                        it.status == HttpStatus.I_AM_A_TEAPOT }
+                .verify()
+
+        then:
+        assertLogMessage()
+    }
+}

--- a/test-suite-logback/src/test/java/io/micronaut/logback/clients/TeapotClient.java
+++ b/test-suite-logback/src/test/java/io/micronaut/logback/clients/TeapotClient.java
@@ -1,0 +1,19 @@
+package io.micronaut.logback.clients;
+
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.annotation.Client;
+import org.reactivestreams.Publisher;
+
+import java.util.concurrent.CompletableFuture;
+
+@Client("/teapot")
+public interface TeapotClient {
+    @Get("/sync-teapot")
+    String syncTeapot();
+
+    @Get("/async-teapot")
+    CompletableFuture<String> asyncTeapot();
+
+    @Get("/reactive-teapot")
+    Publisher<String> reactiveTeapot();
+}

--- a/test-suite-logback/src/test/java/io/micronaut/logback/controllers/TeapotController.java
+++ b/test-suite-logback/src/test/java/io/micronaut/logback/controllers/TeapotController.java
@@ -1,0 +1,32 @@
+package io.micronaut.logback.controllers;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CompletableFuture;
+
+@Controller("/teapot")
+public class TeapotController {
+
+    private HttpResponse<String> teapotResponse() {
+        return HttpResponse.status(HttpStatus.I_AM_A_TEAPOT);
+    }
+
+    @Get("/sync-teapot")
+    public HttpResponse<String> syncNotFound() {
+        return teapotResponse();
+    }
+
+    @Get("/async-teapot")
+    public CompletableFuture<HttpResponse<String>> asyncNotFound() {
+        return CompletableFuture.supplyAsync(this::teapotResponse);
+    }
+
+    @Get("/reactive-teapot")
+    public Mono<HttpResponse<String>> reactiveNotFound() {
+        return Mono.just(teapotResponse());
+    }
+}


### PR DESCRIPTION
Add logging for sync and publisher client types as mentioned in [#10585](https://github.com/micronaut-projects/micronaut-core/issues/10585).