### PR TITLE
Add support `@JsonCreator` annotation for enum path variables

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
     compileOnly(libs.graal)
     compileOnly(libs.managed.kotlin.stdlib)
     compileOnly(libs.managed.netty.common)
+
+    testImplementation(libs.managed.jackson.annotations)
 }
 
 spotless {

--- a/core/src/main/java/io/micronaut/core/convert/CharSequenceToEnumConverter.java
+++ b/core/src/main/java/io/micronaut/core/convert/CharSequenceToEnumConverter.java
@@ -19,8 +19,14 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The converter that converts {@link CharSequence} to an enum.
@@ -32,12 +38,28 @@ import java.util.Optional;
 @Internal
 public final class CharSequenceToEnumConverter<T extends Enum<T>> implements TypeConverter<CharSequence, T> {
 
+    private static final String ANNOTATION_JSON_CREATOR = "com.fasterxml.jackson.annotation.JsonCreator";
+
+    private final Map<String, Optional<Method>> creatorMethodsCache = new ConcurrentHashMap<>();
+
     @Override
-    public Optional<T> convert(CharSequence charSequence, Class<T> targetType, ConversionContext context) {
-        if (StringUtils.isEmpty(charSequence)) {
+    public Optional<T> convert(CharSequence value, Class<T> targetType, ConversionContext context) {
+        if (StringUtils.isEmpty(value)) {
             return Optional.empty();
         }
-        String stringValue = charSequence.toString();
+
+        String stringValue = value.toString();
+
+        var creatorMethodOpt = findCreatorMethod(targetType);
+        if (creatorMethodOpt.isPresent()) {
+            try {
+                var creatorMethod = creatorMethodOpt.get();
+                return Optional.ofNullable((T) creatorMethod.invoke(null, convertStringArg(stringValue, creatorMethod.getParameterTypes()[0], context)));
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                context.reject(value, e);
+                return Optional.empty();
+            }
+        }
         try {
             T val = Enum.valueOf(targetType, stringValue);
             return Optional.of(val);
@@ -47,14 +69,86 @@ public final class CharSequenceToEnumConverter<T extends Enum<T>> implements Typ
                 return Optional.of(val);
             } catch (Exception e1) {
                 Optional<T> valOpt = Arrays.stream(targetType.getEnumConstants())
-                        .filter(val -> val.toString().equals(stringValue))
-                        .findFirst();
+                    .filter(val -> val.toString().equals(stringValue))
+                    .findFirst();
                 if (valOpt.isPresent()) {
                     return valOpt;
                 }
-                context.reject(charSequence, e);
+                context.reject(value, e);
                 return Optional.empty();
             }
         }
+    }
+
+    private Optional<Method> findCreatorMethod(Class<T> targetType) {
+
+        var creatorMethodOpt = creatorMethodsCache.get(targetType.getName());
+        if (creatorMethodOpt != null) {
+            return creatorMethodOpt;
+        }
+
+        Method creatorMethod = null;
+        for (var m : targetType.getDeclaredMethods()) {
+            for (var annotation : m.getDeclaredAnnotations()) {
+                if (ANNOTATION_JSON_CREATOR.equals(annotation.annotationType().getName())) {
+                    creatorMethod = m;
+                    break;
+                }
+            }
+            if (creatorMethod != null) {
+                break;
+            }
+        }
+        creatorMethodOpt = Optional.ofNullable(creatorMethod);
+        creatorMethodsCache.put(targetType.getName(), creatorMethodOpt);
+        return creatorMethodOpt;
+    }
+
+    private Object convertStringArg(String value, Class<?> targetType, ConversionContext context) {
+
+        if (StringUtils.isEmpty(value)) {
+            return null;
+        }
+        var typeName = targetType.getTypeName();
+
+        try {
+            if (String.class.getName().equals(typeName)
+                || CharSequence.class.getName().equals(typeName)) {
+                return value;
+            } else if (Byte.class.getName().equals(typeName)
+                || byte.class.getName().equals(typeName)) {
+                return Byte.valueOf(value);
+            } else if (Short.class.getName().equals(typeName)
+                || short.class.getName().equals(typeName)) {
+                return Short.valueOf(value);
+            } else if (Integer.class.getName().equals(typeName)
+                || int.class.getName().equals(typeName)) {
+                return Integer.valueOf(value);
+            } else if (Long.class.getName().equals(typeName)
+                || long.class.getName().equals(typeName)) {
+                return Long.valueOf(value);
+            } else if (Float.class.getName().equals(typeName)
+                || float.class.getName().equals(typeName)) {
+                return Float.valueOf(value);
+            } else if (Double.class.getName().equals(typeName)
+                || double.class.getName().equals(typeName)) {
+                return Double.valueOf(value);
+            } else if (Character.class.getName().equals(typeName)
+                || char.class.getName().equals(typeName)) {
+                return value.charAt(0);
+            } else if (Boolean.class.getName().equals(typeName)
+                || boolean.class.getName().equals(typeName)) {
+                return Boolean.valueOf(value);
+            } else if (BigInteger.class.getName().equals(typeName)) {
+                return new BigInteger(value);
+            } else if (BigDecimal.class.getName().equals(typeName)) {
+                return new BigDecimal(value);
+            }
+        } catch (Exception e) {
+            context.reject(value, e);
+            return Optional.empty();
+        }
+
+        return Optional.empty();
     }
 }

--- a/core/src/test/groovy/io/micronaut/core/convert/CharSequenceToEnumConverterSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/convert/CharSequenceToEnumConverterSpec.groovy
@@ -1,0 +1,76 @@
+package io.micronaut.core.convert
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
+import spock.lang.Specification
+
+class CharSequenceToEnumConverterSpec extends Specification {
+
+    void "test conversion enum with creator method"() {
+        given:
+        def converter = new CharSequenceToEnumConverter()
+
+        when:
+        def converted = converter.convert("1", EnumWithCreator.class, null).orElse(null)
+
+        then:
+        converted
+        converted == EnumWithCreator.FIRST
+    }
+
+    void "test conversion enum without creator method"() {
+        given:
+        def converter = new CharSequenceToEnumConverter()
+
+        when:
+        def converted = converter.convert("FIRST", EnumWithoutCreator.class, null).orElse(null)
+
+        then:
+        converted
+        converted == EnumWithoutCreator.FIRST
+    }
+
+    enum EnumWithoutCreator {
+
+        FIRST(1),
+        SECOND(2),
+        ;
+
+        @JsonValue
+        private final int value;
+
+        EnumWithoutCreator(int value) {
+            this.value = value;
+        }
+
+        int getValue() {
+            return value;
+        }
+    }
+
+    enum EnumWithCreator {
+
+        @JsonProperty("1")
+        FIRST(1),
+        @JsonProperty("2")
+        SECOND(2),
+        ;
+
+        @JsonValue
+        private final int value;
+
+        EnumWithCreator(int value) {
+            this.value = value;
+        }
+
+        int getValue() {
+            return value;
+        }
+
+        @JsonCreator
+        static EnumWithCreator fromValue(int value) {
+            return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElse(null);
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/condition/NotInNativeImage.java
+++ b/inject/src/main/java/io/micronaut/context/condition/NotInNativeImage.java
@@ -19,7 +19,7 @@ import io.micronaut.core.util.NativeImageUtils;
 
 /**
  * Condition to hide parts of an application that only work when running on the JVM.
- * Internal implementation is identical to {@code if (!ImageInfo.inImageCode()).
+ * Internal implementation is identical to {@code if (!ImageInfo.inImageCode())}.
  * @author Sergio del Amo
  * @since 4.8.0
  */


### PR DESCRIPTION
This fix for case, when you try to use enum for path variables. Now, micronaut support only enum constant names, but it's not enough. Need to support standard case for enums - when you use values with different types and use `@JsonCreator` annotation to map these values to enum constants.

Sample usecase:
```java

@ExecuteOn(TaskExecutors.BLOCKING)
@Slf4j
@Controller
public class MyController {

    // now this works only if I set enum constant name, for example: `http://localhost:8080/test/FIRST`,
    // but because I set annotation `@JsonCreator` must be `http://localhost:8080/test/1`
    @Get("/test/{myEnum}")
    public MyEnum test(MyEnum myEnum) {
        return myEnum;
    }
}

public enum MyEnum {

    @JsonProperty("1")
    FIRST(1),
    @JsonProperty("2")
    SECOND(2),
    ;

    @JsonValue
    private final int value;

    MyEnum(int value) {
        this.value = value;
    }

    public int getValue() {
        return value;
    }

    @JsonCreator
    public static MyEnum fromValue(int value) {
        return Arrays.stream(values()).filter(e -> e.value == value).findFirst().orElse(null);
    }
}
```