### PR TITLE
ThreadLocal bean improvements

### DIFF
--- a/benchmarks/src/jmh/java/io/micronaut/context/scope/ThreadLocalScopeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/context/scope/ThreadLocalScopeBenchmark.java
@@ -1,0 +1,80 @@
+package io.micronaut.context.scope;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.runtime.context.scope.ThreadLocal;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class ThreadLocalScopeBenchmark {
+    ApplicationContext ctx;
+    Holder holder;
+
+    @Setup
+    public void setup() {
+        ctx = ApplicationContext.run(Map.of("spec.name", "ThreadLocalScopeBenchmark"));
+        holder = ctx.getBean(Holder.class);
+    }
+
+    @TearDown
+    public void tearDown() {
+        ctx.close();
+    }
+
+    @Benchmark
+    public int bench() {
+        return holder.myThreadLocal.foo();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        if (false) {
+            ThreadLocalScopeBenchmark b = new ThreadLocalScopeBenchmark();
+            b.setup();
+            for (int i = 0; i < 100; i++) {
+                b.bench();
+            }
+            return;
+        }
+
+        Options opt = new OptionsBuilder()
+            .include(ThreadLocalScopeBenchmark.class.getName() + ".*")
+            .warmupIterations(10)
+            .measurementIterations(10)
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.NANOSECONDS)
+            .forks(1)
+            .build();
+        new Runner(opt).run();
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "ThreadLocalScopeBenchmark")
+    static class Holder {
+        @Inject
+        MyThreadLocal myThreadLocal;
+    }
+
+    @ThreadLocal
+    static class MyThreadLocal {
+        private final int foo = ThreadLocalRandom.current().nextInt();
+
+        int foo() {
+            return foo;
+        }
+    }
+}

--- a/context/src/main/java/io/micronaut/runtime/context/scope/ThreadLocal.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/ThreadLocal.java
@@ -17,11 +17,12 @@ package io.micronaut.runtime.context.scope;
 
 import jakarta.inject.Scope;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * A {@link io.micronaut.context.scope.CustomScope} that stores objects in thread local storage.
@@ -35,4 +36,13 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Scope
 public @interface ThreadLocal {
+    /**
+     * If enabled, track bean life cycle. This means that the bean will be stopped, destroy
+     * listeners will be called etc., when the application context is closed or when the associated
+     * thread terminates. Note that this adds some overhead, so it's off by default.
+     *
+     * @return Whether to enable lifecycle support for this bean
+     * @since 4.9.0
+     */
+    boolean lifecycle() default false;
 }

--- a/context/src/main/java/io/micronaut/runtime/context/scope/ThreadLocalCustomScope.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/ThreadLocalCustomScope.java
@@ -15,14 +15,29 @@
  */
 package io.micronaut.runtime.context.scope;
 
-import io.micronaut.context.scope.AbstractConcurrentCustomScope;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.LifeCycle;
+import io.micronaut.context.exceptions.BeanDestructionException;
+import io.micronaut.context.scope.BeanCreationContext;
 import io.micronaut.context.scope.CreatedBean;
+import io.micronaut.context.scope.CustomScope;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.SupplierUtil;
+import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.ref.Cleaner;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 /**
  * A {@link io.micronaut.context.scope.CustomScope} that stores values in thread local storage.
@@ -31,22 +46,13 @@ import java.util.Map;
  * @since 1.0
  */
 @Singleton
-final class ThreadLocalCustomScope extends AbstractConcurrentCustomScope<ThreadLocal> {
+final class ThreadLocalCustomScope implements CustomScope<ThreadLocal>, LifeCycle<ThreadLocalCustomScope>, AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(ThreadLocalCustomScope.class);
 
-    private final java.lang.ThreadLocal<Map<BeanIdentifier, CreatedBean<?>>> threadScope = java.lang.ThreadLocal.withInitial(HashMap::new);
+    private static final Supplier<Cleaner> LIFECYCLE_CLEANER = SupplierUtil.memoized(Cleaner::create);
 
-    /**
-     * Default constructor.
-     */
-    protected ThreadLocalCustomScope() {
-        super(ThreadLocal.class);
-    }
-
-    @NonNull
-    @Override
-    protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
-        return threadScope.get();
-    }
+    private final java.lang.ThreadLocal<LocalHolder> threadScope = new java.lang.ThreadLocal<>();
+    private final Set<Cleaner.Cleanable> toClean = ConcurrentHashMap.newKeySet();
 
     @Override
     public boolean isRunning() {
@@ -54,12 +60,124 @@ final class ThreadLocalCustomScope extends AbstractConcurrentCustomScope<ThreadL
     }
 
     @Override
