### PR TITLE
Make CorsFilter log on Info level when denying localhost requests

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -155,12 +155,12 @@ public class CorsFilter implements Ordered, ConditionalFilter {
                 return forbidden();
             }
             if (shouldDenyToPreventDriveByLocalhostAttack(corsOriginConfiguration, request)) {
-                LOG.trace("The resolved configuration allows any origin. To prevent drive-by-localhost attacks the request is forbidden");
+                LOG.info("The resolved configuration allows any origin. To prevent drive-by-localhost attacks the request is forbidden");
                 return forbidden();
             }
             return null; // proceed
         } else if (shouldDenyToPreventDriveByLocalhostAttack(origin, request)) {
-            LOG.trace("The request specifies an origin different than localhost. To prevent drive-by-localhost attacks the request is forbidden");
+            LOG.info("The request specifies an origin different than localhost. To prevent drive-by-localhost attacks the request is forbidden");
             return forbidden();
         }
         LOG.trace("CORS configuration not found for {} origin", origin);


### PR DESCRIPTION
This fixes the issue #11950 

I do not think many people run with trace logs enabled and it was frustrating to me when a valid request was denied with absolutely nothing in the logs. See the issue for more details.

Short description of the problem: requests from localhost coming from inside of a browser's extension are not detected as coming from localhost. I do not think it is worth the effort to upgrade the detection of localhost and it is better to just log a line on the info. There is already `micronaut.server.cors.localhostPassThrough` to resolve this problem for a developer, but the developer should at least know where to look for it.