### PR TITLE
Implement jitter in @Retryable to avoid thundering herd

### DIFF
--- a/retry/src/main/java/io/micronaut/retry/RetryState.java
+++ b/retry/src/main/java/io/micronaut/retry/RetryState.java
@@ -69,6 +69,11 @@ public interface RetryState {
     Optional<Duration> getMaxDelay();
 
     /**
+     * @return The jitter factor used to apply random deviation to retry delays
+     */
+    OptionalDouble getJitter();
+
+    /**
      * @return The retry predicate checking for includes/excludes throwable classes
      */
     default RetryPredicate getRetryPredicate() {

--- a/retry/src/main/java/io/micronaut/retry/RetryState.java
+++ b/retry/src/main/java/io/micronaut/retry/RetryState.java
@@ -71,7 +71,9 @@ public interface RetryState {
     /**
      * @return The jitter factor used to apply random deviation to retry delays
      */
-    OptionalDouble getJitter();
+    default OptionalDouble getJitter() {
+        return OptionalDouble.empty();
+    }
 
     /**
      * @return The retry predicate checking for includes/excludes throwable classes

--- a/retry/src/main/java/io/micronaut/retry/annotation/Retryable.java
+++ b/retry/src/main/java/io/micronaut/retry/annotation/Retryable.java
@@ -91,4 +91,10 @@ public @interface Retryable {
      * @return The capture exception types (defaults to RuntimeException)
      */
     Class<? extends Throwable> capturedException() default RuntimeException.class;
+
+    /**
+     * @return The jitter factor used to apply random deviation to retry delays
+     */
+    @Digits(integer = 1, fraction = 2)
+    String jitter() default "0.25";
 }

--- a/retry/src/main/java/io/micronaut/retry/annotation/Retryable.java
+++ b/retry/src/main/java/io/micronaut/retry/annotation/Retryable.java
@@ -96,5 +96,5 @@ public @interface Retryable {
      * @return The jitter factor used to apply random deviation to retry delays
      */
     @Digits(integer = 1, fraction = 2)
-    String jitter() default "0.25";
+    String jitter() default "0.0";
 }

--- a/retry/src/main/java/io/micronaut/retry/intercept/AnnotationRetryStateBuilder.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/AnnotationRetryStateBuilder.java
@@ -43,6 +43,7 @@ class AnnotationRetryStateBuilder implements RetryStateBuilder {
     private static final String EXCLUDES = "excludes";
     private static final String PREDICATE = "predicate";
     private static final String CAPTURED_EXCEPTION = "capturedException";
+    private static final String JITTER = "jitter";
     private static final int DEFAULT_RETRY_ATTEMPTS = 3;
 
     private final AnnotationMetadata annotationMetadata;
@@ -76,7 +77,8 @@ class AnnotationRetryStateBuilder implements RetryStateBuilder {
             delay,
             retry.get(MAX_DELAY, Duration.class).orElse(null),
             predicate,
-            capturedException
+            capturedException,
+            retry.get(JITTER, Double.class).orElse(0d)
         );
     }
 

--- a/retry/src/main/java/io/micronaut/retry/intercept/CircuitBreakerRetry.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/CircuitBreakerRetry.java
@@ -162,6 +162,11 @@ class CircuitBreakerRetry implements MutableRetryState {
         return childState.getCapturedException();
     }
 
+    @Override
+    public OptionalDouble getJitter() {
+        return childState.getJitter();
+    }
+
     /**
      * @return The current state
      */

--- a/retry/src/main/java/io/micronaut/retry/intercept/SimpleRetry.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/SimpleRetry.java
@@ -23,6 +23,7 @@ import io.micronaut.retry.annotation.RetryPredicate;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.OptionalDouble;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -44,6 +45,7 @@ class SimpleRetry implements RetryState, MutableRetryState {
     private final AtomicLong overallDelay = new AtomicLong(0);
     private final RetryPredicate predicate;
     private final Class<? extends Throwable> capturedException;
+    private final double jitter;
 
     /**
      * @param maxAttempts The maximum number of attempts
@@ -59,7 +61,8 @@ class SimpleRetry implements RetryState, MutableRetryState {
         Duration delay,
         Duration maxDelay,
         RetryPredicate predicate,
-        Class<? extends Throwable> capturedException) {
+        Class<? extends Throwable> capturedException,
+        double jitter) {
 
         this.maxAttempts = maxAttempts;
         this.multiplier = multiplier;
@@ -67,6 +70,7 @@ class SimpleRetry implements RetryState, MutableRetryState {
         this.maxDelay = maxDelay;
         this.predicate = predicate;
         this.capturedException = capturedException;
+        this.jitter = jitter;
     }
 
     /**
@@ -75,18 +79,20 @@ class SimpleRetry implements RetryState, MutableRetryState {
      * @param delay The overall delay so far
      * @param maxDelay The maximum overall delay
      * @param capturedException The capture exception types
+     * @param jitter The jitter factor used to apply random deviation to retry delays
      */
-    SimpleRetry(int maxAttempts, double multiplier, Duration delay, Duration maxDelay, Class<? extends Throwable> capturedException) {
-        this(maxAttempts, multiplier, delay, maxDelay, new DefaultRetryPredicate(), capturedException);
+    SimpleRetry(int maxAttempts, double multiplier, Duration delay, Duration maxDelay, Class<? extends Throwable> capturedException, double jitter) {
+        this(maxAttempts, multiplier, delay, maxDelay, new DefaultRetryPredicate(), capturedException, jitter);
     }
 
     /**
      * @param maxAttempts The maximum number of attempts
      * @param multiplier The multiplier to use between delays
      * @param delay The overall delay so far
+     * @param jitter The jitter factor used to apply random deviation to retry delays
      */
-    SimpleRetry(int maxAttempts, double multiplier, Duration delay) {
-        this(maxAttempts, multiplier, delay, null, null);
+    SimpleRetry(int maxAttempts, double multiplier, Duration delay, double jitter) {
+        this(maxAttempts, multiplier, delay, null, null, jitter);
     }
 
     /**
@@ -166,6 +172,14 @@ class SimpleRetry implements RetryState, MutableRetryState {
     }
 
     /**
+     * @return The jitter factor used to apply random deviation to retry delays
+     */
+    @Override
+    public OptionalDouble getJitter() {
+        return jitter > 0 ? OptionalDouble.of(jitter) : OptionalDouble.empty();
+    }
+
+    /**
      * @return Return the millisecond value for the next delay
      */
     @Override
@@ -173,6 +187,10 @@ class SimpleRetry implements RetryState, MutableRetryState {
     public long nextDelay() {
         double multiplier = getMultiplier().orElse(1.0);
         long delay = (long) ((getDelay().toMillis()) * pow(multiplier, attemptNumber.get() - 1));
+        double jitter = getJitter().orElse(0);
+        if(jitter > 0) {
+            delay = Math.max(0, (long) (delay * (1.0 + ThreadLocalRandom.current().nextDouble(-jitter, jitter))));
+        }
         overallDelay.addAndGet(delay);
         return delay;
     }

--- a/retry/src/main/java/io/micronaut/retry/intercept/SimpleRetry.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/SimpleRetry.java
@@ -188,7 +188,7 @@ class SimpleRetry implements RetryState, MutableRetryState {
         double multiplier = getMultiplier().orElse(1.0);
         long delay = (long) ((getDelay().toMillis()) * pow(multiplier, attemptNumber.get() - 1));
         double jitter = getJitter().orElse(0);
-        if(jitter > 0) {
+        if (jitter > 0) {
             delay = Math.max(0, (long) (delay * (1.0 + ThreadLocalRandom.current().nextDouble(-jitter, jitter))));
         }
         overallDelay.addAndGet(delay);

--- a/retry/src/test/groovy/io/micronaut/retry/intercept/CircuitBreakerRetrySpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/intercept/CircuitBreakerRetrySpec.groovy
@@ -38,7 +38,7 @@ class CircuitBreakerRetrySpec extends Specification {
         CircuitBreakerRetry retry = new CircuitBreakerRetry(
                 1000,
                 {->
-                    new SimpleRetry(3, 2.0d, Duration.ofMillis(500))
+                    new SimpleRetry(3, 2.0d, Duration.ofMillis(500), 0)
                 }, null,null,false
         )
         retry.open()

--- a/retry/src/test/groovy/io/micronaut/retry/intercept/SimpleRetryInstanceSpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/intercept/SimpleRetryInstanceSpec.groovy
@@ -134,4 +134,109 @@ class SimpleRetryInstanceSpec extends Specification {
         retryContext.nextDelay() == 4000
 
     }
+
+    void "test retry context next delay with negative jitter"() {
+        given:
+        SimpleRetry retryContext = new SimpleRetry(
+                1,
+                1,
+                Duration.of(1, ChronoUnit.SECONDS),
+                -0.25
+        )
+        RuntimeException r = new RuntimeException("bad")
+
+        when:
+        retryContext.canRetry(r)
+
+        then:
+        retryContext.nextDelay() == 1000
+    }
+
+    void "test retry context next delay with zero jitter"() {
+        given:
+        SimpleRetry retryContext = new SimpleRetry(
+                1,
+                1,
+                Duration.of(1, ChronoUnit.SECONDS),
+                0
+        )
+        RuntimeException r = new RuntimeException("bad")
+
+        when:
+        retryContext.canRetry(r)
+
+        then:
+        retryContext.nextDelay() == 1000
+    }
+
+    void "test retry context next delay with positive jitter"() {
+        given:
+        SimpleRetry retryContext = new SimpleRetry(
+                1,
+                1,
+                Duration.of(1, ChronoUnit.SECONDS),
+                0.25
+        )
+        RuntimeException r = new RuntimeException("bad")
+
+        when:
+        retryContext.canRetry(r)
+
+        then:
+        long delay = retryContext.nextDelay()
+        delay >= 750 && delay <= 1250
+    }
+
+    void "test retry context next delay with jitter greater than 1.0"() {
+        given:
+        SimpleRetry retryContext = new SimpleRetry(
+                1,
+                1,
+                Duration.of(1, ChronoUnit.SECONDS),
+                1.25
+        )
+        RuntimeException r = new RuntimeException("bad")
+
+        when:
+        retryContext.canRetry(r)
+
+        then:
+        long delay = retryContext.nextDelay()
+        delay >= 0 && delay <= 2250
+    }
+
+    void "test retry context next delay is exponential with jitter"() {
+        given:
+        SimpleRetry retryContext = new SimpleRetry(
+                3,
+                2,
+                Duration.of(1, ChronoUnit.SECONDS),
+                0.25
+        )
+        RuntimeException r = new RuntimeException("bad")
+
+        when:
+        retryContext.canRetry(r)
+
+        then:
+        retryContext.currentAttempt() == 1
+        long delay1 = retryContext.nextDelay()
+        delay1 >= 750 && delay1 <= 1250
+
+        when:
+        retryContext.canRetry(r)
+
+        then:
+        retryContext.currentAttempt() == 2
+        long delay2 = retryContext.nextDelay()
+        delay2 >= 1500 && delay2 <= 2500
+
+        when:
+        retryContext.canRetry(r)
+
+        then:
+        retryContext.currentAttempt() == 3
+        long delay3 = retryContext.nextDelay()
+        delay3 >= 3000 && delay3 <= 5000
+    }
 }

--- a/retry/src/test/groovy/io/micronaut/retry/intercept/SimpleRetryInstanceSpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/intercept/SimpleRetryInstanceSpec.groovy
@@ -37,7 +37,8 @@ class SimpleRetryInstanceSpec extends Specification {
                 Duration.of(1, ChronoUnit.SECONDS),
                 null,
                 new DefaultRetryPredicate(Collections.singletonList(DiscoveryException.class), Collections.emptyList()),
-                RuntimeException.class
+                RuntimeException.class,
+                0
         )
         RuntimeException r = new RuntimeException("bad")
 
@@ -55,7 +56,8 @@ class SimpleRetryInstanceSpec extends Specification {
                 Duration.of(1, ChronoUnit.SECONDS),
                 null,
                 new DefaultRetryPredicate(Collections.emptyList(), Collections.singletonList(DiscoveryException.class)),
-                RuntimeException.class
+                RuntimeException.class,
+                0
         )
         RuntimeException r = new RuntimeException("bad")
 
@@ -68,7 +70,7 @@ class SimpleRetryInstanceSpec extends Specification {
     void "test retry context next delay is exponential"() {
 
         given:
-        SimpleRetry retryContext = new SimpleRetry(3, 2, Duration.of(1, ChronoUnit.SECONDS))
+        SimpleRetry retryContext = new SimpleRetry(3, 2, Duration.of(1, ChronoUnit.SECONDS), 0)
         RuntimeException r = new RuntimeException("bad")
 
         when:
@@ -104,7 +106,8 @@ class SimpleRetryInstanceSpec extends Specification {
                 2,
                 Duration.of(1, ChronoUnit.SECONDS),
                 Duration.of(3, ChronoUnit.SECONDS),
-                RuntimeException.class
+                RuntimeException.class,
+                0
         )
         RuntimeException r = new RuntimeException("bad")
 


### PR DESCRIPTION
This PR introduces a jitter parameter to the `@Retryable` annotation, as requested in issue #11631.

Closes #11631