-    public ThreadLocalCustomScope start() {
-        return this;
+    public Class<ThreadLocal> annotationType() {
+        return ThreadLocal.class;
     }
 
     @Override
-    public void close() {
-        threadScope.remove();
+    public <T> T getOrCreate(BeanCreationContext<T> creationContext) {
+        LocalHolder local = threadScope.get();
+        if (local == null) {
+            local = new LocalHolder();
+            threadScope.set(local);
+        }
+        CreatedBean<?> bean = local.beans.get(creationContext.id());
+        if (bean == null) {
+            bean = creationContext.create();
+            local.add(bean);
+        }
+        return (T) bean.bean();
+    }
+
+    @Override
+    public <T> Optional<T> remove(BeanIdentifier identifier) {
+        LocalHolder local = threadScope.get();
+        if (local == null) {
+            return Optional.empty();
+        }
+        CreatedBean<?> bean = local.remove(identifier);
+        if (bean == null) {
+            return Optional.empty();
+        }
+        try {
+            bean.close();
+        } catch (BeanDestructionException e) {
+            handleDestructionException(e);
+        }
+        return Optional.ofNullable((T) bean.bean());
+    }
+
+    @Override
+    public <T> Optional<BeanRegistration<T>> findBeanRegistration(T bean) {
+        LocalHolder local = threadScope.get();
+        if (local == null) {
+            return Optional.empty();
+        }
+        for (CreatedBean<?> createdBean : local.beans.values()) {
+            if (createdBean.bean() == bean) {
+                if (createdBean instanceof BeanRegistration) {
+                    return Optional.of((BeanRegistration<T>) createdBean);
+                }
+                return Optional.of(
+                    new BeanRegistration<>(
+                        createdBean.id(),
+                        (BeanDefinition<T>) createdBean.definition(),
+                        bean
+                    )
+                );
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Method that can be overridden to customize what happens on a shutdown error.
+     * @param e The exception
+     */
+    private void handleDestructionException(BeanDestructionException e) {
+        LOG.error("Error occurred destroying bean of scope @ThreadLocal: {}", e.getMessage(), e);
+    }
+
+    @Override
+    public @NonNull ThreadLocalCustomScope stop() {
+        for (Cleaner.Cleanable cleanable : toClean) {
+            cleanable.clean();
+        }
+        return this;
+    }
+
+    private final class LocalHolder {
+        final Map<BeanIdentifier, CreatedBean<?>> beans = new HashMap<>();
+        LifecycleBeanHolder lifecycleBeans;
+
+        void add(CreatedBean<?> createdBean) {
+            beans.put(createdBean.id(), createdBean);
+            if (createdBean.definition().booleanValue(ThreadLocal.class, "lifecycle").orElse(false)) {
+                if (lifecycleBeans == null) {
+                    LifecycleBeanHolder holder = new LifecycleBeanHolder();
+                    Cleaner.Cleanable cleanable = LIFECYCLE_CLEANER.get().register(this, holder);
+                    holder.cleanable = cleanable;
+                    toClean.add(cleanable);
+                    lifecycleBeans = holder;
+                }
+                lifecycleBeans.lifecycleBeans.add(createdBean);
+            }
+        }
+
+        @Nullable
+        CreatedBean<?> remove(BeanIdentifier identifier) {
+            CreatedBean<?> createdBean = beans.remove(identifier);
+            if (createdBean != null && lifecycleBeans != null) {
+                lifecycleBeans.lifecycleBeans.remove(createdBean);
+            }
+            return createdBean;
+        }
+    }
+
+    private final class LifecycleBeanHolder implements Runnable {
+        final Set<CreatedBean<?>> lifecycleBeans = new HashSet<>();
+        Cleaner.Cleanable cleanable;
+
+        @Override
+        public void run() {
+            toClean.remove(cleanable);
+            for (CreatedBean<?> bean : lifecycleBeans) {
+                try {
+                    bean.close();
+                } catch (BeanDestructionException e) {
+                    handleDestructionException(e);
+                }
+            }
+        }
     }
 }

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -139,6 +139,8 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
     private Collection<Class<?>> requiredComponents;
     @Nullable
     private Argument<?>[] requiredParametrizedArguments;
+    @Nullable
+    private Optional<Class<? extends Annotation>> scope;
 
     private Qualifier<T> declaredQualifier;
 
@@ -302,14 +304,20 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
         return precalculatedInfo.isSingleton;
     }
 
+    @SuppressWarnings({"OptionalAssignedToNull", "unchecked"})
     @Override
     public final Optional<Class<? extends Annotation>> getScope() {
-        return precalculatedInfo.scope.flatMap(scopeClassName -> {
-            if (Singleton.class.getName().equals(scopeClassName)) {
-                return SINGLETON_SCOPE;
-            }
-            return (Optional) ClassUtils.forName(scopeClassName, getClass().getClassLoader());
-        });
+        Optional<Class<? extends Annotation>> scope = this.scope;
+        if (scope == null) {
+            scope = precalculatedInfo.scope.flatMap(scopeClassName -> {
+                if (Singleton.class.getName().equals(scopeClassName)) {
+                    return SINGLETON_SCOPE;
+                }
+                return (Optional) ClassUtils.forName(scopeClassName, getClass().getClassLoader());
+            });
+            this.scope = scope;
+        }
+        return scope;
     }
 
     @Override

--- a/runtime/src/test/groovy/io/micronaut/runtime/context/scope/ThreadLocalScopeSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/context/scope/ThreadLocalScopeSpec.groovy
@@ -16,12 +16,14 @@
 package io.micronaut.runtime.context.scope
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.LifeCycle
 import io.micronaut.context.annotation.Factory
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.support.AbstractBeanDefinitionSpec
-import jakarta.inject.Scope
+import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import spock.util.concurrent.PollingConditions
 
 import java.lang.annotation.ElementType
 import java.lang.annotation.Retention
@@ -150,7 +152,66 @@ class ThreadLocalBean {
         then:
         b.a.total() == 2
         isolated
+    }
 
+    void "cleaned up on context close"() {
+        given:
+        def ctx = ApplicationContext.run("test")
+        def listener = ctx.getBean(CleanupListener)
+
+        def t1 = new Thread(() -> {
+            ctx.getBean(LifecycleBean).someMethod()
+        })
+        t1.start()
+        t1.join()
+
+        def t2 = new Thread(() -> {
+            ctx.getBean(LifecycleBean).someMethod()
+        })
+        t2.start()
+        t2.join()
+
+        when:
+        ctx.close()
+        then:
+        listener.numCleaned == 2
+    }
+
+    void "cleaned up on thread termination"() {
+        given:
+        def ctx = ApplicationContext.run("test")
+        def listener = ctx.getBean(CleanupListener)
+
+        when:
+        def t1 = new Thread(() -> {
+            ctx.getBean(LifecycleBean).someMethod()
+        })
+        t1.start()
+        t1.join()
+
+        def t2 = new Thread(() -> {
+            ctx.getBean(LifecycleBean).someMethod()
+        })
+        t2.start()
+        t2.join()
+
+        then:
+        new PollingConditions().eventually {
+            triggerGc()
+            listener.numCleaned == 2
+        }
+
+        cleanup:
+        ctx.close()
+    }
+
+    private static volatile long sink
+
+    private static void triggerGc() {
+        System.gc()
+        for (int i = 0; i < 1000; i++) {
+            sink = System.identityHashCode(new byte[10000]);
+        }
     }
 }
 
@@ -268,4 +329,28 @@ class BAndFactory {
 @Retention(RUNTIME)
 @Target([ ElementType.TYPE, ElementType.METHOD])
 public @interface MyAnn {
+}
+
+@Singleton
+class CleanupListener {
+    int numCleaned = 0
+}
+
+@ThreadLocal(lifecycle = true)
+class LifecycleBean implements LifeCycle<LifecycleBean> {
+    @Inject
+    CleanupListener cleanupListener
+
+    void someMethod() {}
+
+    @Override
+    boolean isRunning() {
+        return true
+    }
+
+    @Override
+    LifecycleBean stop() {
+        cleanupListener.numCleaned++
+        return this
+    }
 }


### PR DESCRIPTION
Improve performance and lifecycle management of ThreadLocal beans.

- Add a benchmark
- Cache AbstractInitializableBeanDefinition.getScope. This is the majority of the performance improvement
- Implement ThreadLocalCustomScope without the AbstractConcurrentCustomScope superclass. This leads to a minor performance improvement (no more locks)
- Add optional advanced lifecycle handling. Can be turned on with the ThreadLocal.lifecycle flag. There are two cleanup paths: When a thread terminates, its beans are destroyed through a Cleaner on GC. Separately, when the app context terminates, all those cleaner tasks are invoked immediately.

There's still some performance left on the table, see the benchmark, but it's much better than before.

Fixes #11293