### PR TITLE
Fix shutdown hooks

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/EmbeddedApplication.java
+++ b/context/src/main/java/io/micronaut/runtime/EmbeddedApplication.java
@@ -73,4 +73,24 @@ public interface EmbeddedApplication<T extends EmbeddedApplication> extends Appl
     default boolean isForceExit() {
         return false;
     }
+
+    /**
+     * Determines whether the application requires a shutdown hook
+     * for graceful shutdown.
+     * <p>
+     * Due to the JVM's non-deterministic shutdown hook execution order,
+     * a custom hook may be necessary to perform certain actions before
+     * or after closing the application context. Additionally, tests
+     * often close the application context immediately after execution,
+     * making a shutdown hook unnecessary. In such cases, registering
+     * a shutdown hook may lead to memory leaks due to excessive
+     * application context creation.
+     * </p>
+     *
+     * @return {@code true} if the application allows registering shutdown hooks,
+     * {@code false} otherwise
+     */
+    default boolean isShutdownHookNeeded() {
+        return true;
+    }
 }

--- a/context/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/context/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -113,18 +113,31 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
                     Thread mainThread = Thread.currentThread();
                     boolean finalKeepAlive = keepAlive;
                     CountDownLatch countDownLatch = new CountDownLatch(1);
-                    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                        if (LOG.isInfoEnabled()) {
-                            LOG.info("Embedded Application shutting down");
-                        }
-                        if (embeddedApplication.isRunning()) {
-                            embeddedApplication.stop();
-                            countDownLatch.countDown();
-                            if (finalKeepAlive) {
-                                mainThread.interrupt();
+                    try {
+                        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                            if (LOG.isInfoEnabled()) {
+                                LOG.info("Embedded Application shutting down");
                             }
+                            try (applicationContext) {
+                                /* stop the application without checking if it is running,
+                                   as it may have already opened some resources before starting */
+                                embeddedApplication.stop();
+                                countDownLatch.countDown();
+                                if (finalKeepAlive) {
+                                    mainThread.interrupt();
+                                }
+                            }
+                        }));
+                    } catch (IllegalStateException e) {
+                        try (applicationContext) {
+                            embeddedApplication.stop();
+                        } catch (Throwable stopError) {
+                            LOG.error("Embedded Application shutting down", stopError);
                         }
-                    }));
+                        if (LOG.isInfoEnabled()) {
+                            LOG.warn("Embedded Application starting: {}", e.getMessage());
+                        }
+                    }
 
                     if (keepAlive) {
                         new Thread(() -> {


### PR DESCRIPTION
This PR adds

- a protection when the JVM receives SIGINT just before the app context is started
- an ability to disable the Micronaut shutdown hook (it is described in the javadoc)