### PR TITLE
Update bouncy castle bcpkix

### DIFF
--- a/src/main/docs/guide/httpServer/serverConfiguration/https.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/https.adoc
@@ -20,7 +20,7 @@ If you use a pre-generated certificate (as you should, for security), these step
 - Netty can use the JDK-internal `sun.security.x509` package. On newer JDK versions, this package is restricted and may not work. You may need to add `--add-exports=java.base/sun.security.x509=ALL-UNNAMED` as a VM parameter.
 - Alternatively, netty will use the Bouncy Castle BCPKIX API. This needs an additional dependency:
 
-dependency:org.bouncycastle:bcpkix-jdk15on[scope="implementation"]
+dependency:org.bouncycastle:bcpkix-jdk18on[scope="implementation"]
 
 WARNING: This configuration will generate a warning in the browser.
 


### PR DESCRIPTION
The version bcpkix-jdk15on don´t work with java 21, error:

```sh
Caused by: java.security.cert.CertificateException: No provider succeeded to generate a self-signed certificate. See debug log for the root cause.
	at io.netty.handler.ssl.util.SelfSignedCertificate.<init>(SelfSignedCertificate.java:254)
	at io.netty.handler.ssl.util.SelfSignedCertificate.<init>(SelfSignedCertificate.java:166)
	at io.netty.handler.ssl.util.SelfSignedCertificate.<init>(SelfSignedCertificate.java:115)
	at io.netty.handler.ssl.util.SelfSignedCertificate.<init>(SelfSignedCertificate.java:90)
	at io.micronaut.http.server.netty.ssl.SelfSignedSslBuilder.getKeyStore(SelfSignedSslBuilder.java:67)
	at io.micronaut.http.server.netty.ssl.AbstractServerSslBuilder.getKeyManagerFactory(AbstractServerSslBuilder.java:161)
	... 36 common frames omitted
	Suppressed: java.lang.NoClassDefFoundError: org/bouncycastle/cert/X509v3CertificateBuilder
		at io.netty.handler.ssl.util.SelfSignedCertificate.<init>(SelfSignedCertificate.java:240)
		... 41 common frames omitted
	Caused by: java.lang.ClassNotFoundException: org.bouncycastle.cert.X509v3CertificateBuilder
		at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
		at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
		... 42 common frames omitted
Caused by: java.lang.UnsupportedOperationException: OpenJdkSelfSignedCertGenerator not supported on the used JDK version
	at io.netty.handler.ssl.util.OpenJdkSelfSignedCertGenerator.generate(OpenJdkSelfSignedCertGenerator.java:167)
	at io.netty.handler.ssl.util.SelfSignedCertificate.<init>(SelfSignedCertificate.java:251)
	... 41 common frames omitted
```

Update to bcpkix-jdk18on fix issue and according to the bouncy castle documentation, this version is suported for java 8+ 