### PR TITLE
Update creatingClient.adoc

### DIFF
--- a/src/main/docs/guide/quickStart/creatingClient.adoc
+++ b/src/main/docs/guide/quickStart/creatingClient.adoc
@@ -1,4 +1,6 @@
 As mentioned previously, the Micronaut framework includes both an <<httpServer,HTTP server>> and an <<httpClient,HTTP client>>. A <<lowLevelHttpClient,low-level HTTP client>> is provided which you can use to test the `HelloController` created in the previous section.
+Important note: you'll need to add 
+dependency:micronaut-http-client[]
 
 .Testing Hello World
 


### PR DESCRIPTION
documentation is sparse on adding the http-client implementation and the hello world cli command creates an app with the dependency only on compile/testImplementation creating issues with requestInterceptors