### PR TITLE
doc: add @Consumes FORM_URLENCODED to formData.adoc

### DIFF
--- a/src/main/docs/guide/httpServer/formData.adoc
+++ b/src/main/docs/guide/httpServer/formData.adoc
@@ -12,4 +12,4 @@ Alternatively, instead of using a POJO you can bind form data directly to method
 
 snippet::io.micronaut.docs.server.form.PersonController[tags="class,formsaveWithArgs,endclass", title="Binding Form Data to Parameters"]
 
-As you can see from the example above, this approach lets you use features such as support for link:{jdkapi}/java.base/java/util/Optional.html[Optional] types and restrict the parameters to be bound. When using POJOs you must be careful to use Jackson annotations to exclude properties that should not be bound.
+As you can see from the example above, this approach lets you use features such as support for `@Nullable` or link:{jdkapi}/java.base/java/util/Optional.html[Optional] types and restrict the parameters to be bound. When using POJOs you must be careful to use Jackson annotations to exclude properties that should not be bound.

--- a/src/main/docs/guide/httpServer/formData.adoc
+++ b/src/main/docs/guide/httpServer/formData.adoc
@@ -4,12 +4,12 @@ The advantage of this approach is that the same Jackson annotations used for cus
 
 In practice this means that to bind regular form data, the only change required to the previous JSON binding code is updating the api:http.MediaType[] consumed:
 
-snippet::io.micronaut.docs.server.json.PersonController[tags="class,regular,endclass", indent=0, title="Binding Form Data to POJOs"]
+snippet::io.micronaut.docs.server.form.PersonController[tags="class,formbinding,endclass", title="Binding Form Data to POJOs"]
 
 TIP: To avoid denial of service attacks, collection types and arrays created during binding are limited by the setting `jackson.arraySizeThreshold` in your configuration file (e.g `application.yml`)
 
 Alternatively, instead of using a POJO you can bind form data directly to method parameters (which works with JSON too!):
 
