### PR TITLE
Don't clear metadata already cleared by type element visitor

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -1848,6 +1848,16 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
          */
         void update(@NonNull AnnotationMetadata annotationMetadata);
 
+        /**
+         * @return Was the metadata cleared by a previous processor.
+         */
+        boolean wasCleared();
+
+        /**
+         * Mark as cleared.
+         */
+        void markCleared();
+
     }
 
     /**
@@ -1887,6 +1897,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         @Nullable
         private AnnotationMetadata annotationMetadata;
         private boolean isMutated;
+        private boolean cleared;
 
         public DefaultCachedAnnotationMetadata(AnnotationMetadata annotationMetadata) {
             if (annotationMetadata instanceof AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata) {
@@ -1915,6 +1926,16 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             }
             this.annotationMetadata = annotationMetadata;
             isMutated = true;
+        }
+
+        @Override
+        public boolean wasCleared() {
+            return cleared;
+        }
+
+        @Override
+        public void markCleared() {
+            this.cleared = true;
         }
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
@@ -224,6 +224,16 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
             public void update(AnnotationMetadata annotationMetadata) {
                 throw new IllegalStateException("Class element: [" + classElement + "] doesn't support type annotations!");
             }
+
+            @Override
+            public boolean wasCleared() {
+                return false;
+            }
+
+            @Override
+            public void markCleared() {
+                // no-op
+            }
         };
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -179,8 +179,11 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                         PostponeToNextRoundException nextRoundException = postponed.get(className);
                         if (nextRoundException != null) {
                             Object errorElement = nextRoundException.getErrorElement();
-                            if (errorElement != null) {
-                                AbstractAnnotationMetadataBuilder.clearMutated(errorElement);
+                            if (errorElement instanceof Element element) {
+                                AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata cachedAnnotationMetadata = javaVisitorContext.getAnnotationMetadataBuilder().lookupOrBuildForType(element);
+                                if (!cachedAnnotationMetadata.wasCleared()) {
+                                    AbstractAnnotationMetadataBuilder.clearMutated(errorElement);
+                                }
                             }
                         }
                         try {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -459,7 +459,13 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
     private boolean isValidDefaultValue(ExecutableElement executableElement) {
         AnnotationValue defaultValue = executableElement.getDefaultValue();
         if (defaultValue != null) {
-            Object v = defaultValue.getValue();
+            Object v;
+            try {
+                v = defaultValue.getValue();
+            } catch (UnsupportedOperationException e) {
+                // if this is Attribute it can throw UnsupportedOperationException
+                return false;
+            }
             if (v != null) {
                 if (v instanceof String string) {
                     return StringUtils.isNotEmpty(string);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -245,6 +245,10 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
 
             for (Object nativeType : postponedTypes.values()) {
                 AbstractAnnotationMetadataBuilder.clearMutated(nativeType);
+                if (nativeType instanceof Element element) {
+                    AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata cachedAnnotationMetadata = javaVisitorContext.getAnnotationMetadataBuilder().lookupOrBuildForType(element);
+                    cachedAnnotationMetadata.markCleared();
+                }
             }
             postponedTypes.keySet().stream().map(elementUtils::getTypeElement).filter(Objects::nonNull).forEach(elements::add);
             postponedTypes.clear();

--- a/inject-java/src/test/groovy/io/micronaut/visitors/CollectingVisitor.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/CollectingVisitor.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.visitors
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.http.annotation.Get
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.MethodElement
+import io.micronaut.inject.ast.UnresolvedTypeKind
+import io.micronaut.inject.visitor.ElementPostponedToNextRoundException
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+class CollectingVisitor implements TypeElementVisitor<Object, Object> {
+
+    static int numVisited = 0
+    static int numMethodVisited = 0
+    static boolean hasIntrospected
+    static String getPath
+
+    @Override
+    void visitClass(ClassElement element, VisitorContext context) {
+        if (element.getName() != "example.Child") {
+            return
+        }
+
+        if (element.hasUnresolvedTypes(UnresolvedTypeKind.INTERFACE)) {
+            throw new ElementPostponedToNextRoundException(element)
+        }
+
+        ++numVisited
+        hasIntrospected = element.hasStereotype(Introspected)
+    }
+
+    @Override
+    void visitMethod(MethodElement element, VisitorContext context) {
+        if (element.getOwningType().getName() != "example.Child") {
+            return
+        }
+
+        ++numMethodVisited
+        getPath = element.stringValue(Get).orElse(null)
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/GeneratorTrigger.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/GeneratorTrigger.java
@@ -1,0 +1,11 @@
+package io.micronaut.visitors;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GeneratorTrigger {
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/GeneratorVisitor.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/GeneratorVisitor.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.visitors
+
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+import org.intellij.lang.annotations.Language
+
+class GeneratorVisitor implements TypeElementVisitor<GeneratorTrigger, Object> {
+
+    private static final @Language("java") String SOURCE = """
+package example;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Introspected
+public interface Parent {
+
+    @Get("/get")
+    String hello();
+
+}
+"""
+
+    @Override
+    void visitClass(ClassElement element, VisitorContext context) {
+        if (element.hasDeclaredAnnotation(GeneratorTrigger)) {
+            context.visitGeneratedSourceFile("example", "Parent", element)
+                    .ifPresent(generatedFile -> {
+                        try {
+                            generatedFile.write(writer -> writer.write(SOURCE))
+                        } catch (IOException e) {
+                            throw new RuntimeException(e)
+                        }
+                    })
+        }
+
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTestGenVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTestGenVisitor.java
@@ -1,0 +1,31 @@
+package io.micronaut.visitors;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class IntroductionTestGenVisitor implements TypeElementVisitor<IntroductionTestGen, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+            context.visitGeneratedSourceFile(
+                "test",
+                "IntroductionTestParent",
+                element
+            ).ifPresent(sourceFile -> {
+                try {
+                    sourceFile.write(writer -> writer.write("""
+                        package test;
+
+                        public interface IntroductionTestParent {
+                            String getParentMethod();
+                        }
+                        """));
+                } catch (Exception e) {
+                    throw new ProcessingException(element, "Failed to generate a Parent introduction: " + e.getMessage(), e);
+                }
+            });
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTestVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTestVisitor.java
@@ -1,31 +1,33 @@
 package io.micronaut.visitors;
 
 import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.UnresolvedTypeKind;
+import io.micronaut.inject.visitor.ElementPostponedToNextRoundException;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 
-public class IntroductionTestVisitor implements TypeElementVisitor<IntroductionTestGen, Object> {
+public class IntroductionTestVisitor implements TypeElementVisitor<IntroductionTest, Object> {
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return TypeElementVisitor.super.getVisitorKind();
+    }
 
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
-            context.visitGeneratedSourceFile(
-                "test",
-                "IntroductionTestParent",
-                element
-            ).ifPresent(sourceFile -> {
-                try {
-                    sourceFile.write(writer -> writer.write("""
-                        package test;
-
-                        public interface IntroductionTestParent {
-                            String getParentMethod();
-                        }
-                        """));
-                } catch (Exception e) {
-                    throw new ProcessingException(element, "Failed to generate a Parent introduction: " + e.getMessage(), e);
-                }
-            });
+        if (element.hasDeclaredAnnotation(IntroductionTest.class)) {
+            if (element.hasUnresolvedTypes(UnresolvedTypeKind.INTERFACE)) {
+                throw new ElementPostponedToNextRoundException(element);
+            }
+        }
     }
 
+    @Override
+    public void visitMethod(MethodElement element, VisitorContext context) {
+        ClassElement owningType = element.getOwningType();
+        if (owningType.hasDeclaredAnnotation(IntroductionTest.class)) {
+            element.annotate("SomeAnnotation");
+        }
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -17,8 +17,6 @@ import org.intellij.lang.annotations.Language
 import spock.lang.PendingFeature
 
 class PostponedVisitorsSpec extends AbstractTypeElementSpec {
-    private CollectingVisitor collectingVisitor
-
     void 'test postpone introspection generation implementing generated interface'() {
         when:
             def definition = buildBeanIntrospection('test.Walrus', '''
@@ -131,7 +129,7 @@ package example;
 
 import jakarta.inject.Singleton;
 
-@Singleton
+@io.micronaut.visitors.GeneratorTrigger
 class Trigger {}
 
 // Parent is generated, we want to retrieve inherited annotations correctly
@@ -146,82 +144,10 @@ class Child implements Parent {
 }
 ''')
         then:
-        collectingVisitor.numVisited == 1
-        collectingVisitor.numMethodVisited == 1
-        collectingVisitor.getPath == "/get"
-        collectingVisitor.hasIntrospected
+        CollectingVisitor.numVisited == 1
+        CollectingVisitor.numMethodVisited == 1
+        CollectingVisitor.getPath == "/get"
+        CollectingVisitor.hasIntrospected
     }
 
-    @Override
-    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
-        collectingVisitor = new CollectingVisitor()
-        return List.of(new GeneratorVisitor(), collectingVisitor)
-    }
-
-    static class GeneratorVisitor implements TypeElementVisitor<Object, Object> {
-
-        private static final @Language("java") String SOURCE = """
-package example;
-
-import io.micronaut.core.annotation.Introspected;
-import io.micronaut.http.annotation.Controller;
-import io.micronaut.http.annotation.Get;
-
-@Introspected
-public interface Parent {
-
-    @Get("/get")
-    String hello();
-
-}
-"""
-
-        @Override
-        void visitClass(ClassElement element, VisitorContext context) {
-            if (element.getName() != "example.Trigger") {
-                return
-            }
-
-            context.visitGeneratedSourceFile("example", "Parent", element)
-                    .ifPresent(generatedFile -> {
-                        try {
-                            generatedFile.write(writer -> writer.write(SOURCE))
-                        } catch (IOException e) {
-                            throw new RuntimeException(e)
-                        }
-                    })
-        }
-    }
-
-    static class CollectingVisitor implements TypeElementVisitor<Object, Object> {
-
-        int numVisited = 0
-        int numMethodVisited = 0
-        boolean hasIntrospected
-        String getPath
-
-        @Override
-        void visitClass(ClassElement element, VisitorContext context) {
-            if (element.getName() != "example.Child") {
-                return
-            }
-
-            if (element.hasUnresolvedTypes(UnresolvedTypeKind.INTERFACE)) {
-                throw new ElementPostponedToNextRoundException(element)
-            }
-
-            ++numVisited
-            hasIntrospected = element.hasStereotype(Introspected)
-        }
-
-        @Override
-        void visitMethod(MethodElement element, VisitorContext context) {
-            if (element.getOwningType().getName() != "example.Child") {
-                return
-            }
-
-            ++numMethodVisited
-            getPath = element.stringValue(Get).orElse(null)
-        }
-    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.visitors
 
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.writer.BeanDefinitionVisitor
 import spock.lang.PendingFeature
 
@@ -73,9 +74,11 @@ class IntroductionTestInterceptor
 }
 ''')
         def introduction = getBean(context, 'test.MyIntroduction')
+        def definition = getBeanDefinition(context, 'test.MyIntroduction')
 
         then:
         introduction.getParentMethod() == 'good'
+        definition.getRequiredMethod("getParentMethod").hasAnnotation("SomeAnnotation")
     }
 
     void 'test postpone bean definition generation implementing generated interface'() {

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -2,11 +2,22 @@ package io.micronaut.visitors
 
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
 import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.MethodElement
+import io.micronaut.inject.ast.UnresolvedTypeKind
+import io.micronaut.inject.visitor.ElementPostponedToNextRoundException
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import org.intellij.lang.annotations.Language
 import spock.lang.PendingFeature
 
 class PostponedVisitorsSpec extends AbstractTypeElementSpec {
+    private CollectingVisitor collectingVisitor
 
     void 'test postpone introspection generation implementing generated interface'() {
         when:
@@ -111,5 +122,106 @@ class MyBean implements GeneratedInterface  {
 
         then:
         definition.executableMethods.size() == 1
+    }
+
+    void "test information collecting visitor"() {
+        when:
+        buildClassLoader('example.Trigger', '''
+package example;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+class Trigger {}
+
+// Parent is generated, we want to retrieve inherited annotations correctly
+@Singleton
+class Child implements Parent {
+
+    @Override
+    public String hello() {
+        return "Hola!";
+    }
+
+}
+''')
+        then:
+        collectingVisitor.numVisited == 1
+        collectingVisitor.numMethodVisited == 1
+        collectingVisitor.getPath == "/get"
+        collectingVisitor.hasIntrospected
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        collectingVisitor = new CollectingVisitor()
+        return List.of(new GeneratorVisitor(), collectingVisitor)
+    }
+
+    static class GeneratorVisitor implements TypeElementVisitor<Object, Object> {
+
+        private static final @Language("java") String SOURCE = """
+package example;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Introspected
+public interface Parent {
+
+    @Get("/get")
+    String hello();
+
+}
+"""
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.getName() != "example.Trigger") {
+                return
+            }
+
+            context.visitGeneratedSourceFile("example", "Parent", element)
+                    .ifPresent(generatedFile -> {
+                        try {
+                            generatedFile.write(writer -> writer.write(SOURCE))
+                        } catch (IOException e) {
+                            throw new RuntimeException(e)
+                        }
+                    })
+        }
+    }
+
+    static class CollectingVisitor implements TypeElementVisitor<Object, Object> {
+
+        int numVisited = 0
+        int numMethodVisited = 0
+        boolean hasIntrospected
+        String getPath
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.getName() != "example.Child") {
+                return
+            }
+
+            if (element.hasUnresolvedTypes(UnresolvedTypeKind.INTERFACE)) {
+                throw new ElementPostponedToNextRoundException(element)
+            }
+
+            ++numVisited
+            hasIntrospected = element.hasStereotype(Introspected)
+        }
+
+        @Override
+        void visitMethod(MethodElement element, VisitorContext context) {
+            if (element.getOwningType().getName() != "example.Child") {
+                return
+            }
+
+            ++numMethodVisited
+            getPath = element.stringValue(Get).orElse(null)
+        }
     }
 }

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -23,4 +23,6 @@ io.micronaut.aop.introduction.beans.MyRepoVisitor2
 io.micronaut.visitors.WitherVisitor
 io.micronaut.visitors.IntroductionTestGenVisitor
 io.micronaut.visitors.IntroductionTestVisitor
+io.micronaut.visitors.CollectingVisitor
+io.micronaut.visitors.GeneratorVisitor
 io.micronaut.visitors.BuilderVisitor

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -21,5 +21,6 @@ io.micronaut.annotation.AnnotateClassSpec$AnnotateClassVisitor
 io.micronaut.annotation.AnnotateTypeArgSpec$AnnotateTypeArgVisitor
 io.micronaut.aop.introduction.beans.MyRepoVisitor2
 io.micronaut.visitors.WitherVisitor
+io.micronaut.visitors.IntroductionTestGenVisitor
 io.micronaut.visitors.IntroductionTestVisitor
 io.micronaut.visitors.BuilderVisitor


### PR DESCRIPTION
Currently if a type element visitor throws element postponed and then in the next round mutates the metadata then this metadata is cleared by the bean definition inject visitor causing it to be missing. This PR alters the flow such that the type element visitor re-initializes the metadata marking it as cleared and thus the bean definition inject visitor doesn't also clear it.

Also fixes #11791

