### PR TITLE
Improve bean ordering semantics

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/AbstractCompositeCustomizer.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/AbstractCompositeCustomizer.java
@@ -63,7 +63,7 @@ public abstract class AbstractCompositeCustomizer<C, R> {
         assert members instanceof CopyOnWriteArrayList : "only allow adding to root customizer";
         // do the insertion in one operation, so that concurrent readers don't see an inconsistent
         // (unsorted) state
-        int insertionIndex = Collections.binarySearch(members, customizer, OrderUtil.COMPARATOR);
+        int insertionIndex = Collections.binarySearch(members, customizer, OrderUtil.COMPARATOR_ZERO);
         if (insertionIndex < 0) {
             insertionIndex = ~insertionIndex;
         }

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
@@ -214,7 +214,7 @@ public final class ApplicationEventPublisherFactory<T>
 
             private final Supplier<ApplicationEventListener[]> lazyListeners = SupplierUtil.memoized(() -> beanContext.getBeansOfType(ApplicationEventListener.class, Qualifiers.byTypeArguments(eventType.getType()))
                 .stream()
-                .sorted(OrderUtil.COMPARATOR)
+                .sorted(OrderUtil.COMPARATOR_ZERO)
                 .toArray(ApplicationEventListener[]::new));
 
             @Override

--- a/inject/src/test/groovy/io/micronaut/context/BeanEventListenerOrderingSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/BeanEventListenerOrderingSpec.groovy
@@ -1,23 +1,25 @@
 package io.micronaut.context
 
 import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Context
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.event.BeanCreatedEvent
 import io.micronaut.context.event.BeanCreatedEventListener
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Order
 import io.micronaut.core.order.Ordered
+import io.micronaut.core.type.Argument
 import jakarta.inject.Singleton
 import spock.lang.Specification
 
-class BeanDefinitionDelegateSpec extends Specification {
+class BeanEventListenerOrderingSpec extends Specification {
 
     void "test order"() {
         given:
         ApplicationContext ctx = ApplicationContext.run(["spec.name": getClass().simpleName])
 
         when:
-        Collection<OrderedBean> beans = ctx.getBeansOfType(OrderedBean)
+        Collection<OrderedBean> beans = ctx.getBeansOfType(Argument.of(BeanCreatedEventListener, DummyBean))
 
         then:
         beans.size() == 6
@@ -29,7 +31,7 @@ class BeanDefinitionDelegateSpec extends Specification {
         beans[5].class == Hundred
 
         when:
-        ctx.getBean(DummyBean)
+        ctx.getBean(DummyBeanSubclass)
 
         then:
         ON_CREATION_CALLBACKS.size() == 6
@@ -59,11 +61,16 @@ class BeanDefinitionDelegateSpec extends Specification {
     static class DummyBean {
     }
 
+    @Bean
+    static class DummyBeanSubclass extends DummyBean {
+    }
+
     static List<OrderedBean> ON_CREATION_CALLBACKS = new ArrayList<>(10);
 
     static interface OrderedBean extends BeanCreatedEventListener<DummyBean> {
         @Override
         default DummyBean onCreated(@NonNull BeanCreatedEvent<DummyBean> event) {
+            // Verify the ordering of event listener beans when the type is the same.
             ON_CREATION_CALLBACKS.add(this);
             return event.getBean();
         }
@@ -72,56 +79,62 @@ class BeanDefinitionDelegateSpec extends Specification {
     static interface ImplementsOrdered extends Ordered {
     }
 
-    @Requires(property = "spec.name", value = "BeanDefinitionDelegateSpec")
+    @Requires(property = "spec.name", value = "BeanEventListenerOrderingSpec")
     @Singleton
     @Order
     private static class Zero implements OrderedBean {
     }
 
-    @Requires(property = "spec.name", value = "BeanDefinitionDelegateSpec")
+    @Requires(property = "spec.name", value = "BeanEventListenerOrderingSpec")
     @Singleton
     @Order(-1)
-    private static class NegativeOne implements OrderedBean {
+    private static class NegativeOne implements BeanCreatedEventListener<DummyBeanSubclass> {
+        @Override
+        DummyBeanSubclass onCreated(@NonNull BeanCreatedEvent<DummyBeanSubclass> event) {
+            // Verify the ordering of event listener beans when the type is the same.
+            ON_CREATION_CALLBACKS.add(this);
+            return event.getBean();
+        }
     }
 
-    @Requires(property = "spec.name", value = "BeanDefinitionDelegateSpec")
+    @Requires(property = "spec.name", value = "BeanEventListenerOrderingSpec")
     @Singleton
     @Order(value = 1)
     private static class One implements OrderedBean {
     }
 
-    @Requires(property = "spec.name", value = "BeanDefinitionDelegateSpec")
+    @Requires(property = "spec.name", value = "BeanEventListenerOrderingSpec")
     @Singleton
     @Order(value = 10)
     private static class Ten implements OrderedBean {
     }
 
-    @Requires(property = "spec.name", value = "BeanDefinitionDelegateSpec")
+    @Requires(property = "spec.name", value = "BeanEventListenerOrderingSpec")
     @Singleton
     @Order(200) // The order annotation should be ignored because Ordered is implemented
     private static class Fifty implements OrderedBean, Ordered {
         int order = 50
     }
 
-    @Requires(property = "spec.name", value = "BeanDefinitionDelegateSpec")
+    @Requires(property = "spec.name", value = "BeanEventListenerOrderingSpec")
     @Singleton
     @Order(value = 100)
     private static class Hundred implements OrderedBean {
     }
 
-    @Requires(property = "spec.name", value = "BeanDefinitionDelegateSpec")
+    @Requires(property = "spec.name", value = "BeanEventListenerOrderingSpec")
     @Singleton
     private static class Negative100 implements ImplementsOrdered {
         int order = -100
     }
 
-    @Requires(property = "spec.name", value = "BeanDefinitionDelegateSpec")
+    @Requires(property = "spec.name", value = "BeanEventListenerOrderingSpec")
     @Singleton
     private static class Negative50 implements ImplementsOrdered {
         int order = -50
     }
 
-    @Requires(property = "spec.name", value = "BeanDefinitionDelegateSpec")
+    @Requires(property = "spec.name", value = "BeanEventListenerOrderingSpec")
     @Singleton
     @Order(-1000) // the order annotation is ignored
     private static class Negative10 implements ImplementsOrdered {

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -364,7 +364,7 @@ public interface JsonMapper {
                     return Stream.empty();
                 }
             })
-            .sorted(OrderUtil.COMPARATOR)
+            .sorted(OrderUtil.COMPARATOR_ZERO)
             .flatMap(jsonMapperSupplier -> {
                 try {
                     return Stream.of(jsonMapperSupplier.get());

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -799,7 +799,7 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
                 filterEntries.add(filterRoute);
             }
         }
-        filterEntries.sort(OrderUtil.COMPARATOR);
+        filterEntries.sort(OrderUtil.COMPARATOR_ZERO);
         return Collections.unmodifiableList(filterEntries);
     }
 
@@ -829,7 +829,7 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
             }
             httpFilters.add(entry.getFilter());
         }
-        httpFilters.sort(OrderUtil.COMPARATOR);
+        httpFilters.sort(OrderUtil.COMPARATOR_ZERO);
         return Collections.unmodifiableList(httpFilters);
     }
 

--- a/test-suite/src/test/groovy/io/micronaut/EventListenerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/EventListenerSpec.groovy
@@ -47,11 +47,11 @@ class EventListenerSpec extends Specification {
         TestAllEventsListener t = embeddedServer.getApplicationContext().getBean(TestAllEventsListener)
         def serverStartupListeners = embeddedServer.getApplicationContext().getBeansOfType(ApplicationEventListener.class, Qualifiers.byTypeArguments(ServerStartupEvent))
                     .stream()
-                    .sorted(OrderUtil.COMPARATOR)
+                    .sorted(OrderUtil.COMPARATOR_ZERO)
                     .toArray(ApplicationEventListener[]::new)
         def serverShutdownListeners = embeddedServer.getApplicationContext().getBeansOfType(ApplicationEventListener.class, Qualifiers.byTypeArguments(ServerShutdownEvent))
                     .stream()
-                    .sorted(OrderUtil.COMPARATOR)
+                    .sorted(OrderUtil.COMPARATOR_ZERO)
                     .toArray(ApplicationEventListener[]::new)
         then:
         serverStartupListeners.last().getClass().name.contains "NettyServiceDiscovery"


### PR DESCRIPTION
The default order of an object in OrderUtil.getOrder should be zero not LOWEST_PRECEDENCE, as otherwise there is no way to request a bean be last in the list. The intention here is to leave a bean that doesn't request an order un-ordered relative to other beans, so zero is the correct value.

Apply a global ordering to all bean event listeners regardless of requested generic type. Previously, listeners were ordered only relative to other listeners that specified the same generic type, meaning the final ordering could be unexpected in cases where supertypes were matched. Ordering is now done after all the listeners are aggregated.

Fixes #11871 