### PR TITLE
apply .convention-core-library

### DIFF
--- a/aop/build.gradle
+++ b/aop/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-core-library"
+    id("io.micronaut.build.internal.convention-core-library")
     alias libs.plugins.managed.kotlin.jvm
 }
 

--- a/buffer-netty/build.gradle
+++ b/buffer-netty/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/context-propagation/build.gradle
+++ b/context-propagation/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
     alias libs.plugins.managed.kotlin.jvm
     alias libs.plugins.managed.kotlin.kapt
 }

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -1,7 +1,6 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
-
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")

--- a/core-processor/build.gradle
+++ b/core-processor/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/core-reactive/build.gradle
+++ b/core-reactive/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
     alias libs.plugins.managed.kotlin.jvm
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,7 @@ import io.micronaut.build.internal.japicmp.RemovedPackages
 import me.champeau.gradle.japicmp.JapicmpTask
 
 plugins {
-    id "io.micronaut.build.internal.convention-core-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 micronautBuild {

--- a/discovery-core/build.gradle
+++ b/discovery-core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/function-client/build.gradle
+++ b/function-client/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
-}
+    id("io.micronaut.build.internal.convention-core-library")
+ }
 
 dependencies {
     annotationProcessor project(":inject-java")

--- a/function-web/build.gradle
+++ b/function-web/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
-}
+    id("io.micronaut.build.internal.convention-core-library")
+ }
 
 dependencies {
     annotationProcessor project(":inject-java")

--- a/function/build.gradle
+++ b/function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
-}
+    id("io.micronaut.build.internal.convention-core-library")
+ }
 
 dependencies {
 	annotationProcessor project(":inject-java")

--- a/graal/build.gradle
+++ b/graal/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-core-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 dependencies {
     annotationProcessor project(":inject-java")

--- a/http-client-core/build.gradle
+++ b/http-client-core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/http-client-jdk/build.gradle.kts
+++ b/http-client-jdk/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("io.micronaut.build.internal.convention-library")
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 micronautBuild {

--- a/http-client-tck/build.gradle.kts
+++ b/http-client-tck/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("io.micronaut.build.internal.convention-library")
+    id("io.micronaut.build.internal.convention-core-library")
 }
 dependencies {
     annotationProcessor(project(":inject-java"))

--- a/http-client/build.gradle
+++ b/http-client/build.gradle
@@ -1,7 +1,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 micronautBuild {

--- a/http-netty/build.gradle
+++ b/http-netty/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 micronautBuild {

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 import org.apache.tools.ant.taskdefs.condition.Os

--- a/http-server-tck/build.gradle.kts
+++ b/http-server-tck/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("io.micronaut.build.internal.convention-library")
+    id("io.micronaut.build.internal.convention-core-library")
 }
 dependencies {
     annotationProcessor(projects.injectJava)

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/http-tck/build.gradle.kts
+++ b/http-tck/build.gradle.kts
@@ -1,6 +1,5 @@
-
 plugins {
-    id("io.micronaut.build.internal.convention-library")
+    id("io.micronaut.build.internal.convention-core-library")
 }
 dependencies {
     annotationProcessor(projects.injectJava)

--- a/http-validation/build.gradle
+++ b/http-validation/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
     alias libs.plugins.managed.kotlin.jvm
-}
+ }
 
 dependencies {
     annotationProcessor project(":inject-java")

--- a/inject-groovy-test/build.gradle
+++ b/inject-groovy-test/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
     id 'io.micronaut.build.internal.functional-test'
 }
 

--- a/inject-java-test/build.gradle
+++ b/inject-java-test/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 micronautBuild {

--- a/inject-kotlin-test/build.gradle
+++ b/inject-kotlin-test/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
     alias libs.plugins.managed.kotlin.jvm
 }
 

--- a/inject-kotlin/build.gradle
+++ b/inject-kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
     alias libs.plugins.managed.kotlin.jvm
     alias libs.plugins.managed.ksp
 }

--- a/inject/build.gradle
+++ b/inject/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-core-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 micronautBuild {

--- a/jackson-core/build.gradle
+++ b/jackson-core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/jackson-databind/build.gradle
+++ b/jackson-databind/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/json-core/build.gradle
+++ b/json-core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 micronautBuild {

--- a/retry/build.gradle
+++ b/retry/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/router/build.gradle
+++ b/router/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/runtime-osx/build.gradle
+++ b/runtime-osx/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-core-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 dependencies {

--- a/websocket/build.gradle
+++ b/websocket/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.convention-library"
+    id("io.micronaut.build.internal.convention-core-library")
 }
 
 import java.time.Duration


### PR DESCRIPTION
appy `io.micronaut.build.internal.convention-core-library` instead of `io.micronaut.build.internal.convention-library`

`buildSrc` `io.micronaut.build.internal.convention-core-library` already applies `io.micronaut.build.internal.convention-library`

Moreover, use `id("io.micronaut.build.internal.convention-core-library")` to friendly to both Groovy and Kotlin DSL.