### PR TITLE
Prefer constructor over builder if present in introspections

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -724,7 +724,11 @@ final class BeanIntrospectionWriter extends AbstractClassFileWriter {
         buildGetIndexedProperties(classWriter);
         boolean hasBuilder = annotationMetadata != null &&
             (annotationMetadata.isPresent(Introspected.class, "builder") || annotationMetadata.hasDeclaredAnnotation("lombok.Builder"));
+        if (defaultConstructor != null || constructor != null) {
+            writeBooleanMethod(classWriter, "hasConstructor", true);
+        }
         if (defaultConstructor != null) {
+
             writeInstantiateMethod(classWriter, defaultConstructor, "instantiate");
             // in case invoked directly or via instantiateUnsafe
             if (constructor == null) {
@@ -766,7 +770,7 @@ final class BeanIntrospectionWriter extends AbstractClassFileWriter {
     }
 
     private void writeBooleanMethod(ClassWriter classWriter, String methodName, boolean state) {
-        GeneratorAdapter booleanMethod = startPublicMethodZeroArgs(classWriter, boolean.class, methodName);
+        GeneratorAdapter booleanMethod = startPublicFinalMethodZeroArgs(classWriter, boolean.class, methodName);
         booleanMethod.push(state);
         booleanMethod.returnValue();
         booleanMethod.visitMaxs(2, 1);

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -241,7 +241,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                         creatorMethod,
                         writePrefixes,
                         methodElement,
-                        null,
+                        element.getDefaultConstructor().orElse(null),
                         returnType,
                         methodMetadata,
                         index,

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -167,6 +167,15 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
     }
 
     /**
+     * Whether an accessible constructor exists.
+     * @return True if a default constructor exists
+     * @since 4.7.11
+     */
+    protected boolean hasConstructor() {
+        return false;
+    }
+
+    /**
      * Reflection free bean instantiation implementation for the given arguments.
      *
      * @param arguments The arguments
@@ -393,7 +402,11 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
 
     @Override
     public Argument<?>[] getConstructorArguments() {
-        return hasBuilder() ? getBuilderData().constructorArguments : constructorArguments;
+        if (hasConstructor()) {
+            return constructorArguments;
+        } else {
+            return hasBuilder() ? getBuilderData().constructorArguments : constructorArguments;
+        }
     }
 
     @NonNull

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -119,3 +119,5 @@ test {
     exclude '**/classnotfound/**'
 }
 
+//compileTestJava.options.fork = true
+//compileTestJava.options.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/test-suite/src/test/java/io/micronaut/test/lombok/Book.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/Book.java
@@ -1,0 +1,17 @@
+package io.micronaut.test.lombok;
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Introspected
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Book {
+    private Integer id;
+    private String title;
+}

--- a/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
@@ -16,6 +16,14 @@ import java.util.UUID;
 public class LombokIntrospectedBuilderTest {
 
     @Test
+    void testLombokNoArgsConstructor() {
+        BeanIntrospection<Book> introspection = BeanIntrospection.getIntrospection(Book.class);
+        assertEquals(0, introspection.getConstructorArguments().length);
+        Book book = introspection.instantiate();
+        assertNotNull(book);
+    }
+
+    @Test
     void testLombokRecordBuilder() {
         BeanIntrospection<RobotRecord> introspection = BeanIntrospection.getIntrospection(RobotRecord.class);
 


### PR DESCRIPTION
Currently if there is a builder then it is preferred over the constructor. This is a regression from 4.6.x behaviour. This alters the behaviour to prefer the constructor if one is present when returning `getConstructorArguments()`

Fixes https://github.com/micronaut-projects/micronaut-data/issues/3267