### PR TITLE
Inner classes with builder don't get introspected

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -84,21 +84,6 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 processIntrospected(element, context, introspected);
             }
         }
-
-        List<ClassElement> innerIntrospections = element.getEnclosedElements(
-            ElementQuery.ALL_INNER_CLASSES
-                .onlyStatic()
-                .onlyConcrete()
-                .onlyAccessible(element)
-                .annotated(annotationMetadata -> annotationMetadata.hasDeclaredStereotype(Introspected.class))
-        );
-
-        for (ClassElement innerIntrospected : innerIntrospections) {
-            final AnnotationValue<Introspected> introspected = innerIntrospected.getAnnotation(Introspected.class);
-            if (introspected != null && !writers.containsKey(innerIntrospected.getName())) {
-                processIntrospected(innerIntrospected, context, introspected);
-            }
-        }
     }
 
     private boolean isIntrospected(VisitorContext context, ClassElement c) {

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -84,6 +84,21 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 processIntrospected(element, context, introspected);
             }
         }
+
+        List<ClassElement> innerIntrospections = element.getEnclosedElements(
+            ElementQuery.ALL_INNER_CLASSES
+                .onlyStatic()
+                .onlyConcrete()
+                .onlyAccessible(element)
+                .annotated(annotationMetadata -> annotationMetadata.hasDeclaredStereotype(Introspected.class))
+        );
+
+        for (ClassElement innerIntrospected : innerIntrospections) {
+            final AnnotationValue<Introspected> introspected = innerIntrospected.getAnnotation(Introspected.class);
+            if (introspected != null && !writers.containsKey(innerIntrospected.getName())) {
+                processIntrospected(innerIntrospected, context, introspected);
+            }
+        }
     }
 
     private boolean isIntrospected(VisitorContext context, ClassElement c) {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -52,6 +52,65 @@ import java.util.stream.IntStream
 
 class BeanIntrospectionSpec extends AbstractTypeElementSpec {
 
+    void "test inner introspection"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Test$Foo', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.value.OptionalMultiValues;
+import java.util.*;
+import java.lang.annotation.*;
+import static java.lang.annotation.ElementType.*;
+
+@Introspected
+class Test {
+    @Introspected
+    record Foo(String name) {}
+
+    @Introspected(accessKind = Introspected.AccessKind.FIELD)
+    static class Bar {
+        String name;
+    }
+}
+
+
+    ''' )
+
+        then:
+        introspection != null
+        introspection.getBeanType().simpleName == 'Foo'
+    }
+
+    void "test inner introspection - without outer annotation"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Test$Foo', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.value.OptionalMultiValues;
+import java.util.*;
+import java.lang.annotation.*;
+import static java.lang.annotation.ElementType.*;
+
+class Test {
+    @Introspected
+    record Foo(String name) {}
+
+    @Introspected(accessKind = Introspected.AccessKind.FIELD)
+    static class Bar {
+        String name;
+    }
+}
+
+
+    ''' )
+
+        then:
+        introspection != null
+        introspection.getBeanType().simpleName == 'Foo'
+    }
+
     void "test annotations"() {
         when:
         def introspection = buildBeanIntrospection('test.Test', '''

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -275,7 +275,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                             }
                             error(originatingElement.element(), e.getMessage());
                         } catch (PostponeToNextRoundException e) {
-                            postponedTypes.put(javaClassElement.getName(), e.getErrorElement());
+                            postponedTypes.put(javaClassElement.getCanonicalName(), e.getErrorElement());
                         }
                     }
                 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -185,6 +185,11 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     }
 
     @Override
+    public String getCanonicalName() {
+        return classElement.getQualifiedName().toString();
+    }
+
+    @Override
     public JavaNativeElement.@NonNull Class getNativeType() {
         return (JavaNativeElement.Class) super.getNativeType();
     }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -47,6 +47,21 @@ import spock.util.environment.Jvm
 
 class ClassElementSpec extends AbstractTypeElementSpec {
 
+    void "test canonical name"() {
+        expect:
+        buildClassElement('''
+package test;
+
+record Outer() {
+    record Inner() {}
+}
+''') { ClassElement classElement ->
+            assert classElement.canonicalName == 'test.Outer'
+            assert classElement.getEnclosedElement(ElementQuery.ALL_INNER_CLASSES).get().canonicalName == 'test.Outer.Inner'
+            classElement
+        }
+    }
+
     void "test package-private methods with broken different package"() {
         when:
         ClassElement classElement = buildClassElement('''

--- a/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
@@ -4,6 +4,7 @@ import io.micronaut.core.beans.BeanIntrospection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.UUID;
 
 public class LombokIntrospectedBuilderTest {
@@ -30,8 +31,18 @@ public class LombokIntrospectedBuilderTest {
 
         Assertions.assertEquals(id, simpleEntity.getId());
 
-        BeanIntrospection<SimpleEntity.CompartmentCreationTimeIndexPrefix> introspection =
+        BeanIntrospection<SimpleEntity.CompartmentCreationTimeIndexPrefix> innerClassIntrospection =
             BeanIntrospection.getIntrospection(SimpleEntity.CompartmentCreationTimeIndexPrefix.class);
-        Assertions.assertNotNull(introspection);
+        Assertions.assertNotNull(innerClassIntrospection);
+
+        BeanIntrospection.Builder<SimpleEntity.CompartmentCreationTimeIndexPrefix> innerClassBuilder =
+            innerClassIntrospection.builder();
+
+        long current = Instant.now().toEpochMilli();
+        SimpleEntity.CompartmentCreationTimeIndexPrefix innerClassEntity =
+            innerClassBuilder.with("compartmentId", "c1").with("timeCreated", current).build();
+
+        Assertions.assertEquals("c1", innerClassEntity.getCompartmentId());
+        Assertions.assertEquals(current, innerClassEntity.getTimeCreated());
     }
 }

--- a/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
@@ -4,6 +4,8 @@ import io.micronaut.core.beans.BeanIntrospection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 public class LombokIntrospectedBuilderTest {
 
     @Test
@@ -15,5 +17,21 @@ public class LombokIntrospectedBuilderTest {
             .build();
 
         Assertions.assertEquals("foo", robotEntity.getName());
+    }
+
+    @Test
+    void testLombokBuilderWithInnerClasses() {
+        BeanIntrospection.Builder<SimpleEntity> builder = BeanIntrospection.getIntrospection(SimpleEntity.class)
+            .builder();
+
+        String id = UUID.randomUUID().toString();
+        SimpleEntity simpleEntity = builder.with("id", id)
+            .build();
+
+        Assertions.assertEquals(id, simpleEntity.getId());
+
+        BeanIntrospection<SimpleEntity.CompartmentCreationTimeIndexPrefix> introspection =
+            BeanIntrospection.getIntrospection(SimpleEntity.CompartmentCreationTimeIndexPrefix.class);
+        Assertions.assertNotNull(introspection);
     }
 }

--- a/test-suite/src/test/java/io/micronaut/test/lombok/SimpleEntity.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/SimpleEntity.java
@@ -1,0 +1,42 @@
+package io.micronaut.test.lombok;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Value;
+
+@lombok.Builder(builderClassName = "Builder")
+@Data
+@Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = SimpleEntity.Builder.class))
+@AllArgsConstructor
+public class SimpleEntity {
+
+    @NonNull
+    private String id;
+
+    private String displayName;
+
+    @NonNull
+    private String compartmentId;
+
+    @NonNull
+    private String state;
+
+    @NonNull
+    private Long timeCreated;
+
+    @NonNull
+    private Long timeUpdated;
+
+    @Value
+    @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = CompartmentCreationTimeIndexPrefix.Builder.class))
+    @lombok.Builder(builderClassName = "Builder")
+    public static class CompartmentCreationTimeIndexPrefix {
+
+        String compartmentId;
+
+        Long timeCreated;
+    }
+}
+


### PR DESCRIPTION
When an inner class is postponed to the next round the binary class name is used to perform a lookup of the refreshed class when processing gets to the next round. This is an issue because the canonical class name needs to be use to lookup elements. This changes the code to use `getCanonicalName()` which revealed another bug where the implementation of `JavaClassElement.getCanonicalName()` was not correct.