### PR TITLE
Document declarative client and retryable

### DIFF
--- a/src/main/docs/guide/httpClient/clientAnnotation/clientError.adoc
+++ b/src/main/docs/guide/httpClient/clientAnnotation/clientError.adoc
@@ -8,3 +8,5 @@ IMPORTANT: The one exception to this rule is HTTP Not Found (404) responses. Thi
 HTTP Not Found (404) responses for blocking return types is *not* considered an error condition and the client exception will *not* be thrown. That behavior includes methods that return `void`.
 
 If the method returns an `HttpResponse`, the original response is returned. If the return type is `Optional`, an empty optional is returned. For all other types, `null` is returned.
+
+When combining client calls with api:retry.annotation.Retryable[], all thrown exceptions will be retried by default. This will include all 4XX responses, except HTTP Not Found (404) as noted above. Specific retry criteria can be configured with a api:retry.annotation.RetryPredicate[] to filter out responses that shouldn't be retried.


### PR DESCRIPTION
Add a note to the documentation about combining the declarative Http client and `@Retryable` and ignoring 4XX responses

There are currently multiple issues about not retrying 4XX responses (see #1920 and #2123). I understand the behavior is intended to keep `@Retryable` agnostic to what it is retrying, but I think an extra call-out in the docs about what seems to be the recommended solution would help provide extra clarity, since disabling 4XX retries seems like a common desire. 

Additionally, I think an explicit note would make it clearer that with the declarative client and `@Retryable`, by default 404s will not be retried, but other 4XX responses will be. This is implied by the call out that 404 responses are not considered an error condition, but I think it's generally unexpected to see 4XXs being retried but 404s are 'excluded'