### PR TITLE
Remove dynamic postfix for dummy file

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
+++ b/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
@@ -32,7 +32,6 @@ import io.micronaut.inject.writer.GeneratedFile;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -89,7 +88,7 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
      *
      * @return The annotation metadata builder
      *
-     * @since  4.0.0
+     * @since 4.0.0
      */
     @Internal
     @NonNull
@@ -176,13 +175,13 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
             return projectDir;
         }
         // let's find the projectDir
-        Optional<GeneratedFile> dummyFile = visitGeneratedFile("dummy" + System.nanoTime());
+        Optional<GeneratedFile> dummyFile = visitGeneratedFile("dummy");
         if (dummyFile.isPresent()) {
             URI uri = dummyFile.get().toURI();
             // happens in tests 'mem:///CLASS_OUTPUT/dummy'
             if (uri.getScheme() != null && !uri.getScheme().equals("mem")) {
                 // assume files are generated in 'build' or 'target' directories
-                Path dummy = Paths.get(uri).normalize();
+                Path dummy = Path.of(uri).normalize();
                 while (dummy != null) {
                     Path dummyFileName = dummy.getFileName();
                     if (dummyFileName != null && ("build".equals(dummyFileName.toString()) || "target".equals(dummyFileName.toString()))) {
@@ -216,7 +215,7 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
         Optional<GeneratedFile> dummy = visitMetaInfFile("dummy", Element.EMPTY_ELEMENT_ARRAY);
         if (dummy.isPresent()) {
             // we want the parent directory of META-INF/dummy
-            Path classesOutputDir = Paths.get(dummy.get().toURI()).getParent().getParent();
+            Path classesOutputDir = Path.of(dummy.get().toURI()).getParent().getParent();
             return Optional.of(classesOutputDir);
         }
         return Optional.empty();

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
@@ -45,7 +45,6 @@ import java.net.URI
 import java.nio.file.Files
 import java.util.*
 import java.util.function.BiConsumer
-import kotlin.collections.ArrayList
 
 @OptIn(KspExperimental::class)
 internal class KotlinVisitorContext(


### PR DESCRIPTION
Replace `nanoTime()` postfix to random long for deterministic build (See: https://github.com/micronaut-projects/micronaut-openapi/issues/2180).

This fix solves old problem with KSP: when I want to create a directory in `META-INF` and call `visitMetaInfFile("swagger\dummy" + new Random().nextLong(Long.MAX_VALUE))` dummy file created, but after annotaion processing finised, dummy file still exists. 

This problem ONLY with KSP.

Example: how it works now:
<img width="1053" alt="{D4E1AF48-CA94-437F-873F-D50E5456DCF4}" src="https://github.com/user-attachments/assets/72d7611c-bdca-45df-9f5c-4c4ee5e93460" />

After this fix and applied to micronaut openapi:
<img width="1117" alt="{D6955CB4-9491-4876-ADF1-96E4866D4C0F}" src="https://github.com/user-attachments/assets/ea3fe46a-b3a2-4d0b-8708-e84254a88892" />
