### PR TITLE
Do state transitions immediately on error

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/Http1ResponseHandler.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/Http1ResponseHandler.java
@@ -144,8 +144,8 @@ final class Http1ResponseHandler extends SimpleChannelInboundHandlerInstrumented
 
         @Override
         void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            listener.fail(ctx, cause);
             transitionToState(ctx, this, AfterContent.INSTANCE);
+            listener.fail(ctx, cause);
             listener.finish(ctx);
         }
     }
@@ -279,8 +279,8 @@ final class Http1ResponseHandler extends SimpleChannelInboundHandlerInstrumented
 
         @Override
         void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            streaming.error(cause);
             transitionToState(ctx, this, AfterContent.INSTANCE);
+            streaming.error(cause);
             listener.finish(ctx);
         }
 
@@ -381,8 +381,8 @@ final class Http1ResponseHandler extends SimpleChannelInboundHandlerInstrumented
 
         @Override
         void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            streaming.error(cause);
             transitionToState(ctx, this, AfterContent.INSTANCE);
+            streaming.error(cause);
             listener.finish(ctx);
         }
     }


### PR DESCRIPTION
It looks like in some cases, the error callback will change the state, leading to the second transitionToState to fail. This change moves the transitionToState before the error callback, hopefully fixing some tests.