-snippet::io.micronaut.docs.server.json.PersonController[tags="class,args,endclass", indent=0, title="Binding Form Data to Parameters"]
+snippet::io.micronaut.docs.server.form.PersonController[tags="class,formsaveWithArgs,endclass", title="Binding Form Data to Parameters"]
 
 As you can see from the example above, this approach lets you use features such as support for link:{jdkapi}/java.base/java/util/Optional.html[Optional] types and restrict the parameters to be bound. When using POJOs you must be careful to use Jackson annotations to exclude properties that should not be bound.

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/form/Person.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/form/Person.groovy
@@ -1,0 +1,15 @@
+package io.micronaut.docs.server.form
+
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode;
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+@CompileStatic
+@EqualsAndHashCode
+class Person {
+    String firstName
+    String lastName
+    int age
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/form/PersonController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/form/PersonController.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.docs.server.form
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.*
+
+import java.util.concurrent.ConcurrentHashMap
+
+@Requires(property = "spec.name", value = "PersonControllerFormTest")
+@CompileStatic
+//tag::class[]
+@Controller("/people")
+class PersonController {
+
+    Map<String, Person> inMemoryDatastore = new ConcurrentHashMap<>()
+//end::class[]
+
+    @Get
+    Collection<Person> index() {
+        inMemoryDatastore.values()
+    }
+
+//tag::formbinding[]
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post
+    HttpResponse<Person> save(@Body Person person) {
+        inMemoryDatastore.put(person.getFirstName(), person)
+        HttpResponse.created(person);
+    }
+//end::formbinding[]
+//tag::formsaveWithArgs[]
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/saveWithArgs")
+    HttpResponse<Person> save(String firstName, String lastName, @Nullable Integer age) {
+        Person p = new Person()
+        p.firstName = firstName
+        p.lastName = lastName
+        if (age != null) {
+            p.setAge(age)
+        }
+        inMemoryDatastore.put(p.firstName, p)
+        return HttpResponse.created(p);
+    }
+//end::formsaveWithArgs[]
+
+//tag::formsaveWithArgsOptional[]
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/saveWithArgsOptional")
+    HttpResponse<Person> save(String firstName, String lastName, Optional<Integer> age) {
+        Person p = new Person()
+        p.firstName = firstName
+        p.lastName = lastName
+        age.ifPresent(p::setAge);
+        inMemoryDatastore.put(p.getFirstName(), p);
+        return HttpResponse.created(p);
+    }
+//end::formsaveWithArgsOptional[]
+//tag::endclass[]
+}
+//end::endclass[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/form/PersonControllerSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/form/PersonControllerSpec.groovy
@@ -1,0 +1,93 @@
+package io.micronaut.docs.server.form
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@Property(name = "spec.name", value = "PersonControllerFormTest")
+@MicronautTest
+class PersonControllerSpec extends Specification {
+    @Inject
+    @Client("/")
+    HttpClient httpClient
+
+    @Inject
+    PersonController controller
+
+    void testSave() {
+        given:
+        BlockingHttpClient client = httpClient.toBlocking()
+        String payload = "firstName=Fred&lastName=Flintstone&age=45"
+        HttpRequest<?> request = HttpRequest.POST("/people", payload).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+        when:
+        client.exchange(request)
+
+        then:
+        noExceptionThrown()
+
+        when:
+        Person person = controller.inMemoryDatastore.get("Fred")
+
+        then:
+        person
+        "Fred" == person.firstName
+        "Flintstone" == person.lastName
+        45 == person.age
+
+        cleanup:
+        controller.inMemoryDatastore.clear()
+    }
+
+    void saveWithArgsOptional() {
+        BlockingHttpClient client = httpClient.toBlocking()
+        String payload = "firstName=Fred&lastName=Flintstone&age=45"
+        HttpRequest<?> request = HttpRequest.POST("/people/saveWithArgsOptional", payload).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+        when:
+        client.exchange(request)
+
+        then:
+        noExceptionThrown()
+
+        when:
+        Person person = controller.inMemoryDatastore.get("Fred")
+
+        then:
+        person
+        "Fred" == person.firstName
+        "Flintstone" == person.lastName
+        45 == person.age
+
+        cleanup:
+        controller.inMemoryDatastore.clear()
+    }
+
+    void testSaveWithArgs() {
+        BlockingHttpClient client = httpClient.toBlocking()
+        String payload = "firstName=Fred&lastName=Flintstone&age=45"
+        HttpRequest<?> request = HttpRequest.POST("/people/saveWithArgs", payload).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+        when:
+        client.exchange(request)
+
+        then:
+        noExceptionThrown()
+
+        when:
+        Person person = controller.inMemoryDatastore.get("Fred")
+
+        then:
+        person
+        "Fred" == person.firstName
+        "Flintstone" == person.lastName
+        45 == person.age
+
+        cleanup:
+        controller.inMemoryDatastore.clear()
+    }
+
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/form/Person.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/form/Person.kt
@@ -1,0 +1,8 @@
+package io.micronaut.docs.server.form
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+data class Person(val firstName: String,
+                  val lastName: String,
+                  val age: Int)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/form/PersonController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/form/PersonController.kt
@@ -1,0 +1,53 @@
+package io.micronaut.docs.server.form
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.*
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+@Requires(property = "spec.name", value = "PersonControllerFormTest")
+//tag::class[]
+@Controller("/people")
+class PersonController {
+    var inMemoryDatastore: MutableMap<String, Person> = ConcurrentHashMap()
+
+//end::class[]
+    @Get
+    fun index(): Collection<Person> {
+        return inMemoryDatastore.values
+    }
+
+//tag::formbinding[]
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post
+    fun save(@Body person: Person): HttpResponse<Person> {
+        inMemoryDatastore[person.firstName] = person
+        return HttpResponse.created(person)
+    }
+//end::formbinding[]
+
+//tag::formsaveWithArgs[]
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/saveWithArgs")
+    fun save(firstName: String, lastName: String, age: Int?): HttpResponse<Person?>? {
+        val p = Person(firstName, lastName, age?: 0)
+        inMemoryDatastore[p.firstName] = p
+        return HttpResponse.created(p)
+    }
+//end::formsaveWithArgs[]
+
+//tag::formsaveWithArgsOptional[]
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/saveWithArgsOptional")
+    fun save(firstName: String, lastName: String, age: Optional<Int>): HttpResponse<Person> {
+        val p = Person(firstName, lastName, age.orElse(0))
+        inMemoryDatastore[p.firstName] = p
+        return HttpResponse.created(p)
+    }
+//end::formsaveWithArgsOptional[]
+
+//tag::endclass[]
+}
+//end::endclass[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/form/PersonControllerTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/form/PersonControllerTest.kt
@@ -1,0 +1,57 @@
+package io.micronaut.docs.server.form
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@Property(name = "spec.name", value = "PersonControllerFormTest")
+@MicronautTest
+internal class PersonControllerTest {
+    @Test
+    fun testSave(@Client("/") httpClient: HttpClient, controller: PersonController) {
+        val client = httpClient.toBlocking()
+        val payload = "firstName=Fred&lastName=Flintstone&age=45"
+        val request: HttpRequest<*> =
+            HttpRequest.POST("/people", payload).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+        invoke(client, request, controller)
+    }
+
+    @Test
+    fun saveWithArgsOptional(@Client("/") httpClient: HttpClient, controller: PersonController) {
+        val client = httpClient.toBlocking()
+        val payload = "firstName=Fred&lastName=Flintstone&age=45"
+        val request: HttpRequest<*> = HttpRequest.POST("/people/saveWithArgsOptional", payload)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+        invoke(client, request, controller)
+    }
+
+    @Test
+    fun testSaveWithArgs(@Client("/") httpClient: HttpClient, controller: PersonController) {
+        val client = httpClient.toBlocking()
+        val payload = "firstName=Fred&lastName=Flintstone&age=45"
+        val request: HttpRequest<*> =
+            HttpRequest.POST("/people/saveWithArgs", payload).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+        invoke(client, request, controller)
+    }
+
+    fun invoke(client: BlockingHttpClient, request: HttpRequest<*>?, controller: PersonController) {
+        Assertions.assertDoesNotThrow<HttpResponse<Any>> {
+            client.exchange(
+                request
+            )
+        }
+        val person = controller.inMemoryDatastore["Fred"]
+        Assertions.assertNotNull(person)
+        Assertions.assertEquals("Fred", person!!.firstName)
+        Assertions.assertEquals("Flintstone", person.lastName)
+        Assertions.assertEquals(45, person.age)
+        controller.inMemoryDatastore.clear()
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/server/form/Person.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/form/Person.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.form;
+
+import java.util.Objects;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class Person {
+
+    private String firstName, lastName;
+    private int age;
+
+    public Person(String firstName, String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public Person() {
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    @Override
+    public String toString() {
+        return "Person{" +
+                "firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Person person = (Person) o;
+        return age == person.age &&
+                Objects.equals(firstName, person.firstName) &&
+                Objects.equals(lastName, person.lastName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, age);
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/server/form/PersonController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/form/PersonController.java
@@ -1,0 +1,58 @@
+package io.micronaut.docs.server.form;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.*;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Requires(property = "spec.name", value = "PersonControllerFormTest")
+//tag::class[]
+@Controller("/people")
+class PersonController {
+
+    Map<String, Person> inMemoryDatastore = new ConcurrentHashMap<>();
+//end::class[]
+
+
+//tag::formbinding[]
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post
+    HttpResponse<Person> save(@Body Person person) {
+        inMemoryDatastore.put(person.getFirstName(), person);
+        return HttpResponse.created(person);
+    }
+//end::formbinding[]
+
+//tag::formsaveWithArgs[]
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/saveWithArgs")
+    HttpResponse<Person> save(String firstName, String lastName, @Nullable Integer age) {
+        Person p = new Person(firstName, lastName);
+        if (age != null) {
+            p.setAge(age);
+        }
+        inMemoryDatastore.put(p.getFirstName(), p);
+        return HttpResponse.created(p);
+    }
+//end::formsaveWithArgs[]
+
+//tag::formsaveWithArgsOptional[]
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/saveWithArgsOptional")
+    HttpResponse<Person> save(String firstName, String lastName, Optional<Integer> age) {
+        Person p = new Person(firstName, lastName);
+        age.ifPresent(p::setAge);
+        inMemoryDatastore.put(p.getFirstName(), p);
+        return HttpResponse.created(p);
+    }
+//end::formsaveWithArgsOptional[]
+
+//tag::endclass[]
+}
+//end::endclass[]

--- a/test-suite/src/test/java/io/micronaut/docs/server/form/PersonControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/form/PersonControllerTest.java
@@ -1,0 +1,51 @@
+package io.micronaut.docs.server.form;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Property(name = "spec.name", value = "PersonControllerFormTest")
+@MicronautTest
+class PersonControllerTest {
+
+    @Test
+    void testSave(@Client("/") HttpClient httpClient, PersonController controller) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        String payload = "firstName=Fred&lastName=Flintstone&age=45";
+        HttpRequest<?> request = HttpRequest.POST("/people", payload).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        invoke(client, request, controller);
+    }
+
+    @Test
+    void saveWithArgsOptional(@Client("/") HttpClient httpClient, PersonController controller) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        String payload = "firstName=Fred&lastName=Flintstone&age=45";
+        HttpRequest<?> request = HttpRequest.POST("/people/saveWithArgsOptional", payload).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        invoke(client, request, controller);
+    }
+
+    @Test
+    void testSaveWithArgs(@Client("/") HttpClient httpClient, PersonController controller) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        String payload = "firstName=Fred&lastName=Flintstone&age=45";
+        HttpRequest<?> request = HttpRequest.POST("/people/saveWithArgs", payload).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        invoke(client, request, controller);
+    }
+
+    void invoke(BlockingHttpClient client, HttpRequest<?> request, PersonController controller) {
+        assertDoesNotThrow(() -> client.exchange(request));
+        Person person = controller.inMemoryDatastore.get("Fred");
+        assertNotNull(person);
+        assertEquals("Fred", person.getFirstName());
+        assertEquals("Flintstone", person.getLastName());
+        assertEquals(45, person.getAge());
+        controller.inMemoryDatastore.clear();
+    }
+}


### PR DESCRIPTION
Close: https://github.com/micronaut-projects/micronaut-core/issues/5692

Adds `@Consumes(MediaType.APPLICATION_FORM_URLENCODED)` to examples show in form data documentation. Moreover, instead of showing a controller with a method argument with an `Optional`. I changed it to use `@Nullable` as the use `Optional`as a method parameter is discouraged in java.

![CleanShot 2025-01-30 at 10 48 04@2x](https://github.com/user-attachments/assets/35a56b62-df63-4fa8-bcc3-b32f66ced7ef)
