### PR TITLE
Remove regex anchors from CacheControlTest

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/filter/CacheControlTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/filter/CacheControlTest.java
@@ -74,7 +74,7 @@ public class CacheControlTest {
     }
 
     @Requires(property = "spec.name", value = SPEC_NAME)
-    @ServerFilter(patternStyle = FilterPatternStyle.REGEX, value = "^/assets/bootstrap.*$")
+    @ServerFilter(patternStyle = FilterPatternStyle.REGEX, value = "/assets/bootstrap.*")
     static class PublicInmmutableCacheControlFilter {
         @ResponseFilter
         void filterResponse(MutableHttpResponse<?> rsp) {


### PR DESCRIPTION
This broke aws because there's a context path. Fixes https://github.com/micronaut-projects/micronaut-aws/issues/2373