### PR TITLE
Include Argument in BeanCreatedEvent

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/BeanCreationEventListenerSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/BeanCreationEventListenerSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2025 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package io.micronaut.inject.lifecycle.beancreationeventlistener
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
-import io.micronaut.context.DefaultBeanContext
 import io.micronaut.context.exceptions.CircularDependencyException
+import io.micronaut.core.type.Argument
 import io.micronaut.inject.lifecycle.beancreationeventlistener.circular.Bar
 import io.micronaut.inject.lifecycle.beancreationeventlistener.circular.Foo
 import spock.lang.Specification
@@ -110,7 +110,7 @@ class BeanCreationEventListenerSpec extends Specification {
     void "test application bean creation listener"() {
         given:
         ApplicationContext context = ApplicationContext.run()
-        
+
         when:
         B b = context.getBean(B)
 
@@ -155,5 +155,26 @@ class BeanCreationEventListenerSpec extends Specification {
 
         cleanup:
         context.close()
+    }
+
+    void "test bean type in listener"() {
+        when:
+        ApplicationContext context = ApplicationContext.run()
+        I I = context.getBean(Argument.of(I.class, "someName"))
+
+        ICreatedListener iListener = context.getBean(ICreatedListener);
+        JCreatedListener jListener = context.getBean(JCreatedListener);
+
+        then: "Bean type passed to getBean is passed to listener"
+        iListener.executed
+        Argument<I> iBeanType = iListener.beanType
+        iBeanType.getType() == I.class
+        iBeanType.getName() == "someName"
+
+        and: "Bean type for J listener matches injected parameter name"
+        jListener.executed
+        Argument<J> jBeanType = jListener.beanType
+        jBeanType.getType() == J.class
+        jBeanType.getName() == "someParamName"
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/I.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/I.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beancreationeventlistener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class I {
+    public I(J someParamName) {}
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/ICreatedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/ICreatedListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beancreationeventlistener;
+
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.type.Argument;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ICreatedListener implements BeanCreatedEventListener<I> {
+    boolean executed;
+    Argument<I> beanType;
+
+    @Override
+    public I onCreated(BeanCreatedEvent<I> event) {
+        executed = true;
+        beanType = event.getBeanType();
+        return event.getBean();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/J.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/J.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beancreationeventlistener;
+
+import io.micronaut.context.annotation.Bean;
+
+@Bean
+public class J {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/JCreatedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beancreationeventlistener/JCreatedListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beancreationeventlistener;
+
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.type.Argument;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class JCreatedListener implements BeanCreatedEventListener<J> {
+    boolean executed;
+    Argument<J> beanType;
+
+    @Override
+    public J onCreated(BeanCreatedEvent<J> event) {
+        assert !executed : "JCreatedListener is being triggered more than once";
+        executed = true;
+        beanType = event.getBeanType();
+        return event.getBean();
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/event/BeanCreatedEvent.java
+++ b/inject/src/main/java/io/micronaut/context/event/BeanCreatedEvent.java
@@ -16,6 +16,8 @@
 package io.micronaut.context.event;
 
 import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
 
@@ -31,15 +33,30 @@ public class BeanCreatedEvent<T> extends BeanEvent<T> {
 
     private final BeanIdentifier beanIdentifier;
 
+    private final @NonNull Argument<T> beanType;
+
+    public BeanCreatedEvent(BeanContext beanContext,
+                            BeanDefinition<T> beanDefinition,
+                            BeanIdentifier beanIdentifier,
+                            T bean) {
+        this(beanContext, beanDefinition, beanIdentifier, beanDefinition.asArgument(), bean);
+    }
+
     /**
      * @param beanContext    The bean context
      * @param beanDefinition The bean definition
      * @param beanIdentifier The bean identifier
+     * @param beanType       The {@link Argument} used to create the bean
      * @param bean           The bean
      */
-    public BeanCreatedEvent(BeanContext beanContext, BeanDefinition<T> beanDefinition, BeanIdentifier beanIdentifier, T bean) {
+    public BeanCreatedEvent(BeanContext beanContext,
+                            BeanDefinition<T> beanDefinition,
+                            BeanIdentifier beanIdentifier,
+                            @NonNull Argument<T> beanType,
+                            T bean) {
         super(beanContext, beanDefinition, bean);
         this.beanIdentifier = beanIdentifier;
+        this.beanType = beanType;
     }
 
     /**
@@ -47,5 +64,14 @@ public class BeanCreatedEvent<T> extends BeanEvent<T> {
      */
     public BeanIdentifier getBeanIdentifier() {
         return beanIdentifier;
+    }
+
+    /**
+     * @return The argument used to create the bean
+     * @since 4.9.0
+     */
+    @NonNull
+    public Argument<T> getBeanType() {
+        return beanType;
     }
 }


### PR DESCRIPTION
Provides the `Argument<T>` instance that was used to create the bean in the `BeanCreatedEvent`.

In many cases, this is just `Argument.of(beanType)`, but for `createRegistration` this is actually a proper `Argument` instance provided by the user or the dependency injector.