### PR TITLE
Fix for ServiceLoaderFeature

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/ServiceLoaderFeature.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceLoaderFeature.java
@@ -89,6 +89,12 @@ class ServiceLoaderFeature implements Feature {
                             }
                             Class<?> beanType = beanInfo.getBeanType();
                             List<AnnotationValue<Annotation>> values = beanInfo.getAnnotationMetadata().getAnnotationValuesByName("io.micronaut.context.annotation.Requires");
+                            if (values.isEmpty()) {
+                                AnnotationValue<Annotation> requirements = beanInfo.getAnnotationMetadata().getAnnotation("io.micronaut.context.annotation.Requirements");
+                                if (requirements != null) {
+                                    values = requirements.getAnnotations("value");
+                                }
+                            }
                             if (!values.isEmpty()) {
                                 for (AnnotationValue<Annotation> value : values) {
                                     String[] classNames = EMPTY_STRING_ARRAY;


### PR DESCRIPTION
`ServiceLoaderFeature` did not include all the `@Requires` annotations, as some were added with the `@Requirements`. I included such in the native-image `beforeAnalysis`. As an example, this fixes the usage of condition in `io.micronaut.configuration.metrics.binder.web.ClientRequestMetricRegistryFilter`.