### PR TITLE
Add header-less methods to MessageBodyReader and ChunkedMessageBodyReader 

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/body/NettyByteBufMessageBodyHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/NettyByteBufMessageBodyHandler.java
@@ -62,12 +62,22 @@ public final class NettyByteBufMessageBodyHandler implements TypedMessageBodyHan
     }
 
     @Override
+    public Publisher<ByteBuf> readChunked(Argument<ByteBuf> type, MediaType mediaType, Publisher<ByteBuffer<?>> input) {
+        return Flux.from(input).map(bb -> (ByteBuf) bb.asNativeBuffer());
+    }
+
+    @Override
     public ByteBuf read(Argument<ByteBuf> type, MediaType mediaType, Headers httpHeaders, ByteBuffer<?> byteBuffer) throws CodecException {
         return (ByteBuf) byteBuffer.asNativeBuffer();
     }
 
     @Override
     public ByteBuf read(Argument<ByteBuf> type, MediaType mediaType, Headers httpHeaders, InputStream inputStream) throws CodecException {
+        return read(type, mediaType, inputStream);
+    }
+
+    @Override
+    public ByteBuf read(Argument<ByteBuf> type, MediaType mediaType, InputStream inputStream) throws CodecException {
         try {
             return Unpooled.wrappedBuffer(inputStream.readAllBytes());
         } catch (IOException e) {

--- a/http-netty/src/main/java/io/micronaut/http/netty/body/NettyWritableBodyWriter.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/NettyWritableBodyWriter.java
@@ -100,8 +100,18 @@ public final class NettyWritableBodyWriter implements TypedMessageBodyHandler<Wr
     }
 
     @Override
+    public Publisher<? extends Writable> readChunked(Argument<Writable> type, MediaType mediaType, Publisher<ByteBuffer<?>> input) {
+        return defaultWritable.readChunked(type, mediaType, input);
+    }
+
+    @Override
     public Writable read(Argument<Writable> type, MediaType mediaType, Headers httpHeaders, InputStream inputStream) throws CodecException {
         return defaultWritable.read(type, mediaType, httpHeaders, inputStream);
+    }
+
+    @Override
+    public Writable read(Argument<Writable> type, MediaType mediaType, InputStream inputStream) throws CodecException {
+        return defaultWritable.read(type, mediaType, inputStream);
     }
 
 }

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyReaderSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyReaderSpec.groovy
@@ -80,6 +80,11 @@ class CustomBodyReaderSpec extends Specification {
         A read(@NonNull Argument<A> type, @Nullable MediaType mediaType, @NonNull Headers httpHeaders, @NonNull InputStream inputStream) throws CodecException {
             return new A(String.valueOf(httpHeaders.get("my-header")))
         }
+
+        @Override
+        A read(@NonNull Argument<A> type, @Nullable MediaType mediaType, @NonNull InputStream inputStream) throws CodecException {
+            return new A("non-header")
+        }
     }
 
     @Singleton
@@ -92,6 +97,11 @@ class CustomBodyReaderSpec extends Specification {
         C read(@NonNull Argument<C> type, @Nullable MediaType mediaType, @NonNull Headers httpHeaders, @NonNull InputStream inputStream) throws CodecException {
             return new C(String.valueOf(httpHeaders.get("my-header"), String.valueOf(httpHeaders.get("another-header"))))
         }
+
+        @Override
+        C read(@NonNull Argument<C> type, @Nullable MediaType mediaType, @NonNull InputStream inputStream) throws CodecException {
+            return new C("non-header", "non-header")
+        }
     }
 
     @Singleton
@@ -102,6 +112,11 @@ class CustomBodyReaderSpec extends Specification {
         @Override
         String read(@NonNull Argument<String> type, @Nullable MediaType mediaType, @NonNull Headers httpHeaders, @NonNull InputStream inputStream) throws CodecException {
             return "ABC"
+        }
+
+        @Override
+        String read(@NonNull Argument<String> type, @Nullable MediaType mediaType, @NonNull InputStream inputStream) throws CodecException {
+            return "NON"
         }
     }
 

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/DefaultHandlerSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/DefaultHandlerSpec.groovy
@@ -138,6 +138,11 @@ class DefaultHandlerSpec extends Specification {
         }
 
         @Override
