### PR TITLE
Fix env package name in expression language type identifier

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
@@ -61,6 +61,7 @@ import io.micronaut.expressions.parser.token.TokenType;
 import io.micronaut.expressions.parser.token.Tokenizer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static io.micronaut.expressions.parser.token.TokenType.*;
@@ -469,7 +470,7 @@ public final class SingleEvaluatedExpressionParser implements EvaluatedExpressio
         parts.add(eat(IDENTIFIER).value());
         while (lookahead != null && lookahead.type() == DOT) {
             eat(DOT);
-            parts.add(eat(IDENTIFIER).value());
+            parts.add(eat(IDENTIFIER, ENVIRONMENT).value());
         }
 
         if (wrapped) {
@@ -558,5 +559,22 @@ public final class SingleEvaluatedExpressionParser implements EvaluatedExpressio
 
         lookahead = tokenizer.getNextToken();
         return token;
+    }
+
+    private Token eat(TokenType... tokenTypes) {
+        if (lookahead == null) {
+            throw new ExpressionParsingException("Unexpected end of input. Expected any of: '" + Arrays.toString(tokenTypes) + "'");
+        }
+
+        Token token = lookahead;
+
+        for (TokenType type : tokenTypes) {
+            if (token.type() == type) {
+                lookahead = tokenizer.getNextToken();
+                return token;
+            }
+        }
+
+        throw new ExpressionParsingException("Unexpected token: " + token.value() + ". Expected any of: '" + Arrays.toString(tokenTypes) + "'");
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
@@ -141,7 +141,9 @@ public final class Tokenizer {
         if (!hasMoreTokens()) {
             return null;
         }
-
+        // TODO for things like ctx[io.micronaut.core.context.env.Environment] this
+        //  will return the ENVIRONMENT token instead of the IDENTIFIER token because of the env package name.
+        //  Order of the map above matters if multiple things can match it
         remaining = expression.substring(cursor);
         for (TokenPattern pattern: PATTERNS) {
             Token token = pattern.matches(remaining);

--- a/inject-java/src/test/groovy/io/micronaut/expressions/TypeIdentifierExpressionsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/TypeIdentifierExpressionsSpec.groovy
@@ -49,4 +49,20 @@ class TypeIdentifierExpressionsSpec extends AbstractEvaluatedExpressionsSpec {
         expr2 instanceof Class && expr2 == Object.class
     }
 
+    void "test type identifier including env in package naming"(){
+        given:
+        Object expr1 = evaluateAgainstContext("#{ #getType(T(io.micronaut.context.env.Environment)) }",
+          """
+                  @jakarta.inject.Singleton
+                  class Context {
+                      Class<?> getType(Class<?> type) {
+                          return type;
+                      }
+                  }
+              """)
+    
+        expect:
+        expr1 instanceof Class && expr1 == Environment.class
+    }
+
 }


### PR DESCRIPTION
Working on fixing #11410 

The root of the issue seems to be from `Tokenizer.getNextToken()` coupled with how `SingleEvaluatedExpressionParser.typeIdentifier()` loops through the identifiers. 

`Tokenizer.getNextToken()` has an order in which it checks for token types, when this is called to find the lookahead it doesn't seem to take into account what the previous token was which might be important for things like this type identifier. 

While the solution of checking for multiple token types specifically for `typeIdentifier()` works, it doesn't feel very optimal. Right now it only checks `IDENTIFIER` or `ENVIRONMENT` for this specific example, but it should likely also include things like `ctx`, or any other expected package naming that could trigger another token type if this approach is what gets adopted. 