### PR TITLE
Fix env package name in expression langauge type

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
@@ -465,7 +465,7 @@ public final class SingleEvaluatedExpressionParser implements EvaluatedExpressio
         if (wrapped) {
             eat(TYPE_IDENTIFIER);
         }
-        
+
         List<String> parts = new ArrayList<>();
         parts.add(eat(IDENTIFIER).value());
         while (lookahead != null && lookahead.type() == DOT) {

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
@@ -465,11 +465,9 @@ public final class SingleEvaluatedExpressionParser implements EvaluatedExpressio
         if (wrapped) {
             eat(TYPE_IDENTIFIER);
         }
-
+        
         List<String> parts = new ArrayList<>();
-
         parts.add(eat(IDENTIFIER).value());
-
         while (lookahead != null && lookahead.type() == DOT) {
             eat(DOT);
             parts.add(eat(IDENTIFIER, ENVIRONMENT).value());

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
@@ -61,6 +61,7 @@ import io.micronaut.expressions.parser.token.TokenType;
 import io.micronaut.expressions.parser.token.Tokenizer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static io.micronaut.expressions.parser.token.TokenType.*;
@@ -466,10 +467,12 @@ public final class SingleEvaluatedExpressionParser implements EvaluatedExpressio
         }
 
         List<String> parts = new ArrayList<>();
+
         parts.add(eat(IDENTIFIER).value());
+
         while (lookahead != null && lookahead.type() == DOT) {
             eat(DOT);
-            parts.add(eat(IDENTIFIER).value());
+            parts.add(eat(IDENTIFIER, ENVIRONMENT).value());
         }
 
         if (wrapped) {
@@ -558,5 +561,22 @@ public final class SingleEvaluatedExpressionParser implements EvaluatedExpressio
 
         lookahead = tokenizer.getNextToken();
         return token;
+    }
+
+    private Token eat(TokenType... tokenTypes) {
+        if (lookahead == null) {
+            throw new ExpressionParsingException("Unexpected end of input. Expected any of: '" + Arrays.toString(tokenTypes) + "'");
+        }
+
+        Token token = lookahead;
+
+        for (TokenType type : tokenTypes) {
+            if (token.type() == type) {
+                lookahead = tokenizer.getNextToken();
+                return token;
+            }
+        }
+
+        throw new ExpressionParsingException("Unexpected token: " + token.value() + ". Expected any of: '" + Arrays.toString(tokenTypes) + "'");
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
@@ -144,6 +144,9 @@ public final class Tokenizer {
 
         remaining = expression.substring(cursor);
         for (TokenPattern pattern: PATTERNS) {
+            // TODO for things like ctx[io.micronaut.core.context.env.Environment] this will return the wrong token
+            //  it will return the ENVIRONMENT token instead of the IDENTIFIER token because of the env package name.
+            //  Order of the map above matters if multiple things can match it
             Token token = pattern.matches(remaining);
             if (token == null) {
                 continue;

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
@@ -144,8 +144,8 @@ public final class Tokenizer {
 
         remaining = expression.substring(cursor);
         for (TokenPattern pattern: PATTERNS) {
-            // TODO for things like ctx[io.micronaut.core.context.env.Environment] this will return the wrong token
-            //  it will return the ENVIRONMENT token instead of the IDENTIFIER token because of the env package name.
+            // TODO for things like ctx[io.micronaut.core.context.env.Environment] this
+            //  will return the ENVIRONMENT token instead of the IDENTIFIER token because of the env package name.
             //  Order of the map above matters if multiple things can match it
             Token token = pattern.matches(remaining);
             if (token == null) {

--- a/inject-java/src/test/groovy/io/micronaut/expressions/TypeIdentifierExpressionsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/TypeIdentifierExpressionsSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.expressions
 
 import io.micronaut.annotation.processing.test.AbstractEvaluatedExpressionsSpec
+import io.micronaut.context.env.Environment
 
 class TypeIdentifierExpressionsSpec extends AbstractEvaluatedExpressionsSpec {
 
@@ -49,4 +50,19 @@ class TypeIdentifierExpressionsSpec extends AbstractEvaluatedExpressionsSpec {
         expr2 instanceof Class && expr2 == Object.class
     }
 
+    void "test type identifier including env in package naming"(){
+        given:
+        Object expr1 = evaluateAgainstContext("#{ #getType(T(io.micronaut.context.env.Environment)) }",
+          """
+              @jakarta.inject.Singleton
+              class Context {
+                  Class<?> getType(Class<?> type) {
+                      return type;
+                  }
+              }
+          """)
+
+        expect:
+        expr1 instanceof Class && expr1 == Environment.class
+    }
 }


### PR DESCRIPTION
Working on fixing #11410 

The root of the issue seems to be from `Tokenizer.getNextToken()` coupled with how `SingleEvaluatedExpressionParser.typeIdentifier()` loops through the identifiers. 

`Tokenizer.getNextToken()` has an order in which it checks for token types, when this is called to find the lookahead it doesn't seem to take into account what the previous token was which might be important for things like this type identifier. 

While the solution of checking for multiple token types specifically for `typeIdentifier()` works, it doesn't feel very optimal. Right now it only checks `IDENTIFIER` or `ENVIRONMENT` for this specific example, but it should likely also include things like `ctx`, or any other expected package naming that could trigger another token type