### PR TITLE
Fail on unresolved annotation values

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -373,15 +373,18 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
             Object resolvedValue = resolver.resolvedValue;
 
             if (resolvedValue != null) {
-                if ("<error>".equals(resolvedValue) &&
-                    Class.class.getName().equals(this.modelUtils.resolveTypeName(((ExecutableElement) member).getReturnType()))) {
-                    resolvedValue = new AnnotationClassValue<>(
-                        new AnnotationClassValue.UnresolvedClass(new PostponeToNextRoundException(
-                            originatingElement,
-                            originatingElement.getSimpleName().toString() + "@" + annotationName + "(" + memberName + ")"
-                        ))
-                    );
-                    annotationValues.put(memberName, resolvedValue);
+                if ("<error>".equals(resolvedValue)) {
+                    if (Class.class.getName().equals(this.modelUtils.resolveTypeName(((ExecutableElement) member).getReturnType()))) {
+                        resolvedValue = new AnnotationClassValue<>(
+                            new AnnotationClassValue.UnresolvedClass(new PostponeToNextRoundException(
+                                originatingElement,
+                                originatingElement.getSimpleName().toString() + "@" + annotationName + "(" + memberName + ")"
+                            ))
+                        );
+                        annotationValues.put(memberName, resolvedValue);
+                    } else {
+                        throw new PostponeToNextRoundException(originatingElement,  memberName);
+                    }
                 } else {
                     if (isEvaluatedExpression(resolvedValue)) {
                         resolvedValue = buildEvaluatedExpressionReference(originatingElement, annotationName, memberName, resolvedValue);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -274,12 +274,15 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                 List<JavaClassElement> javaClassElements = elements.stream()
                     .map(typeElement -> elementFactory.newSourceClassElement(typeElement, elementAnnotationMetadataFactory))
                     .collect(Collectors.toCollection(() -> new ArrayList<>(elements.size())));
-
                 List<ClassElement> extraClasses = new ArrayList<>();
-                for (JavaClassElement javaClassElement : javaClassElements) {
-                    extraClasses.addAll(VisitorUtils.collectImportedElements(javaClassElement, javaVisitorContext));
+                for (JavaClassElement javaClassElement : new ArrayList<>(javaClassElements)) {
+                    try {
+                        extraClasses.addAll(VisitorUtils.collectImportedElements(javaClassElement, javaVisitorContext));
+                        javaClassElements.addAll((Collection) extraClasses);
+                    } catch (PostponeToNextRoundException e) {
+                        postponeElement(javaClassElement, e.getNativeErrorElement(), e);
+                    }
                 }
-                javaClassElements.addAll((Collection) extraClasses);
 
                 for (LoadedVisitor loadedVisitor : loadedVisitors) {
                     for (JavaClassElement javaClassElement : javaClassElements) {

--- a/test-suite/src/test/groovy/io/micronaut/lombok/LombokClassElementSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/lombok/LombokClassElementSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.lombok
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.annotation.processing.test.JavaParser
+import io.micronaut.context.ApplicationContext
+
+import javax.annotation.processing.Processor
+
+class LombokClassElementSpec extends AbstractTypeElementSpec {
+
+    void 'test lombok compile'() {
+        given:
+        ApplicationContext context = buildContext('test.FooBean', '''
+package test;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import lombok.experimental.FieldNameConstants;
+
+@FieldNameConstants
+@Singleton
+@Requires(property = "spec.name", value = FooBean.Fields.lombokFieldsTest)
+class FooBean {
+
+    private String lombokFieldsTest;
+
+}
+
+''', true, ["spec.name": "lombokFieldsTest"])
+        expect:
+        context.containsBean(context.classLoader.loadClass('test.FooBean'))
+    }
+
+    @Override
+    protected JavaParser newJavaParser() {
+        return new JavaParser() {
+
+            @Override
+            protected List<Processor> getAnnotationProcessors() {
+                def processors = super.getAnnotationProcessors()
+                processors.add(0, getClass().getClassLoader().loadClass('lombok.launch.AnnotationProcessorHider$ClaimingProcessor').newInstance())
+                processors.add(0, getClass().getClassLoader().loadClass('lombok.launch.AnnotationProcessorHider$AnnotationProcessor').newInstance())
+                return processors
+            }
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/test/lombok/FooBean.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/FooBean.java
@@ -1,0 +1,14 @@
+package io.micronaut.test.lombok;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import lombok.experimental.FieldNameConstants;
+
+@FieldNameConstants
+@Singleton
+@Requires(property = "spec.name", value = FooBean.Fields.lombokFieldsTest)
+public class FooBean {
+
+    private String lombokFieldsTest;
+
+}

--- a/test-suite/src/test/java/io/micronaut/test/lombok/LombokFieldsTest.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/LombokFieldsTest.java
@@ -1,0 +1,22 @@
+package io.micronaut.test.lombok;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@Property(name = "spec.name", value = "lombokFieldsTest")
+@MicronautTest
+public class LombokFieldsTest {
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Test
+    public void testBean() {
+        Assertions.assertTrue(applicationContext.containsBean(FooBean.class));
+    }
+
+}


### PR DESCRIPTION
Fixes using Lombok's `@FieldNameConstants`, it might remove the need of `AnnotationClassValue.UnresolvedClass`.