### PR TITLE
test:  Kotlin DataClasss serialised with JacksonDatabind require reflective access

### DIFF
--- a/inject/src/main/java/io/micronaut/context/condition/NotInNativeImage.java
+++ b/inject/src/main/java/io/micronaut/context/condition/NotInNativeImage.java
@@ -19,7 +19,7 @@ import io.micronaut.core.util.NativeImageUtils;
 
 /**
  * Condition to hide parts of an application that only work when running on the JVM.
- * Internal implementation is identical to {@code if (!ImageInfo.inImageCode()).
+ * Internal implementation is identical to {@code if (!ImageInfo.inImageCode())}.
  * @author Sergio del Amo
  * @since 4.8.0
  */

--- a/src/main/docs/guide/httpServer/jsonBinding/serializationUsingJacksonDatabind.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding/serializationUsingJacksonDatabind.adoc
@@ -4,7 +4,7 @@ dependency:micronaut-jackson-databind[]
 
 === Kotlin Data Classes Jackson Databind Serialization
 
-WARNING: If you use Kotlin https://kotlinlang.org/docs/data-classes.html[Data Classes] and Jackson Databind. Your data classes will be accessed via reflection for serialization. When you use https://www.graalvm.org/latest/reference-manual/native-image/[native image], you need to annotate those data classes with ann:core.annotation.ReflectiveAccess[]
+WARNING: If you use Kotlin https://kotlinlang.org/docs/data-classes.html[Data Classes] and Jackson Databind. Your data classes will be accessed via reflection for serialization. When you use https://www.graalvm.org/latest/reference-manual/native-image/[native image], you need to annotate those data classes with ann:core.annotation.ReflectiveAccess[]. Learn more about <<graal, Micronaut GraalVM>> integration.
 
 [source, kotlin]
 ----

--- a/src/main/docs/guide/httpServer/jsonBinding/serializationUsingJacksonDatabind.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding/serializationUsingJacksonDatabind.adoc
@@ -1,3 +1,12 @@
 To serialize using https://github.com/FasterXML/jackson[Jackson] Databind include the following dependency:
 
 dependency:micronaut-jackson-databind[]
+
+=== Kotlin Data Classes Jackson Databind Serialization
+
+WARNING: If you use Kotlin https://kotlinlang.org/docs/data-classes.html[Data Classes] and Jackson Databind. Your data classes will be accessed via reflection for serialization. When you use https://www.graalvm.org/latest/reference-manual/native-image/[native image], you need to annotate those data classes with ann:core.annotation.ReflectiveAccess[]
+
+[source, kotlin]
+----
+include::test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/Greeting.kt[tags=clazz,indent=0]
+----

--- a/test-suite-kotlin-graalvm/build.gradle.kts
+++ b/test-suite-kotlin-graalvm/build.gradle.kts
@@ -13,6 +13,7 @@ tasks.withType<Test>().configureEach {
 dependencies {
     testImplementation(libs.managed.kotlin.reflect)
     kspTest(projects.micronautInjectKotlin)
+    kspTest(projects.micronautGraal)
     testImplementation(projects.micronautHttpServerNetty)
     testImplementation(projects.micronautHttpClient)
     testImplementation(projects.micronautJacksonDatabind)

--- a/test-suite-kotlin-graalvm/build.gradle.kts
+++ b/test-suite-kotlin-graalvm/build.gradle.kts
@@ -11,6 +11,7 @@ tasks.withType<Test>().configureEach {
 }
 
 dependencies {
+    testImplementation(libs.managed.kotlin.reflect)
     kspTest(projects.micronautInjectKotlin)
     testImplementation(projects.micronautHttpServerNetty)
     testImplementation(projects.micronautHttpClient)

--- a/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/DataClassSerializationTest.kt
+++ b/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/DataClassSerializationTest.kt
@@ -1,0 +1,35 @@
+package example.micronaut.jacksondatabind
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+
+@Property(name = "spec.name", value = "JacksonDatabindDataClassSerialization")
+@MicronautTest
+class DataClassSerializationTest {
+
+    @Inject
+    lateinit var client: GreetingClient
+
+    @Test
+    fun testHelloGet() {
+        Assertions.assertEquals(
+                "Hola Mundo",
+                Flux.from(client.hello()).blockFirst()!!.message
+        )
+    }
+}
+
+@Property(name = "spec.name", value = "JacksonDatabindDataClassSerialization")
+@Client("/")
+interface GreetingClient {
+
+    @Get("/hola")
+    fun hello() : Publisher<Greeting>
+}

--- a/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/Greeting.kt
+++ b/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/Greeting.kt
@@ -1,0 +1,9 @@
+package example.micronaut.jacksondatabind
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
+
+@Requires(property = "spec.name", value = "JacksonDatabindDataClassSerialization")
+@Introspected
+data class Greeting(val message: String)

--- a/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/Greeting.kt
+++ b/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/Greeting.kt
@@ -5,5 +5,8 @@ import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.ReflectiveAccess
 
 @Requires(property = "spec.name", value = "JacksonDatabindDataClassSerialization")
+//tag::clazz[]
+@ReflectiveAccess
 @Introspected
 data class Greeting(val message: String)
+//end::clazz[]

--- a/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/GreetingService.kt
+++ b/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/GreetingService.kt
@@ -1,0 +1,12 @@
+package example.micronaut.jacksondatabind
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import jakarta.inject.Singleton
+import reactor.core.publisher.Mono
+
+@Requires(property = "spec.name", value = "JacksonDatabindDataClassSerialization")
+@Singleton
+class GreetingService {
+    fun sayHi(): Greeting = Greeting("Hola Mundo")
+}

--- a/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/HolaController.kt
+++ b/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/jacksondatabind/HolaController.kt
@@ -1,0 +1,12 @@
+package example.micronaut.jacksondatabind
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Requires(property = "spec.name", value = "JacksonDatabindDataClassSerialization")
+@Controller
+class HolaController(private val greetingService: GreetingService) {
+    @Get("/hola")
+    fun sayHi(): Greeting = greetingService.sayHi()
+}


### PR DESCRIPTION
[With Jackson Databind 2.17 `@ReflectiveAccess` was not necessary.](https://github.com/micronaut-projects/micronaut-core/pull/11697). With JacksonDatabind 2.18, `@ReflectiveAccess` is necessary. 