### PR TITLE
fix: Allow other executor instrumentations than context propagation

### DIFF
--- a/context-propagation/src/main/java/io/micronaut/context/propagation/instrument/execution/ContextPropagatingExecutorService.java
+++ b/context-propagation/src/main/java/io/micronaut/context/propagation/instrument/execution/ContextPropagatingExecutorService.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.propagation.instrument.execution;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.scheduling.instrument.InstrumentedExecutorService;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Wraps {@link ExecutorService} to instrument it for propagating the {@link PropagatedContext}
+ * across threads.
+ *
+ * @author Hauke Lange
+ * @since 4.9.0
+ */
+@Internal
+public class ContextPropagatingExecutorService implements InstrumentedExecutorService {
+    private final ExecutorService target;
+
+    private final PropagatedContext propagatedContext;
+
+    public ContextPropagatingExecutorService(ExecutorService target) {
+        this(target, null);
+    }
+
+    public ContextPropagatingExecutorService(
+        ExecutorService target,
+        @Nullable PropagatedContext propagatedContext
+    ) {
+        this.target = target;
+        this.propagatedContext = propagatedContext;
+    }
+
+    @Override
+    public ExecutorService getTarget() {
+        return target;
+    }
+
+    @Override
+    public <T> Callable<T> instrument(Callable<T> task) {
+        if (propagatedContext != null) {
+            return propagatedContext.wrap(task);
+        } else {
+            return PropagatedContext.wrapCurrent(task);
+        }
+    }
+
+    @Override
+    public Runnable instrument(Runnable task) {
+        if (propagatedContext != null) {
+            return propagatedContext.wrap(task);
+        } else {
+            return PropagatedContext.wrapCurrent(task);
+        }
+    }
+
+    /**
+     * Unwraps the target {@link ExecutorService} from the given {@link InstrumentedExecutorService}
+     * if it is instrumented with {@link ContextPropagatingExecutorService}.
+     *
+     * @param executorService The instrumented executor service
+     * @return The target executor service of the {@link ContextPropagatingScheduledExecutorService}
+     *  or empty if not found
+     */
+    public static Optional<ExecutorService> unwrap(ExecutorService executorService) {
+        if (!(executorService instanceof InstrumentedExecutorService)) {
+            return Optional.empty();
+        }
+        ExecutorService target = executorService;
+        while (target instanceof InstrumentedExecutorService ies) {
+            if (target instanceof ContextPropagatingExecutorService contextPropagatingExecutorService) {
+                return Optional.of(contextPropagatingExecutorService.getTarget());
+            }
+            target = ies.getTarget();
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Checks if the given {@link ExecutorService} is instrumented with
+     * {@link ContextPropagatingExecutorService}.
+     *
+     * @param executorService The executor service to check
+     * @return true if it is instrumented, false otherwise
+     */
+    public static boolean isInstrumented(ExecutorService executorService) {
+        return executorService instanceof InstrumentedExecutorService ies && unwrap(ies).isPresent();
+    }
+}

--- a/context-propagation/src/main/java/io/micronaut/context/propagation/instrument/execution/ContextPropagatingScheduledExecutorService.java
+++ b/context-propagation/src/main/java/io/micronaut/context/propagation/instrument/execution/ContextPropagatingScheduledExecutorService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.propagation.instrument.execution;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.scheduling.instrument.InstrumentedScheduledExecutorService;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Wraps {@link ScheduledExecutorService} to instrument it for propagating the {@link PropagatedContext}
+ * across threads.
+ *
+ * @author Hauke Lange
+ * @since 4.9.0
+ */
+@Internal
+public class ContextPropagatingScheduledExecutorService extends ContextPropagatingExecutorService implements InstrumentedScheduledExecutorService {
+    private final ScheduledExecutorService target;
+
+    public ContextPropagatingScheduledExecutorService(ScheduledExecutorService target) {
+        super(target, null);
+        this.target = target;
+    }
+
+    public ContextPropagatingScheduledExecutorService(
+        ScheduledExecutorService target,
+        @Nullable PropagatedContext propagatedContext
+    ) {
+        super(target, propagatedContext);
+        this.target = target;
+    }
+
+    @Override
+    public ScheduledExecutorService getTarget() {
+        return this.target;
+    }
+}

--- a/context-propagation/src/main/java/io/micronaut/context/propagation/instrument/execution/ExecutorServiceInstrumenter.java
+++ b/context-propagation/src/main/java/io/micronaut/context/propagation/instrument/execution/ExecutorServiceInstrumenter.java
@@ -21,7 +21,6 @@ import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.scheduling.instrument.InstrumentedExecutorService;
-import io.micronaut.scheduling.instrument.InstrumentedScheduledExecutorService;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -50,43 +49,12 @@ final class ExecutorServiceInstrumenter implements BeanCreatedEventListener<Exec
             return event.getBean();
         }
         ExecutorService executorService = event.getBean();
-        if (executorService instanceof InstrumentedExecutorService) {
+        if (ContextPropagatingExecutorService.isInstrumented(executorService)) {
             return executorService;
         }
         if (executorService instanceof ScheduledExecutorService service) {
-            return new InstrumentedScheduledExecutorService() {
-                @Override
-                public ScheduledExecutorService getTarget() {
-                    return service;
-                }
-
-                @Override
-                public <T> Callable<T> instrument(Callable<T> task) {
-                    return PropagatedContext.wrapCurrent(task);
-                }
-
-                @Override
-                public Runnable instrument(Runnable command) {
-                    return PropagatedContext.wrapCurrent(command);
-                }
-            };
+            return new ContextPropagatingScheduledExecutorService(service);
         }
-        return new InstrumentedExecutorService() {
-            @Override
-            public ExecutorService getTarget() {
-                return executorService;
-            }
-
-            @Override
-            public <T> Callable<T> instrument(Callable<T> task) {
-                return PropagatedContext.wrapCurrent(task);
-            }
-
-            @Override
-            public Runnable instrument(Runnable command) {
-                return PropagatedContext.wrapCurrent(command);
-            }
-        };
+        return new ContextPropagatingExecutorService(executorService);
     }
-
 }

