### PR TITLE
Update MicronautMetaServiceLoaderUtils.java to fix single threaded service loader #11229 

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -257,7 +257,7 @@ public final class MicronautMetaServiceLoaderUtils {
                 List<S> collection = new ArrayList<>(serviceEntries.size());
                 for (String serviceEntry : serviceEntries) {
                     S val = instantiate(serviceEntry, classLoader);
-                    if (val != null && predicate != null && !predicate.test(val)) {
+                    if (val != null && !collection.contains(val) && (predicate == null || predicate.test(val))) {
                         collection.add(val);
                     }
                 }

--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -257,7 +257,7 @@ public final class MicronautMetaServiceLoaderUtils {
                 List<S> collection = new ArrayList<>(serviceEntries.size());
                 for (String serviceEntry : serviceEntries) {
                     S val = instantiate(serviceEntry, classLoader);
-                    if (val != null && !collection.contains(val) && (predicate == null || predicate.test(val))) {
+                    if (val != null && (predicate == null || predicate.test(val))) {
                         collection.add(val);
                     }
                 }
@@ -309,7 +309,7 @@ public final class MicronautMetaServiceLoaderUtils {
             if (throwable != null) {
                 throw new SoftServiceLoader.ServiceLoadingException("Failed to load a service: " + throwable.getMessage(), throwable);
             }
-            if (result != null && !values.contains(result)) {
+            if (result != null) {
                 values.add(result);
             }
         }


### PR DESCRIPTION
 Fix for service loader #11229 

@andriy-dmytruk @graemerocher @dstepanov

I believe the change is not complete and still has a logical error. Another way to change the parallelisim would be to set -XX:ActiveProcessorCount. This option is used in dockerized environments to limit resources used by the application.

In my tests, wenn I set the option a value smaller than 3 (parallelism is active processor count -1), then micronaut application will not start.

I believe the condition to add the services in the class MicronautMetaServiceLoaderUtils (line 260) is not correct:

is:

if (val != null && predicate != null && !predicate.test(val)) {

but should be:

if (val != null && !collection.contains(val) && (predicate == null || predicate.test(val))) {