### PR TITLE
Fix a memory ordering issue in ThreadLocalScopeSpec

### DIFF
--- a/runtime/src/test/groovy/io/micronaut/runtime/context/scope/ThreadLocalScopeSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/context/scope/ThreadLocalScopeSpec.groovy
@@ -174,7 +174,7 @@ class ThreadLocalBean {
         when:
         ctx.close()
         then:
-        listener.numCleaned == 2
+        synchronized (listener) { listener.numCleaned == 2 }
     }
 
     void "cleaned up on thread termination"() {
@@ -198,7 +198,7 @@ class ThreadLocalBean {
         then:
         new PollingConditions().eventually {
             triggerGc()
-            listener.numCleaned == 2
+            synchronized (listener) { listener.numCleaned == 2 }
         }
 
         cleanup:
@@ -350,7 +350,9 @@ class LifecycleBean implements LifeCycle<LifecycleBean> {
 
     @Override
     LifecycleBean stop() {
-        cleanupListener.numCleaned++
+        synchronized (cleanupListener) {
+            cleanupListener.numCleaned++
+        }
         return this
     }
 }


### PR DESCRIPTION
On ARM it's important to always use synchronized on data that can be written from multiple threads even if there's a thread join in between.