### PR TITLE
fix getBoundGenericTypes() not returning resolved type arguments

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -643,6 +643,9 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     @NonNull
     @Override
     public List<ClassElement> getBoundGenericTypes() {
+        if (resolvedTypeArguments != null) {
+            return List.copyOf(resolvedTypeArguments.values());
+        }
         if (typeArguments == null) {
             return Collections.emptyList();
         }

--- a/inject-java/src/test/groovy/io/micronaut/annotation/processing/visitor/JavaReconstructionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/processing/visitor/JavaReconstructionSpec.groovy
@@ -14,6 +14,23 @@ import spock.lang.Unroll
  * {@link ClassElement}s returned by various methods look like.
  */
 class JavaReconstructionSpec extends AbstractTypeElementSpec {
+    def 'test with type arguments'() {
+        given:
+        def element = buildClassElement("""
+package example;
+
+import java.util.*;
+
+class Test<T> {
+}
+""").withTypeArguments(List.of(ClassElement.of(String)))
+
+        expect:
+        element.getBoundGenericTypes()[0].name == String.name
+        element.getTypeArguments().get("T").name == String.name
+    }
+
+
     @Unroll("field type is #fieldType")
     def 'field type'() {
         given:


### PR DESCRIPTION
Currently if you use `withTypeArguments` on a `ClassElement` then `JavaClassElement` does not factor in this mutated types. The issue doesn't seem to impact Kotlin or Groovy.