### PR TITLE
Fix compatibility with the Espresso JVM.

### DIFF
--- a/management/src/main/java/io/micronaut/management/health/indicator/threads/DeadlockedThreadsHealthIndicator.java
+++ b/management/src/main/java/io/micronaut/management/health/indicator/threads/DeadlockedThreadsHealthIndicator.java
@@ -66,7 +66,12 @@ class DeadlockedThreadsHealthIndicator extends AbstractHealthIndicator {
     @Override
     protected Object getHealthInformation() {
             ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-            long[] deadlockedThreads = threadMXBean.findDeadlockedThreads();
+            long[] deadlockedThreads = null;
+            if (threadMXBean.isSynchronizerUsageSupported()) {
+                deadlockedThreads = threadMXBean.findDeadlockedThreads();
+            } else if (threadMXBean.isObjectMonitorUsageSupported()) {
+                deadlockedThreads = threadMXBean.findMonitorDeadlockedThreads();
+            }
             if (deadlockedThreads == null) {
                 this.healthStatus = HealthStatus.UP;
                 return null;


### PR DESCRIPTION
According to the API spec findMonitorDeadlockedThreads isn't guaranteed to be supported on non-HotSpot JVMs.