### PR TITLE
Backport three fixes to 4.7.x and fix logged exception in response handling

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -208,6 +208,7 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
                 queued.handler.discardOutbound();
             }
         }
+        inboundHandler.discard();
         outboundQueue.clear();
         requestHandler.removed();
     }
@@ -337,6 +338,9 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
          * @see #channelReadComplete
          */
         void readComplete() {
+        }
+
+        void discard() {
         }
     }
 
@@ -515,6 +519,14 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
             }
             streamingInboundHandler.dest.setExpectedLengthFrom(request.headers());
             requestHandler.accept(ctx, request, new StreamingNettyByteBody(streamingInboundHandler.dest), outboundAccess);
+        }
+
+        @Override
+        void discard() {
+            for (HttpContent content : buffer) {
+                content.release();
+            }
+            buffer.clear();
         }
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -66,6 +66,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
+import java.io.EOFException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -557,6 +558,12 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
         }
 
         @Override
+        void discard() {
+            // note: this has to match RoutingInBoundHandler#IGNORABLE_ERROR_MESSAGE
+            handleUpstreamError(new EOFException("Connection closed before full body was received"));
+        }
+
+        @Override
         void handleUpstreamError(Throwable cause) {
             if (inboundHandler instanceof DecompressingInboundHandler dih) {
                 dih.dispose();
@@ -699,6 +706,12 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
         @Override
         void handleUpstreamError(Throwable cause) {
             delegate.handleUpstreamError(cause);
+        }
+
+        @Override
+        void discard() {
+            dispose();
+            delegate.discard();
         }
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FlagAppender.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FlagAppender.java
@@ -19,6 +19,10 @@ public class FlagAppender extends AppenderBase<ILoggingEvent> {
 
     @Override
     protected void append(ILoggingEvent eventObject) {
+        if (eventObject.getLoggerName().equals(BufferLeakDetection.class.getName())) {
+            // ignore 'Canary leak detection failed.' messages
+            return;
+        }
         triggered = true;
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
@@ -1,14 +1,19 @@
 package io.micronaut.http.server.netty.fuzzing
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanProvider
+import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.netty.channel.EventLoopGroupConfiguration
 import io.micronaut.http.netty.channel.EventLoopGroupRegistry
+import io.micronaut.http.server.HttpServerConfiguration
 import io.micronaut.http.server.netty.NettyHttpServer
+import io.micronaut.http.server.util.DefaultHttpHostResolver
 import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.Unpooled
@@ -22,6 +27,7 @@ import io.netty.util.ReferenceCountUtil
 import jakarta.inject.Singleton
 import org.reactivestreams.Publisher
 import spock.lang.Specification
+
 /**
  * HTTP inputs generated from fuzzing.
  */
@@ -139,6 +145,7 @@ class FuzzyInputSpec extends Specification {
                         "LCwsSWYtTWF0L3JjdGg6LTAKQ29udGVudC1MZW5ndGg6NDMKCv/+LgAIdGlyZW5jZUNvdW50VXRp" +
                         "bM3ac3NXaG5nWVlZWVkJ/wAAAABSZWZlbXQCCf9sYXQLSFRUUC8yLjAKVHJhbnNmZXItRW5jb2Rp" +
                         "bmc6c25hcHB5LCw6LTAKQ29udGVudC1MZW5ndGg6NDQKCv/+LgAIdGlyZUhUVDosdA01Cg=="),
+                Base64.decoder.decode("cG9zdA0vZWNoby1hcnJheQtIVFRQLzIuMApDb250ZW50LUxlbmd0aDo5Ck9yaWdpbjoKCg=="),
         ]
     }
 
@@ -156,9 +163,30 @@ class FuzzyInputSpec extends Specification {
             return foo
         }
 
+        @Post("/echo-array")
+        public byte[] echo(@Body byte[] foo) {
+            return foo;
+        }
+
         @Post("/echo-publisher")
         public Publisher<byte[]> echo(@Body Publisher<byte[]> foo) {
             return foo;
+        }
+    }
+
+    @Singleton
+    @Replaces(DefaultHttpHostResolver.class)
+    @Requires(property = "spec.name", value = "FuzzyInputSpec")
+    public static class StableHttpHostResolver extends DefaultHttpHostResolver {
+        private static final boolean LOCAL = false;
+
+        public StableHttpHostResolver(HttpServerConfiguration serverConfiguration, @Nullable BeanProvider<EmbeddedServer> embeddedServer) {
+            super(serverConfiguration, embeddedServer);
+        }
+
+        @Override
+        protected String getEmbeddedHost() {
+            return LOCAL ? "http://localhost:8080" : "http://example.com:8080";
         }
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.http.server.netty.fuzzing
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
@@ -84,8 +85,10 @@ class FuzzyInputSpec extends Specification {
         when:
         def embeddedChannel = embeddedServer.buildEmbeddedChannel(false)
 
-        embeddedChannel.writeInbound(Unpooled.wrappedBuffer(input));
-        embeddedChannel.runPendingTasks();
+        def b = embeddedChannel.alloc().buffer(input.length)
+        b.writeBytes(input)
+        embeddedChannel.writeInbound(b)
+        embeddedChannel.runPendingTasks()
 
         embeddedChannel.releaseOutbound()
         // don't release inbound, that doesn't happen normally either
@@ -109,6 +112,8 @@ class FuzzyInputSpec extends Specification {
                 Base64.decoder.decode("UE9TVCAvIEhUVFAvMS40NApBY2NlcHQ6IGFwcNTU1NTU1NTU1NTU1NTU0NTU////////////////////////////////Z2dnZy4xCkhvc3Q6IDQKQWNjZXB0OiAqLyoKdC5ldToyNDQ0CkFjY2VwdDogYXBwbGljYXRQT1NUIC8g///////////U1NTU1NTU1NTU1NTU1NTU0NTU////////////////////////////////////////Z2dnZy4xCkhvc3Q6IDQKQWNjZXB0OiAqLyoKdC5ldToyNDQ0CkFjY2VwdDogYXBwbGljYXRQT1NUIEdFVCAvIC8g/////////////////////yT/YXBw1NTU1NTU1NTU1NTU1NTQ1NT///////////////////////////////9nZ2dnLjEKSG9zdDogNApBY2NlcHQ6ICovKgp0LmV1OjI0NDQKQUhvc3Q6IDQKQWNjZXB0OiAqL3B0OiBhcHDU1NTU1NTU1NTU1NTU1NDU1P///////////////////////////////2dnZ2cuMQpIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwcGxpY2F0UE9TVCAvIP//////////1NTU1NTU1NTU1NTU1NTU1NDU1P///////////////////////////////////////2dnZ2cuMQpIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwcGxpY2F0UE9TVCBHRVQgLyAvIP////////////////////8k/2FwcNTU1NTU1NTU1NTU1NTU0NTU////////////////////////////////Z2dnZy4xCkhvc3Q6IDQKQWNjZXB0OiAqLyoKdC5ldToyNDQ0CkFIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwcGxpY2F0UE9TVCAvIP////////////////////8k/////////////////////////9TU1E9QVP//////////////Z2dnZy4xCkhvc3Q6IDQKQWNjZXB0OiAqVCAvIP///////yoKdC5ldToyNDQ0CkFjY2VwdDogYXBwbGljYXRQT1NUIC8g/////////////////////yT/////////////////////////1NTUT1BU//////////////9nZ2dnLjEKSG9zdDogNApBY2NlcHQ6ICovKgp0LmV1OjI0NDQKQWNjZXB0OiBldToyNDQ0CkFjY2VwdDogYXAscGxpY2F0UE9TVCAvIP////////////////////8k/////////////////////////9TU1E9QVElPTsQz1NTU1C8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwcGxpY2F0UE9TVCAvIP//MQpIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwLHBsaWNhdFBPU1QgLyD/////////////////////JP/////////////////////////U1NRPUFRJT07EM9TU1NTU1NTU1GFwaS5iZS1wcm9qZWN0LmV1OjQ0MwpBY2NlcHQ6IGFwcGxpY2F0UE9TVCgvIP//Ki8qCnQuZXU6MjQ0NApBY2NlcHQ6IGH////////////////////////U1NRPUFT//////////////2dnZ2cuMQpIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwcGxpY2F0UE9TVCAvIP//MQpIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwcGxpY2F0UCD/////////////////////JP/////////////////////////U1NRPUFT//////////////2dnZ2cuMQpIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwcGxpY2F0UE9TVCAvIP//MQpIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwLHBsaWNhdFBPU1QgLyD/////////////////////JP/////////////////////////U1NRPUFRJT07EM9TU1NTU1NTU1GFwaS5iZS1wcm9qZWN0LmV1OjQ0MwpBY2NlcHQ6IGFwcGxpY2F0UE9TVCgvIP//Ki8qCnQuZXU6MjQ0NApBY2NlcHQ6IGH////////////////////////U1NRPUFT//////////////2dnZ2cuMQpIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjQ0NApBY2NlcHQ6IGFwcGxpY2F0UE9TVCAvIP//MQpIb3N0OiA0CkFjY2VwdDogKi8qCnQuZXU6MjT///9nZ2dnLjEKSG9zdDogNApBY2NlcHQ6ICovKgp0LmV1OjI0NDQKQWNjZXB0OiBhcHBsaWNhdFBPU1QgLyD//////////9TU1NTU1NTU1NTU1NTU1NTQ1NT//////////w=="),
                 Base64.decoder.decode("VCB4dCBQLzUuMQoKUDIg/CBIUFRQLzEuMgotdHlwZTo3ClRyYX5zZmVyLUVuRVRUbmc6ZGVmbGF0ZQoKL7lFUDIg/CBIUFRQLzEuMQotdHlwZTotdHlwZTo3ClRyYW5zZmVyeXBlOjf///////////////////////////////////////////////////////////////////////////////////////////8KVHJhbnNmZXItRW5jb2Rpbmc6ZGVmbGF0ZQpjb250ZW50LWxlbmd0aDo4CgoNSU9OUyAvILiqVFAvCgovuUVQMkdHR0d3AC07biE="),
                 Base64.decoder.decode("UyAvIFAvMC4xMQpjb250ZW50LWxlbmd0aDo0ClRyYW5zZmVyLUVuY29kaW5nOmRlZmxhdGUKCi+5RVAyIPwgSC8xLjEK"),
+                Base64.decoder.decode("cA1ACUhUVFAvOC4wCkhvc3Q6OgpPcmlnaW46Cgo="),
+                Base64.decoder.decode("SEVDc3QNQP/9P/8JSFRUUC8wLjEKZXB0OgoKcG9zdA1A/T/9Oi8v/y9lY2hvLXB1Ymxpc2hlcglIVFRQLzAuMQp0OgpDb250ZW50LUxlbmd0aDo1Cgr/"),
                 Base64.decoder.decode("UEFUQ0gLDQ0jLzovL9s6Ly8NAEhUVFAvMi4wCm8uVjpEIcAvJwpBY2NlcHQ6LHRleHQvaHRtbAoK" +
                         "RU1UDUD///8JSFRUUC8wLjEKQWNjZXB0Oglpby7///////9lcHQ6LGVwdDosZXB0Oix0ZXh0L2h0" +
                         "bWwsZS5ObgoKdA1A/////T/9Oi8v////CUhUVFAvMC4xCkFjY2VwdDoJaW9hbmdlOix0ZXh0L2h0" +
@@ -149,6 +154,11 @@ class FuzzyInputSpec extends Specification {
         @Post
         public Publisher<String> index(Publisher<String> foo) {
             return foo
+        }
+
+        @Post("/echo-publisher")
+        public Publisher<byte[]> echo(@Body Publisher<byte[]> foo) {
+            return foo;
         }
     }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
@@ -36,7 +36,12 @@ import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.filter.FilterRunner;
 import io.micronaut.http.filter.GenericHttpFilter;
-import io.micronaut.http.server.exceptions.*;
+import io.micronaut.http.server.exceptions.ExceptionHandler;
+import io.micronaut.http.server.exceptions.NotAcceptableException;
+import io.micronaut.http.server.exceptions.NotAllowedException;
+import io.micronaut.http.server.exceptions.NotFoundException;
+import io.micronaut.http.server.exceptions.NotWebSocketRequestException;
+import io.micronaut.http.server.exceptions.UnsupportedMediaException;
 import io.micronaut.http.server.exceptions.response.ErrorContext;
 import io.micronaut.http.server.types.files.FileCustomizableResponseType;
 import io.micronaut.inject.BeanDefinition;
@@ -249,7 +254,8 @@ public class RequestLifecycle {
             }
             if (RouteExecutor.isIgnorable(cause)) {
                 RouteExecutor.logIgnoredException(cause);
-                return ExecutionFlow.empty();
+                // the client won't see this response, but we need one for filters and such
+                return ExecutionFlow.just(HttpResponse.badRequest("Stream closed"));
             }
             return createDefaultErrorResponseFlow(request, cause);
         }

--- a/http-server/src/main/java/io/micronaut/http/server/util/DefaultHttpHostResolver.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/DefaultHttpHostResolver.java
@@ -173,10 +173,14 @@ public class DefaultHttpHostResolver implements HttpHostResolver {
         }
 
         Integer port;
-        if (isPortInHost && host != null && host.contains(":")) {
-            String[] parts = host.split(":");
-            host = parts[0].trim();
-            port = Integer.valueOf(parts[1].trim());
+        int separatorIndex = host == null ? -1 : host.indexOf(':');
+        if (isPortInHost && separatorIndex != -1) {
+            try {
+                port = Integer.valueOf(host.substring(separatorIndex + 1).trim());
+            } catch (NumberFormatException e) {
+                port = null;
+            }
+            host = host.substring(0, separatorIndex).trim();
         } else if (portHeader != null) {
             port = headers.get(portHeader, Integer.class).orElse(null);
         } else {

--- a/http-server/src/test/groovy/io/micronaut/http/server/util/DefaultHttpHostResolverSpec.groovy
+++ b/http-server/src/test/groovy/io/micronaut/http/server/util/DefaultHttpHostResolverSpec.groovy
@@ -30,4 +30,21 @@ class DefaultHttpHostResolverSpec extends Specification {
         expect:
         hostResolver.resolve(request) == "https://www.example.com"
     }
+
+    void "test host resolver with invalid host header"(String header, String result) {
+        ApplicationContext applicationContext = ApplicationContext.run()
+        HttpHostResolver hostResolver = applicationContext.getBean(HttpHostResolver)
+        def request = Stub(HttpRequest) {
+            getHeaders() >> new MockHttpHeaders(['Host': [header]])
+            getUri() >> new URI("/")
+        }
+
+        expect:
+        hostResolver.resolve(request) == result
+
+        where:
+        header            | result
+        ':'               | 'http://'
+        'example.com:foo' | 'http://example.com'
+    }
 }


### PR DESCRIPTION
https://github.com/micronaut-projects/micronaut-core/commit/491d6609f8ea785b1d6ac65e238228d34fdc04c4 contains a fix for a log message found by fuzzing.

The other three commits are backports of other fixes that are necessary to reproduce this bug. This PR is against 4.7 because I've learned my lesson and don't want to debug the same issues twice.

Ideally merge this without squashing.