### PR TITLE
Update KotlinVisitorContext.kt to accommodate changes in Kotlin 2.1.20

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
@@ -79,7 +79,14 @@ internal class KotlinVisitorContext(
             val resolverImplClass = ClassUtils.forName("com.google.devtools.ksp.processing.impl.ResolverImpl", javaClass.classLoader).orElseThrow()
             val kotlinTypeMapperClass = ClassUtils.forName("org.jetbrains.kotlin.codegen.state.KotlinTypeMapper", javaClass.classLoader).orElseThrow()
             val kotlinTypeMapperInstance = ReflectionUtils.getFieldValue(resolverImplClass, "typeMapper", resolver).orElseThrow()
-            ReflectionUtils.setField(kotlinTypeMapperClass, "useOldManglingRulesForFunctionAcceptingInlineClass", kotlinTypeMapperInstance, false)
+            try {
+                // Pre-2.1.20 field name
+                ReflectionUtils.setField(kotlinTypeMapperClass, "useOldManglingRulesForFunctionAcceptingInlineClass", kotlinTypeMapperInstance, false)
+            } catch (e: Exception) {
+                // Ignore
+            }
+            // 2.1.20+ field name
+            ReflectionUtils.setField(kotlinTypeMapperClass, "useOldInlineClassesManglingScheme", kotlinTypeMapperInstance, false)
         } catch (e: Exception) {
             // Ignore
         }


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/commit/a4e7d036504416f10e41cca4afb1cb48cf5803a2 refactored KotlinTypeMapper and removed the field this code was adjusting.

Ref: https://github.com/micronaut-projects/micronaut-core/issues/5290, https://github.com/google/ksp/issues/1493