### PR TITLE
Delay initialization at build time

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/ServiceLoaderFeature.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceLoaderFeature.java
@@ -78,7 +78,7 @@ class ServiceLoaderFeature implements Feature {
                                     initializeAtBuildTime(buildInitClass);
                                 }
                             }
-                            initializeAtBuildTime(c);
+
                             BeanInfo<?> beanInfo;
                             try {
                                 beanInfo = (BeanInfo<?>) c.getDeclaredConstructor().newInstance();
@@ -120,14 +120,14 @@ class ServiceLoaderFeature implements Feature {
                             }
                         }
 
+                        initializeAtBuildTime(c);
                         registerForReflectiveInstantiation(c);
                         registerRuntimeReflection(c);
+                        final Class<?> exec = access.findClassByName(typeName + "$Exec");
+                        if (exec != null) {
+                            initializeAtBuildTime(exec);
+                        }
                     }
-                    final Class<?> exec = access.findClassByName(typeName + "$Exec");
-                    if (exec != null) {
-                        initializeAtBuildTime(exec);
-                    }
-
 
                 } catch (NoClassDefFoundError | InstantiationException e) {
                     i.remove();


### PR DESCRIPTION
This change delays the call to initialise a definition at build time until after dependent beans are inspected and established to be available. Without this change incorrect initialisation data can result.