### PR TITLE
Backport 4.8.x leak fixes to 4.7.x

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -1128,6 +1128,12 @@ public class ConnectionManager {
          * Notify any {@link NettyClientCustomizer} that the request pipeline has been built.
          */
         public abstract void notifyRequestPipelineBuilt();
+
+        public final void touch() {
+            if (tracker != null) {
+                tracker.record();
+            }
+        }
     }
 
     /**
@@ -1629,6 +1635,7 @@ public class ConnectionManager {
                             @Override
                             public void taint() {
                                 // do nothing, we don't reuse stream channels
+                                touch();
                             }
 
                             @Override

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1572,6 +1572,7 @@ public class DefaultHttpClient implements
         // first: connect
         return connectionManager.connect(requestKey, blockHint)
             .flatMap(poolHandle -> {
+                poolHandle.touch();
                 // build the raw request
                 request.setAttribute(NettyClientHttpRequest.CHANNEL, poolHandle.channel);
 
@@ -1640,6 +1641,7 @@ public class DefaultHttpClient implements
         io.micronaut.http.HttpRequest<?> request,
         NettyByteBody byteBody
     ) {
+        poolHandle.touch();
         URI uri = request.getUri();
         String uriWithoutHost = uri.getRawPath();
         if (uri.getRawQuery() != null) {
@@ -1650,6 +1652,7 @@ public class DefaultHttpClient implements
             .setUri(uriWithoutHost);
 
         return Mono.<NettyClientByteBodyResponse>create(sink -> {
+            poolHandle.touch();
             if (log.isDebugEnabled()) {
                 log.debug("Sending HTTP {} to {}", request.getMethodName(), request.getUri());
             }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/Http1ResponseHandler.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/Http1ResponseHandler.java
@@ -144,7 +144,9 @@ final class Http1ResponseHandler extends SimpleChannelInboundHandlerInstrumented
 
         @Override
         void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            transitionToState(ctx, this, AfterContent.INSTANCE);
             listener.fail(ctx, cause);
+            listener.finish(ctx);
         }
     }
 
@@ -277,7 +279,9 @@ final class Http1ResponseHandler extends SimpleChannelInboundHandlerInstrumented
 
         @Override
         void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            transitionToState(ctx, this, AfterContent.INSTANCE);
             streaming.error(cause);
+            listener.finish(ctx);
         }
 
         @Override
@@ -377,7 +381,9 @@ final class Http1ResponseHandler extends SimpleChannelInboundHandlerInstrumented
 
         @Override
         void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            transitionToState(ctx, this, AfterContent.INSTANCE);
             streaming.error(cause);
+            listener.finish(ctx);
         }
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -811,6 +811,11 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
                 return;
             }
 
+            if (removed) {
+                handler.discardOutbound();
+                return;
+            }
+
             if (this.handler instanceof ContinueOutboundHandler cont) {
                 cont.next = handler;
                 writeSome();


### PR DESCRIPTION
#11528 and #11898.

There's also some new leak recording for PoolHandle. This may require some work to merge up to newer releases, but it's worthwhile doing.