### PR TITLE
extract HttpHeadersUtil::parseCharacterEncoding and parseAcceptCharset

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -21,7 +21,6 @@ import io.micronaut.http.util.HttpHeadersUtil;
 import jakarta.annotation.Nullable;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -744,17 +743,7 @@ public interface HttpHeaders extends Headers {
      */
     default Optional<Charset> findAcceptCharset() {
         return findFirst(HttpHeaders.ACCEPT_CHARSET)
-            .map(text -> {
-                text = HttpHeadersUtil.splitAcceptHeader(text);
-                if (text != null) {
-                    try {
-                        return Charset.forName(text);
-                    } catch (Exception ignored) {
-                    }
-                }
-                // default to UTF-8
-                return StandardCharsets.UTF_8;
-            });
+            .map(HttpHeadersUtil::parseAcceptCharset);
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
+++ b/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
@@ -160,6 +160,7 @@ public final class HttpHeadersUtil {
      * Resolve the {@link Charset} to use for the request.
      *
      * @param contentType ContenType
+     * @param acceptCharset Accept Charset
      * @return An {@link Optional} of {@link Charset}
      * @since 4.8.8
      */

--- a/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
+++ b/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
@@ -39,6 +39,7 @@ import java.util.regex.Pattern;
  * @since 3.8.0
  */
 public final class HttpHeadersUtil {
+    private final static Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
     private static final Supplier<Pattern> HEADER_MASK_PATTERNS = SupplierUtil.memoized(() ->
         Pattern.compile(".*(password|cred|cert|key|secret|token|auth|signat).*", Pattern.CASE_INSENSITIVE)
     );
@@ -175,13 +176,12 @@ public final class HttpHeadersUtil {
                     try {
                         return Charset.forName(charset);
                     } catch (Exception e) {
-                        // unsupported charset, default to UTF-8
-                        return Charset.defaultCharset();
+                        return DEFAULT_CHARSET;
                     }
                 }
             }
         } catch (UnsupportedCharsetException e) {
-            return StandardCharsets.UTF_8;
+            return DEFAULT_CHARSET;
         }
         return acceptCharset;
     }
@@ -201,6 +201,6 @@ public final class HttpHeadersUtil {
             } catch (Exception ignored) {
             }
         }
-        return StandardCharsets.UTF_8;
+        return DEFAULT_CHARSET;
     }
 }

