### PR TITLE
fix compiler warning for unrecognised options

### DIFF
--- a/core-processor/src/main/java/io/micronaut/context/visitor/InternalApiTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/context/visitor/InternalApiTypeElementVisitor.java
@@ -55,6 +55,11 @@ public class InternalApiTypeElementVisitor implements TypeElementVisitor<Object,
         );
     }
 
+    @Override
+    public Set<String> getSupportedOptions() {
+        return Set.of(MICRONAUT_PROCESSING_INTERNAL_WARNINGS)
+    }
+
     @NonNull
     @Override
     public VisitorKind getVisitorKind() {

--- a/core-processor/src/main/java/io/micronaut/context/visitor/InternalApiTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/context/visitor/InternalApiTypeElementVisitor.java
@@ -57,7 +57,7 @@ public class InternalApiTypeElementVisitor implements TypeElementVisitor<Object,
 
     @Override
     public Set<String> getSupportedOptions() {
-        return Set.of(MICRONAUT_PROCESSING_INTERNAL_WARNINGS)
+        return Set.of(MICRONAUT_PROCESSING_INTERNAL_WARNINGS);
     }
 
     @NonNull


### PR DESCRIPTION
Currently the following warnings are being printed when compiling with Micronaut

```
warning: The following options were not recognized by any processor: '[micronaut.processing.internal.warnings]'
1 warning

warning: The following options were not recognized by any processor: '[micronaut.processing.internal.warnings]'
```

This regression was introduced by https://github.com/micronaut-projects/micronaut-core/commit/51e35b16bbf0074e2741a250578f557b7621ae1b

Which didn't return `getSupportedOptions()` for the new annotation processor argument.