### PR TITLE
fix introduction advise skipping methods of generated super interfaces

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -30,6 +30,7 @@ import io.micronaut.inject.processing.BeanDefinitionCreatorFactory;
 import io.micronaut.inject.processing.JavaModelUtils;
 import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.visitor.BeanElementVisitor;
+import io.micronaut.inject.visitor.ElementPostponedToNextRoundException;
 import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
 import io.micronaut.inject.writer.BeanDefinitionVisitor;
 import io.micronaut.inject.writer.BeanDefinitionWriter;
@@ -91,7 +92,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
     private Set<String> beanDefinitions;
     private final Set<String> processed = new HashSet<>();
-    private final Map<String, PostponeToNextRoundException> postponed = new HashMap<>();
+    private final Map<String, Element> postponed = new HashMap<>();
 
     @Override
     public final synchronized void init(ProcessingEnvironment processingEnv) {
@@ -197,7 +198,10 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                             error(((JavaNativeElement) ex.getOriginatingElement()).element(), ex.getMessage());
                         } catch (PostponeToNextRoundException e) {
                             processed.remove(className);
-                            postponed.put(className, e);
+                            postponed.put(className, (Element) e.getErrorElement());
+                        } catch (ElementPostponedToNextRoundException e) {
+                            processed.remove(className);
+                            postponed.put(className, ((JavaNativeElement) e.getOriginatingElement().getNativeType()).element());
                         }
                     }
                 }
@@ -209,9 +213,9 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         processing round.
         */
         if (processingOver) {
-            for (Map.Entry<String, PostponeToNextRoundException> e : postponed.entrySet()) {
-                javaVisitorContext.warn("Bean definition generation [" + e.getKey() + "] skipped from processing because of prior error: [" + e.getValue().getPath() + "]." +
-                    " This error is normally due to missing classes on the classpath. Verify the compilation classpath is correct to resolve the problem.", (Element) e.getValue().getErrorElement());
+            for (Map.Entry<String, Element> e : postponed.entrySet()) {
+                javaVisitorContext.warn("Bean definition generation [" + e.getKey() + "] skipped from processing because of prior error." +
+                    " This error is normally due to missing classes on the classpath. Verify the compilation classpath is correct to resolve the problem.", e.getValue());
             }
 
             try {

--- a/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTest.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTest.java
@@ -1,0 +1,11 @@
+package io.micronaut.visitors;
+
+import io.micronaut.aop.Introduction;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Introduction
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IntroductionTest {
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTestGen.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTestGen.java
@@ -1,0 +1,10 @@
+package io.micronaut.visitors;
+
+import io.micronaut.aop.Introduction;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IntroductionTestGen {
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTestVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTestVisitor.java
@@ -1,0 +1,31 @@
+package io.micronaut.visitors;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class IntroductionTestVisitor implements TypeElementVisitor<IntroductionTestGen, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+            context.visitGeneratedSourceFile(
+                "test",
+                "IntroductionTestParent",
+                element
+            ).ifPresent(sourceFile -> {
+                try {
+                    sourceFile.write(writer -> writer.write("""
+                        package test;
+
+                        public interface IntroductionTestParent {
+                            String getParentMethod();
+                        }
+                        """));
+                } catch (Exception e) {
+                    throw new ProcessingException(element, "Failed to generate a Parent introduction: " + e.getMessage(), e);
+                }
+            });
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -2,10 +2,11 @@ package io.micronaut.visitors
 
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.writer.BeanDefinitionVisitor
 
 class PostponedVisitorsSpec extends AbstractTypeElementSpec {
 
-    void 'test'() {
+    void 'test postpone introspection generation implementing generated interface'() {
         when:
             def definition = buildBeanIntrospection('test.Walrus', '''
 package test;
@@ -27,5 +28,42 @@ public record Walrus (
 ''')
         then:
             definition
+    }
+
+    void 'test postpone introduction generation implementing generated interface'() {
+        when:
+        def context = buildContext('test.MyIntroduction' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.visitors.IntroductionTest;
+import io.micronaut.visitors.IntroductionTestGen;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+
+
+@IntroductionTestGen
+class Foo {}
+
+@IntroductionTest
+interface MyIntroduction extends IntroductionTestParent  {
+}
+
+
+@InterceptorBean(IntroductionTest.class)
+class IntroductionTestInterceptor
+    implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return "good";
+    }
+}
+''')
+        def introduction = getBean(context, 'test.MyIntroduction')
+
+        then:
+        introduction.getParentMethod() == 'good'
     }
 }

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -20,3 +20,4 @@ io.micronaut.annotation.AnnotateClassSpec$AnnotateClassVisitor
 io.micronaut.annotation.AnnotateTypeArgSpec$AnnotateTypeArgVisitor
 io.micronaut.aop.introduction.beans.MyRepoVisitor2
 io.micronaut.visitors.WitherVisitor
+io.micronaut.visitors.IntroductionTestVisitor


### PR DESCRIPTION
previously super interfaces were filtered out if there were errors but the correct thing to do is throw `ElementPostponedToNextRoundException` on first access. In addition BeanDefinitionInjectProcessor was not handling `ElementPostponedToNextRoundException` so exceptions thrown during bean definition processing did not cause a retry on the second round. Ideally we should get rid of the non-public `PostponeToNextRoundException` at some point.