### PR TITLE
doc: split bean mapper merging docs

### DIFF
--- a/src/main/docs/guide/ioc/beanMappers.adoc
+++ b/src/main/docs/guide/ioc/beanMappers.adoc
@@ -46,28 +46,4 @@ You can retrieve from the context or inject a bean of type `ProductMappers`. The
 
 snippet::io.micronaut.docs.ioc.mappers.MappersSpec[tags="mappers", indent="0"]
 
-=== Merging example
 
-Given the following types:
-
-snippet::io.micronaut.docs.ioc.mappers.ChristmasTypes[tags="beans", indent=0]
-
-You can write an interface and method to merge the types by simply specifying two or more
-arguments to the method and annotating the method with ann:context.annotation.Mapper[@Mapper].
-Optionally, define custom mapping rules using ann:context.annotation.Mapper.Mapping[@Mapping].
-
-snippet::io.micronaut.docs.ioc.mappers.ChristmasMappers[tags="imports, mapper"]
-
-You can then inject the type `ChristmasMappers` and easily merge the types.
-
-snippet::io.micronaut.docs.ioc.mappers.MappersSpec[tags="merge", indent=0]
-
-=== Additional Mapping Examples
-
-And much more is possible! See more mapping examples in the following snippet.
-
-snippet::io.micronaut.docs.ioc.mappers.AdditionalMappers[tags="mapper", indent=0]
-
-<1> Merge three or more types.
-<2> Create mappings that specify `Map` as a parameter and define mappings for this parameter.
-<3> Define a custom merge strategy as a singleton and use it for mapping.

--- a/src/main/docs/guide/ioc/beanMappers/beanMappersMerging.adoc
+++ b/src/main/docs/guide/ioc/beanMappers/beanMappersMerging.adoc
@@ -1,0 +1,13 @@
+Given the following types:
+
+snippet::io.micronaut.docs.ioc.mappers.ChristmasTypes[tags="beans", indent=0]
+
+You can write an interface and method to merge the types by simply specifying two or more
+arguments to the method and annotating the method with ann:context.annotation.Mapper[@Mapper].
+Optionally, define custom mapping rules using ann:context.annotation.Mapper.Mapping[@Mapping].
+
+snippet::io.micronaut.docs.ioc.mappers.ChristmasMappers[tags="imports, mapper"]
+
+You can then inject the type `ChristmasMappers` and easily merge the types.
+
+snippet::io.micronaut.docs.ioc.mappers.MappersSpec[tags="merge", indent=0]

--- a/src/main/docs/guide/ioc/beanMappers/beanMappersMerging/beanMappersMergingStrategy.adoc
+++ b/src/main/docs/guide/ioc/beanMappers/beanMappersMerging/beanMappersMergingStrategy.adoc
@@ -1,0 +1,7 @@
+And much more is possible! See more mapping examples in the following snippet.
+
+snippet::io.micronaut.docs.ioc.mappers.AdditionalMappers[tags="mapper", indent=0]
+
+<1> Merge three or more types.
+<2> Create mappings that specify `Map` as a parameter and define mappings for this parameter.
+<3> Define a custom merge strategy as a singleton and use it for mapping.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -58,7 +58,11 @@ ioc:
     beanWrapperApi: The BeanWrapper API
     jacksonAndBeanIntrospection: Jackson and Bean Introspection
     kotlinAndBeanIntrospection: Kotlin and Bean Introspection
-  beanMappers: Bean Mappers
+  beanMappers:
+    title: Bean Mappers
+    beanMappersMerging:
+      title: Bean Mappers Merging
+      beanMappersMergingStrategy: Merging Strategy
   beanValidation: Bean Validation
   annotationMetadata: Bean Annotation Metadata
   beanImport: Importing Beans from Libraries


### PR DESCRIPTION
Individual section facilitate the sharing of links to specific sections of the documentation.