### PR TITLE
On route mismatch, only consider alternate media types if method matches

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/errors/ErrorSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/errors/ErrorSpec.groovy
@@ -186,6 +186,19 @@ class ErrorSpec extends AbstractMicronautSpec {
         json._links.self.href == '/errors/server-error'
     }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11468")
+    void "test 405 error for wrong content type"() {
+        when:
+        httpClient.toBlocking().retrieve(
+                HttpRequest.POST('/errors/server-error', 'blah')
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        )
+
+        then:
+        def e = thrown HttpClientResponseException
+        e.code() == HttpStatus.METHOD_NOT_ALLOWED.code
+    }
+
     void "test content type for error handler"() {
         given:
         HttpResponse response = Flux.from(httpClient.exchange(

--- a/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
@@ -484,12 +484,13 @@ public class RequestLifecycle {
             final String routeMethod = anyRoute.getRouteInfo().getHttpMethodName();
             if (!requestMethodName.equals(routeMethod)) {
                 allowedMethods.add(routeMethod);
-            }
-            if (contentType != null && !anyRoute.getRouteInfo().doesConsume(contentType)) {
-                acceptableContentTypes.addAll(anyRoute.getRouteInfo().getConsumes());
-            }
-            if (hasAcceptHeader && !anyRoute.getRouteInfo().doesProduce(acceptedTypes)) {
-                produceableContentTypes.addAll(anyRoute.getRouteInfo().getProduces());
+            } else {
+                if (contentType != null && !anyRoute.getRouteInfo().doesConsume(contentType)) {
+                    acceptableContentTypes.addAll(anyRoute.getRouteInfo().getConsumes());
+                }
+                if (hasAcceptHeader && !anyRoute.getRouteInfo().doesProduce(acceptedTypes)) {
+                    produceableContentTypes.addAll(anyRoute.getRouteInfo().getProduces());
+                }
             }
             declaringType = anyRoute.getDeclaringType();
         }


### PR DESCRIPTION
If the method doesn't match, that should be the error, not the fact that the content type is also wrong.

Fixes #11468