### PR TITLE
adds configuration endpoints.health.discovery-client-health.enabled

### DIFF
--- a/management/src/main/java/io/micronaut/management/health/indicator/discovery/DiscoveryClientHealthIndicator.java
+++ b/management/src/main/java/io/micronaut/management/health/indicator/discovery/DiscoveryClientHealthIndicator.java
@@ -16,9 +16,11 @@
 package io.micronaut.management.health.indicator.discovery;
 
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.discovery.DiscoveryClient;
 import io.micronaut.discovery.ServiceInstance;
 import io.micronaut.health.HealthStatus;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
 import jakarta.inject.Singleton;
@@ -41,6 +43,7 @@ import java.util.stream.Stream;
  */
 @Requires(beans = {DiscoveryClient.class, DiscoveryClientHealthIndicatorConfiguration.class})
 @Singleton
+@Requires(property = HealthEndpoint.PREFIX + ".discovery-client-health.enabled", defaultValue = StringUtils.TRUE, notEquals = StringUtils.FALSE)
 public class DiscoveryClientHealthIndicator implements HealthIndicator {
 
     private final DiscoveryClient discoveryClient;

--- a/management/src/test/java/io/micronaut/management/health/indicator/client/ServiceHttpClientHealthIndicatorTest.java
+++ b/management/src/test/java/io/micronaut/management/health/indicator/client/ServiceHttpClientHealthIndicatorTest.java
@@ -1,0 +1,36 @@
+package io.micronaut.management.health.indicator.client;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
+import io.micronaut.management.health.aggregator.DefaultHealthAggregator;
+import io.micronaut.management.health.indicator.discovery.DiscoveryClientHealthIndicator;
+import io.micronaut.management.health.indicator.diskspace.DiskSpaceIndicator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceHttpClientHealthIndicatorTest {
+
+    @Test
+    void serviceHttpClientHealthIndicatorViaConfiguration() {
+        Consumer<ApplicationContext> healthBeansConsumer = context -> {
+            assertTrue(context.containsBean(HealthEndpoint.class));
+            assertTrue(context.containsBean(DefaultHealthAggregator.class));
+        };
+        Map<String, Object> configuration = Map.of("endpoints.health.service-http-client.enabled", StringUtils.FALSE);
+        try (ApplicationContext context = ApplicationContext.run(configuration)) {
+            healthBeansConsumer.accept(context);
+            assertFalse(context.containsBean(ServiceHttpClientHealthIndicator.class));
+        }
+        // service http client health indicator is disabled by default
+        try (ApplicationContext context = ApplicationContext.run()) {
+            healthBeansConsumer.accept(context);
+            assertFalse(context.containsBean(ServiceHttpClientHealthIndicator.class));
+        }
+    }
+}

--- a/management/src/test/java/io/micronaut/management/health/indicator/discovery/DiscoveryClientHealthIndicatorTest.java
+++ b/management/src/test/java/io/micronaut/management/health/indicator/discovery/DiscoveryClientHealthIndicatorTest.java
@@ -1,0 +1,40 @@
+package io.micronaut.management.health.indicator.discovery;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
+import io.micronaut.management.health.aggregator.DefaultHealthAggregator;
+import io.micronaut.management.health.indicator.diskspace.DiskSpaceIndicator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DiscoveryClientHealthIndicatorTest {
+
+    @Test
+    void disableDiscoveryClientHealthIndicatorViaConfiguration() {
+        Consumer<ApplicationContext> healthBeansConsumer = context -> {
+            assertTrue(context.containsBean(HealthEndpoint.class));
+            assertTrue(context.containsBean(DefaultHealthAggregator.class));
+        };
+        Map<String, Object> configuration = Map.of("endpoints.health.discovery-client-health.enabled", StringUtils.FALSE);
+        try (ApplicationContext context = ApplicationContext.run(configuration)) {
+            healthBeansConsumer.accept(context);
+            assertFalse(context.containsBean(DiscoveryClientHealthIndicator.class));
+        }
+        configuration = Map.of("endpoints.health.discovery-client-health.enabled", StringUtils.TRUE);
+        try (ApplicationContext context = ApplicationContext.run(configuration)) {
+            healthBeansConsumer.accept(context);
+            assertTrue(context.containsBean(DiscoveryClientHealthIndicator.class));
+        }
+        // enabled by default
+        try (ApplicationContext context = ApplicationContext.run()) {
+            healthBeansConsumer.accept(context);
+            assertTrue(context.containsBean(DiscoveryClientHealthIndicator.class));
+        }
+    }
+}

--- a/management/src/test/java/io/micronaut/management/health/indicator/diskspace/DiskSpaceIndicatorTest.java
+++ b/management/src/test/java/io/micronaut/management/health/indicator/diskspace/DiskSpaceIndicatorTest.java
@@ -1,0 +1,35 @@
+package io.micronaut.management.health.indicator.diskspace;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
+import io.micronaut.management.health.aggregator.DefaultHealthAggregator;
+import io.micronaut.management.health.indicator.discovery.DiscoveryClientHealthIndicator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DiskSpaceIndicatorTest {
+
+    @Test
+    void diskSpaceHealthIndicatorViaConfiguration() {
+        Consumer<ApplicationContext> healthBeansConsumer = context -> {
+            assertTrue(context.containsBean(HealthEndpoint.class));
+            assertTrue(context.containsBean(DefaultHealthAggregator.class));
+        };
+        Map<String, Object> configuration = Map.of("endpoints.health.disk-space.enabled", StringUtils.FALSE);
+        try (ApplicationContext context = ApplicationContext.run(configuration)) {
+            healthBeansConsumer.accept(context);
+            assertFalse(context.containsBean(DiskSpaceIndicator.class));
+        }
+        // enabled by default
+        try (ApplicationContext context = ApplicationContext.run()) {
+            healthBeansConsumer.accept(context);
+            assertTrue(context.containsBean(DiskSpaceIndicator.class));
+        }
+    }
+}

--- a/management/src/test/java/io/micronaut/management/health/indicator/jdbc/JdbcIndicatorTest.java
+++ b/management/src/test/java/io/micronaut/management/health/indicator/jdbc/JdbcIndicatorTest.java
@@ -1,0 +1,87 @@
+package io.micronaut.management.health.indicator.jdbc;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JdbcIndicatorTest {
+
+    @Test
+    void jdbcHealthIndicatorViaConfiguration() {
+        Map<String, Object> configuration = Map.of(
+            "endpoints.health.jdbc.enabled", StringUtils.FALSE,
+            "spec.name", "JdbcIndicatorTest");
+        try (ApplicationContext context = ApplicationContext.run(configuration)) {
+            assertFalse(context.containsBean(JdbcIndicator.class));
+        }
+        // enabled by default
+        configuration = Map.of("spec.name", "JdbcIndicatorTest");
+        try (ApplicationContext context = ApplicationContext.run(configuration)) {
+            assertTrue(context.containsBean(JdbcIndicator.class));
+        }
+    }
+
+    @Requires(property = "spec.name", value = "JdbcIndicatorTest")
+    @Singleton
+    static class DataSourceMock implements DataSource {
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PrintWriter getLogWriter() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) throws SQLException {
+
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) throws SQLException {
+
+        }
+
+        @Override
+        public int getLoginTimeout() throws SQLException {
+            return 0;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return null;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return false;
+        }
+    }
+}

