### PR TITLE
fix: always return `Content-Type: text/event-stream` on SSE endpoints

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/sse/ServerSentEventSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/sse/ServerSentEventSpec.groovy
@@ -36,6 +36,7 @@ import jakarta.inject.Inject
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import java.time.Duration
 import java.time.temporal.ChronoUnit
@@ -91,9 +92,10 @@ class ServerSentEventSpec extends Specification {
         ex.message == "Client '/sse': Internal Server Error"
     }
 
+    @Unroll
     void "test Content-Type header is correct"() {
         def httpRequest = HttpRequest
-                .GET(server.getURI().toString() + "/sse/object")
+                .GET(server.getURI().toString() + "/sse" + path)
                 .accept(MediaType.TEXT_EVENT_STREAM)
 
         when:
@@ -102,6 +104,9 @@ class ServerSentEventSpec extends Specification {
         then:
         response.status() == HttpStatus.OK
         response.header(HttpHeaders.CONTENT_TYPE) == MediaType.TEXT_EVENT_STREAM
+
+        where:
+        path << ['/object', '/string', '/rich']
     }
 
     @Client('/sse')

--- a/http/src/main/java/io/micronaut/http/body/TextStreamBodyWriter.java
+++ b/http/src/main/java/io/micronaut/http/body/TextStreamBodyWriter.java
@@ -21,7 +21,6 @@ import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.MutableHeaders;
-import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Produces;
@@ -122,11 +121,9 @@ final class TextStreamBodyWriter<T> implements MessageBodyWriter<T> {
                 }
             }
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            messageBodyWriter.writeTo(bodyType, MediaType.APPLICATION_JSON_TYPE, data, outgoingHeaders, baos);
+            messageBodyWriter.writeTo(bodyType, mediaType, data, outgoingHeaders, baos);
             body = baos.toByteArray();
         }
-
-        outgoingHeaders.set(HttpHeaders.CONTENT_TYPE, mediaType != null ? mediaType : MediaType.TEXT_EVENT_STREAM_TYPE);
 
         writeAttribute(output, COMMENT_PREFIX, event.getComment());
         writeAttribute(output, ID_PREFIX, event.getId());


### PR DESCRIPTION
fixes #11810

The root cause for #11810 was that the body writer for the content of SSE events received `MediaType.APPLICATION_JSON_TYPE` as `mediaType` when called from `TextStreamBodyWriter`. The called body writer would set that `mediaType` on the `MutableHeaders`. #9696 added a line after the call to the body writer that set the `Content-Type` back to `MediaType.TEXT_EVENT_STREAM_TYPE`. However, this fix left in a brief period during which the `Content-Type` header was set to `application/json`. If, by chance, the response headers were written to the wire precisely during this period, the `application/json` was written to the response headers.

This fix passes the `mediaType` received by `TextStreamBodyWriter` on to the inner body write, ensuring that the inner body writer doesn’t change the desired `Content-Type`.

I failed to find a way to reproduce the exact race condition for #11810 in a unit test. However, we were able to reproduce the race condition reliably using tens of thousands of requests against a resource-restricted docker container. These tests failed ~1% of the time, and are not failing at all after this fix.