### PR TITLE
fix combination of lombok.Builder with Introspected without builder

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -722,7 +722,8 @@ final class BeanIntrospectionWriter extends AbstractClassFileWriter {
         dispatchWriter.buildGetTargetMethodByIndex(classWriter);
         buildFindIndexedProperty(classWriter);
         buildGetIndexedProperties(classWriter);
-        boolean hasBuilder = annotationMetadata != null && annotationMetadata.isPresent(Introspected.class, "builder");
+        boolean hasBuilder = annotationMetadata != null &&
+            (annotationMetadata.isPresent(Introspected.class, "builder") || annotationMetadata.hasDeclaredAnnotation("lombok.Builder"));
         if (defaultConstructor != null) {
             writeInstantiateMethod(classWriter, defaultConstructor, "instantiate");
             // in case invoked directly or via instantiateUnsafe

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -35,6 +35,7 @@ import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MemberElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.ElementPostponedToNextRoundException;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
@@ -42,6 +43,7 @@ import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import java.io.IOException;
@@ -276,6 +278,15 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                             error(originatingElement.element(), e.getMessage());
                         } catch (PostponeToNextRoundException e) {
                             postponedTypes.put(javaClassElement.getCanonicalName(), e.getErrorElement());
+                        } catch (ElementPostponedToNextRoundException e) {
+                            Object nativeType = e.getOriginatingElement().getNativeType();
+                            if (nativeType instanceof JavaNativeElement jne) {
+                                Element element = jne.element();
+                                postponedTypes.put(javaClassElement.getCanonicalName(), element);
+                            } else {
+                                // should never happen.
+                                throw e;
+                            }
                         }
                     }
                 }

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -91,11 +91,11 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
     private IntrospectionBuilderData builderData;
 
     protected AbstractInitializableBeanIntrospection(Class<B> beanType,
-                                                  AnnotationMetadata annotationMetadata,
-                                                  AnnotationMetadata constructorAnnotationMetadata,
-                                                  Argument<?>[] constructorArguments,
-                                                  BeanPropertyRef<Object>[] propertiesRefs,
-                                                  BeanMethodRef<Object>[] methodsRefs) {
+                                                     AnnotationMetadata annotationMetadata,
+                                                     AnnotationMetadata constructorAnnotationMetadata,
+                                                     Argument<?>[] constructorArguments,
+                                                     BeanPropertyRef<Object>[] propertiesRefs,
+                                                     BeanMethodRef<Object>[] methodsRefs) {
         this.beanType = beanType;
         this.annotationMetadata = annotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : EvaluatedAnnotationMetadata.wrapIfNecessary(annotationMetadata);
         this.constructorAnnotationMetadata = constructorAnnotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : EvaluatedAnnotationMetadata.wrapIfNecessary(constructorAnnotationMetadata);
@@ -265,7 +265,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
      * @param index  The method index
      * @param target The target
      * @param arg    The argument
-     * @param <V> The result type
+     * @param <V>    The result type
      * @return The result
      */
     @Nullable
@@ -472,67 +472,65 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
 
             AnnotationValue<Introspected.IntrospectionBuilder> builderAnn = getAnnotationMetadata().findAnnotation(Introspected.class)
                 .flatMap(a -> a.getAnnotation("builder", Introspected.IntrospectionBuilder.class)).orElse(null);
-            if (builderAnn != null) {
-                Class<?> builderClass = getAnnotationMetadata().classValue(Introspected.class, "builderClass").orElse(null);
-                if (builderClass != null) {
-                    BeanIntrospection<Object> builderIntrospection = (BeanIntrospection<Object>) BeanIntrospection.getIntrospection(builderClass);
-                    Collection<BeanMethod<Object, Object>> beanMethods = builderIntrospection.getBeanMethods();
+            Class<?> builderClass = getAnnotationMetadata().classValue(Introspected.class, "builderClass").orElse(null);
+            if (builderAnn != null || builderClass != null) {
+                BeanIntrospection<Object> builderIntrospection = (BeanIntrospection<Object>) BeanIntrospection.getIntrospection(builderClass);
+                Collection<BeanMethod<Object, Object>> beanMethods = builderIntrospection.getBeanMethods();
 
-                    // find the creator method
-                    BeanMethod<Object, Object> constructorMethod = beanMethods.stream()
-                        .filter(m -> m.getReturnType().getType().equals(getBeanType()))
-                        .findFirst().orElse(null);
-                    if (constructorMethod == null) {
-                        throw new IntrospectionException("No build method found in builder: " + builderClass.getName());
-                    } else {
-                        BeanMethod<Object, Object>[] builderMethods = beanMethods.stream()
-                            .filter(m ->
-                                m.getReturnType().getType().isAssignableFrom(builderIntrospection.getBeanType())
-                            )
-                            .toArray(BeanMethod[]::new);
-
-                        List<Argument<?>> arguments = new ArrayList<>(builderMethods.length);
-                        Set<String> properties = CollectionUtils.newHashSet(builderMethods.length);
-                        Set<BeanMethod<?, ?>> excludedMethods = new HashSet<>();
-                        for (BeanMethod<Object, Object> builderMethod : builderMethods) {
-                            Argument<?> argument;
-                            @NonNull Argument<?>[] methodArgs = builderMethod.getArguments();
-                            if (ArrayUtils.isNotEmpty(methodArgs)) {
-                                argument = toWrapperIfNecessary(methodArgs[0]);
-                            } else {
-                                argument = Argument.of(Boolean.class, builderMethod.getName());
-                            }
-                            if (!properties.add(argument.getName())) {
-                                excludedMethods.add(builderMethod);
-                            } else {
-                                arguments.add(argument);
-                            }
-                        }
-                        if (!excludedMethods.isEmpty()) {
-                            builderMethods = Arrays.stream(builderMethods)
-                                .filter(bm -> !excludedMethods.contains(bm))
-                                .toArray(BeanMethod[]::new);
-                        }
-                        this.builderData = new IntrospectionBuilderData(
-                            builderIntrospection,
-                            constructorMethod,
-                            builderMethods,
-                            arguments.toArray(Argument.ZERO_ARGUMENTS)
-                        );
-                    }
+                // find the creator method
+                BeanMethod<Object, Object> constructorMethod = beanMethods.stream()
+                    .filter(m -> m.getReturnType().getType().equals(getBeanType()))
+                    .findFirst().orElse(null);
+                if (constructorMethod == null) {
+                    throw new IntrospectionException("No build method found in builder: " + builderClass.getName());
                 } else {
-                    throw new IntrospectionException("Introspection defines invalid builder member for type: " + getBeanType());
+                    BeanMethod<Object, Object>[] builderMethods = beanMethods.stream()
+                        .filter(m ->
+                            m.getReturnType().getType().isAssignableFrom(builderIntrospection.getBeanType())
+                        )
+                        .toArray(BeanMethod[]::new);
+
+                    List<Argument<?>> arguments = new ArrayList<>(builderMethods.length);
+                    Set<String> properties = CollectionUtils.newHashSet(builderMethods.length);
+                    Set<BeanMethod<?, ?>> excludedMethods = new HashSet<>();
+                    for (BeanMethod<Object, Object> builderMethod : builderMethods) {
+                        Argument<?> argument;
+                        @NonNull Argument<?>[] methodArgs = builderMethod.getArguments();
+                        if (ArrayUtils.isNotEmpty(methodArgs)) {
+                            argument = toWrapperIfNecessary(methodArgs[0]);
+                        } else {
+                            argument = Argument.of(Boolean.class, builderMethod.getName());
+                        }
+                        if (!properties.add(argument.getName())) {
+                            excludedMethods.add(builderMethod);
+                        } else {
+                            arguments.add(argument);
+                        }
+                    }
+                    if (!excludedMethods.isEmpty()) {
+                        builderMethods = Arrays.stream(builderMethods)
+                            .filter(bm -> !excludedMethods.contains(bm))
+                            .toArray(BeanMethod[]::new);
+                    }
+                    this.builderData = new IntrospectionBuilderData(
+                        builderIntrospection,
+                        constructorMethod,
+                        builderMethods,
+                        arguments.toArray(Argument.ZERO_ARGUMENTS)
+                    );
                 }
             } else {
-                int constructorLength = constructorArguments.length;
-                @NonNull UnsafeBeanProperty<B, Object>[] writeableProperties = resolveWriteableProperties(beanPropertiesList);
-
-                this.builderData = new IntrospectionBuilderData(
-                    constructorArguments,
-                    constructorLength,
-                    (UnsafeBeanProperty<Object, Object>[]) writeableProperties
-                );
+                throw new IntrospectionException("Introspection defines invalid builder member for type: " + getBeanType());
             }
+        } else {
+            int constructorLength = constructorArguments.length;
+            @NonNull UnsafeBeanProperty<B, Object>[] writeableProperties = resolveWriteableProperties(beanPropertiesList);
+
+            this.builderData = new IntrospectionBuilderData(
+                constructorArguments,
+                constructorLength,
+                (UnsafeBeanProperty<Object, Object>[]) writeableProperties
+            );
         }
         return builderData;
     }
@@ -669,7 +667,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
     }
 
     private static final class IntrospectionBuilder<B> implements Builder<B> {
-        private static final Object[] NULL_ARG = { null };
+        private static final Object[] NULL_ARG = {null};
         private final Object[] params;
         private final IntrospectionBuilderData builderData;
         private final AbstractInitializableBeanIntrospection<B> introspection;
@@ -992,10 +990,10 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
         @Override
         public String toString() {
             return "BeanProperty{" +
-                    "beanType=" + beanType +
-                    ", type=" + ref.argument.getType() +
-                    ", name='" + ref.argument.getName() + '\'' +
-                    '}';
+                "beanType=" + beanType +
+                ", type=" + ref.argument.getType() +
+                ", name='" + ref.argument.getName() + '\'' +
+                '}';
         }
     }
 