--- a/management/src/test/java/io/micronaut/management/health/indicator/service/ServiceReadyIndicatorTest.java
+++ b/management/src/test/java/io/micronaut/management/health/indicator/service/ServiceReadyIndicatorTest.java
@@ -1,0 +1,35 @@
+package io.micronaut.management.health.indicator.service;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
+import io.micronaut.management.health.aggregator.DefaultHealthAggregator;
+import io.micronaut.management.health.indicator.jdbc.JdbcIndicator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceReadyIndicatorTest {
+
+    @Test
+    void serviceReadyHealthIndicatorViaConfiguration() {
+        Consumer<ApplicationContext> healthBeansConsumer = context -> {
+            assertTrue(context.containsBean(HealthEndpoint.class));
+            assertTrue(context.containsBean(DefaultHealthAggregator.class));
+        };
+        Map<String, Object> configuration = Map.of("endpoints.health.service-ready-indicator-enabled", StringUtils.FALSE);
+        try (ApplicationContext context = ApplicationContext.run(configuration)) {
+            healthBeansConsumer.accept(context);
+            assertFalse(context.containsBean(ServiceReadyHealthIndicator.class));
+        }
+        // enabled by default
+        try (ApplicationContext context = ApplicationContext.run()) {
+            healthBeansConsumer.accept(context);
+            assertTrue(context.containsBean(ServiceReadyHealthIndicator.class));
+        }
+    }
+}

--- a/management/src/test/java/io/micronaut/management/health/indicator/threads/DeadlockedThreadsHealthIndicatorTest.java
+++ b/management/src/test/java/io/micronaut/management/health/indicator/threads/DeadlockedThreadsHealthIndicatorTest.java
@@ -1,18 +1,18 @@
 package io.micronaut.management.health.indicator.threads;
 
 import io.micronaut.context.ApplicationContext;
-import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.StartupEvent;
 import io.micronaut.core.type.Argument;
-import io.micronaut.health.HealthStatus;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.management.endpoint.health.DetailsVisibility;
-import io.micronaut.management.endpoint.health.HealthLevelOfDetail;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
+import io.micronaut.management.health.aggregator.DefaultHealthAggregator;
 import io.micronaut.runtime.server.EmbeddedServer;
 import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Test;
@@ -22,11 +22,23 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 class DeadlockedThreadsHealthIndicatorTest {
+    @Test
+    void diskSpaceHealthIndicatorViaConfiguration() {
+        Map<String, Object> configuration = Map.of("endpoints.health.deadlocked-threads.enabled", StringUtils.FALSE);
+        try (ApplicationContext context = ApplicationContext.run(configuration)) {
+            assertFalse(context.containsBean(DeadlockedThreadsHealthIndicator.class));
+        }
+        // enabled by default
+        try (ApplicationContext context = ApplicationContext.run()) {
+            assertTrue(context.containsBean(DeadlockedThreadsHealthIndicator.class));
+        }
+    }
 
     @Test
     void testDeadlockedThreadsHealthIndicator() {


### PR DESCRIPTION
Every other health indicator had a toggle.

It adds test for health indicators configuration toggles