### PR TITLE
Fix loading primitive classes + support primitive classes in annotations

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 public class JavaModelUtils {
 
     public static final Map<String, String> NAME_TO_TYPE_MAP = new HashMap<>();
+    public static final Map<String, Type> NAME_TO_REAL_TYPE_MAP = new HashMap<>();
     private static final ElementKind RECORD_KIND = ReflectionUtils.findDeclaredField(ElementKind.class, "RECORD").flatMap(field -> {
         try {
             return Optional.of((ElementKind) field.get(ElementKind.class));
@@ -61,6 +62,15 @@ public class JavaModelUtils {
         JavaModelUtils.NAME_TO_TYPE_MAP.put("double", "D");
         JavaModelUtils.NAME_TO_TYPE_MAP.put("float", "F");
         JavaModelUtils.NAME_TO_TYPE_MAP.put("short", "S");
+        JavaModelUtils.NAME_TO_REAL_TYPE_MAP.put("void", Type.VOID_TYPE);
+        JavaModelUtils.NAME_TO_REAL_TYPE_MAP.put("boolean", Type.BOOLEAN_TYPE);
+        JavaModelUtils.NAME_TO_REAL_TYPE_MAP.put("char", Type.CHAR_TYPE);
+        JavaModelUtils.NAME_TO_REAL_TYPE_MAP.put("int", Type.INT_TYPE);
+        JavaModelUtils.NAME_TO_REAL_TYPE_MAP.put("byte", Type.BYTE_TYPE);
+        JavaModelUtils.NAME_TO_REAL_TYPE_MAP.put("long", Type.LONG_TYPE);
+        JavaModelUtils.NAME_TO_REAL_TYPE_MAP.put("double", Type.DOUBLE_TYPE);
+        JavaModelUtils.NAME_TO_REAL_TYPE_MAP.put("float", Type.FLOAT_TYPE);
+        JavaModelUtils.NAME_TO_REAL_TYPE_MAP.put("short", Type.SHORT_TYPE);
     }
 
     // Primitives

--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -853,6 +853,10 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
      * @return The {@link Type}
      */
     protected static Type getTypeReferenceForName(String className, String... genericTypes) {
+        Type type = JavaModelUtils.NAME_TO_REAL_TYPE_MAP.get(className);
+        if (type != null) {
+            return type;
+        }
         String referenceString = getTypeDescriptor(className, genericTypes);
         return Type.getType(referenceString);
     }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -628,6 +628,19 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
                     String className = JavaModelUtils.getClassName(element);
                     resolvedValue = new AnnotationClassValue<>(className);
                 }
+            } else {
+                resolvedValue = switch (t.getKind()) {
+                    case BOOLEAN -> new AnnotationClassValue<>(boolean.class);
+                    case BYTE -> new AnnotationClassValue<>(byte.class);
+                    case SHORT -> new AnnotationClassValue<>(short.class);
+                    case INT -> new AnnotationClassValue<>(int.class);
+                    case LONG -> new AnnotationClassValue<>(long.class);
+                    case CHAR -> new AnnotationClassValue<>(char.class);
+                    case FLOAT -> new AnnotationClassValue<>(float.class);
+                    case DOUBLE -> new AnnotationClassValue<>(double.class);
+                    case VOID -> new AnnotationClassValue<>(void.class);
+                    default -> null;
+                };
             }
             return null;
         }

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
@@ -40,6 +40,45 @@ import java.lang.annotation.Retention
  */
 class AnnotationMetadataWriterSpec extends AbstractTypeElementSpec {
 
+    void "test primitive classes in metadata"() {
+        given:
+        def annotationMetadata = buildTypeAnnotationMetadata("""
+package inneranntest;
+
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.*;
+import io.micronaut.inject.annotation.Outer;
+
+@io.micronaut.inject.annotation.MyAnnotationX(
+clazz1 = void.class,
+clazz2 = int.class,
+clazz3 = long.class,
+clazz4 = byte.class,
+clazz5 = boolean.class,
+clazz6 = char.class,
+clazz7 = float.class,
+clazz8 = double.class,
+clazz9 = short.class
+)
+class Test {
+
+}
+""")
+
+        annotationMetadata = writeAndLoadMetadata('annmetadatatest.Test', annotationMetadata)
+
+        expect:
+        annotationMetadata.classValue(MyAnnotationX, "clazz1").get() == void
+        annotationMetadata.classValue(MyAnnotationX, "clazz2").get() == int
+        annotationMetadata.classValue(MyAnnotationX, "clazz3").get() == long
+        annotationMetadata.classValue(MyAnnotationX, "clazz4").get() == byte
+        annotationMetadata.classValue(MyAnnotationX, "clazz5").get() == boolean
+        annotationMetadata.classValue(MyAnnotationX, "clazz6").get() == char
+        annotationMetadata.classValue(MyAnnotationX, "clazz7").get() == float
+        annotationMetadata.classValue(MyAnnotationX, "clazz8").get() == double
+        annotationMetadata.classValue(MyAnnotationX, "clazz9").get() == short
+    }
+
     void "test inner annotations in metadata"() {
         given:
         def annotationMetadata = buildTypeAnnotationMetadata("""

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/MyAnnotationX.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/MyAnnotationX.java
@@ -1,0 +1,33 @@
+package io.micronaut.inject.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE})
+public @interface MyAnnotationX {
+
+    Class<?> clazz1();
+
+    Class<?> clazz2();
+
+    Class<?> clazz3();
+
+    Class<?> clazz4();
+
+    Class<?> clazz5();
+
+    Class<?> clazz6();
+
+    Class<?> clazz7();
+
+    Class<?> clazz8();
+
+    Class<?> clazz9();
+
+}


### PR DESCRIPTION
When the correct primitive type is referenced it will generate primitive class reference instead