@@ -1089,10 +1087,10 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
         @Override
         public String toString() {
             return "BeanWriteProperty{" +
-                    "beanType=" + beanType +
-                    ", type=" + argument.getType() +
-                    ", name='" + argument.getName() + '\'' +
-                    '}';
+                "beanType=" + beanType +
+                ", type=" + argument.getType() +
+                ", name='" + argument.getName() + '\'' +
+                '}';
         }
     }
 
@@ -1160,10 +1158,10 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
         @Override
         public String toString() {
             return "BeanReadProperty{" +
-                    "beanType=" + beanType +
-                    ", type=" + argument.getType() +
-                    ", name='" + argument.getName() + '\'' +
-                    '}';
+                "beanType=" + beanType +
+                ", type=" + argument.getType() +
+                ", name='" + argument.getName() + '\'' +
+                '}';
         }
     }
 

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -118,3 +118,4 @@ test {
     // Prevent scanning classes with missing classes
     exclude '**/classnotfound/**'
 }
+

--- a/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
@@ -1,5 +1,7 @@
 package io.micronaut.test.lombok;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.micronaut.core.beans.BeanIntrospection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -17,7 +19,19 @@ public class LombokIntrospectedBuilderTest {
         RobotEntity robotEntity = builder.with("name", "foo")
             .build();
 
-        Assertions.assertEquals("foo", robotEntity.getName());
+        assertEquals("foo", robotEntity.getName());
+    }
+
+    @Test
+    void testLombokBuilder2() {
+        BeanIntrospection.Builder<MyEntity> builder = BeanIntrospection.getIntrospection(MyEntity.class)
+            .builder();
+        MyEntity.MyEntityBuilder builder1 = MyEntity.builder();
+        builder.with("name", "foo");
+        builder.with("id", "123");
+        MyEntity myEntity = builder.build();
+        assertEquals("foo", myEntity.getName());
+        assertEquals("123", myEntity.getId());
     }
 
     @Test
