### PR TITLE
Fixes #11838 for clearing mutated annotation metadata

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -448,7 +448,7 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement {
         if (this == o) {
             return true;
         }
-        if (o == null) {
+        if (!(o instanceof io.micronaut.inject.ast.Element)) {
             return false;
         }
         io.micronaut.inject.ast.Element that = (io.micronaut.inject.ast.Element) o;

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaElementFactory.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaElementFactory.java
@@ -225,14 +225,14 @@ public class JavaElementFactory implements ElementFactory<Element, TypeElement, 
         TypeMirror returnType = executableElement.getReturnType();
         TypeKind returnKind = returnType.getKind();
         if (returnKind == TypeKind.ERROR) {
-            throw new PostponeToNextRoundException(executableElement, member.getName() + " " + executableElement);
+            throw new PostponeToNextRoundException(member, member.getName() + " " + executableElement);
         }
     }
 
     private void failIfPostponeIsNeeded(TypedElement member, VariableElement variableElement) {
         TypeMirror type = variableElement.asType();
         if (type.getKind() == TypeKind.ERROR) {
-            throw new PostponeToNextRoundException(variableElement, member.getName() + " " + variableElement);
+            throw new PostponeToNextRoundException(member, member.getName() + " " + variableElement);
         }
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/visitors/CollectingVisitor.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/CollectingVisitor.groovy
@@ -19,6 +19,12 @@ class CollectingVisitor implements TypeElementVisitor<Object, Object> {
     static String controllerPath
 
     @Override
+    void start(VisitorContext visitorContext) {
+        numVisited = 0
+        numMethodVisited = 0
+    }
+
+    @Override
     void visitClass(ClassElement element, VisitorContext context) {
         if (element.getName() != "example.Child") {
             return
@@ -29,6 +35,9 @@ class CollectingVisitor implements TypeElementVisitor<Object, Object> {
         }
 
         controllerPath = element.stringValue(Controller.class).orElse(null)
+        if ("<error>".equalsIgnoreCase(controllerPath)) {
+            throw new ElementPostponedToNextRoundException(element)
+        }
         ++numVisited
         hasIntrospected = element.hasStereotype(Introspected)
     }
@@ -40,6 +49,8 @@ class CollectingVisitor implements TypeElementVisitor<Object, Object> {
         }
 
         ++numMethodVisited
-        getPath = element.stringValue(Get).orElse(null)
+
+        def path = element.stringValue(Get).orElse(null)
+        getPath = path
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/CollectingVisitor.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/CollectingVisitor.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.visitors
 
 import io.micronaut.core.annotation.Introspected
+import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.MethodElement
@@ -15,6 +16,7 @@ class CollectingVisitor implements TypeElementVisitor<Object, Object> {
     static int numMethodVisited = 0
     static boolean hasIntrospected
     static String getPath
+    static String controllerPath
 
     @Override
     void visitClass(ClassElement element, VisitorContext context) {
@@ -26,6 +28,7 @@ class CollectingVisitor implements TypeElementVisitor<Object, Object> {
             throw new ElementPostponedToNextRoundException(element)
         }
 
+        controllerPath = element.stringValue(Controller.class).orElse(null)
         ++numVisited
         hasIntrospected = element.hasStereotype(Introspected)
     }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/GeneratorVisitor.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/GeneratorVisitor.groovy
@@ -17,6 +17,8 @@ import io.micronaut.http.annotation.Get;
 @Introspected
 public interface Parent {
 
+    String BASE_PATH = "/hello";
+
     @Get("/get")
     String hello();
 

--- a/inject-java/src/test/groovy/io/micronaut/visitors/GeneratorVisitor.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/GeneratorVisitor.groovy
@@ -20,7 +20,20 @@ public interface Parent {
     String BASE_PATH = "/hello";
 
     @Get("/get")
-    String hello();
+    TestModel hello();
+
+}
+"""
+
+    private static final @Language("java") String SOURCE_MODEL = """
+package example;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public record TestModel(
+        String greeting
+) {
 
 }
 """
@@ -32,6 +45,15 @@ public interface Parent {
                     .ifPresent(generatedFile -> {
                         try {
                             generatedFile.write(writer -> writer.write(SOURCE))
+                        } catch (IOException e) {
+                            throw new RuntimeException(e)
+                        }
+                    })
+
+            context.visitGeneratedSourceFile("example", "TestModel", element)
+                    .ifPresent(generatedFile -> {
+                        try {
+                            generatedFile.write(writer -> writer.write(SOURCE_MODEL))
                         } catch (IOException e) {
                             throw new RuntimeException(e)
                         }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -139,8 +139,8 @@ class Trigger {}
 class Child implements Parent {
 
     @Override
-    public String hello() {
-        return "Hola!";
+    public TestModel hello() {
+        return new TestModel("Hola!");
     }
 
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -128,12 +128,14 @@ class MyBean implements GeneratedInterface  {
 package example;
 
 import jakarta.inject.Singleton;
+import io.micronaut.http.annotation.Controller;
 
 @io.micronaut.visitors.GeneratorTrigger
 class Trigger {}
 
 // Parent is generated, we want to retrieve inherited annotations correctly
 @Singleton
+@Controller(Parent.BASE_PATH)
 class Child implements Parent {
 
     @Override
@@ -148,6 +150,38 @@ class Child implements Parent {
         CollectingVisitor.numMethodVisited == 1
         CollectingVisitor.getPath == "/get"
         CollectingVisitor.hasIntrospected
+        CollectingVisitor.controllerPath == "/hello"
+    }
+
+    void "test information collecting visitor not through parent"() {
+        when:
+        buildClassLoader('example.Trigger', '''
+package example;
+
+import jakarta.inject.Singleton;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@io.micronaut.visitors.GeneratorTrigger
+class Trigger {}
+
+// Parent is generated, we want to retrieve the value correctly
+@Singleton
+@Controller(Parent.BASE_PATH)
+class Child {
+
+    @Get("/get")
+    public String hello() {
+        return "Hola!";
+    }
+
+}
+''')
+        then:
+        CollectingVisitor.numVisited == 1
+        CollectingVisitor.numMethodVisited == 1
+        CollectingVisitor.getPath == "/get"
+        CollectingVisitor.controllerPath == "/hello"
     }
 
 }


### PR DESCRIPTION
The metadata is cleared correctly in more cases.

Verified that it works for my use case.