--- a/context-propagation/src/test/groovy/io/micronaut/context/propagation/instrument/execution/ExecutorServiceInstrumenterSpec.groovy
+++ b/context-propagation/src/test/groovy/io/micronaut/context/propagation/instrument/execution/ExecutorServiceInstrumenterSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.propagation.instrument.execution
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.event.BeanCreatedEventListener
+import io.micronaut.core.order.Ordered
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.scheduling.instrument.InstrumentedExecutorService
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.util.concurrent.ExecutorService
+
+class ExecutorServiceInstrumenterSpec extends Specification {
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11653")
+    void "test ExecutorServiceInstrumenter instruments executor service if other instrumentations are present"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run([
+                'spec.name': 'ExecutorServiceInstrumenterSpec'
+        ])
+
+        when:
+        ExecutorService io = applicationContext.getBean(ExecutorService, Qualifiers.byName("io"))
+
+        then:"The last instrumentation is applied"
+        io instanceof InstrumentedExecutorService
+
+        and:"The context propagation instrumentation is applied"
+        (io as InstrumentedExecutorService).getTarget() instanceof ContextPropagatingExecutorService
+
+        and:"The first instrumentation is applied"
+        ((io as InstrumentedExecutorService).getTarget() as InstrumentedExecutorService).getTarget() instanceof InstrumentedExecutorService
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    @Requires(property = 'spec.name', value = 'ExecutorServiceInstrumenterSpec')
+    @Prototype
+    static class FirstExecutorServiceInstrumentation implements BeanCreatedEventListener<ExecutorService>, Ordered {
+        @Override
+        ExecutorService onCreated(BeanCreatedEvent<ExecutorService> event) {
+            ExecutorService executorService = event.bean
+            return new InstrumentedExecutorService() {
+                @Override
+                ExecutorService getTarget() {
+                    return executorService
+                }
+
+                @Override
+                void execute(Runnable command) {
+                    getTarget().execute(instrument(command))
+                }
+            }
+        }
+
+        @Override
+        int getOrder() {
+            // Ensure this instrumentation is applied before the ExecutorServiceInstrumenter
+            return HIGHEST_PRECEDENCE
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'ExecutorServiceInstrumenterSpec')
+    @Prototype
+    static class LastExecutorServiceInstrumentation implements BeanCreatedEventListener<ExecutorService>, Ordered {
+        @Override
+        ExecutorService onCreated(BeanCreatedEvent<ExecutorService> event) {
+            ExecutorService executorService = event.bean
+            return new InstrumentedExecutorService() {
+                @Override
+                ExecutorService getTarget() {
+                    return executorService
+                }
+
+                @Override
+                void execute(Runnable command) {
+                    getTarget().execute(instrument(command))
+                }
+            }
+        }
+
+        @Override
+        int getOrder() {
+            // Ensure this instrumentation is applied after the ExecutorServiceInstrumenter
+            return LOWEST_PRECEDENCE
+        }
+    }
+}

--- a/context-propagation/src/test/groovy/io/micronaut/context/propagation/instrument/execution/ExecutorServiceInstrumenterSpec.groovy
+++ b/context-propagation/src/test/groovy/io/micronaut/context/propagation/instrument/execution/ExecutorServiceInstrumenterSpec.groovy
@@ -23,10 +23,12 @@ import io.micronaut.context.event.BeanCreatedEventListener
 import io.micronaut.core.order.Ordered
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.scheduling.instrument.InstrumentedExecutorService
+import io.micronaut.scheduling.instrument.InstrumentedScheduledExecutorService
 import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledExecutorService
 
 class ExecutorServiceInstrumenterSpec extends Specification {
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11653")
@@ -52,25 +54,64 @@ class ExecutorServiceInstrumenterSpec extends Specification {
         applicationContext.close()
     }
 
-    @Requires(property = 'spec.name', value = 'ExecutorServiceInstrumenterSpec')
-    @Prototype
-    static class FirstExecutorServiceInstrumentation implements BeanCreatedEventListener<ExecutorService>, Ordered {
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11653")
+    void "test ExecutorServiceInstrumenter instruments scheduled executor service if other instrumentations are present"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run([
+                'spec.name': 'ExecutorServiceInstrumenterSpec'
+        ])
+
+        when:
+        ExecutorService scheduled = applicationContext.getBean(ExecutorService, Qualifiers.byName("scheduled"))
+
+        then:"The last instrumentation is applied"
+        scheduled instanceof InstrumentedScheduledExecutorService
+
+        and:"The context propagation instrumentation is applied"
+        (scheduled as InstrumentedExecutorService).getTarget() instanceof ContextPropagatingScheduledExecutorService
+
+        and:"The first instrumentation is applied"
+        ((scheduled as InstrumentedExecutorService).getTarget() as InstrumentedExecutorService).getTarget() instanceof InstrumentedScheduledExecutorService
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    abstract static class ExecutorServiceInstrumentation implements BeanCreatedEventListener<ExecutorService>, Ordered {
         @Override
         ExecutorService onCreated(BeanCreatedEvent<ExecutorService> event) {
             ExecutorService executorService = event.bean
-            return new InstrumentedExecutorService() {
-                @Override
-                ExecutorService getTarget() {
-                    return executorService
-                }
+            if (executorService instanceof ScheduledExecutorService) {
+                return new InstrumentedScheduledExecutorService() {
+                    @Override
+                    ScheduledExecutorService getTarget() {
+                        return executorService as ScheduledExecutorService
+                    }
 
-                @Override
-                void execute(Runnable command) {
-                    getTarget().execute(instrument(command))
+                    @Override
+                    void execute(Runnable command) {
+                        getTarget().execute(instrument(command))
+                    }
+                }
+            } else {
+                return new InstrumentedExecutorService() {
+                    @Override
+                    ExecutorService getTarget() {
+                        return executorService
+                    }
+
+                    @Override
+                    void execute(Runnable command) {
+                        getTarget().execute(instrument(command))
+                    }
                 }
             }
         }
+    }
 
+    @Requires(property = 'spec.name', value = 'ExecutorServiceInstrumenterSpec')
+    @Prototype
+    static class FirstExecutorServiceInstrumentation extends ExecutorServiceInstrumentation {
         @Override
         int getOrder() {
             // Ensure this instrumentation is applied before the ExecutorServiceInstrumenter
@@ -80,23 +121,7 @@ class ExecutorServiceInstrumenterSpec extends Specification {
 
     @Requires(property = 'spec.name', value = 'ExecutorServiceInstrumenterSpec')
     @Prototype
-    static class LastExecutorServiceInstrumentation implements BeanCreatedEventListener<ExecutorService>, Ordered {
-        @Override
-        ExecutorService onCreated(BeanCreatedEvent<ExecutorService> event) {
-            ExecutorService executorService = event.bean
-            return new InstrumentedExecutorService() {
-                @Override
-                ExecutorService getTarget() {
-                    return executorService
-                }
-
-                @Override
-                void execute(Runnable command) {
-                    getTarget().execute(instrument(command))
-                }
-            }
-        }
-
+    static class LastExecutorServiceInstrumentation extends ExecutorServiceInstrumentation {
         @Override
         int getOrder() {
             // Ensure this instrumentation is applied after the ExecutorServiceInstrumenter

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -17,6 +17,8 @@ package io.micronaut.http.server;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.exceptions.BeanCreationException;
+import io.micronaut.context.propagation.instrument.execution.ContextPropagatingExecutorService;
+import io.micronaut.context.propagation.instrument.execution.ContextPropagatingScheduledExecutorService;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
@@ -52,8 +54,6 @@ import io.micronaut.http.server.exceptions.response.ErrorResponseProcessor;
 import io.micronaut.inject.BeanType;
 import io.micronaut.inject.MethodReference;
 import io.micronaut.scheduling.executor.ExecutorSelector;
-import io.micronaut.scheduling.instrument.InstrumentedExecutorService;
-import io.micronaut.scheduling.instrument.InstrumentedScheduledExecutorService;
 import io.micronaut.web.router.DefaultRouteInfo;
 import io.micronaut.web.router.MethodBasedRouteInfo;
 import io.micronaut.web.router.RouteAttributes;
@@ -78,7 +78,6 @@ import java.time.LocalDateTime;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
@@ -376,45 +375,18 @@ public final class RouteExecutor {
         if (executor == null) {
             return Flux.from(publisher).subscribeOn(Schedulers.fromExecutor(command -> propagatedContext.wrap(command).run()));
         }
-        if (executor instanceof InstrumentedExecutorService instrumentedExecutorService) {
-            executor = instrumentedExecutorService.getTarget();
+        Optional<ExecutorService> wrappedTarget = ContextPropagatingExecutorService.unwrap(executor);
+        if (wrappedTarget.isPresent()) {
+            executor = wrappedTarget.get();
         }
         if (executor instanceof ScheduledExecutorService scheduledExecutorService) {
-            executor = new InstrumentedScheduledExecutorService() {
-                @Override
-                public ScheduledExecutorService getTarget() {
-                    return scheduledExecutorService;
-                }
-
-                @Override
-                public <X> Callable<X> instrument(Callable<X> task) {
-                    return propagatedContext.wrap(task);
-                }
-
-                @Override
-                public Runnable instrument(Runnable command) {
-                    return propagatedContext.wrap(command);
-                }
-            };
+            executor = new ContextPropagatingScheduledExecutorService(
+                scheduledExecutorService,
+                propagatedContext
+            );
         } else {
             ExecutorService finalExecutor = executor;
-            executor = new InstrumentedExecutorService() {
-
-                @Override
-                public ExecutorService getTarget() {
-                    return finalExecutor;
-                }
-
-                @Override
-                public <X> Callable<X> instrument(Callable<X> task) {
-                    return propagatedContext.wrap(task);
-                }
-
-                @Override
-                public Runnable instrument(Runnable command) {
-                    return propagatedContext.wrap(command);
-                }
-            };
+            executor = new ContextPropagatingExecutorService(finalExecutor, propagatedContext);
         }
         final Scheduler scheduler = Schedulers.fromExecutorService(executor);
         return Flux.from(publisher)


### PR DESCRIPTION
fixes #11653

The `InstrumentedExecutorService` interface is also used in micrometer.

The current instrumentation only checks if a given executor service is instrumented, but there is no notion of which specific instrumentation it is instrumented with.

This means that if the [micrometer instrumentation](https://github.com/micronaut-projects/micronaut-micrometer/blob/56217245d1cc33cf6894c925ebed71eaf990dc28/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/executor/ExecutorServiceMetricsBinder.java#L91-L125) is applied first, the context propagation instrumentation is skipped.

To solve this for context propagation, we provide an implementation of the `InstrumentedExecutorService` and traverse the targets to find that specific implementation. It's not perfect, but should be better than before.