### PR TITLE
Add thread-core-ratio config option and change default to 1

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupConfiguration.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupConfiguration.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 public class DefaultEventLoopGroupConfiguration implements EventLoopGroupConfiguration {
 
     private final int numThreads;
+    private final double threadCoreRatio;
     private final Integer ioRatio;
     private final boolean preferNativeTransport;
     private final String name;
@@ -48,6 +49,8 @@ public class DefaultEventLoopGroupConfiguration implements EventLoopGroupConfigu
      *
      * @param name                  The name of the group
      * @param numThreads            The number of threads
+     * @param threadCoreRatio       The number of threads per core to use if
+     *                              {@link #getNumThreads()} is set to 0.
      * @param ioRatio               The IO ratio (optional)
      * @param preferNativeTransport Whether native transport is to be preferred
      * @param executor              A named executor service to use for event loop threads
@@ -62,6 +65,7 @@ public class DefaultEventLoopGroupConfiguration implements EventLoopGroupConfigu
     public DefaultEventLoopGroupConfiguration(
             @Parameter String name,
             @Bindable(defaultValue = "0") int numThreads,
+            @Bindable(defaultValue = DEFAULT_THREAD_CORE_RATIO + "") double threadCoreRatio,
             @Nullable Integer ioRatio,
             @Bindable(defaultValue = StringUtils.FALSE) boolean preferNativeTransport,
             @Nullable String executor,
@@ -70,6 +74,7 @@ public class DefaultEventLoopGroupConfiguration implements EventLoopGroupConfigu
     ) {
         this.name = name;
         this.numThreads = numThreads;
+        this.threadCoreRatio = threadCoreRatio;
         this.ioRatio = ioRatio;
         this.preferNativeTransport = preferNativeTransport;
         this.executor = executor;
@@ -79,12 +84,26 @@ public class DefaultEventLoopGroupConfiguration implements EventLoopGroupConfigu
             .orElse(Duration.ofSeconds(DEFAULT_SHUTDOWN_TIMEOUT));
     }
 
+    @Deprecated
+    public DefaultEventLoopGroupConfiguration(
+        String name,
+        int numThreads,
+        Integer ioRatio,
+        boolean preferNativeTransport,
+        String executor,
+        Duration shutdownQuietPeriod,
+        Duration shutdownTimeout
+    ) {
+        this(name, numThreads, DEFAULT_THREAD_CORE_RATIO, ioRatio, preferNativeTransport, executor, shutdownQuietPeriod, shutdownTimeout);
+    }
+
     /**
      * Default constructor.
      */
     public DefaultEventLoopGroupConfiguration() {
         this.name = DEFAULT;
         this.numThreads = 0;
+        this.threadCoreRatio = DEFAULT_THREAD_CORE_RATIO;
         this.ioRatio = null;
         this.preferNativeTransport = false;
         this.executor = null;
@@ -98,6 +117,11 @@ public class DefaultEventLoopGroupConfiguration implements EventLoopGroupConfigu
     @Override
     public int getNumThreads() {
         return numThreads;
+    }
+
+    @Override
+    public double getThreadCoreRatio() {
+        return threadCoreRatio;
     }
 
     /**

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupConfiguration.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupConfiguration.java
@@ -39,6 +39,10 @@ public interface EventLoopGroupConfiguration extends Named {
      * The default.
      */
     String DEFAULT_LOOP = EVENT_LOOPS + "." + DEFAULT;
+    /**
+     * Default {@link #getThreadCoreRatio()}.
+     */
+    double DEFAULT_THREAD_CORE_RATIO = 1.0;
 
     /**
      * The default shutdown quiet period in seconds.
@@ -55,9 +59,19 @@ public interface EventLoopGroupConfiguration extends Named {
     long DEFAULT_SHUTDOWN_TIMEOUT = 15;
 
     /**
-     * @return The number of threads for the event loop
+     * @return The number of threads for the event loop, or 0 to use {@link #getThreadCoreRatio()}
      */
     int getNumThreads();
+
+    /**
+     * The number of threads per core to use if {@link #getNumThreads()} is set to 0.
+     *
+     * @return The thread-to-core ratio
+     * @since 4.8.0
+     */
+    default double getThreadCoreRatio() {
+        return DEFAULT_THREAD_CORE_RATIO;
+    }
 
     /**
      * @return The I/O ratio.

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
@@ -73,7 +73,7 @@ public interface EventLoopGroupFactory {
         ArgumentUtils.requireNonNull("configuration", configuration);
         ArgumentUtils.requireNonNull("threadFactory", threadFactory);
         return createEventLoopGroup(
-                configuration.getNumThreads(),
+                DefaultEventLoopGroupRegistry.numThreads(configuration),
                 threadFactory,
                 configuration.getIoRatio().orElse(null)
         );

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/channel/EventLoopGroupSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/channel/EventLoopGroupSpec.groovy
@@ -36,7 +36,7 @@ class EventLoopGroupSpec extends Specification {
 
         then:
         !eventLoopGroup.isTerminated()
-        eventLoopGroup.executorCount() == NettyRuntime.availableProcessors() * 2
+        eventLoopGroup.executorCount() == NettyRuntime.availableProcessors()
         ResourceLeakDetector.level == ResourceLeakDetector.Level.DISABLED
 
         when:

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/channel/EventLoopGroupSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/channel/EventLoopGroupSpec.groovy
@@ -129,7 +129,7 @@ class EventLoopGroupSpec extends Specification {
 
         then:
         !eventLoopGroup.isTerminated()
-        eventLoopGroup.executorCount() == NettyRuntime.availableProcessors() * 2
+        eventLoopGroup.executorCount() == NettyRuntime.availableProcessors()
 
         when:
         def eventLoopGroup2 = context.getBean(EventLoopGroup, Qualifiers.byName("one"))

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/channel/EventLoopGroupSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/channel/EventLoopGroupSpec.groovy
@@ -89,6 +89,29 @@ class EventLoopGroupSpec extends Specification {
         eventLoopGroup.isShuttingDown()
     }
 
+    void "test core ratio"(int ratio) {
+        given:
+        def context = ApplicationContext.run(
+                'micronaut.netty.event-loops.default.thread-core-ratio': ratio
+        )
+
+        when:
+        def eventLoopGroup = context.getBean(EventLoopGroup)
+
+        then:
+        !eventLoopGroup.isTerminated()
+        eventLoopGroup.executorCount() == ratio * Runtime.getRuntime().availableProcessors()
+
+        when:
+        context.close()
+
+        then:
+        eventLoopGroup.isShuttingDown()
+
+        where:
+        ratio << [1, 2, 3]
+    }
+
     void "test configure additional event loop groups"() {
         given:
         def context = ApplicationContext.run(

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -32,6 +32,7 @@ import io.micronaut.http.context.event.HttpRequestReceivedEvent;
 import io.micronaut.http.context.event.HttpRequestTerminatedEvent;
 import io.micronaut.http.netty.channel.ChannelPipelineListener;
 import io.micronaut.http.netty.channel.DefaultEventLoopGroupConfiguration;
+import io.micronaut.http.netty.channel.DefaultEventLoopGroupRegistry;
 import io.micronaut.http.netty.channel.EventLoopGroupConfiguration;
 import io.micronaut.http.netty.channel.NettyChannelType;
 import io.micronaut.http.netty.channel.converters.ChannelOptionFactory;
@@ -770,7 +771,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                     .flatMap(name -> applicationContext.findBean(ExecutorService.class, Qualifiers.byName(name))).orElse(null);
             if (executorService != null) {
                 return nettyEmbeddedServices.createEventLoopGroup(
-                        config.getNumThreads(),
+                        DefaultEventLoopGroupRegistry.numThreads(config),
                         executorService,
                         config.getIoRatio().orElse(null)
                 );
@@ -964,7 +965,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
         }
     }
 
-    private static class DomainSocketHolder {
+    private static final class DomainSocketHolder {
         @NonNull
         private static SocketAddress makeDomainSocketAddress(String path) {
             try {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -1297,6 +1297,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public abstract static class EventLoopConfig implements EventLoopGroupConfiguration {
         private int threads;
+        private double threadCoreRatio = DEFAULT_THREAD_CORE_RATIO;
         private Integer ioRatio;
         private String executor;
         private boolean preferNativeTransport = false;
@@ -1413,6 +1414,21 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
         @Override
         public int getNumThreads() {
             return threads;
+        }
+
+        @Override
+        public double getThreadCoreRatio() {
+            return threadCoreRatio;
+        }
+
+        /**
+         * The number of threads per core to use if {@link #getNumThreads()} is set to 0.
+         *
+         * @param threadCoreRatio The thread-to-core ratio
+         * @since 4.8.0
+         */
+        public void setThreadCoreRatio(double threadCoreRatio) {
+            this.threadCoreRatio = threadCoreRatio;
         }
 
         @Override


### PR DESCRIPTION
We already have options to set the number of threads for event loops explicitly, but none that scale with host core count.

This PR adds a thread-core-ratio config option that allows for dynamically changing event loop thread count based on core count. Netty previously did the same thing when num-threads is 0, but this PR moves that logic to our code.

The default ratio is changed from nettys 2 to 1. A single thread per core reduces jitter and should achieve the same throughput in most scenarios.