### PR TITLE
feat: allow endpoint path customization

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointConfiguration.java
@@ -17,6 +17,7 @@ package io.micronaut.management.endpoint;
 
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.annotation.Nullable;
 
 import java.util.Optional;
 
@@ -37,6 +38,7 @@ public class EndpointConfiguration {
 
     private Boolean enabled;
     private Boolean sensitive;
+    @Nullable
     private String path;
     private final String id;
 
@@ -101,8 +103,8 @@ public class EndpointConfiguration {
      * Endpoint's path. If not set the endpoint name is used as the path.
      * @param path Endpoint's path
      */
-    public void setPath(String path) {
-        this.path = path.startsWith(SLASH)
+    public void setPath(@Nullable String path) {
+        this.path = path != null && path.startsWith(SLASH)
             ? path.substring(1)
             : path;
     }
@@ -111,6 +113,7 @@ public class EndpointConfiguration {
      * Endpoint's path. If not set the endpoint name is used as the path.
      * @return Endpoint's path
      */
+    @Nullable
     public String getPath() {
         return path;
     }

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointConfiguration.java
@@ -102,6 +102,7 @@ public class EndpointConfiguration {
     /**
      * Endpoint's path. If not set the endpoint name is used as the path.
      * @param path Endpoint's path
+     * @since 4.8.0
      */
     public void setPath(@Nullable String path) {
         this.path = path != null && path.startsWith(SLASH)
@@ -112,6 +113,7 @@ public class EndpointConfiguration {
     /**
      * Endpoint's path. If not set the endpoint name is used as the path.
      * @return Endpoint's path
+     * @since 4.8.0
      */
     @Nullable
     public String getPath() {

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointConfiguration.java
@@ -33,11 +33,13 @@ public class EndpointConfiguration {
      * The prefix for endpoints configurations.
      */
     public static final String PREFIX = "endpoints";
+    private static final String SLASH = "/";
 
     private Boolean enabled;
     private Boolean sensitive;
-
+    private String path;
     private final String id;
+
     private EndpointDefaultConfiguration defaultConfiguration;
 
     /**
@@ -93,5 +95,23 @@ public class EndpointConfiguration {
      */
     public void setSensitive(Boolean sensitive) {
         this.sensitive = sensitive;
+    }
+
+    /**
+     * Endpoint's path. If not set the endpoint name is used as the path.
+     * @param path Endpoint's path
+     */
+    public void setPath(String path) {
+        this.path = path.startsWith(SLASH)
+            ? path.substring(1)
+            : path;
+    }
+
+    /**
+     * Endpoint's path. If not set the endpoint name is used as the path.
+     * @return Endpoint's path
+     */
+    public String getPath() {
+        return path;
     }
 }

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
@@ -17,6 +17,7 @@ package io.micronaut.management.endpoint.processors;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.LifeCycle;
+import io.micronaut.context.exceptions.NoSuchBeanException;
 import io.micronaut.context.processor.ExecutableMethodProcessor;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
@@ -134,11 +135,10 @@ abstract class AbstractEndpointRouteBuilder extends DefaultRouteBuilder implemen
                 BeanDefinition<?> beanDefinition = opt.get();
                 if (beanDefinition.hasStereotype(Endpoint.class)) {
                     String id = beanDefinition.stringValue(Endpoint.class).orElse(null);
-                    if (beanContext.containsBean(EndpointConfiguration.class, Qualifiers.byName(id))) {
-                        String path = beanContext.getBean(EndpointConfiguration.class, Qualifiers.byName(id)).getPath();
-                        if (StringUtils.isNotEmpty(path)) {
-                            return Optional.of(path);
-                        }
+                    final EndpointConfiguration endpointConfiguration = beanContext.getProvider(EndpointConfiguration.class, Qualifiers.byName(id))
+                        .orElse(null);
+                    if (endpointConfiguration != null && StringUtils.isNotEmpty(endpointConfiguration.getPath())) {
+                        return Optional.of(endpointConfiguration.getPath());
                     }
                     if (id == null || !ENDPOINT_ID_PATTERN.matcher(id).matches()) {
                         id = NameUtils.hyphenate(beanDefinition.getName());

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
@@ -144,7 +144,6 @@ abstract class AbstractEndpointRouteBuilder extends DefaultRouteBuilder implemen
                         id = NameUtils.hyphenate(beanDefinition.getName());
                     }
 
-
                     return Optional.ofNullable(id);
                 }
             }

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
@@ -29,6 +29,8 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.uri.UriTemplate;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.management.endpoint.EndpointConfiguration;
 import io.micronaut.management.endpoint.EndpointDefaultConfiguration;
 import io.micronaut.management.endpoint.annotation.Endpoint;
 import io.micronaut.management.endpoint.annotation.Selector;
@@ -132,9 +134,16 @@ abstract class AbstractEndpointRouteBuilder extends DefaultRouteBuilder implemen
                 BeanDefinition<?> beanDefinition = opt.get();
                 if (beanDefinition.hasStereotype(Endpoint.class)) {
                     String id = beanDefinition.stringValue(Endpoint.class).orElse(null);
+                    if (beanContext.containsBean(EndpointConfiguration.class, Qualifiers.byName(id))) {
+                        String path = beanContext.getBean(EndpointConfiguration.class, Qualifiers.byName(id)).getPath();
+                        if (StringUtils.isNotEmpty(path)) {
+                            return Optional.of(path);
+                        }
+                    }
                     if (id == null || !ENDPOINT_ID_PATTERN.matcher(id).matches()) {
                         id = NameUtils.hyphenate(beanDefinition.getName());
                     }
+
 
                     return Optional.ofNullable(id);
                 }

--- a/management/src/test/groovy/io/micronaut/management/endpoint/health/HealthEndpointCustomPathSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/health/HealthEndpointCustomPathSpec.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.management.endpoint.health;
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.management.endpoint.EndpointConfiguration;
+import io.micronaut.runtime.server.EmbeddedServer;
+import spock.lang.Specification
+import spock.lang.Unroll;
+
+class HealthEndpointCustomPathSpec extends Specification {
+
+    @Unroll
+    void "health path can be changed"(String path) {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, [
+                "endpoints.health.path": path
+        ])
+        expect:
+        path.substring(1) == server.applicationContext.getBean(EndpointConfiguration.class, Qualifiers.byName("health")).getPath()
+
+        when:
+        HttpClient httpClient = server.applicationContext.createBean(HttpClient, server.getURL())
+        BlockingHttpClient client = httpClient.toBlocking()
+        client.exchange(HttpRequest.GET(path))
+        then:
+        noExceptionThrown()
+        cleanup:
+        client.close()
+        httpClient.close()
+        server.close()
+
+        where:
+        path << ["/up", "/health/check"]
+    }
+}


### PR DESCRIPTION
For example, [kamal](https://kamal-deploy.org) expects health check to be in /up