@@ -29,7 +43,7 @@ public class LombokIntrospectedBuilderTest {
         SimpleEntity simpleEntity = builder.with("id", id)
             .build();
 
-        Assertions.assertEquals(id, simpleEntity.getId());
+        assertEquals(id, simpleEntity.getId());
 
         BeanIntrospection<SimpleEntity.CompartmentCreationTimeIndexPrefix> innerClassIntrospection =
             BeanIntrospection.getIntrospection(SimpleEntity.CompartmentCreationTimeIndexPrefix.class);
@@ -42,7 +56,7 @@ public class LombokIntrospectedBuilderTest {
         SimpleEntity.CompartmentCreationTimeIndexPrefix innerClassEntity =
             innerClassBuilder.with("compartmentId", "c1").with("timeCreated", current).build();
 
-        Assertions.assertEquals("c1", innerClassEntity.getCompartmentId());
-        Assertions.assertEquals(current, innerClassEntity.getTimeCreated());
+        assertEquals("c1", innerClassEntity.getCompartmentId());
+        assertEquals(current, innerClassEntity.getTimeCreated());
     }
 }

--- a/test-suite/src/test/java/io/micronaut/test/lombok/MyEntity.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/MyEntity.java
@@ -1,0 +1,19 @@
+package io.micronaut.test.lombok;
+
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.Builder;
+import lombok.Value;
+
+@Introspected
+@Value
+@Builder
+public class MyEntity {
+    public static final String NAME_INDEX = "name";
+
+    @lombok.NonNull
+    String id;
+
+    @lombok.NonNull
+    String name;
+}


### PR DESCRIPTION
Currently users have to manually defined `@Introspected(builder=..)` when using Lombok. This change adds native processing of Lombok builder. Not a huge fan of the direct references to Lombok annotation names but I don't see many other options.

Fixes #11344 