+        Object read(@NonNull Argument<Object> type, @Nullable MediaType mediaType, @NonNull InputStream inputStream) throws CodecException {
+            return null
+        }
+
+        @Override
         void writeTo(@NonNull Argument<Object> type, @NonNull MediaType mediaType, Object object, @NonNull MutableHeaders outgoingHeaders, @NonNull OutputStream outputStream) throws CodecException {
 
         }

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/NettyJsonStreamHandlerSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/NettyJsonStreamHandlerSpec.groovy
@@ -17,7 +17,7 @@ class NettyJsonStreamHandlerSpec extends Specification {
 
         when:
         def buf = NettyByteBufferFactory.DEFAULT.wrap(input.getBytes(StandardCharsets.UTF_8))
-        def actual = Flux.from(reader.readChunked(type, null, null, Flux.just(buf)))
+        def actual = Flux.from(reader.readChunked(type, null, Flux.just(buf)))
                 .collectList()
                 .block()
         then:

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/CustomFileUploadSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/CustomFileUploadSpec.groovy
@@ -67,12 +67,7 @@ class CustomFileUploadSpec extends Specification {
     static class MyFileUpdateReader implements MessageBodyReader<MyFileUpload> {
 
         @Override
-        MyFileUpload read(Argument<MyFileUpload> type, MediaType mediaType, Headers httpHeaders, InputStream inputStream) throws CodecException {
-            return read(type, mediaType, inputStream)
-        }
-
-        @Override
-        MyFileUpload read(Argument<MyFileUpload> type, MediaType mediaType, InputStream inputStream) throws CodecException {
+        MyFileUpload read(Argument<MyFileUpload> type, @Nullable MediaType mediaType, InputStream inputStream) throws CodecException {
             MIMEMessage mimeMessage = new MIMEMessage(inputStream, mediaType.getParameters().get("boundary").orElse(""))
             mimeMessage.parseAll()
             def attachments = mimeMessage.getAttachments()
@@ -80,6 +75,11 @@ class CustomFileUploadSpec extends Specification {
             def part = attachments.get(0)
             def headers = part.getAllHeaders().stream().map { Header h -> h.name + ": " + h.value }.collect(Collectors.joining(", "))
             return new MyFileUpload(headers + " " + new String(part.read().readAllBytes(), StandardCharsets.UTF_8))
+        }
+
+        @Override
+        MyFileUpload read(Argument<MyFileUpload> type, MediaType mediaType, Headers httpHeaders, InputStream inputStream) throws CodecException {
+            return read(type, mediaType, inputStream)
         }
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/CustomFileUploadSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/CustomFileUploadSpec.groovy
@@ -68,6 +68,11 @@ class CustomFileUploadSpec extends Specification {
 
         @Override
         MyFileUpload read(Argument<MyFileUpload> type, MediaType mediaType, Headers httpHeaders, InputStream inputStream) throws CodecException {
+            return read(type, mediaType, inputStream)
+        }
+
+        @Override
+        MyFileUpload read(Argument<MyFileUpload> type, MediaType mediaType, InputStream inputStream) throws CodecException {
             MIMEMessage mimeMessage = new MIMEMessage(inputStream, mediaType.getParameters().get("boundary").orElse(""))
             mimeMessage.parseAll()
             def attachments = mimeMessage.getAttachments()

--- a/http/src/main/java/io/micronaut/http/body/AbstractMessageBodyHandlerRegistry.java
+++ b/http/src/main/java/io/micronaut/http/body/AbstractMessageBodyHandlerRegistry.java
@@ -132,6 +132,11 @@ abstract sealed class AbstractMessageBodyHandlerRegistry implements MessageBodyH
         public Object read(Argument<Object> type, MediaType mediaType, Headers httpHeaders, InputStream inputStream) throws CodecException {
             return null;
         }
+
+        @Override
+        public Object read(Argument<Object> type, MediaType mediaType, InputStream inputStream) throws CodecException {
+            return null;
+        }
     }
 
     private static final class NoWriter implements MessageBodyWriter<Object> {

--- a/http/src/main/java/io/micronaut/http/body/ByteArrayBodyHandler.java
+++ b/http/src/main/java/io/micronaut/http/body/ByteArrayBodyHandler.java
@@ -74,6 +74,16 @@ final class ByteArrayBodyHandler implements TypedMessageBodyHandler<byte[]>, Chu
     }
 
     @Override
+    public byte[] read(Argument<byte[]> type, MediaType mediaType, InputStream inputStream)
+        throws CodecException {
+        try {
+            return inputStream.readAllBytes();
+        } catch (IOException e) {
+            throw new CodecException("Failed to read InputStream", e);
+        }
+    }
+
+    @Override
     public void writeTo(Argument<byte[]> type, MediaType mediaType, byte[] object, MutableHeaders outgoingHeaders, OutputStream outputStream) throws CodecException {
         addContentType(outgoingHeaders, mediaType);
         try {
@@ -91,6 +101,12 @@ final class ByteArrayBodyHandler implements TypedMessageBodyHandler<byte[]>, Chu
 
     @Override
     public Publisher<byte[]> readChunked(Argument<byte[]> type, MediaType mediaType, Headers httpHeaders, Publisher<ByteBuffer<?>> input) {
+        return Flux.from(input).map(ByteArrayBodyHandler::read0);
+    }
+
+    @Override
+    public Publisher<byte[]> readChunked(Argument<byte[]> type, MediaType mediaType,
+                                                   Publisher<ByteBuffer<?>> input) {
         return Flux.from(input).map(ByteArrayBodyHandler::read0);
     }
 

--- a/http/src/main/java/io/micronaut/http/body/ByteBufferBodyHandler.java
+++ b/http/src/main/java/io/micronaut/http/body/ByteBufferBodyHandler.java
@@ -65,6 +65,11 @@ final class ByteBufferBodyHandler implements TypedMessageBodyHandler<ByteBuffer<
 
     @Override
     public ByteBuffer<?> read(Argument<ByteBuffer<?>> type, MediaType mediaType, Headers httpHeaders, InputStream inputStream) throws CodecException {
+        return read(type, mediaType, inputStream);
+    }
+
+    @Override
+    public ByteBuffer<?> read(Argument<ByteBuffer<?>> type, MediaType mediaType, InputStream inputStream) throws CodecException {
         try {
             return byteBufferFactory.wrap(inputStream.readAllBytes());
         } catch (IOException e) {
@@ -102,4 +107,8 @@ final class ByteBufferBodyHandler implements TypedMessageBodyHandler<ByteBuffer<
         return input;
     }
 
+    @Override
+    public Publisher<? extends ByteBuffer<?>> readChunked(Argument<ByteBuffer<?>> type, MediaType mediaType, Publisher<ByteBuffer<?>> input) {
+        return input;
+    }
 }

--- a/http/src/main/java/io/micronaut/http/body/ChunkedMessageBodyReader.java
+++ b/http/src/main/java/io/micronaut/http/body/ChunkedMessageBodyReader.java
@@ -39,4 +39,11 @@ public interface ChunkedMessageBodyReader<T> extends MessageBodyReader<T> {
         @NonNull Headers httpHeaders,
         @NonNull Publisher<ByteBuffer<?>> input
     );
+
+    @NonNull
+    Publisher<? extends T> readChunked(
+        @NonNull Argument<T> type,
+        @Nullable MediaType mediaType,
+        @NonNull Publisher<ByteBuffer<?>> input
+    );
 }

--- a/http/src/main/java/io/micronaut/http/body/ConversionTextPlainHandler.java
+++ b/http/src/main/java/io/micronaut/http/body/ConversionTextPlainHandler.java
@@ -65,6 +65,11 @@ final class ConversionTextPlainHandler<T> implements MessageBodyHandler<T> {
 
     @Override
     public T read(Argument<T> type, MediaType mediaType, Headers httpHeaders, InputStream inputStream) throws CodecException {
+       return read(type, mediaType, inputStream);
+    }
+
+    @Override
+    public T read(Argument<T> type, MediaType mediaType, InputStream inputStream) throws CodecException {
         String text;
         try {
             text = new String(inputStream.readAllBytes(), configuration.getDefaultCharset());

--- a/json-core/src/main/java/io/micronaut/json/body/JsonMessageHandler.java
+++ b/json-core/src/main/java/io/micronaut/json/body/JsonMessageHandler.java
@@ -113,6 +113,11 @@ public final class JsonMessageHandler<T> implements MessageBodyHandler<T>, Custo
 
     @Override
     public T read(@NonNull Argument<T> type, MediaType mediaType, @NonNull Headers httpHeaders, @NonNull InputStream inputStream) throws CodecException {
+        return read(type, mediaType, inputStream);
+    }
+
+    @Override
+    public T read(Argument<T> type, MediaType mediaType, InputStream inputStream) throws CodecException {
         try {
             return jsonMapper.readValue(inputStream, type);
         } catch (IOException e) {


### PR DESCRIPTION
I think the interfaces we have now are too demanding. Most of the implemented methods of these interfaces don't actually use the headers param, so I think we should provide new interfaces without the headers param.

We also added `MessageBodyReader` as a replacement for`MediaTypeCodec`, but we will not be able to replace MediaTypeCodec interface such as `<T> T decode(Argument<T> type, InputStream inputStream)` method because in many cases where these interface are used there are no headers instance and we also cannot pass it as null reference because headers param is marked with an annotation by `@NonNull`