### PR TITLE
add support for programmatically adding bean configurations

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanSpec.groovy
@@ -84,7 +84,7 @@ class RequiresBeanSpec extends Specification {
 
         then:
         def e = thrown(ConfigurationException)
-        e.message == 'Custom bean configurations cannot be added for internal packages: io.micronaut.inject.configurations.requiresconditiontrue'
+        e.message == 'Custom bean configurations cannot be added for internal Micronaut packages: io.micronaut.inject.configurations.requiresconditiontrue'
     }
 
     void "test runtime bean configuration condition returning #condition"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanSpec.groovy
@@ -16,13 +16,16 @@
 package io.micronaut.inject.configurations
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.ConfigurationException
 import io.micronaut.context.exceptions.NoSuchBeanException
+import io.micronaut.inject.BeanConfiguration
 import io.micronaut.inject.configurations.requiresbean.RequiresBean
 import io.micronaut.inject.configurations.requiresconditionfalse.GitHubActionsBean
 import io.micronaut.inject.configurations.requiresconditiontrue.TrueBean
 import io.micronaut.inject.configurations.requiresconfig.RequiresConfig
 import io.micronaut.inject.configurations.requiresproperty.RequiresProperty
 import io.micronaut.inject.configurations.requiressdk.RequiresJava9
