### PR TITLE
Introduce memoizer API for AnnotationMetadata

### DIFF
--- a/benchmarks/src/jmh/java/io/micronaut/core/util/memo/MemoBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/core/util/memo/MemoBenchmark.java
@@ -59,12 +59,12 @@ public class MemoBenchmark {
 
     @Benchmark
     public boolean memoized() {
-        return property.getMemoized(ANNOTATED_FLAG);
+        return ANNOTATED_FLAG.get(property);
     }
 
     @Benchmark
     public boolean memoizedFallback() {
-        // this is the default implementation of Memoizer.getMemoized
+        // this is the default implementation of get()
         return ANNOTATED_FLAG.compute(property);
     }
 

--- a/benchmarks/src/jmh/java/io/micronaut/core/util/memo/MemoBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/core/util/memo/MemoBenchmark.java
@@ -1,0 +1,123 @@
+package io.micronaut.core.util.memo;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.core.beans.BeanProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@State(Scope.Benchmark)
+public class MemoBenchmark {
+    private static final MemoizedFlag<AnnotationMetadata> ANNOTATED_FLAG =
+        AnnotationMetadata.MEMOIZER_NAMESPACE.newFlag(m -> m.hasAnnotation(Ann1.class));
+
+    @Param({"Bare", "Extra1", "Extra2"})
+    String type;
+    @Param({"true", "false"})
+    boolean annotated;
+
+    private BeanProperty<?, ?> property;
+
+    @Setup
+    public void setup() throws Throwable {
+        BeanIntrospection<?> introspection = BeanIntrospector.SHARED.getIntrospection(Class.forName(MemoBenchmark.class.getName() + "$" + type));
+        property = introspection.getProperty(annotated ? "annotatedField" : "notAnnotatedField").orElseThrow();
+
+        if (memoized() != annotated) {
+            throw new AssertionError();
+        }
+        if (memoizedFallback() != annotated) {
+            throw new AssertionError();
+        }
+        if (direct() != annotated) {
+            throw new AssertionError();
+        }
+    }
+
+    @Benchmark
+    public boolean memoized() {
+        return property.getMemoized(ANNOTATED_FLAG);
+    }
+
+    @Benchmark
+    public boolean memoizedFallback() {
+        // this is the default implementation of Memoizer.getMemoized
+        return ANNOTATED_FLAG.compute(property);
+    }
+
+    @Benchmark
+    public boolean direct() {
+        return property.hasAnnotation(Ann1.class);
+    }
+
+    public static void main(String[] args) throws Throwable {
+        MemoBenchmark memoBenchmark = new MemoBenchmark();
+        memoBenchmark.type = "Bare";
+        memoBenchmark.annotated = true;
+        memoBenchmark.setup();
+        memoBenchmark.memoizedFallback();
+
+        Options opt = new OptionsBuilder()
+            .include(MemoBenchmark.class.getName() + ".*")
+            //.addProfiler(LinuxPerfAsmProfiler.class)
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    @Introspected
+    record Bare(
+        @Ann1 String annotatedField,
+        String notAnnotatedField
+    ) {
+    }
+
+    @Introspected
+    record Extra1(
+        @Ann1 @Ann2 String annotatedField,
+        @Ann2 String notAnnotatedField
+    ) {
+    }
+
+    @Introspected
+    record Extra2(
+        @Ann1 @Ann2 @Ann3 String annotatedField,
+        @Ann2 @Ann3 String notAnnotatedField
+    ) {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Ann1 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Ann2 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Ann3 {
+    }
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     compileOnly(libs.graal)
     compileOnly(libs.managed.kotlin.stdlib)
     compileOnly(libs.managed.netty.common)
+    testImplementation(libs.junit.jupiter.params)
 }
 
 spotless {

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
@@ -63,6 +63,9 @@ public interface AnnotationMetadata extends AnnotationSource, Memoizer<Annotatio
      */
     AnnotationMetadata EMPTY_METADATA = new EmptyAnnotationMetadata();
 
+    /**
+     * Namespace to use for memoized field access. See {@link Memoizer}.
+     */
     MemoizerNamespace<AnnotationMetadata> MEMOIZER_NAMESPACE = MemoizerNamespace.create();
 
     /**

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
@@ -22,6 +22,8 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.memo.Memoizer;
+import io.micronaut.core.util.memo.MemoizerNamespace;
 import io.micronaut.core.value.OptionalValues;
 
 import java.lang.annotation.Annotation;
@@ -55,11 +57,13 @@ import java.util.Set;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface AnnotationMetadata extends AnnotationSource {
+public interface AnnotationMetadata extends AnnotationSource, Memoizer<AnnotationMetadata> {
     /**
      * A constant for representing empty metadata.
      */
     AnnotationMetadata EMPTY_METADATA = new EmptyAnnotationMetadata();
+
+    MemoizerNamespace<AnnotationMetadata> MEMOIZER_NAMESPACE = MemoizerNamespace.create();
 
     /**
      * The default {@code value()} member.

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
@@ -16,8 +16,7 @@
 package io.micronaut.core.annotation;
 
 import io.micronaut.core.type.Argument;
-import io.micronaut.core.util.memo.MemoizedFlag;
-import io.micronaut.core.util.memo.MemoizedReference;
+import io.micronaut.core.util.memo.MemoizerDelegate;
 import io.micronaut.core.value.OptionalValues;
 
 import java.lang.annotation.Annotation;
@@ -36,7 +35,7 @@ import java.util.Set;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface AnnotationMetadataDelegate extends AnnotationMetadataProvider, AnnotationMetadata {
+public interface AnnotationMetadataDelegate extends AnnotationMetadataProvider, AnnotationMetadata, MemoizerDelegate<AnnotationMetadata> {
 
     @Override
     default Set<String> getStereotypeAnnotationNames() {
@@ -685,12 +684,8 @@ public interface AnnotationMetadataDelegate extends AnnotationMetadataProvider, 
     }
 
     @Override
-    default boolean getMemoized(@NonNull MemoizedFlag<AnnotationMetadata> flag) {
-        return getAnnotationMetadata().getMemoized(flag);
-    }
-
-    @Override
-    default <R> R getMemoized(@NonNull MemoizedReference<AnnotationMetadata, R> reference) {
-        return getAnnotationMetadata().getMemoized(reference);
+    @Internal
+    default AnnotationMetadata getMemoizerDelegate() {
+        return getAnnotationMetadata();
     }
 }

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
@@ -16,10 +16,18 @@
 package io.micronaut.core.annotation;
 
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.memo.MemoizedFlag;
+import io.micronaut.core.util.memo.MemoizedReference;
 import io.micronaut.core.value.OptionalValues;
 
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.Set;
 
 /**
  * An interface that can be implemented by other classes that delegate the resolution of the {@link AnnotationMetadata}
@@ -674,5 +682,15 @@ public interface AnnotationMetadataDelegate extends AnnotationMetadataProvider, 
     @Override
     default AnnotationMetadata getTargetAnnotationMetadata() {
         return getAnnotationMetadata().getTargetAnnotationMetadata();
+    }
+
+    @Override
+    default boolean getMemoized(@NonNull MemoizedFlag<AnnotationMetadata> flag) {
+        return getAnnotationMetadata().getMemoized(flag);
+    }
+
+    @Override
+    default <R> R getMemoized(@NonNull MemoizedReference<AnnotationMetadata, R> reference) {
+        return getAnnotationMetadata().getMemoized(reference);
     }
 }

--- a/core/src/main/java/io/micronaut/core/annotation/EmptyAnnotationMetadata.java
+++ b/core/src/main/java/io/micronaut/core/annotation/EmptyAnnotationMetadata.java
@@ -18,10 +18,20 @@ package io.micronaut.core.annotation;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.memo.AbstractMemoizer;
+import io.micronaut.core.util.memo.MemoizerNamespace;
 import io.micronaut.core.value.OptionalValues;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.Set;
 
 /**
  * An empty representation of {@link AnnotationMetadata}.
@@ -30,7 +40,11 @@ import java.util.*;
  * @since 1.0
  */
 @Internal
-final class EmptyAnnotationMetadata implements AnnotationMetadata {
+final class EmptyAnnotationMetadata extends AbstractMemoizer<AnnotationMetadata> implements AnnotationMetadata {
+    @Override
+    protected MemoizerNamespace<AnnotationMetadata> getMemoizerNamespace() {
+        return MEMOIZER_NAMESPACE;
+    }
 
     @Override
     public boolean hasPropertyExpressions() {

--- a/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
@@ -68,9 +68,8 @@ public abstract class AbstractMemoizer<M extends Memoizer<M>> implements Memoize
         flags = 0;
     }
 
-    @Override
     @SuppressWarnings("unchecked")
-    public final <R> R getMemoized(MemoizedReference<M, R> reference) {
+    final <R> R getMemoized(MemoizedReference<M, R> reference) {
         Object[] items = (Object[]) ITEMS_FIELD.getAcquire(this);
         int index = reference.index;
         if (index >= items.length) {
@@ -105,8 +104,7 @@ public abstract class AbstractMemoizer<M extends Memoizer<M>> implements Memoize
         return item;
     }
 
-    @Override
-    public final boolean getMemoized(@NonNull MemoizedFlag<M> flag) {
+    final boolean getMemoized(@NonNull MemoizedFlag<M> flag) {
         if (!(flag instanceof MemoizedFlag.InBitmask<M> ib)) {
             return getMemoizedViaReference(flag);
         }

--- a/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
@@ -21,7 +21,6 @@ import io.micronaut.core.util.ArrayUtils;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.util.Arrays;
 
 /**
  * Implementation of {@link Memoizer} with backing storage.
@@ -76,9 +75,12 @@ public abstract class AbstractMemoizer<M extends Memoizer<M>> implements Memoize
     }
 
     private Object[] ensureCapacity(Object[] items, int accessedIndex) {
-        items = Arrays.copyOf(items, accessedIndex + 1);
-        this.items = items;
-        return items;
+        Object[] newItems = new Object[accessedIndex + 1];
+        for (int i = 0; i < items.length; i++) {
+            ITEMS_ENTRY.setRelease(newItems, i, ITEMS_ENTRY.getAcquire(items, i));
+        }
+        this.items = newItems;
+        return newItems;
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
@@ -32,7 +32,7 @@ import java.lang.invoke.VarHandle;
 @Internal
 public abstract class AbstractMemoizer<M extends Memoizer<M>> implements Memoizer<M> {
     private static final Object NULL_SENTINEL = new Object();
-    private static final VarHandle ITEMS_ENTRY = MethodHandles.arrayElementVarHandle(Object[].class);
+    private static final VarHandle ITEMS_ENTRY = MethodHandles.arrayElementVarHandle(Object[].class).withInvokeExactBehavior();
 
     private Object[] items = ArrayUtils.EMPTY_OBJECT_ARRAY;
     private long flags;

--- a/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.util.memo;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.ArrayUtils;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+/**
+ * Implementation of {@link Memoizer} with backing storage.
+ *
+ * @param <M> This memoizer type
+ * @author Jonas Konrad
+ * @since 4.10.0
+ */
+@Internal
+public abstract class AbstractMemoizer<M extends Memoizer<M>> implements Memoizer<M> {
+    private static final Object NULL_SENTINEL = new Object();
+    private static final VarHandle ITEMS_FIELD;
+    private static final VarHandle ITEMS_ENTRY = MethodHandles.arrayElementVarHandle(Object[].class);
+
+    @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
+    private Object[] items = ArrayUtils.EMPTY_OBJECT_ARRAY;
+    private long flags;
+
+    static {
+        try {
+            ITEMS_FIELD = MethodHandles.lookup().findVarHandle(AbstractMemoizer.class, "items", Object[].class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Get the namespace that should be used for this memoizer. This is a method instead of a field
+     * to save on memory. This namespace is only spot-checked on field population.
+     *
+     * @return The namespace
+     */
+    @NonNull
+    @Internal
+    protected abstract MemoizerNamespace<M> getMemoizerNamespace();
+
+    /**
+     * Clear all memoized values, for use when this instance is modified and memoization may now
+     * return a different value. This is a cheap operation.
+     */
+    @Internal
+    protected final void clearMemoized() {
+        items = ArrayUtils.EMPTY_OBJECT_ARRAY;
+        flags = 0;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final <R> R getMemoized(MemoizedReference<M, R> reference) {
+        Object[] items = (Object[]) ITEMS_FIELD.getAcquire(this);
+        int index = reference.index;
+        if (index >= items.length) {
+            items = ensureCapacity(items, index);
+        }
+        Object item = ITEMS_ENTRY.getAcquire(items, index);
+        if (item == null) {
+            item = computeItem(reference, items, index);
+        }
+        if (item == NULL_SENTINEL) {
+            item = null;
+        }
+        return (R) item;
+    }
+
+    private Object[] ensureCapacity(Object[] items, int accessedIndex) {
+        items = Arrays.copyOf(items, accessedIndex + 1);
+        ITEMS_FIELD.setRelease(this, items);
+        return items;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object computeItem(MemoizedReference<M, ?> reference, Object[] items, int index) {
+        if (reference.namespace != getMemoizerNamespace()) {
+            throw new IllegalStateException("Reference not in right namespace");
+        }
+        Object item = reference.compute.apply((M) this);
+        if (item == null) {
+            item = NULL_SENTINEL;
+        }
+        ITEMS_ENTRY.setRelease(items, index, item);
+        return item;
+    }
+
+    @Override
+    public final boolean getMemoized(@NonNull MemoizedFlag<M> flag) {
+        if (!(flag instanceof MemoizedFlag.InBitmask<M> ib)) {
+            return getMemoizedViaReference(flag);
+        }
+        long flags = this.flags;
+        if ((flags & ib.maskIsSet) == 0) {
+            flags = computeFlag(flags, ib);
+        }
+        return (flags & ib.maskValue) != 0;
+    }
+
+    private boolean getMemoizedViaReference(MemoizedFlag<M> flag) {
+        return getMemoized(((MemoizedFlag.InReference<M>) flag).reference);
+    }
+
+    @SuppressWarnings("unchecked")
+    private long computeFlag(long flags, MemoizedFlag.InBitmask<M> ib) {
+        flags |= ib.maskIsSet;
+        if (ib.compute.test((M) this)) {
+            flags |= ib.maskValue;
+        } else {
+            flags &= ~ib.maskValue;
+        }
+        this.flags = flags;
+        return flags;
+    }
+}

--- a/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/AbstractMemoizer.java
@@ -33,20 +33,10 @@ import java.util.Arrays;
 @Internal
 public abstract class AbstractMemoizer<M extends Memoizer<M>> implements Memoizer<M> {
     private static final Object NULL_SENTINEL = new Object();
-    private static final VarHandle ITEMS_FIELD;
     private static final VarHandle ITEMS_ENTRY = MethodHandles.arrayElementVarHandle(Object[].class);
 
-    @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
     private Object[] items = ArrayUtils.EMPTY_OBJECT_ARRAY;
     private long flags;
-
-    static {
-        try {
-            ITEMS_FIELD = MethodHandles.lookup().findVarHandle(AbstractMemoizer.class, "items", Object[].class);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new AssertionError(e);
-        }
-    }
 
     /**
      * Get the namespace that should be used for this memoizer. This is a method instead of a field
@@ -70,7 +60,7 @@ public abstract class AbstractMemoizer<M extends Memoizer<M>> implements Memoize
 
     @SuppressWarnings("unchecked")
     final <R> R getMemoized(MemoizedReference<M, R> reference) {
-        Object[] items = (Object[]) ITEMS_FIELD.getAcquire(this);
+        Object[] items = this.items;
         int index = reference.index;
         if (index >= items.length) {
             items = ensureCapacity(items, index);
@@ -87,7 +77,7 @@ public abstract class AbstractMemoizer<M extends Memoizer<M>> implements Memoize
 
     private Object[] ensureCapacity(Object[] items, int accessedIndex) {
         items = Arrays.copyOf(items, accessedIndex + 1);
-        ITEMS_FIELD.setRelease(this, items);
+        this.items = items;
         return items;
     }
 

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizedFlag.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizedFlag.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.util.memo;
+
+import java.util.function.Predicate;
+
+/**
+ * Store a boolean value in a {@link Memoizer} object.
+ *
+ * @param <M> The memoized object type
+ * @author Jonas Konrad
+ * @since 4.10.0
+ */
+@SuppressWarnings("unused")
+public abstract sealed class MemoizedFlag<M extends Memoizer<M>> {
+    private MemoizedFlag() {
+    }
+
+    abstract boolean compute(M memoizer);
+
+    /**
+     * Implementation that stores in the {@code long} bitmask.
+     *
+     * @param <M> The memoized object type
+     */
+    static final class InBitmask<M extends Memoizer<M>> extends MemoizedFlag<M> {
+        final MemoizerNamespace<M> namespace;
+        final Predicate<? super M> compute;
+        final long maskIsSet;
+        final long maskValue;
+
+        InBitmask(MemoizerNamespace<M> namespace, Predicate<? super M> compute, int index) {
+            this.namespace = namespace;
+            this.compute = compute;
+            assert index < 32;
+            maskIsSet = (1L << (index * 2));
+            maskValue = (1L << (index * 2 + 1));
+        }
+
+        @Override
+        boolean compute(M memoizer) {
+            return compute.test(memoizer);
+        }
+    }
+
+    /**
+     * Implementation that stores using {@link MemoizedReference}. This should be avoided, but
+     * exists as a fallback when there are too many flags in a namespace.
+     *
+     * @param <M> The memoized object type
+     */
+    static final class InReference<M extends Memoizer<M>> extends MemoizedFlag<M> {
+        final MemoizedReference<M, Boolean> reference;
+
+        InReference(MemoizedReference<M, Boolean> reference) {
+            this.reference = reference;
+        }
+
+        @Override
+        boolean compute(M memoizer) {
+            return reference.compute.apply(memoizer);
+        }
+    }
+}

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizedFlag.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizedFlag.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.core.util.memo;
 
-import io.micronaut.core.annotation.AnnotationMetadataDelegate;
+import io.micronaut.core.annotation.NonNull;
 
 import java.util.function.Predicate;
 
@@ -33,12 +33,19 @@ public abstract sealed class MemoizedFlag<M extends Memoizer<M>> {
 
     abstract boolean compute(M memoizer);
 
+    /**
+     * Get the memoized boolean value.
+     *
+     * @param memoizer The memoizer to load or compute this field from
+     * @return The memoized value
+     * @implNote The default implementation does no storage and computes the memoized value each time.
+     */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public boolean get(M memoizer) {
+    public boolean get(@NonNull M memoizer) {
         if (memoizer instanceof AbstractMemoizer am) {
             return am.getMemoized(this);
-        } else if (memoizer instanceof AnnotationMetadataDelegate amd) {
-            return get((M) amd.getAnnotationMetadata());
+        } else if (memoizer instanceof MemoizerDelegate<?> md) {
+            return get((M) md.getMemoizerDelegate());
         } else {
             return compute(memoizer);
         }

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizedFlag.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizedFlag.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.core.util.memo;
 
+import io.micronaut.core.annotation.AnnotationMetadataDelegate;
+
 import java.util.function.Predicate;
 
 /**
@@ -30,6 +32,17 @@ public abstract sealed class MemoizedFlag<M extends Memoizer<M>> {
     }
 
     abstract boolean compute(M memoizer);
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public boolean get(M memoizer) {
+        if (memoizer instanceof AbstractMemoizer am) {
+            return am.getMemoized(this);
+        } else if (memoizer instanceof AnnotationMetadataDelegate amd) {
+            return get((M) amd.getAnnotationMetadata());
+        } else {
+            return compute(memoizer);
+        }
+    }
 
     /**
      * Implementation that stores in the {@code long} bitmask.

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizedFlag.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizedFlag.java
@@ -44,7 +44,14 @@ public abstract sealed class MemoizedFlag<M extends Memoizer<M>> {
     public boolean get(@NonNull M memoizer) {
         if (memoizer instanceof AbstractMemoizer am) {
             return am.getMemoized(this);
-        } else if (memoizer instanceof MemoizerDelegate<?> md) {
+        } else {
+            return fallback(memoizer);
+        }
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private boolean fallback(@NonNull M memoizer) {
+        if (memoizer instanceof MemoizerDelegate<?> md) {
             return get((M) md.getMemoizerDelegate());
         } else {
             return compute(memoizer);

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizedReference.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizedReference.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.util.memo;
+
+import java.util.function.Function;
+
+/**
+ * Store a reference value in a {@link Memoizer} object.
+ *
+ * @param <M> The memoized object type
+ * @param <R> The stored field type
+ * @author Jonas Konrad
+ * @since 4.10.0
+ */
+public final class MemoizedReference<M extends Memoizer<M>, R> {
+    final MemoizerNamespace<M> namespace;
+    final Function<? super M, ? extends R> compute;
+    final int index;
+
+    MemoizedReference(MemoizerNamespace<M> namespace, Function<? super M, ? extends R> compute, int index) {
+        this.namespace = namespace;
+        this.compute = compute;
+        this.index = index;
+    }
+}

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizedReference.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizedReference.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.core.util.memo;
 
-import io.micronaut.core.annotation.AnnotationMetadataDelegate;
+import io.micronaut.core.annotation.NonNull;
 
 import java.util.function.Function;
 
@@ -38,12 +38,19 @@ public final class MemoizedReference<M extends Memoizer<M>, R> {
         this.index = index;
     }
 
+    /**
+     * Get a memoized reference value.
+     *
+     * @param memoizer The memoizer to load this field from
+     * @return The memoized value
+     * @implNote The default implementation does no storage and computes the memoized value each time.
+     */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public R get(M memoizer) {
+    public R get(@NonNull M memoizer) {
         if (memoizer instanceof AbstractMemoizer am) {
             return (R) am.getMemoized(this);
-        } else if (memoizer instanceof AnnotationMetadataDelegate amd) {
-            return get((M) amd.getAnnotationMetadata());
+        } else if (memoizer instanceof MemoizerDelegate<?> md) {
+            return get((M) md.getMemoizerDelegate());
         } else {
             return compute.apply(memoizer);
         }

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizedReference.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizedReference.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.core.util.memo;
 
+import io.micronaut.core.annotation.AnnotationMetadataDelegate;
+
 import java.util.function.Function;
 
 /**
@@ -34,5 +36,16 @@ public final class MemoizedReference<M extends Memoizer<M>, R> {
         this.namespace = namespace;
         this.compute = compute;
         this.index = index;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public R get(M memoizer) {
+        if (memoizer instanceof AbstractMemoizer am) {
+            return (R) am.getMemoized(this);
+        } else if (memoizer instanceof AnnotationMetadataDelegate amd) {
+            return get((M) amd.getAnnotationMetadata());
+        } else {
+            return compute.apply(memoizer);
+        }
     }
 }

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizedReference.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizedReference.java
@@ -49,7 +49,14 @@ public final class MemoizedReference<M extends Memoizer<M>, R> {
     public R get(@NonNull M memoizer) {
         if (memoizer instanceof AbstractMemoizer am) {
             return (R) am.getMemoized(this);
-        } else if (memoizer instanceof MemoizerDelegate<?> md) {
+        } else {
+            return fallback(memoizer);
+        }
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private R fallback(@NonNull M memoizer) {
+        if (memoizer instanceof MemoizerDelegate<?> md) {
             return get((M) md.getMemoizerDelegate());
         } else {
             return compute.apply(memoizer);

--- a/core/src/main/java/io/micronaut/core/util/memo/Memoizer.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/Memoizer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.util.memo;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+
+/**
+ * An object that can optionally store additional caller-customizable memoized data. Essentially,
+ * a memoizer contains a {@code Map<MemoizedReference, T>}, and {@link #getMemoized} does a
+ * {@code computeIfAbsent} on that map.
+ *
+ * <p>Each {@link Memoizer} <i>type</i> is associated with a {@link MemoizerNamespace}. The
+ * namespace keeps track of the fields ({@link MemoizedReference}s and {@link MemoizedFlag}s) that
+ * are permitted for that namespace.
+ *
+ * <p>The namespace allows for the {@link Memoizer} implementation to be more efficient than a
+ * simple {@link java.util.Map}, e.g. by storing booleans as a bit field.
+ *
+ * @param <SELF> The type the memoization functions use
+ * @since 4.10.0
+ * @author Jonas Konrad
+ */
+@Experimental
+public interface Memoizer<SELF extends Memoizer<SELF>> {
+    /**
+     * Get a memoized reference value.
+     *
+     * @param reference The memoized field to load or compute
+     * @param <R>       The memoized value type
+     * @return The memoized value
+     * @implNote The default implementation does no storage and computes the memoized value each time.
+     */
+    @SuppressWarnings("unchecked")
+    default <R> R getMemoized(@NonNull MemoizedReference<SELF, R> reference) {
+        return reference.compute.apply((SELF) this);
+    }
+
+    /**
+     * Get a memoized boolean value.
+     *
+     * @param flag The memoized flag to load or compute
+     * @return The memoized value
+     * @implNote The default implementation does no storage and computes the memoized value each time.
+     */
+    @SuppressWarnings("unchecked")
+    default boolean getMemoized(@NonNull MemoizedFlag<SELF> flag) {
+        return flag.compute((SELF) this);
+    }
+}

--- a/core/src/main/java/io/micronaut/core/util/memo/Memoizer.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/Memoizer.java
@@ -16,11 +16,10 @@
 package io.micronaut.core.util.memo;
 
 import io.micronaut.core.annotation.Experimental;
-import io.micronaut.core.annotation.NonNull;
 
 /**
  * An object that can optionally store additional caller-customizable memoized data. Essentially,
- * a memoizer contains a {@code Map<MemoizedReference, T>}, and {@link #getMemoized} does a
+ * a memoizer contains a {@code Map<MemoizedReference, T>}, and {@link MemoizedReference#get(Memoizer)} does a
  * {@code computeIfAbsent} on that map.
  *
  * <p>Each {@link Memoizer} <i>type</i> is associated with a {@link MemoizerNamespace}. The
@@ -30,34 +29,14 @@ import io.micronaut.core.annotation.NonNull;
  * <p>The namespace allows for the {@link Memoizer} implementation to be more efficient than a
  * simple {@link java.util.Map}, e.g. by storing booleans as a bit field.
  *
- * @param <SELF> The type the memoization functions use
+ * <p>To avoid interface calls, the actual accessor methods are on {@link MemoizedReference} and {@link MemoizedFlag},
+ * and not part of this interface.
+ *
+ * @param <SELF> The type of the memoization namespace
  * @since 4.10.0
  * @author Jonas Konrad
  */
+@SuppressWarnings("unused")
 @Experimental
 public interface Memoizer<SELF extends Memoizer<SELF>> {
-    /**
-     * Get a memoized reference value.
-     *
-     * @param reference The memoized field to load or compute
-     * @param <R>       The memoized value type
-     * @return The memoized value
-     * @implNote The default implementation does no storage and computes the memoized value each time.
-     */
-    @SuppressWarnings("unchecked")
-    default <R> R getMemoized(@NonNull MemoizedReference<SELF, R> reference) {
-        return reference.compute.apply((SELF) this);
-    }
-
-    /**
-     * Get a memoized boolean value.
-     *
-     * @param flag The memoized flag to load or compute
-     * @return The memoized value
-     * @implNote The default implementation does no storage and computes the memoized value each time.
-     */
-    @SuppressWarnings("unchecked")
-    default boolean getMemoized(@NonNull MemoizedFlag<SELF> flag) {
-        return flag.compute((SELF) this);
-    }
 }

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizerDelegate.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizerDelegate.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.util.memo;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+
+/**
+ * Special memoizer that should delegate to another. This is used for
+ * {@link io.micronaut.core.annotation.AnnotationMetadataDelegate}. Generally try to avoid this, as
+ * it can lead to unnecessary interface calls.
+ *
+ * @param <M> The memoizer type
+ * @since 4.10.0
+ * @author Jonas Konrad
+ */
+@Internal
+public interface MemoizerDelegate<M extends Memoizer<M>> extends Memoizer<M> {
+    /**
+     * The delegate to use for storage.
+     *
+     * @return The delegate
+     */
+    @NonNull
+    M getMemoizerDelegate();
+}

--- a/core/src/main/java/io/micronaut/core/util/memo/MemoizerNamespace.java
+++ b/core/src/main/java/io/micronaut/core/util/memo/MemoizerNamespace.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.util.memo;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A namespace for a {@link Memoizer}. Each memoizer <i>type</i> is associated with exactly one
+ * namespace. For example, {@link io.micronaut.core.annotation.AnnotationMetadata} has the
+ * namespace {@link io.micronaut.core.annotation.AnnotationMetadata#MEMOIZER_NAMESPACE}.
+ *
+ * <p>The namespace can be used to create new "fields" that are then memoized in the
+ * {@link Memoizer} instances. Note that fields should be used sparingly, as each field may use
+ * some memory in <i>all</i> {@link Memoizer} instances in the namespace, not just those where the
+ * field is actually used.
+ *
+ * @param <M> The memoizer type
+ * @author Jonas Konrad
+ * @since 4.10.0
+ */
+public final class MemoizerNamespace<M extends Memoizer<M>> {
+    private final AtomicInteger nextReference = new AtomicInteger();
+    private final AtomicInteger nextFlag = new AtomicInteger();
+
+    private MemoizerNamespace() {
+    }
+
+    /**
+     * Create a new namespace. There should be exactly one namespace per {@link Memoizer} type.
+     *
+     * <p><b>Note: This is internal to micronaut-core for the moment.</b></p>
+     *
+     * @param <M> The memoizer type
+     * @return The namespace
+     */
+    @Internal
+    @NonNull
+    public static <M extends Memoizer<M>> MemoizerNamespace<M> create() {
+        return new MemoizerNamespace<>();
+    }
+
+    /**
+     * Create a new memoizer field that can store an arbitrary reference type.
+     *
+     * @param compute The function to compute the reference value
+     * @param <R>     The field type
+     * @return The field
+     */
+    @NonNull
+    public <R> MemoizedReference<M, R> newReference(@NonNull Function<? super M, ? extends R> compute) {
+        return new MemoizedReference<>(this, compute, nextReference.getAndIncrement());
+    }
+
+    /**
+     * Create a new memoizer field that can store a boolean flag.
+     *
+     * @param compute The function to compute the boolean value
+     * @return The field
+     */
+    @NonNull
+    public MemoizedFlag<M> newFlag(@NonNull Predicate<? super M> compute) {
+        int index = nextFlag.getAndIncrement();
+        if (index >= 32) {
+            return new MemoizedFlag.InReference<>(newReference(compute::test));
+        } else {
+            return new MemoizedFlag.InBitmask<>(this, compute, index);
+        }
+    }
+}

--- a/core/src/test/java/io/micronaut/core/util/memo/MemoizedTest.java
+++ b/core/src/test/java/io/micronaut/core/util/memo/MemoizedTest.java
@@ -22,9 +22,9 @@ class MemoizedTest {
 
         MyClass cl = new MyClass("bar");
         assertEquals(0, cl.getCount);
-        assertEquals("bar", cl.getMemoized(ref));
+        assertEquals("bar", ref.get(cl));
         assertEquals(1, cl.getCount);
-        assertEquals("bar", cl.getMemoized(ref));
+        assertEquals("bar", ref.get(cl));
         assertEquals(1, cl.getCount);
     }
 

--- a/core/src/test/java/io/micronaut/core/util/memo/MemoizedTest.java
+++ b/core/src/test/java/io/micronaut/core/util/memo/MemoizedTest.java
@@ -1,0 +1,99 @@
+package io.micronaut.core.util.memo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MemoizedTest {
+    @Test
+    public void referenceStored() {
+        MemoizedReference<MyClass, String> ref = MyClass.NS.newReference(m -> {
+            m.getCount++;
+            return m.foo;
+        });
+
+        MyClass cl = new MyClass("bar");
+        assertEquals(0, cl.getCount);
+        assertEquals("bar", cl.getMemoized(ref));
+        assertEquals(1, cl.getCount);
+        assertEquals("bar", cl.getMemoized(ref));
+        assertEquals(1, cl.getCount);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void flagStored(boolean value) {
+        MemoizedFlag<MyClass> flag = MyClass.NS.newFlag(m -> {
+            m.getCount++;
+            return value;
+        });
+
+        MyClass cl = new MyClass("bar");
+        assertEquals(0, cl.getCount);
+        assertEquals(value, cl.getMemoized(flag));
+        assertEquals(1, cl.getCount);
+        assertEquals(value, cl.getMemoized(flag));
+        assertEquals(1, cl.getCount);
+    }
+
+    @Test
+    public void manyFlagsStored() {
+        class Cl extends AbstractMemoizer<Cl> {
+            // isolated namespace for each instance
+            final MemoizerNamespace<Cl> ns = MemoizerNamespace.create();
+
+            @Override
+            protected MemoizerNamespace<Cl> getMemoizerNamespace() {
+                return ns;
+            }
+        }
+
+        Cl cl = new Cl();
+        List<MemoizedFlag<Cl>> flags = new ArrayList<>();
+        BitSet set = new BitSet();
+        List<Integer> getCounts = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            set.set(i, ThreadLocalRandom.current().nextBoolean());
+            getCounts.add(0);
+            int index = i;
+            flags.add(cl.ns.newFlag(c -> {
+                getCounts.set(index, getCounts.get(index) + 1);
+                return set.get(index);
+            }));
+        }
+
+        assertTrue(getCounts.stream().allMatch(i -> i == 0));
+        for (int i = 0; i < flags.size(); i++) {
+            assertEquals(set.get(i), cl.getMemoized(flags.get(i)));
+        }
+        assertTrue(getCounts.stream().allMatch(i -> i == 1));
+        for (int i = 0; i < flags.size(); i++) {
+            assertEquals(set.get(i), cl.getMemoized(flags.get(i)));
+        }
+        assertTrue(getCounts.stream().allMatch(i -> i == 1));
+    }
+
+    static class MyClass extends AbstractMemoizer<MyClass> {
+        static final MemoizerNamespace<MyClass> NS = MemoizerNamespace.create();
+
+        final String foo;
+        int getCount;
+
+        MyClass(String foo) {
+            this.foo = foo;
+        }
+
+        @Override
+        protected MemoizerNamespace<MyClass> getMemoizerNamespace() {
+            return NS;
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
@@ -19,14 +19,19 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.memo.AbstractMemoizer;
+import io.micronaut.core.util.memo.MemoizerNamespace;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static io.micronaut.core.annotation.AnnotationUtil.ZERO_ANNOTATIONS;
@@ -38,7 +43,7 @@ import static io.micronaut.core.annotation.AnnotationUtil.ZERO_ANNOTATIONS;
  * @since 1.0
  */
 @Internal
-abstract class AbstractAnnotationMetadata implements AnnotationMetadata {
+abstract class AbstractAnnotationMetadata extends AbstractMemoizer<AnnotationMetadata> implements AnnotationMetadata {
 
     private volatile Map<String, Annotation> annotationMap;
     private volatile Map<String, Annotation> declaredAnnotationMap;
@@ -49,6 +54,11 @@ abstract class AbstractAnnotationMetadata implements AnnotationMetadata {
      * Constructs a default metadata.
      */
     protected AbstractAnnotationMetadata() {
+    }
+
+    @Override
+    protected final MemoizerNamespace<AnnotationMetadata> getMemoizerNamespace() {
+        return MEMOIZER_NAMESPACE;
     }
 
     private Map<String, Annotation> getAnnotationMap() {

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
@@ -24,6 +24,8 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.memo.AbstractMemoizer;
+import io.micronaut.core.util.memo.MemoizerNamespace;
 import io.micronaut.core.value.OptionalValues;
 
 import java.lang.annotation.Annotation;
@@ -58,7 +60,7 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING_ARRAY;
  * @author graemerocher
  * @since 1.3.0
  */
-public final class AnnotationMetadataHierarchy implements AnnotationMetadata, EnvironmentAnnotationMetadata, Iterable<AnnotationMetadata> {
+public final class AnnotationMetadataHierarchy extends AbstractMemoizer<AnnotationMetadata> implements AnnotationMetadata, EnvironmentAnnotationMetadata, Iterable<AnnotationMetadata> {
     /**
      * Constant to represent an empty hierarchy.
      */
@@ -104,6 +106,11 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
         System.arraycopy(existing, 0, hierarchy, 0, existing.length);
         hierarchy[0] = newChild;
         delegateDeclaredToAllElements = false;
+    }
+
+    @Override
+    protected @NonNull MemoizerNamespace<AnnotationMetadata> getMemoizerNamespace() {
+        return MEMOIZER_NAMESPACE;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/annotation/MutableAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/MutableAnnotationMetadata.java
@@ -18,10 +18,10 @@ package io.micronaut.inject.annotation;
 import io.micronaut.context.env.DefaultPropertyPlaceholderResolver;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 
@@ -293,6 +293,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
             }
         }
         putValues(annotation, values, annotationDefaults);
+        clearMemoized();
     }
 
     /**
@@ -580,6 +581,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
         if (retentionPolicy == RetentionPolicy.SOURCE || retentionPolicy == RetentionPolicy.CLASS) {
             addSourceRetentionAnnotation(annotation);
         }
+        clearMemoized();
     }
 
     private void addSourceRetentionAnnotation(String annotation) {
@@ -700,6 +702,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
             newValues.add(annotationValue);
             values.put(AnnotationMetadata.VALUE_MEMBER, newValues);
         }
+        clearMemoized();
     }
 
     /**
@@ -797,6 +800,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
                 }
             }
         }
+        clearMemoized();
     }
 
     /**
@@ -840,6 +844,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
                 annotationRepeatableContainer.putAll(annotationMetadata.annotationRepeatableContainer);
             }
         }
+        clearMemoized();
     }
 
     /**
@@ -962,6 +967,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
     public <A extends Annotation> void removeAnnotationIf(@NonNull Predicate<AnnotationValue<A>> predicate) {
         removeAnnotationsIf(predicate, this.declaredAnnotations);
         removeAnnotationsIf(predicate, this.allAnnotations);
+        clearMemoized();
     }
 
     private <A extends Annotation> void removeAnnotationsIf(@NonNull Predicate<AnnotationValue<A>> predicate, Map<String, Map<CharSequence, Object>> annotations) {
@@ -1001,6 +1007,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
         if (annotationRepeatableContainer != null) {
             annotationRepeatableContainer.remove(annotationType);
         }
+        clearMemoized();
     }
 
     /**
@@ -1030,6 +1037,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
                 i.remove();
             }
         }
+        clearMemoized();
     }
 
     private void removeFromStereotypes(String annotationType) {


### PR DESCRIPTION
micronaut-validation makes extensive use of AnnotationMetadata APIs on the hot path, with these calls combined taking 200-300ns even for the simplest validation benchmarks. Some of these computations could be cached in simple Maps in micronaut-validation, but even the hasAnnotation calls add up. These calls are fairly well optimized in core, but still take ~10ns each, for Map access.

This PR adds a new Memoizer API that can move the caching to an efficient data structure inside AnnotationMetadata itself. The API is inspired by FastThreadLocal. `metadata.hasAnnotation(MyAnnotation.class)` will be replaced by:

```java
private static final MemoizedFlag<AnnotationMetadata> HAS_MY_ANNOTATION = 
                AnnotationMetadata.MEMOIZER_NAMESPACE.newFlag(m -> m.hasAnnotation(MyAnnotation.class));

metadata.getMemoized(HAS_MY_ANNOTATION)
```

Internally, creating a `MemoizedFlag` reserves a "slot" in a bit field that stores the memoized value on each AnnotationMetadata. Creating too many MemoizedFlags can lead to higher memory use for *every* AnnotationMetadata, so MemoizedFlags should be created sparingly and should always be `static`.

When accessed, the field value is computed lazily and stored in the bit field. Future calls will not have to call `hasAnnotation` anymore.

For compatibility, the implementation is split into two parts. The Memoizer interface specifies the API, and has default implementations that fall back to computing the default value each time. AbstractMemoizer actually implements the storage using fields. It is only used where necessary, i.e. in DefaultAnnotationMetadata and the EmptyAnnotationMetadata. To make sure the memoized values don't become inconsistent when DefaultAnnotationMetadata is modified, the mutation methods clear the memoization cache.

## Performance

Here are some JMH results:

```
Benchmark                       (annotated)  (type)  Mode  Cnt   Score   Error  Units
MemoBenchmark.direct                   true    Bare  avgt    5   5.691 ± 0.558  ns/op
MemoBenchmark.direct                   true  Extra1  avgt    5  10.485 ± 0.604  ns/op
MemoBenchmark.direct                   true  Extra2  avgt    5  10.907 ± 0.545  ns/op
MemoBenchmark.direct                  false    Bare  avgt    5   0.945 ± 0.078  ns/op
MemoBenchmark.direct                  false  Extra1  avgt    5  14.922 ± 1.386  ns/op
MemoBenchmark.direct                  false  Extra2  avgt    5  15.162 ± 1.475  ns/op
MemoBenchmark.memoized                 true    Bare  avgt    5   1.409 ± 0.027  ns/op
MemoBenchmark.memoized                 true  Extra1  avgt    5   1.443 ± 0.107  ns/op
MemoBenchmark.memoized                 true  Extra2  avgt    5   1.435 ± 0.112  ns/op
MemoBenchmark.memoized                false    Bare  avgt    5   1.432 ± 0.061  ns/op
MemoBenchmark.memoized                false  Extra1  avgt    5   1.398 ± 0.019  ns/op
MemoBenchmark.memoized                false  Extra2  avgt    5   1.351 ± 0.091  ns/op
MemoBenchmark.memoizedFallback         true    Bare  avgt    5   5.580 ± 0.070  ns/op
MemoBenchmark.memoizedFallback         true  Extra1  avgt    5  10.591 ± 0.170  ns/op
MemoBenchmark.memoizedFallback         true  Extra2  avgt    5  13.291 ± 0.253  ns/op
MemoBenchmark.memoizedFallback        false    Bare  avgt    5   1.115 ± 0.011  ns/op
MemoBenchmark.memoizedFallback        false  Extra1  avgt    5  13.521 ± 0.578  ns/op
MemoBenchmark.memoizedFallback        false  Extra2  avgt    5  14.191 ± 0.902  ns/op
```

The `direct` benchmark tests a direct call to `hasAnnotation`, the `memoized` benchmark the memoized version, and `memoizedFallback` the default non-cache implementation (i.e. using the Memoizer API but without AbstractMemoizer). The `annotated` parameter checks whether the field in question is annotated or not, and the `type` parameter compares versions without additional annotations, with one extra annotation, or with two extra annotations. Extra annotations affect the efficiency of the direct `hasAnnotation` call, since the backing Maps become larger.

In the results you can see that the fallback option (no caching) is only very slightly slower (~0.5ns) than the normal direct call. This gives us assurance that even in edge cases where no memoization is available, performance won't suffer when using the Memoizer API.

The `AbstractMemoization` implementation (with caching) takes a consistent <1.5ns, making it faster than the direct call to hasAnnotation in almost all cases – excepting the case where the field is not annotated at all.