### PR TITLE
Avoid double completion in DefaultHttpClient

### DIFF
--- a/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlow.java
+++ b/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlow.java
@@ -46,6 +46,22 @@ public sealed interface DelayedExecutionFlow<T> extends ExecutionFlow<T> permits
     void completeExceptionally(Throwable exc);
 
     /**
+     * Complete this flow normally.
+     *
+     * @param result The result value
+     * @return {@code false} if this flow has already been completed
+     */
+    boolean tryComplete(@Nullable T result);
+
+    /**
+     * Complete this flow with an exception.
+     *
+     * @param exc The exception
+     * @return {@code false} if this flow has already been completed
+     */
+    boolean tryCompleteExceptionally(Throwable exc);
+
+    /**
      * Check for cancellation.
      *
      * @return {@code true} iff this flow or any downstream flow has been cancelled


### PR DESCRIPTION
There are a few cases in DefaultHttpClient where a connection error could lead to two exceptions, with both sent to the DelayedExecutionFlow. This patch adds an atomic tryCompleteExceptionally method to avoid this.

The new tryComplete methods are thread-safe, but the old complete methods remain unsafe to avoid performance regressions. I don't think the atomicity is even really necessary for DefaultHttpClient, but it can't hurt.

Fixes #11824