### PR TITLE
improve error message when multiple bean candidates are present and all are Secondary

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -3278,13 +3278,13 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
         if (candidates.size() == 1) {
             return candidates.iterator().next();
         }
-        Collection<BeanDefinition<T>> candidates originalCandidates = candidates;
+        Collection<BeanDefinition<T>> originalCandidates = candidates;
         candidates = candidates.stream().filter(candidate -> !candidate.hasDeclaredStereotype(Secondary.class)).toList();
         if (candidates.size() == 1) {
             return candidates.iterator().next();
         }
-        if (candidates.size() == 0) {
-            throw new NonUniqueBeanException(beanType, originalCandidates.iterator());
+        if (candidates.isEmpty()) {
+            throw new NonUniqueBeanException(beanType.getType(), originalCandidates.iterator());
         }
         // pick the bean with the highest priority
         ArrayList<BeanDefinition<T>> listCandidates = new ArrayList<>(candidates);

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -3278,9 +3278,13 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
         if (candidates.size() == 1) {
             return candidates.iterator().next();
         }
+        Collection<BeanDefinition<T>> candidates originalCandidates = candidates;
         candidates = candidates.stream().filter(candidate -> !candidate.hasDeclaredStereotype(Secondary.class)).toList();
         if (candidates.size() == 1) {
             return candidates.iterator().next();
+        }
+        if (candidates.size() == 0) {
+            throw new NonUniqueBeanException(beanType, originalCandidates.iterator());
         }
         // pick the bean with the highest priority
         ArrayList<BeanDefinition<T>> listCandidates = new ArrayList<>(candidates);

--- a/test-suite/src/test/java/io/micronaut/context/DefaultBeanContextTest.java
+++ b/test-suite/src/test/java/io/micronaut/context/DefaultBeanContextTest.java
@@ -1,0 +1,29 @@
+package io.micronaut.context;
+
+import io.micronaut.context.annotation.Secondary;
+import io.micronaut.context.exceptions.NonUniqueBeanException;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import spock.lang.Specification;
+
+class DefaultBeanContextTest extends Specification {
+    @Test
+    void testMultipleSecondaryBeans() {
+        try (DefaultBeanContext beanContext = new DefaultBeanContext()) {
+            beanContext.configure();
+            Assertions.assertThrows(
+                NonUniqueBeanException.class,
+                () -> beanContext.getBean(Foo.class)
+            );
+        }
+    }
+    // classes used by testMultipleSecondaryBeans
+    interface Foo {}
+    @Singleton
+    @Secondary
+    static class Foo1 implements Foo {}
+    @Singleton
+    @Secondary
+    static class Foo2 implements Foo {}
+}

--- a/test-suite/src/test/java/io/micronaut/context/DefaultBeanContextTest.java
+++ b/test-suite/src/test/java/io/micronaut/context/DefaultBeanContextTest.java
@@ -12,9 +12,14 @@ class DefaultBeanContextTest extends Specification {
     void testMultipleSecondaryBeans() {
         try (DefaultBeanContext beanContext = new DefaultBeanContext()) {
             beanContext.configure();
-            Assertions.assertThrows(
+            NonUniqueBeanException e = Assertions.assertThrows(
                 NonUniqueBeanException.class,
                 () -> beanContext.getBean(Foo.class)
+            );
+            Assertions.assertTrue(
+                "Multiple possible bean candidates found: [Foo1, Foo2]".equals(e.getMessage()) ||
+                    "Multiple possible bean candidates found: [Foo2, Foo1]".equals(e.getMessage()),
+                "Exception message was incorrect. Expected \"Multiple possible bean candidates found: [Foo1, Foo2]\"; got " + e.getMessage()
             );
         }
     }


### PR DESCRIPTION
e.g. if you have this code: (kotlin syntax, hopefully the intent is clear)
```kotlin
@Singleton
class SomeOtherBean(val foo: Foo)

interface Foo

@Singleton
@Secondary
class Foo1 : Foo

@Singleton
@Secondary
class Foo2 : Foo
```

micronaut throws a cryptic `java.util.NoSuchElementException`, because it blindly calls `iterator.next()`.

This PR just adds a check for empty list, and throws a more informative exception.

(wasn't sure how to update the unit tests to verify this - DefaultBeanContextSpec didn't seem like the right place? I'd appreciate a pointer to the relevant test suite)