### PR TITLE
Add maxEncodeSize configuration for zstd compression

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/DefaultHttpCompressionStrategy.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/DefaultHttpCompressionStrategy.java
@@ -36,6 +36,7 @@ final class DefaultHttpCompressionStrategy implements HttpCompressionStrategy {
 
     private final int compressionThreshold;
     private final int compressionLevel;
+    private final int maxZstdEncodeSize;
 
     /**
      * @param serverConfiguration The netty server configuration
@@ -44,15 +45,17 @@ final class DefaultHttpCompressionStrategy implements HttpCompressionStrategy {
     DefaultHttpCompressionStrategy(NettyHttpServerConfiguration serverConfiguration) {
         this.compressionThreshold = serverConfiguration.getCompressionThreshold();
         this.compressionLevel = serverConfiguration.getCompressionLevel();
+        this.maxZstdEncodeSize = serverConfiguration.getMaxZstdEncodeSize();
     }
 
     /**
      * @param compressionThreshold The compression threshold
      * @param compressionLevel The compression level (0-9)
      */
-    DefaultHttpCompressionStrategy(int compressionThreshold, int compressionLevel) {
+    DefaultHttpCompressionStrategy(int compressionThreshold, int compressionLevel, int maxZstdEncodeSize) {
         this.compressionThreshold = compressionThreshold;
         this.compressionLevel = compressionLevel;
+        this.maxZstdEncodeSize = maxZstdEncodeSize;
     }
 
     @Override
@@ -78,5 +81,10 @@ final class DefaultHttpCompressionStrategy implements HttpCompressionStrategy {
     @Override
     public int getCompressionLevel() {
         return compressionLevel;
+    }
+
+    @Override
+    public int getMaxZstdEncodeSize() {
+        return maxZstdEncodeSize;
     }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpCompressionStrategy.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpCompressionStrategy.java
@@ -39,4 +39,9 @@ public interface HttpCompressionStrategy extends Toggleable {
     default int getCompressionLevel() {
         return StandardCompressionOptions.gzip().compressionLevel();
     }
+
+    /**
+     * @return The maximum size of data that can be encoded using the zstd algorithm.
+     */
+    int getMaxZstdEncodeSize();
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -110,6 +110,12 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     public static final int DEFAULT_COMPRESSIONLEVEL = 6;
 
     /**
+     * The default size of the largest data that can be encoded using the zstd algorithm.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final int DEFAULT_MAX_ZSTD_ENCODE_SIZE = 1024 * 1024 * 32;
+
+    /**
      * The default configuration for boolean flag indicating whether to add connection header `keep-alive` to responses with HttpStatus > 499.
      */
     @SuppressWarnings("WeakerAccess")
@@ -200,6 +206,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     private LogLevel logLevel;
     private int compressionThreshold = DEFAULT_COMPRESSIONTHRESHOLD;
     private int compressionLevel = DEFAULT_COMPRESSIONLEVEL;
+    private int maxZstdEncodeSize = DEFAULT_MAX_ZSTD_ENCODE_SIZE;
     private boolean useNativeTransport = DEFAULT_USE_NATIVE_TRANSPORT;
     private String fallbackProtocol = ApplicationProtocolNames.HTTP_1_1;
     private AccessLogger accessLogger;
@@ -473,6 +480,16 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     }
 
     /**
+     * The default maximum size of data that can be encoded using the zstd algorithm.
+     * Default value ({@value #DEFAULT_MAX_ZSTD_ENCODE_SIZE}).
+     *
+     * @return The maximum size of data that can be encoded using the zstd algorithm.
+     */
+    public int getMaxZstdEncodeSize() {
+        return maxZstdEncodeSize;
+    }
+
+    /**
      * @return The Netty child channel options.
      * @see io.netty.bootstrap.ServerBootstrap#childOption(io.netty.channel.ChannelOption, Object)
      */
@@ -655,6 +672,15 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public void setCompressionLevel(@ReadableBytes int compressionLevel) {
         this.compressionLevel = compressionLevel;
+    }
+
+    /**
+     * Sets the maximum size of data that can be encoded using the zstd algorithm. Default value ({@value #DEFAULT_MAX_ZSTD_ENCODE_SIZE}).
+     *
+     * @param maxZstdEncodeSize The maximum size of block.
+     */
+    public void setMaxZstdEncodeSize(int maxZstdEncodeSize) {
+        this.maxZstdEncodeSize = maxZstdEncodeSize;
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Compressor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Compressor.java
@@ -65,8 +65,11 @@ final class Compressor {
         this.gzipOptions = StandardCompressionOptions.gzip(strategy.getCompressionLevel(), stdGzip.windowBits(), stdGzip.memLevel());
         DeflateOptions stdDeflate = StandardCompressionOptions.deflate();
         this.deflateOptions = StandardCompressionOptions.deflate(strategy.getCompressionLevel(), stdDeflate.windowBits(), stdDeflate.memLevel());
-        ZstdOptions zstdOptions = StandardCompressionOptions.zstd();
-        this.zstdOptions = Zstd.isAvailable() ? StandardCompressionOptions.zstd(strategy.getCompressionLevel(), zstdOptions.blockSize(), strategy.getMaxZstdEncodeSize()) : null;
+        this.zstdOptions = Zstd.isAvailable()
+            ? StandardCompressionOptions.zstd(strategy.getCompressionLevel(),
+            StandardCompressionOptions.zstd().blockSize(),
+            strategy.getMaxZstdEncodeSize())
+            : null;
         this.snappyOptions = StandardCompressionOptions.snappy();
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Compressor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Compressor.java
@@ -65,7 +65,8 @@ final class Compressor {
         this.gzipOptions = StandardCompressionOptions.gzip(strategy.getCompressionLevel(), stdGzip.windowBits(), stdGzip.memLevel());
         DeflateOptions stdDeflate = StandardCompressionOptions.deflate();
         this.deflateOptions = StandardCompressionOptions.deflate(strategy.getCompressionLevel(), stdDeflate.windowBits(), stdDeflate.memLevel());
-        this.zstdOptions = Zstd.isAvailable() ? StandardCompressionOptions.zstd() : null;
+        ZstdOptions zstdOptions = StandardCompressionOptions.zstd();
+        this.zstdOptions = Zstd.isAvailable() ? StandardCompressionOptions.zstd(strategy.getCompressionLevel(), zstdOptions.blockSize(), strategy.getMaxZstdEncodeSize()) : null;
         this.snappyOptions = StandardCompressionOptions.snappy();
     }
 
@@ -96,7 +97,7 @@ final class Compressor {
         response.headers().add(HttpHeaderNames.CONTENT_ENCODING, encoding.contentEncoding);
         ChannelHandler handler = switch (encoding) {
             case BR -> makeBrotliEncoder();
-            case ZSTD -> new ZstdEncoder(zstdOptions.compressionLevel(), zstdOptions.blockSize(), zstdOptions.maxEncodeSize());
+            case ZSTD -> new ZstdEncoder(zstdOptions.compressionLevel(), zstdOptions.blockSize(), strategy.getMaxZstdEncodeSize());
             case SNAPPY -> new SnappyFrameEncoder();
             case GZIP -> ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP, gzipOptions.compressionLevel(), gzipOptions.windowBits(), gzipOptions.memLevel());
             case DEFLATE -> ZlibCodecFactory.newZlibEncoder(ZlibWrapper.ZLIB, deflateOptions.compressionLevel(), deflateOptions.windowBits(), deflateOptions.memLevel());


### PR DESCRIPTION
As mentioned in #11343, Zstd encoder in Netty has a unique parameter of maxEncoded size, and if users of Micronaut want to use Zstd with files more than ≈31Mb Netty will throw an exception like "requested encode buffer size exceeds the maximum allowable size) so I thing we should enable change this parameters for MK's users if they would like to handle bigger files at MK server