### PR TITLE
Properly discard inbound HttpContent when connection cancels before readComplete

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -209,6 +209,7 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
                 queued.handler.discardOutbound();
             }
         }
+        inboundHandler.discard();
         outboundQueue.clear();
         requestHandler.removed();
     }
@@ -338,6 +339,9 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
          * @see #channelReadComplete
          */
         void readComplete() {
+        }
+
+        void discard() {
         }
     }
 
@@ -516,6 +520,14 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
             }
             streamingInboundHandler.dest.setExpectedLengthFrom(request.headers());
             requestHandler.accept(ctx, request, new StreamingNettyByteBody(streamingInboundHandler.dest), outboundAccess);
+        }
+
+        @Override
+        void discard() {
+            for (HttpContent content : buffer) {
+                content.release();
+            }
+            buffer.clear();
         }
     }
 


### PR DESCRIPTION
When a connection is closed before readComplete is called, OptimisticBufferingInboundHandler would not release the input buffer correctly.

Discovered by fuzzing with EmbeddedChannel. I'm not sure if this can happen with a non-embedded channel, but better safe than sorry. A test is not feasible, detection relies on finding dangling buffers, which the test suite is too noisy for.