### PR TITLE
fix bug aggregating processing that has postponed elements

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -247,11 +247,14 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
             ).filter(notGroovyObject).forEach(elements::add);
 
             for (Object nativeType : postponedTypes.values()) {
-                AbstractAnnotationMetadataBuilder.clearMutated(nativeType);
-                javaVisitorContext.getNativeElementsHelper().cleanupForClass(nativeType);
                 if (nativeType instanceof Element element) {
                     AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata cachedAnnotationMetadata = javaVisitorContext.getAnnotationMetadataBuilder().lookupOrBuildForType(element);
-                    cachedAnnotationMetadata.markCleared();
+                    if (!cachedAnnotationMetadata.wasCleared()) {
+                        AbstractAnnotationMetadataBuilder.clearMutated(nativeType);
+                        cachedAnnotationMetadata = javaVisitorContext.getAnnotationMetadataBuilder().lookupOrBuildForType(element);
+                        javaVisitorContext.getNativeElementsHelper().cleanupForClass(nativeType);
+                        cachedAnnotationMetadata.markCleared();
+                    }
                 }
             }
             postponedTypes.keySet().stream().map(elementUtils::getTypeElement).filter(Objects::nonNull).forEach(elements::add);

--- a/inject-java/src/test/groovy/io/micronaut/visitors/AnnotatingVisitor.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/AnnotatingVisitor.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.visitors
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.MethodElement
+import io.micronaut.inject.ast.UnresolvedTypeKind
+import io.micronaut.inject.visitor.ElementPostponedToNextRoundException
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+class AnnotatingVisitor implements TypeElementVisitor<Object, Object> {
+
+
+    @Override
+    VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING
+    }
+
+
+
+    @Override
+    void visitMethod(MethodElement element, VisitorContext context) {
+        if (element.getOwningType().getName() != "example.Child") {
+            return
+        }
+
+        element.annotate("test.CustomAnn")
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/CollectingVisitor.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/CollectingVisitor.groovy
@@ -19,6 +19,11 @@ class CollectingVisitor implements TypeElementVisitor<Object, Object> {
     static String controllerPath
 
     @Override
+    VisitorKind getVisitorKind() {
+        return VisitorKind.AGGREGATING
+    }
+
+    @Override
     void start(VisitorContext visitorContext) {
         numVisited = 0
         numMethodVisited = 0

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -124,7 +124,7 @@ class MyBean implements GeneratedInterface  {
 
     void "test information collecting visitor"() {
         when:
-        buildClassLoader('example.Trigger', '''
+        def definition = buildBeanDefinition('example.Child', '''
 package example;
 
 import jakarta.inject.Singleton;
@@ -146,6 +146,7 @@ class Child implements Parent {
 }
 ''')
         then:
+        definition.executableMethods.first().hasAnnotation("test.CustomAnn")
         CollectingVisitor.numVisited == 1
         CollectingVisitor.numMethodVisited == 1
         CollectingVisitor.getPath == "/get"
@@ -155,7 +156,7 @@ class Child implements Parent {
 
     void "test information collecting visitor not through parent"() {
         when:
-        buildClassLoader('example.Trigger', '''
+        def definition = buildBeanDefinition('example.Child', '''
 package example;
 
 import jakarta.inject.Singleton;
@@ -178,6 +179,7 @@ class Child {
 }
 ''')
         then:
+        definition.executableMethods.first().hasAnnotation("test.CustomAnn")
         CollectingVisitor.numVisited == 1
         CollectingVisitor.numMethodVisited == 1
         CollectingVisitor.getPath == "/get"

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -24,6 +24,7 @@ io.micronaut.visitors.WitherVisitor
 io.micronaut.visitors.IntroductionTestGenVisitor
 io.micronaut.visitors.IntroductionTestVisitor
 io.micronaut.visitors.CollectingVisitor
+io.micronaut.visitors.AnnotatingVisitor
 io.micronaut.visitors.GeneratorVisitor
 io.micronaut.visitors.BuilderVisitor
 io.micronaut.visitors.ImportTypeElementSpec$DefaultTypeElementVisitor


### PR DESCRIPTION
Something broke or changed in 4.9.x whereby annotation processors that call `annotate(..)` no longer work because the metadata is cleared by the aggregating visitor. This fixes it.