### PR TITLE
Fix duplicate error in HTTP client

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/Http1ResponseHandler.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/Http1ResponseHandler.java
@@ -144,6 +144,7 @@ final class Http1ResponseHandler extends SimpleChannelInboundHandlerInstrumented
 
         @Override
         void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            transitionToState(ctx, this, AfterContent.INSTANCE);
             listener.fail(ctx, cause);
         }
     }


### PR DESCRIPTION
When there's two errors, the DefaultHttpClient would try to complete the same future twice, leading to a logged message. This change adds a state transition so that the second exception is handled by AfterContent, which leads to pool-level handling instead.

A test is not possible because the only thing fixed here is a superfluous log statement.