### PR TITLE
Add support records for groovy

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanPropertiesSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanPropertiesSpec.groovy
@@ -32,4 +32,72 @@ class Test extends SuperClass {
         expect:
         classElement.getBeanProperties().every { it.hasAnnotation(NotBlank) }
     }
+
+    void "test groovy and java records"() {
+        def classElement = buildClassElement("""
+package test
+
+import io.micronaut.ast.groovy.visitor.GroovyRecord
+import io.micronaut.sample.EmptyRecord
+import io.micronaut.sample.JavaRecord 
+
+class ObjectWithProps {
+
+    private GroovyRecord groovyRecord
+    private JavaRecord javaRecord
+    private EmptyRecord emptyRecord
+    
+    GroovyRecord getGroovyRecord() {
+        return groovyRecord
+    }
+
+    void setGroovyRecord(GroovyRecord groovyRecord) {
+        this.groovyRecord = groovyRecord
+    }
+
+    JavaRecord getJavaRecord() {
+        return javaRecord
+    }
+
+    void setJavaRecord(JavaRecord javaRecord) {
+        this.javaRecord = javaRecord
+    }
+
+    EmptyRecord getEmptyRecord() {
+        return emptyRecord
+    }
+
+    void setEmptyRecord(EmptyRecord emptyRecord) {
+        this.emptyRecord = emptyRecord
+    }
+}
+
+""")
+
+        var props = classElement.getBeanProperties()
+
+        expect:
+        props.size() == 3
+        props[0].type.isRecord()
+        props[1].type.isRecord()
+        props[2].type.isRecord()
+
+        when:
+        var props1 = props[0].type.getBeanProperties()
+
+        then:
+        props1.size() == 2
+
+        when:
+        var props2 = props[1].type.getBeanProperties()
+
+        then:
+        props2.size() == 2
+
+        when:
+        var props3 = props[2].type.getBeanProperties()
+
+        then:
+        props3.size() == 0
+    }
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyRecord.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyRecord.groovy
@@ -1,0 +1,6 @@
+package io.micronaut.ast.groovy.visitor
+
+record GroovyRecord(
+        String param1,
+        int param2
+) {}

--- a/inject-groovy/src/test/java/io/micronaut/sample/EmptyRecord.java
+++ b/inject-groovy/src/test/java/io/micronaut/sample/EmptyRecord.java
@@ -1,0 +1,4 @@
+package io.micronaut.sample;
+
+public record EmptyRecord() {
+}

--- a/inject-groovy/src/test/java/io/micronaut/sample/JavaRecord.java
+++ b/inject-groovy/src/test/java/io/micronaut/sample/JavaRecord.java
@@ -1,0 +1,8 @@
+package io.micronaut.sample;
+
+public record JavaRecord(
+    String field1,
+    Integer field2
+) {
+
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -414,26 +414,24 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     private List<MethodElement> getRecordMethods() {
         var recordComponents = new HashSet<String>();
         var methodElements = new ArrayList<MethodElement>();
-        if (JavaModelUtils.isRecord(classElement)) {
-            for (Element enclosedElement : classElement.getEnclosedElements()) {
-                if (JavaModelUtils.isRecordComponent(enclosedElement) || enclosedElement instanceof ExecutableElement) {
-                    if (enclosedElement.getKind() == ElementKind.CONSTRUCTOR) {
-                        continue;
+        for (Element enclosedElement : classElement.getEnclosedElements()) {
+            if (JavaModelUtils.isRecordComponent(enclosedElement) || enclosedElement instanceof ExecutableElement) {
+                if (enclosedElement.getKind() == ElementKind.CONSTRUCTOR) {
+                    continue;
+                }
+                String name = enclosedElement.getSimpleName().toString();
+                if (enclosedElement instanceof ExecutableElement executableElement) {
+                    if (recordComponents.contains(name)) {
+                        methodElements.add(
+                            new JavaMethodElement(
+                                JavaClassElement.this,
+                                new JavaNativeElement.Method(executableElement),
+                                elementAnnotationMetadataFactory,
+                                visitorContext)
+                        );
                     }
-                    String name = enclosedElement.getSimpleName().toString();
-                    if (enclosedElement instanceof ExecutableElement executableElement) {
-                        if (recordComponents.contains(name)) {
-                            methodElements.add(
-                                new JavaMethodElement(
-                                    JavaClassElement.this,
-                                    new JavaNativeElement.Method(executableElement),
-                                    elementAnnotationMetadataFactory,
-                                    visitorContext)
-                            );
-                        }
-                    } else if (enclosedElement instanceof VariableElement) {
-                        recordComponents.add(name);
-                    }
+                } else if (enclosedElement instanceof VariableElement) {
+                    recordComponents.add(name);
                 }
             }
         }
@@ -442,17 +440,15 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
 
     private List<FieldElement> getRecordFields() {
         var fieldElements = new ArrayList<FieldElement>();
-        if (JavaModelUtils.isRecord(classElement)) {
-            for (Element enclosedElement : classElement.getEnclosedElements()) {
-                if (!JavaModelUtils.isRecordComponent(enclosedElement) && enclosedElement instanceof VariableElement variableElement) {
-                    fieldElements.add(
-                        new JavaFieldElement(
-                            JavaClassElement.this,
-                            new JavaNativeElement.Variable(variableElement),
-                            elementAnnotationMetadataFactory,
-                            visitorContext)
-                    );
-                }
+        for (Element enclosedElement : classElement.getEnclosedElements()) {
+            if (!JavaModelUtils.isRecordComponent(enclosedElement) && enclosedElement instanceof VariableElement variableElement) {
+                fieldElements.add(
+                    new JavaFieldElement(
+                        JavaClassElement.this,
+                        new JavaNativeElement.Variable(variableElement),
+                        elementAnnotationMetadataFactory,
+                        visitorContext)
+                );
             }
         }
         return fieldElements;


### PR DESCRIPTION
See https://github.com/micronaut-projects/micronaut-openapi/issues/2168

Groovy AST already supported groovy / java records, but now `getBeanProperties()` returns empty list for every record, because `GroovyClassElement` don't understand that class is record.

This PR added this lost functionality