--- a/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
+++ b/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
@@ -152,7 +152,7 @@ public final class HttpHeadersUtil {
     @NonNull
     public static Charset parseCharacterEncoding(@Nullable String contentTypeHeaderValue, @Nullable String acceptCharsetHeaderValue) {
         MediaType contentType = contentTypeHeaderValue == null ? null : MediaType.of(contentTypeHeaderValue);
-        Charset charset = acceptCharsetHeaderValue != null ? HttpHeadersUtil.parseAcceptCharset(acceptCharsetHeaderValue) : StandardCharsets.UTF_8;
+        Charset charset = acceptCharsetHeaderValue != null ? parseAcceptCharset(acceptCharsetHeaderValue) : StandardCharsets.UTF_8;
         return parseCharacterEncoding(contentType, charset);
     }
 

--- a/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
+++ b/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
@@ -20,9 +20,14 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.MediaType;
 import org.slf4j.Logger;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -134,5 +139,67 @@ public final class HttpHeadersUtil {
             text = text.split(",")[0];
         }
         return text;
+    }
+
+    /**
+     * Resolve the {@link Charset} to use for request identified by the Content-Type HTTP Header value and the Accept-Charset HTTP Header value.
+     *
+     * @param contentTypeHeaderValue Content-Type HTTP Header Value
+     * @param acceptCharsetHeaderValue Accept-Charset HTTP Header Value
+     * @return A {@link Charset}
+     * @since 4.8.8
+     */
+    @NonNull
+    public static Charset parseCharacterEncoding(@Nullable String contentTypeHeaderValue, @Nullable String acceptCharsetHeaderValue) {
+        MediaType contentType = contentTypeHeaderValue == null ? null : MediaType.of(contentTypeHeaderValue);
+        Charset charset = acceptCharsetHeaderValue != null ? HttpHeadersUtil.parseAcceptCharset(acceptCharsetHeaderValue) : StandardCharsets.UTF_8;
+        return parseCharacterEncoding(contentType, charset);
+    }
+
+    /**
+     * Resolve the {@link Charset} to use for the request.
+     *
+     * @param contentType ContenType
+     * @return An {@link Optional} of {@link Charset}
+     * @since 4.8.8
+     */
+    @NonNull
+    public static Charset parseCharacterEncoding(@Nullable MediaType contentType,
+                                                 @NonNull Charset acceptCharset) {
+        try {
+
+            if (contentType != null) {
+                String charset = contentType.getParametersMap().get(MediaType.CHARSET_PARAMETER);
+                if (charset != null) {
+                    try {
+                        return Charset.forName(charset);
+                    } catch (Exception e) {
+                        // unsupported charset, default to UTF-8
+                        return Charset.defaultCharset();
+                    }
+                }
+            }
+        } catch (UnsupportedCharsetException e) {
+            return StandardCharsets.UTF_8;
+        }
+        return acceptCharset;
+    }
+
+    /**
+     *
+     * @param acceptCharsetHeaderValue Accept-Charset HeaderValue
+     * @return Accept Charset
+     * @since 4.8.8
+     */
+    @NonNull
+    public static Charset parseAcceptCharset(@NonNull String acceptCharsetHeaderValue) {
+        String text = HttpHeadersUtil.splitAcceptHeader(acceptCharsetHeaderValue);
+        if (text != null) {
+            try {
+                return Charset.forName(text);
+            } catch (Exception ignored) {
+            }
+        }
+        return StandardCharsets.UTF_8;
     }
 }

--- a/http/src/main/java/io/micronaut/http/util/HttpUtil.java
+++ b/http/src/main/java/io/micronaut/http/util/HttpUtil.java
@@ -86,22 +86,8 @@ public class HttpUtil {
     @SuppressWarnings("Duplicates")
     @NonNull
     public static Charset getCharset(@NonNull HttpMessage<?> request) {
-        try {
-            MediaType contentType = request.getContentType().orElse(null);
-            if (contentType != null) {
-                String charset = contentType.getParametersMap().get(MediaType.CHARSET_PARAMETER);
-                if (charset != null) {
-                    try {
-                        return Charset.forName(charset);
-                    } catch (Exception e) {
-                        // unsupported charset, default to UTF-8
-                        return Charset.defaultCharset();
-                    }
-                }
-            }
-        } catch (UnsupportedCharsetException e) {
-            return StandardCharsets.UTF_8;
-        }
-        return request.getHeaders().findAcceptCharset().orElse(StandardCharsets.UTF_8);
+        MediaType contentType = request.getContentType().orElse(null);
+        return HttpHeadersUtil.parseCharacterEncoding(contentType,
+            request.getHeaders().findAcceptCharset().orElse(StandardCharsets.UTF_8));
     }
 }

--- a/http/src/main/java/io/micronaut/http/util/HttpUtil.java
+++ b/http/src/main/java/io/micronaut/http/util/HttpUtil.java
@@ -32,6 +32,7 @@ import java.util.Optional;
  * @since 1.0
  */
 public class HttpUtil {
+    private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
     /**
      * Return whether the given request features {@link MediaType#APPLICATION_FORM_URLENCODED} or
@@ -88,6 +89,6 @@ public class HttpUtil {
     public static Charset getCharset(@NonNull HttpMessage<?> request) {
         MediaType contentType = request.getContentType().orElse(null);
         return HttpHeadersUtil.parseCharacterEncoding(contentType,
-            request.getHeaders().findAcceptCharset().orElse(StandardCharsets.UTF_8));
+            request.getHeaders() != null ? request.getHeaders().findAcceptCharset().orElse(DEFAULT_CHARSET) : DEFAULT_CHARSET);
     }
 }


### PR DESCRIPTION
To allow the usage of those methods in runtimes where no HttpRequest or HttpMessage is available