### PR TITLE
Support merging with mapper annotation

### DIFF
--- a/context/src/test/groovy/io/micronaut/runtime/beans/MapperAnnotationSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/runtime/beans/MapperAnnotationSpec.groovy
@@ -6,7 +6,6 @@ import io.micronaut.context.annotation.Mapper
 import io.micronaut.core.annotation.AccessorsStyle
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.convert.ConversionService
-import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -142,6 +141,23 @@ class MapperAnnotationSpec extends Specification {
         result.companyId == 'rab'
         result.parts == 10
     }
+
+    void "list mapper test"() {
+        when:
+        VacuumCleanersEntity result = testBean.toEntities(
+                new VacuumCleanerCollection([
+                        new VacuumCleaner("first"),
+                        new VacuumCleaner("second"),
+                        new VacuumCleaner("third")
+                ])
+        )
+
+        then:
+        result.cleaners[0].name == 'first'
+        result.cleaners[1].name == 'second'
+        result.cleaners[2].name == 'third'
+    }
+
 }
 
 @Singleton
@@ -172,6 +188,12 @@ abstract class Test {
     String calcCompanyId(CreateRobot createRobot) {
         return createRobot.companyId.reverse()
     }
+
+    @Mapper
+    abstract VacuumCleanersEntity toEntity(VacuumCleaner cleaner)
+
+    @Mapper
+    abstract VacuumCleanersEntity toEntities(VacuumCleanerCollection cleaner)
 }
 
 @Introspected
@@ -291,4 +313,40 @@ class SimpleRobotEntity {
         }
     }
 
+}
+
+@Introspected
+final class VacuumCleaner {
+    final String name
+
+    VacuumCleaner(String name) {
+        this.name = name
+    }
+}
+
+@Introspected
+final class VacuumCleanerEntity {
+    final String name
+
+    VacuumCleanerEntity(String name) {
+        this.name = name
+    }
+}
+
+@Introspected
+final class VacuumCleanerCollection {
+    final List<VacuumCleaner> cleaners
+
+    VacuumCleanerCollection(List<VacuumCleaner> cleaners) {
+        this.cleaners = cleaners
+    }
+}
+
+@Introspected
+final class VacuumCleanersEntity {
+    final ArrayList<VacuumCleanerEntity> cleaners
+
+    VacuumCleanersEntity(ArrayList<VacuumCleanerEntity> cleaners) {
+        this.cleaners = cleaners
+    }
 }

