### PR TITLE
Environment refresh issues

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -959,6 +959,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements Con
         public Environment stop() {
             if (bootstrapEnvironment != null) {
                 bootstrapEnvironment.stop();
+                bootstrapEnvironment = null;
             }
             return super.stop();
         }

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -883,7 +883,11 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         return changes;
     }
 
-    private void diffMap(Map<String, DefaultPropertyEntry> map, Map<String, DefaultPropertyEntry> newMap, Map<String, Object> changes) {
+    private void diffMap(
+        Map<String, DefaultPropertyEntry> map,
+        Map<String, DefaultPropertyEntry> newMap,
+        Map<String, Object> changes) {
+        Map<String, DefaultPropertyEntry> remainingMap = new LinkedHashMap<>(map);
         for (Map.Entry<String, DefaultPropertyEntry> entry : newMap.entrySet()) {
             String key = entry.getKey();
             Object newValue = entry.getValue().value();
@@ -900,8 +904,12 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                 } else if (hasNew && hasOld && hasChanged(newValue, oldValue)) {
                     changes.put(key, oldValue);
                 }
+                remainingMap.remove(key);
             }
         }
+        remainingMap.forEach((key, value) -> {
+            changes.put(key, value.value());
+        });
     }
 
     private static boolean hasChanged(Object newValue, Object oldValue) {

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -18,8 +18,10 @@ package io.micronaut.context.env
 import com.github.stefanbirkner.systemlambda.SystemLambda
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.ApplicationContextConfiguration
+import io.micronaut.context.DefaultApplicationContext
 import io.micronaut.context.exceptions.ConfigurationException
 import io.micronaut.core.naming.NameUtils
+import io.micronaut.core.util.StringUtils
 import io.micronaut.core.version.SemanticVersion
 import spock.lang.Issue
 import spock.lang.Requires
@@ -63,6 +65,20 @@ class DefaultEnvironmentSpec extends Specification {
 
         expect:
         env.getProperty("test.foo", Map.class).get() == [bar: "10", baz: "20"]
+    }
+
+    void "test environment refresh and diff"() {
+        given:
+        System.setProperty(Environment.BOOTSTRAP_CONTEXT_PROPERTY, StringUtils.TRUE)
+        System.setProperty("micronaut.bootstrap.name", "custom-bootstrap")
+        DefaultApplicationContext context = new DefaultApplicationContext("test")
+        context.start()
+
+        when:
+        def diff = context.getEnvironment().refreshAndDiff()
+
+        then:
+        diff.isEmpty()
     }
 
     void "test environment system property refresh"() {

--- a/inject/src/test/resources/custom-bootstrap.yml
+++ b/inject/src/test/resources/custom-bootstrap.yml
@@ -1,0 +1,3 @@
+test:
+prop1: value1
+prop2: value2


### PR DESCRIPTION
Added a test which can be used to reproduce two micronaut environment refresh related issues:
1. the `diffMap` method from `DefaultEnvironment` class doesn't record a change when the `newMap` doesn't have a value which exists in the `map`
2. the `refresh` method stops `bootstrap` and `runtime` environments but starts only the `runtime` environment which causes all property sources to be removed from the `bootstrap` env but not re-added later when the `start` method is called. Because of that, the `bootstrap` properties don't exist in the `runtime` catalog after refresh is done.

The added test currently doesn't fail because of the first issue. When the first issue gets fixed, the test will fail and require the fix of the second issue. 