### PR TITLE
Bean definition executable methods skipped if implementing a generated interface

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -36,6 +36,7 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.visitor.VisitorContext;
+import org.jetbrains.annotations.NotNull;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
@@ -1584,6 +1585,16 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     @Internal
     public static void clearMutated(@NonNull Object key) {
         MUTATED_ANNOTATION_METADATA.remove(key);
+        Set<Object> keys = new HashSet<>(MUTATED_ANNOTATION_METADATA.keySet());
+        for (Object cachedKey : keys) {
+            if (cachedKey instanceof Iterable<?> iterable) {
+                for (Object object : iterable) {
+                    if (key.equals(object)) {
+                        MUTATED_ANNOTATION_METADATA.remove(cachedKey);
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -1844,24 +1855,34 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     /**
      * Key used to reference mutated metadata.
      *
-     * @param e1  The element 1
+     * @param owningType  The element 1
      * @param e2  The element 2
      * @param <T> the element type
      */
     @Internal
-    private record Key2<T>(T e1, T e2) {
+    private record Key2<T>(T owningType, T e2) implements Iterable<T> {
+        @NotNull
+        @Override
+        public Iterator<T> iterator() {
+            return List.of(owningType, e2).iterator();
+        }
     }
 
     /**
      * Key used to reference mutated metadata.
      *
-     * @param e1  The element 1
+     * @param owningType  The element 1
      * @param e2  The element 2
      * @param e3  The element 3
      * @param <T> the element type
      */
     @Internal
-    private record Key3<T>(T e1, T e2, T e3) {
+    private record Key3<T>(T owningType, T e2, T e3) implements Iterable<T> {
+        @NotNull
+        @Override
+        public Iterator<T> iterator() {
+            return List.of(owningType, e2, e3).iterator();
+        }
     }
 
     private static final class DefaultCachedAnnotationMetadata implements CachedAnnotationMetadata {

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -36,7 +36,6 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.visitor.VisitorContext;
-import org.jetbrains.annotations.NotNull;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
@@ -1861,7 +1860,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      */
     @Internal
     private record Key2<T>(T owningType, T e2) implements Iterable<T> {
-        @NotNull
+        @NonNull
         @Override
         public Iterator<T> iterator() {
             return List.of(owningType, e2).iterator();
@@ -1878,7 +1877,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      */
     @Internal
     private record Key3<T>(T owningType, T e2, T e3) implements Iterable<T> {
-        @NotNull
+        @NonNull
         @Override
         public Iterator<T> iterator() {
             return List.of(owningType, e2, e3).iterator();

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -24,6 +24,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Vetoed;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.ast.UnresolvedTypeKind;
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import io.micronaut.inject.processing.BeanDefinitionCreator;
@@ -175,6 +176,13 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 for (String className : beanDefinitions) {
                     if (processed.add(className)) {
                         final TypeElement typeElement = elementUtils.getTypeElement(className);
+                        PostponeToNextRoundException nextRoundException = postponed.get(className);
+                        if (nextRoundException != null) {
+                            Object errorElement = nextRoundException.getErrorElement();
+                            if (errorElement != null) {
+                                AbstractAnnotationMetadataBuilder.clearMutated(errorElement);
+                            }
+                        }
                         try {
                             Name classElementQualifiedName = typeElement.getQualifiedName();
                             if ("java.lang.Record".equals(classElementQualifiedName.toString())) {

--- a/inject-java/src/test/groovy/io/micronaut/visitors/InterfaceGen.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/InterfaceGen.java
@@ -1,0 +1,8 @@
+package io.micronaut.visitors;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InterfaceGen {
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/InterfaceGenVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/InterfaceGenVisitor.java
@@ -1,0 +1,52 @@
+package io.micronaut.visitors;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class InterfaceGenVisitor implements TypeElementVisitor<InterfaceGen, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        context.visitGeneratedSourceFile(
+            "test",
+            "GeneratedInterface",
+            element
+        ).ifPresent(sourceFile -> {
+            try {
+                sourceFile.write(writer -> writer.write("""
+                        package test;
+
+                        import io.micronaut.context.annotation.Executable;
+
+                        public interface GeneratedInterface {
+                            @Executable
+                            Bar test(Bar bar);
+                        }
+                        """));
+            } catch (Exception e) {
+                throw new ProcessingException(element, "Failed to generate a Parent interface: " + e.getMessage(), e);
+            }
+        });
+
+        context.visitGeneratedSourceFile(
+            "test",
+            "Bar",
+            element
+        ).ifPresent(sourceFile -> {
+            try {
+                sourceFile.write(writer -> writer.write("""
+                        package test;
+
+
+                        public class Bar {
+                        }
+                        """));
+            } catch (Exception e) {
+                throw new ProcessingException(element, "Failed to generate a Parent interface: " + e.getMessage(), e);
+            }
+        });
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -77,4 +77,36 @@ class IntroductionTestInterceptor
         then:
         introduction.getParentMethod() == 'good'
     }
+
+    void 'test postpone bean definition generation implementing generated interface'() {
+        when:
+        def context = buildContext('test.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.visitors.InterfaceGen;
+import io.micronaut.visitors.IntroductionTestGen;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import jakarta.inject.Singleton;
+
+
+@InterfaceGen
+class Foo {}
+
+@Singleton
+class MyBean implements GeneratedInterface  {
+    @Override
+    public Bar test(Bar bar) {
+        return bar;
+    }
+}
+''')
+        def definition = getBeanDefinition(context, 'test.MyBean')
+
+        then:
+        definition.executableMethods.size() == 1
+    }
 }

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -1,3 +1,4 @@
+io.micronaut.visitors.InterfaceGenVisitor
 io.micronaut.visitors.ControllerGetVisitor
 io.micronaut.visitors.IntroductionVisitor
 io.micronaut.visitors.AllElementsVisitor


### PR DESCRIPTION
If the a bean definition implements a generated interface then the executable methods are skipped / empty because the first round of compilation caches the metadata for the methods. This PR clears the caches on the next round of compilation so that the metadata can be correctly rebuilt.