--- a/context/src/test/groovy/io/micronaut/runtime/beans/MapperMergingAnnotationSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/runtime/beans/MapperMergingAnnotationSpec.groovy
@@ -1,0 +1,194 @@
+package io.micronaut.runtime.beans
+
+import groovy.transform.EqualsAndHashCode
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Mapper
+import io.micronaut.core.annotation.Introspected
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MapperMergingAnnotationSpec extends Specification {
+
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+    @Shared TestMerge testMerge = context.getBean(TestMerge)
+
+    void "test merge beans"() {
+        given:
+        var a = new SkeletonPartA(description: "Spooky", age: 120)
+        var b = new SkeletonPartB(numBones: 130, height: 184)
+        var c = new SkeletonPartC(numToes: 10)
+
+        when:
+        Skeleton result = testMerge.merge(a, b, c)
+
+        then:
+        result.description == 'Spooky'
+        result.age == 120
+        result.numBones == 130
+        result.height == 184
+        result.numToes == 10
+    }
+
+    void "test merge beans with mapping"() {
+        given:
+        var a = new CustomPart(halloweenDescription: "Spooky and gloomy", aliveAge: 100, deadAge: 100)
+        var b = new SkeletonPartB(numBones: 130, height: 184)
+        var c = new SkeletonPartC(numToes: 10)
+
+        when:
+        Skeleton result = testMerge.merge(a, b, c)
+
+        then:
+        result.description == 'Spooky and gloomy'
+        result.age == 200
+        result.numBones == 130
+        result.height == 184
+        result.numToes == 10
+    }
+
+    void "test update from map"() {
+        given:
+        var s = new Skeleton(description: "Spooky", age: 102)
+        var update = ["description": "Boo!!!", "numBones": 200]
+
+        when:
+        Skeleton result = testMerge.update(s, update)
+
+        then:
+        result.description == 'Boo!!!'
+        result.age == 102
+        result.numBones == 200
+    }
+
+    void "test merge from maps with mapping"() {
+        given:
+        var a = ["description": "Spooky", deadAge: 100]
+        var b = ["halloweenDescription": "Boo!!!", "numBones": 200]
+
+        when:
+        Skeleton result = testMerge.merge(a, b)
+
+        then:
+        result.description == 'Boo!!!'
+        result.age == 100
+        result.numBones == 200
+    }
+
+    void "test update default merge strategy"() {
+        when:
+        var skeleton = new Skeleton(description: "Spooky", age: 100, numBones: 12, height: 100, numToes: 2)
+        var update = new SkeletonUpdater(halloweenDescription: "Very spooky")
+
+        then:
+        testMerge.updateNotNullOverride(skeleton, update) == new Skeleton(description: "Very spooky", age: 100, numBones: 12, height: 100, numToes: 2)
+        testMerge.updateAlwaysOverride(skeleton, update) == new Skeleton(description: "Very spooky", height: 100, numToes: 2)
+    }
+
+    void "test update custom merge strategy"() {
+        when:
+        var skeleton = new Skeleton(description: "Spooky", age: 100, numBones: 12, height: 100, numToes: 2)
+        var update1 = new SkeletonUpdater(halloweenDescription: "Very spooky", explicitlySet: [])
+        var update2 = new SkeletonUpdater(halloweenDescription: "Very spooky", explicitlySet: ["halloweenDescription"])
+        var update3 = new SkeletonUpdater(halloweenDescription: "Very spooky", explicitlySet: ["halloweenDescription", "age", "numBones"])
+
+        then:
+        // Nothing explicitly set
+        testMerge.updateExplicitlySet(skeleton, update1) == skeleton
+        // Item was explicitly set
+        testMerge.updateExplicitlySet(skeleton, update2) == new Skeleton(description: "Very spooky", age: 100, numBones: 12, height: 100, numToes: 2)
+        // Item was explicitly null-ed
+        testMerge.updateExplicitlySet(skeleton, update3) == new Skeleton(description: "Very spooky", height: 100, numToes: 2)
+    }
+
+}
+
+@Singleton
+@Mapper
+abstract class TestMerge {
+
+    @Mapper
+    abstract Skeleton merge(SkeletonPartA a, SkeletonPartB b, SkeletonPartC c);
+
+    @Mapper.Mapping(from = "a.halloweenDescription", to = "description")
+    @Mapper.Mapping(from = "#{a.deadAge + a.aliveAge}", to = "age")
+    abstract Skeleton merge(CustomPart a, SkeletonPartB b, SkeletonPartC c);
+
+    @Mapper
+    abstract Skeleton update(Skeleton skeleton, Map<String, Object> values);
+
+    @Mapper.Mapping(from = "values.halloweenDescription", to = "description")
+    @Mapper.Mapping(from = "#{skeleton.get('deadAge')}", to = "age")
+    abstract Skeleton merge(Map<String, Object> skeleton, Map<String, Object> values);
+
+    @Mapper(mergeStrategy = "EXPLICITLY_SET")
+    @Mapper.Mapping(from = "updater.halloweenDescription", to = "description")
+    abstract Skeleton updateExplicitlySet(Skeleton current, SkeletonUpdater updater)
+
+    @Mapper(mergeStrategy = Mapper.MERGE_STRATEGY_ALWAYS_OVERRIDE)
+    @Mapper.Mapping(from = "updater.halloweenDescription", to = "description")
+    abstract Skeleton updateAlwaysOverride(Skeleton current, SkeletonUpdater updater)
+
+    @Mapper(mergeStrategy = Mapper.MERGE_STRATEGY_NOT_NULL_OVERRIDE)
+    @Mapper.Mapping(from = "updater.halloweenDescription", to = "description")
+    abstract Skeleton updateNotNullOverride(Skeleton current, SkeletonUpdater updater)
+
+}
+
+@Introspected
+@EqualsAndHashCode
+final class Skeleton {
+    String description
+    Integer age
+    Integer numBones
+    Float height
+    Integer numToes
+}
+
+@Introspected
+final class SkeletonUpdater {
+    String halloweenDescription
+    Integer age
+    Integer numBones
+    Set<String> explicitlySet
+}
+
+@Introspected
+final class SkeletonPartA {
+    String description
+    Integer age
+}
+
+@Introspected
+final class SkeletonPartB {
+    Integer numBones
+    double height
+}
+
+@Introspected
+final class SkeletonPartC {
+    Integer numToes
+}
+
+@Introspected
+final class CustomPart {
+    String halloweenDescription
+    Integer deadAge
+    Integer aliveAge
+}
+
+@Singleton
+@Named("EXPLICITLY_SET")
+final class ExplicitlySetMergeStrategy implements Mapper.MergeStrategy {
+
+    @Override
+    Object merge(Object currentValue, Object value, Object valueOwner, String propertyName, String mappedPropertyName) {
+        if (valueOwner instanceof SkeletonUpdater) {
+            return valueOwner.explicitlySet.contains(mappedPropertyName) ? value : currentValue
+        } else {
+            value
+        }
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -1569,6 +1569,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
 
     /**
      * Used to clear mutated metadata at the end of a compilation cycle.
+     * @param key The mutated annotation metadata to remove
      */
     @Internal
     public static void clearMutated(@NonNull Object key) {

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/MapperVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/MapperVisitor.java
@@ -22,7 +22,6 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
-import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.ast.PropertyElementQuery;
 import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.visitor.TypeElementVisitor;

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/MapperVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/MapperVisitor.java
@@ -71,6 +71,7 @@ public final class MapperVisitor implements TypeElementVisitor<Object, Mapper> {
         }
     }
 
+    @SuppressWarnings("java:S1192")
     private void validateMappingAnnotations(MethodElement element, List<AnnotationValue<Mapper.Mapping>> values, ClassElement toType) {
         @NonNull ParameterElement[] parameters = element.getParameters();
 

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/MapperVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/MapperVisitor.java
@@ -53,60 +53,90 @@ public final class MapperVisitor implements TypeElementVisitor<Object, Mapper> {
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {
         if (element.hasDeclaredAnnotation(Mapper.class)) {
-            if (element.isAbstract()) {
-
-                ClassElement toType = element.getGenericReturnType();
-                @NonNull ParameterElement[] parameters = element.getParameters();
-                if (parameters.length == 1) {
-                    if (toType.isVoid()) {
-                        throw new ProcessingException(element, "A void return type is not permitted for a mapper");
-                    } else {
-
-                        List<AnnotationValue<Mapper.Mapping>> values = element.getAnnotationMetadata().getAnnotationValuesByType(Mapper.Mapping.class);
-                        if (CollectionUtils.isNotEmpty(values)) {
-                            ParameterElement fromParameter = parameters[0];
-                            ClassElement fromType = fromParameter.getGenericType();
-                            boolean isMap = fromType.isAssignable(Map.class);
-                            if (isMap) {
-                                List<? extends ClassElement> boundGenerics = fromType.getBoundGenericTypes();
-                                if (boundGenerics.isEmpty() || !boundGenerics.iterator().next().isAssignable(String.class)) {
-                                    throw new ProcessingException(element, "@Mapping from parameter that is a Map must have String keys");
-                                }
-                            }
-
-                            Set<String> toDefs = new HashSet<>();
-                            for (AnnotationValue<Mapper.Mapping> value : values) {
-                                value.stringValue("to").ifPresent(to -> {
-                                    if (toDefs.contains(to)) {
-                                        throw new ProcessingException(element, "Multiple @Mapping definitions map to the same property: " + to);
-                                    } else {
-                                        toDefs.add(to);
-                                        List<PropertyElement> beanProperties = toType.getBeanProperties(PropertyElementQuery.of(toType).includes(Set.of(to)));
-                                        if (beanProperties.isEmpty()) {
-                                            throw new ProcessingException(element, "@Mapping(to=\"" + to + "\") specifies a property that doesn't exist in type " + toType.getName());
-                                        }
-                                    }
-                                });
-                                value.stringValue("from").ifPresent(from -> {
-                                    if (!from.contains("#{")) {
-                                        List<PropertyElement> beanProperties = fromType.getBeanProperties(PropertyElementQuery.of(fromType).includes(Set.of(from)));
-                                        if (beanProperties.isEmpty()) {
-                                            throw new ProcessingException(element, "@Mapping(from=\"" + from + "\") specifies a property that doesn't exist in type " + fromType.getName());
-                                        }
-                                    }
-                                });
-                            }
-                        }
-                        if (lastClassElement !=  null) {
-                            lastClassElement.annotate(Mapper.class);
-                        }
-                    }
-                } else {
-                    throw new ProcessingException(element, "Only a single parameter is permitted on a mapping method");
-                }
-            } else {
+            if (!element.isAbstract()) {
                 throw new ProcessingException(element, "@Mapper can only be declared on abstract methods");
             }
+            ClassElement toType = element.getGenericReturnType();
+            if (toType.isVoid()) {
+                throw new ProcessingException(element, "A void return type is not permitted for a mapper");
+            }
+
+            List<AnnotationValue<Mapper.Mapping>> values = element.getAnnotationMetadata().getAnnotationValuesByType(Mapper.Mapping.class);
+            if (!CollectionUtils.isEmpty(values)) {
+                validateMappingAnnotations(element, values, toType);
+            }
+            if (lastClassElement != null) {
+                lastClassElement.annotate(Mapper.class);
+            }
+        }
+    }
+
+    private void validateMappingAnnotations(MethodElement element, List<AnnotationValue<Mapper.Mapping>> values, ClassElement toType) {
+        @NonNull ParameterElement[] parameters = element.getParameters();
+
+        for (int i = 0; i < parameters.length; i++) {
+            ParameterElement parameter = parameters[i];
+            ClassElement fromType = parameter.getGenericType();
+            boolean isMap = fromType.isAssignable(Map.class);
+
+            if (isMap) {
+                List<? extends ClassElement> boundGenerics = fromType.getBoundGenericTypes();
+                if (boundGenerics.isEmpty() || !boundGenerics.iterator().next().isAssignable(String.class)) {
+                    throw new ProcessingException(element, "@Mapping from parameter that is a Map must have String keys");
+                }
+            }
+        }
+
+        Set<String> toDefs = new HashSet<>();
+        for (AnnotationValue<Mapper.Mapping> value : values) {
+            value.stringValue("to").ifPresent(to -> {
+                if (toDefs.contains(to)) {
+                    throw new ProcessingException(element, "Multiple @Mapping definitions map to the same property: " + to);
+                } else {
+                    toDefs.add(to);
+                    List<PropertyElement> beanProperties = toType.getBeanProperties(PropertyElementQuery.of(toType).includes(Set.of(to)));
+                    if (beanProperties.isEmpty()) {
+                        throw new ProcessingException(element, "@Mapping(to=\"" + to + "\") specifies a property that doesn't exist in type " + toType.getName());
+                    }
+                }
+            });
+            value.stringValue("from").ifPresent(from -> {
+                if (from.contains("#{")) {
+                    return;
+                }
+                if (from.contains(".")) {
+                    int index = from.indexOf(".");
+                    String argumentName = from.substring(0, index);
+                    String propertyName = from.substring(index + 1);
+
+                    boolean anyMatch = false;
+                    for (ParameterElement parameter: parameters) {
+                        if (parameter.getName().equals(argumentName)) {
+                            anyMatch = true;
+                            if (parameter.getType().getName().equals(Map.class.getName())) {
+                                break;
+                            }
+                            if (parameter.getGenericType().getBeanProperties().stream().noneMatch(p -> p.getName().equals(propertyName))) {
+                                throw new ProcessingException(element, "@Mapping(from=\"" + from + "\") specifies property " + propertyName + " that doesn't exist in type " + parameter.getGenericType().getName());
+                            }
+                            break;
+                        }
+                    }
+                    if (!anyMatch) {
+                        throw new ProcessingException(element, "@Mapping(from=\"" + from + "\") specifies argument " + argumentName + " that doesn't exist for method");
+                    }
+                } else {
+                    String propertyName = from.substring(from.indexOf(".") + 1);
+                    for (ParameterElement parameter: parameters) {
+                        if (parameter.getType().getName().equals(Map.class.getName())) {
+                            continue;
+                        }
+                        if (parameter.getGenericType().getBeanProperties().stream().noneMatch(p -> p.getName().equals(propertyName))) {
+                            throw new ProcessingException(element, "@Mapping(from=\"" + from + "\") specifies property " + propertyName + " that doesn't exist in type " + parameter.getGenericType().getName());
+                        }
+                    }
+                }
+            });
         }
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/MapperVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/MapperVisitor.java
@@ -28,6 +28,7 @@ import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -117,7 +118,7 @@ public final class MapperVisitor implements TypeElementVisitor<Object, Mapper> {
                             if (parameter.getType().getName().equals(Map.class.getName())) {
                                 break;
                             }
-                            if (parameter.getGenericType().getBeanProperties().stream().noneMatch(p -> p.getName().equals(propertyName))) {
+                            if (parameter.getGenericType().getBeanProperties(new PropertyElementQuery().includes(Collections.singleton(propertyName))).isEmpty()) {
                                 throw new ProcessingException(element, "@Mapping(from=\"" + from + "\") specifies property " + propertyName + " that doesn't exist in type " + parameter.getGenericType().getName());
                             }
                             break;
@@ -132,7 +133,7 @@ public final class MapperVisitor implements TypeElementVisitor<Object, Mapper> {
                         if (parameter.getType().getName().equals(Map.class.getName())) {
                             continue;
                         }
-                        if (parameter.getGenericType().getBeanProperties().stream().noneMatch(p -> p.getName().equals(propertyName))) {
+                        if (parameter.getGenericType().getBeanProperties(new PropertyElementQuery().includes(Collections.singleton(propertyName))).isEmpty()) {
                             throw new ProcessingException(element, "@Mapping(from=\"" + from + "\") specifies property " + propertyName + " that doesn't exist in type " + parameter.getGenericType().getName());
                         }
                     }

--- a/core/src/test/java/io/micronaut/core/io/service/SoftServiceLoaderTest.java
+++ b/core/src/test/java/io/micronaut/core/io/service/SoftServiceLoaderTest.java
@@ -32,7 +32,7 @@ public class SoftServiceLoaderTest {
             ServiceCollector<String> collector = SoftServiceLoader.newCollector("io.micronaut.inject.BeanDefinitionReference", null, layer.findLoader(modulename), Function.identity());
             List<String> services = new ArrayList<>();
             collector.collect(services::add);
-     
+
             assertEquals(1, services.size());
             assertEquals("io.micronaut.logging.$PropertiesLoggingLevelsConfigurer$Definition", services.get(0));
         }

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/visitor/MapperVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/visitor/MapperVisitorSpec.groovy
@@ -1,0 +1,92 @@
+package io.micronaut.inject.beans
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.InterceptorBinding
+import io.micronaut.aop.InterceptorKind
+import io.micronaut.context.annotation.Mapper
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
+
+
+class MapperVisitorSpec extends AbstractTypeElementSpec {
+
+    void 'test mapper visitor'() {
+        given:
+        def className = 'test.MyMapper'
+        def loader = buildClassLoader(className, '''
+package test;
+
+import io.micronaut.context.annotation.Mapper;
+import io.micronaut.core.annotation.Introspected;
+import jakarta.inject.Singleton;
+
+@Singleton
+public abstract class MyMapper {
+
+    @Mapper.Mapping(from = "typeB.a", to = "propA")
+    @Mapper.Mapping(from = "b", to = "propB")
+    abstract TypeA map(TypeB typeB);
+
+}
+
+@Introspected
+record TypeA(
+        String propA,
+        String propB
+) {}
+
+@Introspected
+record TypeB(
+        String a,
+        String b
+) {}
+        ''')
+
+        def definition = loader.loadClass('test.$MyMapper' +  BeanDefinitionVisitor.PROXY_SUFFIX + BeanDefinitionWriter.CLASS_SUFFIX).newInstance() as BeanDefinition<?>
+        definition.annotationMetadata.hasAnnotation(Mapper.class)
+        def binding = definition.annotationMetadata.getAnnotation(InterceptorBinding)
+        binding != null
+        binding.classValue().get() == Mapper.class
+        binding.enumValue("kind", InterceptorKind).get() == InterceptorKind.INTRODUCTION
+    }
+
+    void 'test mapper visitor fail'() {
+        when:
+        buildClassLoader('test.MyMapper', """
+package test;
+
+import io.micronaut.context.annotation.Mapper;
+import io.micronaut.core.annotation.Introspected;
+import jakarta.inject.Singleton;
+
+@Singleton
+public abstract class MyMapper {
+
+    ${annotation}
+    abstract TypeA map(TypeB typeB);
+
+}
+
+@Introspected
+record TypeA(
+        String propA
+) {}
+
+@Introspected
+record TypeB(
+        String a
+) {}
+        """)
+
+        then:
+        var e = thrown(RuntimeException)
+        e.message.contains(message)
+
+        where:
+        annotation                                                  | message
+        '@Mapper.Mapping(from = "typeB.nonExistent", to = "propA")' | '@Mapping(from="typeB.nonExistent") specifies property nonExistent that doesn\'t exist in type test.TypeB'
+        '@Mapper.Mapping(from = "nonExistent", to = "propA")'       | '@Mapping(from="nonExistent") specifies property nonExistent that doesn\'t exist in type test.TypeB'
+        '@Mapper.Mapping(from = "nonExistent.a", to = "propA")'     | '@Mapping(from="nonExistent.a") specifies argument nonExistent that doesn\'t exist for method'
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/annotation/Mapper.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/Mapper.java
@@ -24,7 +24,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation that can be used on abstract methods that define a return type and exactly a single argument.
+ * An annotation that can be used on abstract methods for mapping, merging multiple objects.
+ * The method needs to define a single return type and at least one argument.
  *
  * <p>Inspired by similar frameworks like MapStruct but internally uses the {@link io.micronaut.core.beans.BeanIntrospection} model.</p>
  *
@@ -38,6 +39,18 @@ import java.lang.annotation.Target;
 public @interface Mapper {
 
     /**
+     * A merge strategy to supply to {@link #mergeStrategy()}.
+     * Properties from subsequent arguments will always override properties from previous arguments with the same name.
+     */
+    String MERGE_STRATEGY_ALWAYS_OVERRIDE = "ALWAYS_OVERRIDE";
+
+    /**
+     * A merge strategy to supply to {@link #mergeStrategy()}.
+     * Non-null properties from subsequent arguments will override properties from previous arguments.
+     */
+    String MERGE_STRATEGY_NOT_NULL_OVERRIDE = "NOT_NULL_OVERRIDE";
+
+    /**
      * @return Defined mappings.
      */
     Mapping[] value() default {};
@@ -46,6 +59,19 @@ public @interface Mapper {
      * @return The conflict strategy.
      */
     ConflictStrategy conflictStrategy() default ConflictStrategy.CONVERT;
+
+    /**
+     * The merge strategy to use if method has more than one parameter.
+     *
+     * <p>By default, any non-null property from subsequent arguments will
+     * override property with the same name from previous arguments.</p>
+     *
+     * <p>To define a custom strategy, create a named singleton of type {@link MergeStrategy}
+     * and specify the same name here.</p>
+     *
+     * @return The merge strategy
+     */
+    String mergeStrategy() default MERGE_STRATEGY_NOT_NULL_OVERRIDE;
 
     /**
      * The mappings.
@@ -103,5 +129,29 @@ public @interface Mapper {
          * Throw an {@link IllegalArgumentException}.
          */
         ERROR
+    }
+
+    /**
+     * An interface for defining merge strategies.
+     * Merge strategies are used when the mapping has two or more arguments.
+     */
+    interface MergeStrategy {
+
+        /**
+         * Merge a single property by returning the value to set the property to.
+         * The merge strategy will be called every time a property needs to be set, even for properties of the first argument.
+         *
+         * <p>The property that is returned from the method will be set. For example, if you do not want
+         * to update the property, return the {@code currentValue}.</p>
+         *
+         * @param currentValue The currently specified value
+         * @param value The newly supplied value
+         * @param valueOwner The owner of the new value
+         * @param propertyName The name of the property to merge
+         * @param mappedPropertyName The name of the property from the owner
+         * @return The new value to set
+         */
+        Object merge(Object currentValue, Object value, Object valueOwner, String propertyName, String mappedPropertyName);
+
     }
 }

--- a/inject/src/main/java/io/micronaut/context/annotation/Mapper.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/Mapper.java
@@ -16,6 +16,8 @@
 package io.micronaut.context.annotation;
 
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;
@@ -151,7 +153,8 @@ public @interface Mapper {
          * @param mappedPropertyName The name of the property from the owner
          * @return The new value to set
          */
-        Object merge(Object currentValue, Object value, Object valueOwner, String propertyName, String mappedPropertyName);
+        @Nullable
+        Object merge(@Nullable Object currentValue, @Nullable Object value, @NonNull Object valueOwner, @NonNull String propertyName, @NonNull String mappedPropertyName);
 
     }
 }

--- a/src/main/docs/guide/ioc/beanMappers.adoc
+++ b/src/main/docs/guide/ioc/beanMappers.adoc
@@ -1,4 +1,4 @@
-Since 4.1.x the ann:context.annotation.Mapper[] annotation can be used on any abstract method to automatically create a mapping between one type and another.
+Since 4.1.x the ann:context.annotation.Mapper[] annotation can be used on any abstract method to automatically create a mapping between one type and another. Since 4.8.x the annotation can also be used for merging beans.
 
 Inspired by similar functionality in libraries like https://mapstruct.org[Map Struct], a `Mapper` uses the <<introspections, Bean Introspection>> and <<evaluatedExpressions, Expressions>> features, built into the Micronaut Framework, which are already reflection free.
 
@@ -46,6 +46,28 @@ You can retrieve from the context or inject a bean of type `ProductMappers`. The
 
 snippet::io.micronaut.docs.ioc.mappers.MappersSpec[tags="mappers", indent="0"]
 
+=== Merging example
 
+Given the following types:
 
+snippet::io.micronaut.docs.ioc.mappers.ChristmasTypes[tags="beans", indent=0]
 
+You can write an interface and method to merge the types by simply specifying two or more
+arguments to the method and annotating the method with ann:context.annotation.Mapper[@Mapper].
+Optionally, define custom mapping rules using ann:context.annotation.Mapper.Mapping[@Mapping].
+
+snippet::io.micronaut.docs.ioc.mappers.ChristmasMappers[tags="imports, mapper"]
+
+You can then inject the type `ChristmasMappers` and easily merge the types.
+
+snippet::io.micronaut.docs.ioc.mappers.MappersSpec[tags="merge", indent=0]
+
+=== Additional Mapping Examples
+
+And much more is possible! See more mapping examples in the following snippet.
+
+snippet::io.micronaut.docs.ioc.mappers.AdditionalMappers[tags="mapper", indent=0]
+
+<1> Merge three or more types.
+<2> Create mappings that specify `Map` as a parameter and define mappings for this parameter.
+<3> Define a custom merge strategy as a singleton and use it for mapping.

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/AdditionalMappers.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/AdditionalMappers.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.docs.ioc.mappers
+
+import groovy.transform.Canonical;
+import io.micronaut.context.annotation.Mapper;
+import io.micronaut.context.annotation.Mapper.Mapping;
+import io.micronaut.context.annotation.Mapper.MergeStrategy
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Requires(property = "spec.name", value = "MappersSpec")
+// tag::mapper[]
+interface AdditionalMappers {
+
+    @Mapper // <1>
+    ChristmasPresent merge(PresentPackaging packaging, Present present, Card christmasCard)
+
+    @Mapping(
+        from = "#{updateFields.get('christmasCard') + '!!'}", to = "greetingCard"
+    ) // <2>
+    ChristmasPresent update(ChristmasPresent present, Map<String, Object> updateFields)
+
+    @Mapper(mergeStrategy = "add-numbers") // <3>
+    @Mapping(from = "packaging.color", to = "packagingColor")
+    ChristmasPresent mergeWithMergeStrategy(PresentPackaging packaging, Present present)
+
+    @Singleton
+    @Named("add-numbers")
+    class MyMergeStrategy implements MergeStrategy {
+        @Override
+        Object merge(Object currentValue, Object value, Object valueOwner, String propertyName, String mappedPropertyName) {
+            if (currentValue instanceof Float && value instanceof Float) {
+                return (Float) (currentValue + value)
+            }
+            return value
+        }
+    }
+
+    @Canonical
+    @Introspected
+    class Card {
+        String greetingCard
+    }
+
+}
+// end::mapper[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/ChristmasMappers.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/ChristmasMappers.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.docs.ioc.mappers;
+
+//tag::imports[]
+import io.micronaut.context.annotation.Mapper.Mapping
+//end::imports[]
+import io.micronaut.context.annotation.Requires
+
+@Requires(property = "spec.name", value = "MappersSpec")
+//tag::mapper[]
+interface ChristmasMappers {
+
+    @Mapping(from = "packaging.color", to = "packagingColor")
+    @Mapping(from = "#{packaging.weight + present.weight}", to = "weight")
+    @Mapping(from = "#{'Merry christmas'}", to = "greetingCard")
+    ChristmasPresent merge(PresentPackaging packaging, Present present)
+
+}
+//end::mapper[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/ChristmasTypes.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/ChristmasTypes.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.docs.ioc.mappers
+
+import groovy.transform.Canonical;
+import io.micronaut.core.annotation.Introspected;
+
+// tag::beans[]
+@Canonical
+@Introspected
+class ChristmasPresent {
+    String packagingColor
+    String type
+    Float weight
+    String greetingCard
+}
+
+@Canonical
+@Introspected
+class PresentPackaging {
+    Float weight
+    String color
+}
+
+@Canonical
+@Introspected
+class Present {
+    Float weight
+    String type
+}
+// end::beans[]
+

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/MappersSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/MappersSpec.groovy
@@ -1,11 +1,13 @@
 package io.micronaut.docs.ioc.mappers
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
 import spock.lang.AutoCleanup
 import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
+@Property(name = "spec.name", value = "MappersSpec")
 class MappersSpec extends Specification {
     @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/MappersSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/MappersSpec.groovy
@@ -1,15 +1,13 @@
 package io.micronaut.docs.ioc.mappers
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.annotation.Property
 import spock.lang.AutoCleanup
 import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
-@Property(name = "spec.name", value = "MappersSpec")
 class MappersSpec extends Specification {
-    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run(["spec.name": "MappersSpec"])
 
     @PendingFeature(reason = "Investigate Groovy incorrect method metadata and implementing default methods broken")
     void testMappers() {

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/MappersSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/mappers/MappersSpec.groovy
@@ -28,4 +28,69 @@ class MappersSpec extends Specification {
         productDTO.distributor == "Great Product Company"
         // end::mappers[]
     }
+
+    void testMerging() {
+        // tag::merge[]
+        given:
+        ChristmasMappers mappers = context.getBean(ChristmasMappers.class)
+
+        when:
+        ChristmasPresent result = mappers.merge(
+                new PresentPackaging(1f, "red"),
+                new Present(10f, "teddy bear")
+        )
+
+        then:
+        11 == result.weight
+        "red" == result.packagingColor
+        "teddy bear" == result.type
+        "Merry christmas" == result.greetingCard
+        // end::merge[]
+    }
+
+    void testAdditionalMappers() {
+        // tag::additional[]
+        given:
+        AdditionalMappers mappers = context.getBean(AdditionalMappers.class)
+
+        when:
+        ChristmasPresent result = mappers.merge(
+                new PresentPackaging(1f, "red"),
+                new Present(10f, "teddy bear"),
+                new AdditionalMappers.Card("Merry Christmas!")
+        )
+
+        then:
+        10 == result.weight
+        result.packagingColor == null
+        "teddy bear" == result.type
+        "Merry Christmas!" == result.greetingCard
+
+        when:
+        result = mappers.update(
+                result,
+                [
+                        "packagingColor": "blue",
+                        "christmasCard": "Merry Christmas!"
+                ]
+        )
+
+        then:
+        10 == result.weight;
+        result.packagingColor == "blue"
+        result.type == "teddy bear"
+        result.greetingCard == "Merry Christmas!!!"
+
+        when:
+        result = mappers.mergeWithMergeStrategy(
+                new PresentPackaging(1, "red"),
+                new Present(10, "teddy bear")
+        )
+
+        then:
+        result.weight == 11
+        result.packagingColor == "red"
+        result.type == "teddy bear"
+        // end::additional[]
+    }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/mappers/AdditionalMappers.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/mappers/AdditionalMappers.kt
@@ -1,0 +1,42 @@
+package io.micronaut.docs.ioc.mappers
+
+import io.micronaut.context.annotation.Mapper
+import io.micronaut.context.annotation.Mapper.Mapping
+import io.micronaut.context.annotation.Mapper.MergeStrategy
+import io.micronaut.core.annotation.Introspected
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+
+// tag::mapper[]
+interface AdditionalMappers {
+
+    @Mapper // <1>
+    fun merge(packaging: PresentPackaging, present: Present, christmasCard: Card): ChristmasPresent
+
+    @Mapping(
+        from = "#{updateFields.get('christmasCard') + '!!'}", to = "greetingCard"
+    ) // <2>
+    fun update(present: ChristmasPresent, updateFields: Map<String, Any>): ChristmasPresent
+
+    @Mapper(mergeStrategy = "add-numbers") // <3>
+    @Mapping(from = "packaging.color", to = "packagingColor")
+    fun mergeWithMergeStrategy(packaging: PresentPackaging, present: Present): ChristmasPresent
+
+    @Singleton
+    @Named("add-numbers")
+    class MyMergeStrategy: MergeStrategy {
+        override fun merge(currentValue: Any?, value: Any?, valueOwner: Any, propertyName: String, mappedPropertyName: String): Any? {
+            if (currentValue is Float && value is Float) {
+                return currentValue + value
+            }
+            return value
+        }
+    }
+
+    @Introspected
+    data class Card(
+        val greetingCard: String
+    )
+
+}
+// end::mapper[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/mappers/ChristmasMappers.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/mappers/ChristmasMappers.kt
@@ -1,0 +1,14 @@
+package io.micronaut.docs.ioc.mappers;
+
+//tag::mapper[]
+import io.micronaut.context.annotation.Mapper.Mapping
+
+interface ChristmasMappers {
+
+    @Mapping(from = "packaging.color", to = "packagingColor")
+    @Mapping(from = "#{packaging.weight + present.weight}", to = "weight")
+    @Mapping(from = "#{'Merry christmas'}", to = "greetingCard")
+    fun merge(packaging: PresentPackaging, present: Present): ChristmasPresent
+
+}
+//end::mapper[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/mappers/ChristmasTypes.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/mappers/ChristmasTypes.kt
@@ -1,0 +1,26 @@
+package io.micronaut.docs.ioc.mappers
+
+import io.micronaut.core.annotation.Introspected
+
+// tag::beans[]
+@Introspected
+data class ChristmasPresent (
+    val packagingColor: String?,
+    val type: String?,
+    val weight: Float?,
+    val greetingCard: String?
+)
+
+@Introspected
+data class PresentPackaging (
+    val weight: Float?,
+    val color: String?
+)
+
+@Introspected
+data class Present (
+    val weight: Float?,
+    val type: String?
+)
+// end::beans[]
+

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/mappers/MappersSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/mappers/MappersSpec.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 internal class MappersSpec {
+
     @Test
     fun testMappers() {
         ApplicationContext.run().use { context ->
@@ -23,4 +24,67 @@ internal class MappersSpec {
             // end::mappers[]
         }
     }
+
+
+    @Test
+    fun testMerging() {
+        ApplicationContext.run().use { context ->
+            // tag::merge[]
+            val mappers = context.getBean(ChristmasMappers::class.java)
+
+            val result: ChristmasPresent = mappers.merge(
+                PresentPackaging(1f, "red"),
+                Present(10f, "teddy bear")
+            )
+
+            Assertions.assertEquals(11f, result.weight)
+            Assertions.assertEquals("red", result.packagingColor)
+            Assertions.assertEquals("teddy bear", result.type)
+            Assertions.assertEquals("Merry christmas", result.greetingCard)
+            // end::merge[]
+        }
+    }
+
+    @Test
+    fun testAdditionalMappers() {
+        ApplicationContext.run().use { context ->
+            // tag::additional[]
+            val mappers = context.getBean(AdditionalMappers::class.java)
+
+            var result: ChristmasPresent = mappers.merge(
+                PresentPackaging(1f, "red"),
+                Present(10f, "teddy bear"),
+                AdditionalMappers.Card("Merry Christmas!")
+            )
+
+            Assertions.assertEquals(10f, result.weight)
+            Assertions.assertNull(result.packagingColor)
+            Assertions.assertEquals("teddy bear", result.type)
+            Assertions.assertEquals("Merry Christmas!", result.greetingCard)
+
+            result = mappers.update(
+                result,
+                mapOf(
+                    Pair("packagingColor", "blue"),
+                    Pair("christmasCard", "Merry Christmas!")
+                )
+            )
+
+            Assertions.assertEquals(10f, result.weight)
+            Assertions.assertEquals("blue", result.packagingColor)
+            Assertions.assertEquals("teddy bear", result.type)
+            Assertions.assertEquals("Merry Christmas!!!", result.greetingCard)
+
+            result = mappers.mergeWithMergeStrategy(
+                PresentPackaging(1f, "red"),
+                Present(10f, "teddy bear")
+            )
+
+            Assertions.assertEquals(11f, result.weight)
+            Assertions.assertEquals("red", result.packagingColor)
+            Assertions.assertEquals("teddy bear", result.type)
+            //end::additional[]
+        }
+    }
+
 }

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/AdditionalMappers.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/AdditionalMappers.java
@@ -1,0 +1,53 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.context.annotation.Mapper;
+import io.micronaut.context.annotation.Mapper.Mapping;
+import io.micronaut.context.annotation.Mapper.MergeStrategy;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.docs.ioc.mappers.ChristmasTypes.ChristmasPresent;
+import io.micronaut.docs.ioc.mappers.ChristmasTypes.Present;
+import io.micronaut.docs.ioc.mappers.ChristmasTypes.PresentPackaging;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.util.Map;
+
+// tag::mapper[]
+public interface AdditionalMappers {
+
+    @Mapper // <1>
+    ChristmasPresent merge(PresentPackaging packaging, Present present, Card christmasCard);
+
+    @Mapping(
+        from = "#{updateFields.get('christmasCard') + '!!'}", to = "greetingCard"
+    ) // <2>
+    ChristmasPresent update(ChristmasPresent present, Map<String, Object> updateFields);
+
+    @Mapper(
+        mergeStrategy = "add-numbers",
+        value = {
+            @Mapping(from = "packaging.color", to = "packagingColor")
+        }
+    ) // <3>
+    ChristmasPresent mergeWithMergeStrategy(PresentPackaging packaging, Present present);
+
+    @Singleton
+    @Named("add-numbers")
+    class MyMergeStrategy implements MergeStrategy {
+        @Override
+        public Object merge(Object currentValue, Object value, Object valueOwner, String propertyName, String mappedPropertyName) {
+            if (currentValue instanceof Float a && value instanceof Float b) {
+                return a + b;
+            }
+            return value;
+        }
+    }
+
+    @Introspected
+    record Card(
+        String greetingCard
+    ) {
+    }
+
+}
+// end::mapper[]

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ChristmasMappers.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ChristmasMappers.java
@@ -1,0 +1,19 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.docs.ioc.mappers.ChristmasTypes.ChristmasPresent;
+import io.micronaut.docs.ioc.mappers.ChristmasTypes.Present;
+import io.micronaut.docs.ioc.mappers.ChristmasTypes.PresentPackaging;
+
+// tag::mapper[]
+import io.micronaut.context.annotation.Mapper.Mapping;
+
+//tag::mapper[]
+public interface ChristmasMappers {
+
+    @Mapping(from = "packaging.color", to = "packagingColor")
+    @Mapping(from = "#{packaging.weight + present.weight}", to = "weight")
+    @Mapping(from = "#{'Merry christmas'}", to = "greetingCard")
+    ChristmasPresent merge(PresentPackaging packaging, Present present);
+
+}
+//end::mapper[]

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ChristmasTypes.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ChristmasTypes.java
@@ -1,0 +1,32 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.core.annotation.Introspected;
+
+public interface ChristmasTypes {
+
+    // tag::beans[]
+    @Introspected
+    record ChristmasPresent(
+        String packagingColor,
+        String type,
+        Float weight,
+        String greetingCard
+    ) {
+    }
+
+    @Introspected
+    record PresentPackaging(
+        Float weight,
+        String color
+    ) {
+    }
+
+    @Introspected
+    record Present(
+        Float weight,
+        String type
+    ) {
+    }
+    // end::beans[]
+
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/MappersSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/MappersSpec.java
@@ -1,10 +1,17 @@
 package io.micronaut.docs.ioc.mappers;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.docs.ioc.mappers.AdditionalMappers.Card;
+import io.micronaut.docs.ioc.mappers.ChristmasTypes.ChristmasPresent;
+import io.micronaut.docs.ioc.mappers.ChristmasTypes.Present;
+import io.micronaut.docs.ioc.mappers.ChristmasTypes.PresentPackaging;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class MappersSpec {
     @Test
@@ -27,7 +34,7 @@ class MappersSpec {
     }
 
     @Test
-    void tetError() {
+    void testError() {
         try (ApplicationContext context = ApplicationContext.run()) {
             ProductMappers2 productMappers = context.getBean(ProductMappers2.class);
 
@@ -38,6 +45,67 @@ class MappersSpec {
                     "Apple"
                 ))
             );
+        }
+    }
+
+    @Test
+    void testMerging() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            // tag::merge[]
+            ChristmasMappers mappers = context.getBean(ChristmasMappers.class);
+
+            ChristmasPresent result = mappers.merge(
+                new PresentPackaging(1f, "red"),
+                new Present(10f, "teddy bear")
+            );
+
+            assertEquals(11f, result.weight());
+            assertEquals("red", result.packagingColor());
+            assertEquals("teddy bear", result.type());
+            assertEquals("Merry christmas", result.greetingCard());
+            // end::merge[]
+        }
+    }
+
+    @Test
+    void testAdditionalMappers() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            // tag::additional[]
+            AdditionalMappers mappers = context.getBean(AdditionalMappers.class);
+
+            ChristmasPresent result = mappers.merge(
+                new PresentPackaging(1f, "red"),
+                new Present(10f, "teddy bear"),
+                new Card("Merry Christmas!")
+            );
+
+            assertEquals(10f, result.weight());
+            assertNull(result.packagingColor());
+            assertEquals("teddy bear", result.type());
+            assertEquals("Merry Christmas!", result.greetingCard());
+
+            result = mappers.update(
+                result,
+                Map.of(
+                    "packagingColor", "blue",
+                    "christmasCard", "Merry Christmas!"
+                )
+            );
+
+            assertEquals(10f, result.weight());
+            assertEquals("blue", result.packagingColor());
+            assertEquals("teddy bear", result.type());
+            assertEquals("Merry Christmas!!!", result.greetingCard());
+
+            result = mappers.mergeWithMergeStrategy(
+                new PresentPackaging(1f, "red"),
+                new Present(10f, "teddy bear")
+            );
+
+            assertEquals(11f, result.weight());
+            assertEquals("red", result.packagingColor());
+            assertEquals("teddy bear", result.type());
+            // end::additional[]
         }
     }
 }


### PR DESCRIPTION
Support merging with `@Mapper` annotation.

For example, the following method definitions are supported:
```groovy
@Singleton
@Mapper
abstract class TestMerge {

    @Mapper
    abstract Skeleton merge(SkeletonPartA a, SkeletonPartB b, SkeletonPartC c);

    @Mapper.Mapping(from = "a.halloweenDescription", to = "description")
    @Mapper.Mapping(from = "#{a.deadAge + a.aliveAge}", to = "age")
    abstract Skeleton merge(CustomPart a, SkeletonPartB b, SkeletonPartC c);

    @Mapper
    abstract Skeleton update(Skeleton skeleton, Map<String, Object> values);

    @Mapper.Mapping(from = "values.halloweenDescription", to = "description")
    @Mapper.Mapping(from = "#{skeleton.get('deadAge')}", to = "age")
    abstract Skeleton merge(Map<String, Object> skeleton, Map<String, Object> values);

    @Mapper(mergeStrategy = "EXPLICITLY_SET")
    @Mapper.Mapping(from = "updater.halloweenDescription", to = "description")
    abstract Skeleton updateExplicitlySet(Skeleton current, SkeletonUpdater updater)

    @Mapper(mergeStrategy = Mapper.MERGE_STRATEGY_ALWAYS_OVERRIDE)
    @Mapper.Mapping(from = "updater.halloweenDescription", to = "description")
    abstract Skeleton updateAlwaysOverride(Skeleton current, SkeletonUpdater updater)

    @Mapper(mergeStrategy = Mapper.MERGE_STRATEGY_NOT_NULL_OVERRIDE)
    @Mapper.Mapping(from = "updater.halloweenDescription", to = "description")
    abstract Skeleton updateNotNullOverride(Skeleton current, SkeletonUpdater updater)
}
```