+import org.atinject.jakartatck.auto.accessories.Cupholder
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.util.environment.Jvm
@@ -67,6 +70,40 @@ class RequiresBeanSpec extends Specification {
 
         cleanup:
         context.close()
+    }
+
+    void "test that a bean configuration cannot disable internal package"() {
+        when:
+        ApplicationContext
+                .builder()
+                .beanConfigurations(BeanConfiguration.of(
+                        "io.micronaut.inject.configurations.requiresconditiontrue",
+                        {false}
+                ))
+                .start()
+
+        then:
+        def e = thrown(ConfigurationException)
+        e.message == 'Custom bean configurations cannot be added for internal packages: io.micronaut.inject.configurations.requiresconditiontrue'
+    }
+
+    void "test runtime bean configuration condition returning #condition"() {
+        given:
+        def context = ApplicationContext
+                .builder()
+                .beanConfigurations(BeanConfiguration.of(
+                        "org.atinject.jakartatck.auto",
+                        {condition}
+                ))
+                .start()
+
+        expect:
+        context.containsBean(Cupholder) == present
+
+        where:
+        condition | present
+        false     | false
+        true      | true
     }
 
     void "test requires property when not present"() {

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.context;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.BeanConfiguration;
 import io.micronaut.inject.BeanDefinitionReference;
+import java.util.function.Predicate;
 
 /**
  * An abstract implementation of the {@link BeanConfiguration} method. Not typically used directly from user code,

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -21,6 +21,7 @@ import io.micronaut.core.util.ArgumentUtils;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.inject.BeanConfiguration;
 import jakarta.inject.Singleton;
 
 import java.lang.annotation.Annotation;
@@ -142,6 +143,16 @@ public interface ApplicationContextBuilder {
      * @since 4.5.0
      */
     default @NonNull ApplicationContextBuilder beanDefinitions(@NonNull RuntimeBeanDefinition<?>... definitions) {
+        return this;
+    }
+
+    /**
+     * Register additional bean configurations.
+     * @param configurations The configurations.
+     * @return This builder
+     * @since 4.8.0
+     */
+    default @NonNull ApplicationContextBuilder beanConfigurations(@NonNull BeanConfiguration... configurations) {
         return this;
     }
 

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -82,6 +82,19 @@ public interface BeanDefinitionRegistry {
     }
 
     /**
+     * Registers a bean configuration. This allows disabling a set of beans based on a condition.
+     *
+     * @param configuration The configuration
+     * @return The registry
+     * @since 4.8.0
+     */
+    @NonNull
+    @Experimental
+    default BeanDefinitionRegistry registerBeanConfiguration(BeanConfiguration configuration) {
+        throw new UnsupportedOperationException("This implementation of BeanDefinitionRegistry doesn't support runtime registration of bean configurations");
+    }
+
+    /**
      * Registers a new reference at runtime. Not that registering beans can impact
      * the object graph therefore should this should be done as soon as possible prior to
      * the creation of other beans preferably with a high priority {@link io.micronaut.context.annotation.Context} scope bean.

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -28,6 +28,7 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
 
+import io.micronaut.inject.BeanConfiguration;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,6 +52,7 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING_ARRAY;
 public class DefaultApplicationContextBuilder implements ApplicationContextBuilder, ApplicationContextConfiguration {
     private final List<Object> singletons = new ArrayList<>();
     private final List<RuntimeBeanDefinition<?>> beanDefinitions = new ArrayList<>();
+    private final Collection<BeanConfiguration> beanConfigurations = new HashSet<>();
     private final List<String> environments = new ArrayList<>();
     private final List<String> defaultEnvironments = new ArrayList<>();
     private final List<String> packages = new ArrayList<>();
@@ -183,6 +185,14 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     public ApplicationContextBuilder beanDefinitions(@NonNull RuntimeBeanDefinition<?>... definitions) {
         if (definitions != null) {
             beanDefinitions.addAll(Arrays.asList(definitions));
+        }
+        return this;
+    }
+
+    @Override
+    public ApplicationContextBuilder beanConfigurations(@NonNull BeanConfiguration... configurations) {
+        if (configurations != null) {
+            beanConfigurations.addAll(Arrays.asList(configurations));
         }
         return this;
     }
@@ -383,6 +393,12 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
         if (!beanDefinitions.isEmpty()) {
             for (RuntimeBeanDefinition<?> beanDefinition : beanDefinitions) {
                 applicationContext.registerBeanDefinition(beanDefinition);
+            }
+        }
+
+        if (!beanConfigurations.isEmpty()) {
+            for (BeanConfiguration beanConfiguration : beanConfigurations) {
+                applicationContext.registerBeanConfiguration(beanConfiguration);
             }
         }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1673,6 +1673,13 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     }
 
     @Override
+    public BeanContext registerBeanConfiguration(BeanConfiguration configuration) {
+        Objects.requireNonNull(configuration, "Configuration cannot be null");
+        this.beanConfigurations.put(configuration.getName(), configuration);
+        return this;
+    }
+
+    @Override
     @NonNull
     public <B> BeanContext registerBeanDefinition(@NonNull RuntimeBeanDefinition<B> definition) {
         Objects.requireNonNull(definition, "Bean definition cannot be null");

--- a/inject/src/main/java/io/micronaut/inject/ConditionalBeanConfiguration.java
+++ b/inject/src/main/java/io/micronaut/inject/ConditionalBeanConfiguration.java
@@ -20,7 +20,6 @@ import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.exceptions.ConfigurationException;
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * Runtime implementation of {@link BeanConfiguration}.
@@ -33,9 +32,8 @@ record ConditionalBeanConfiguration(
     ConditionalBeanConfiguration {
         Objects.requireNonNull(packageName, "Package cannot be null");
         Objects.requireNonNull(condition, "Condition cannot be null");
-        if (Stream.of("io.micronaut.context", "io.micronaut.inject", "io.micronaut.runtime")
-            .anyMatch(packageName::startsWith)) {
-            throw new ConfigurationException("Custom bean configurations cannot be added for internal packages: " + packageName);
+        if (packageName.startsWith("io.micronaut.")) {
+            throw new ConfigurationException("Custom bean configurations cannot be added for internal Micronaut packages: " + packageName);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/inject/ConditionalBeanConfiguration.java
+++ b/inject/src/main/java/io/micronaut/inject/ConditionalBeanConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.context.exceptions.ConfigurationException;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Runtime implementation of {@link BeanConfiguration}.
+ * @param packageName The package name
+ * @param condition The condition
+ */
+record ConditionalBeanConfiguration(
+    String packageName, Predicate<BeanContext> condition) implements BeanConfiguration {
+
+    ConditionalBeanConfiguration {
+        Objects.requireNonNull(packageName, "Package cannot be null");
+        Objects.requireNonNull(condition, "Condition cannot be null");
+        if (Stream.of("io.micronaut.context", "io.micronaut.inject", "io.micronaut.runtime")
+            .anyMatch(packageName::startsWith)) {
+            throw new ConfigurationException("Custom bean configurations cannot be added for internal packages: " + packageName);
+        }
+    }
+
+    @Override
+    public Package getPackage() {
+        throw new UnsupportedOperationException("Package not retrievable");
+    }
+
+    @Override
+    public String getName() {
+        return packageName;
+    }
+
+    @Override
+    public String getVersion() {
+        return null;
+    }
+
+    @Override
+    public boolean isEnabled(BeanContext context, BeanResolutionContext resolutionContext) {
+        return condition.test(context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConditionalBeanConfiguration that = (ConditionalBeanConfiguration) o;
+        return Objects.equals(packageName, that.packageName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(packageName);
+    }
+}


### PR DESCRIPTION
Allows adding bean configurations at runtime that allow, for example, disabling certain beans within a package. Later it may make sense to allow `@MicronautTest` to use this disable certain beans as necessary.