### PR TITLE
Add configurable max header size for HTTP client

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -92,6 +92,24 @@ public abstract class HttpClientConfiguration {
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 1024 * 1024 * 10; // 10MiB;
 
     /**
+     * The default max header size in bytes.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final int DEFAULT_MAX_HEADER_SIZE = 8192;
+
+    /**
+     * The default max initial line length for HTTP client codec in bytes.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final int DEFAULT_MAX_INITIAL_LINE_LENGTH = 4096;
+
+    /**
+     * The default max chunk size for HTTP client codec in bytes.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final int DEFAULT_MAX_CHUNK_SIZE = 8192;
+
+    /**
      * The default follow redirects value.
      */
     @SuppressWarnings("WeakerAccess")
@@ -140,6 +158,8 @@ public abstract class HttpClientConfiguration {
     private Duration shutdownTimeout = Duration.ofMillis(DEFAULT_SHUTDOWN_TIMEOUT_MILLISECONDS);
 
     private int maxContentLength = DEFAULT_MAX_CONTENT_LENGTH;
+
+    private int maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
 
     private Proxy.Type proxyType = Proxy.Type.DIRECT;
 
@@ -218,6 +238,7 @@ public abstract class HttpClientConfiguration {
             this.logLevel = copy.logLevel;
             this.loggerName = copy.loggerName;
             this.maxContentLength = copy.maxContentLength;
+            this.maxHeaderSize = copy.maxHeaderSize;
             this.proxyAddress = copy.proxyAddress;
             this.proxyPassword = copy.proxyPassword;
             this.proxySelector = copy.proxySelector;
@@ -616,6 +637,24 @@ public abstract class HttpClientConfiguration {
      */
     public void setMaxContentLength(@ReadableBytes int maxContentLength) {
         this.maxContentLength = maxContentLength;
+    }
+
+    /**
+     * [available in the Netty HTTP client].
+     *
+     * @return The maximum header size the client can handle
+     */
+    public int getMaxHeaderSize() {
+        return maxHeaderSize;
+    }
+
+    /**
+     * Sets the maximum header size the client can handle. Default value ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_MAX_HEADER_SIZE}).
+     *
+     * @param maxHeaderSize The maximum header size the client can handle
+     */
+    public void setMaxHeaderSize(@ReadableBytes int maxHeaderSize) {
+        this.maxHeaderSize = maxHeaderSize;
     }
 
     /**

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -553,7 +553,10 @@ public class ConnectionManager {
                 }
 
                 ch.pipeline()
-                    .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, new HttpClientCodec())
+                    .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, new HttpClientCodec(
+                        HttpClientConfiguration.DEFAULT_MAX_INITIAL_LINE_LENGTH,
+                        configuration.getMaxHeaderSize(),
+                        HttpClientConfiguration.DEFAULT_MAX_CHUNK_SIZE))
                     .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_AGGREGATOR, new HttpObjectAggregator(configuration.getMaxContentLength()));
 
                 Optional<Duration> readIdleTime = configuration.getReadIdleTimeout();
@@ -673,7 +676,10 @@ public class ConnectionManager {
         addLogHandler(ch);
 
         ch.pipeline()
-            .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, new HttpClientCodec())
+            .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, new HttpClientCodec(
+                HttpClientConfiguration.DEFAULT_MAX_INITIAL_LINE_LENGTH,
+                configuration.getMaxHeaderSize(),
+                HttpClientConfiguration.DEFAULT_MAX_CHUNK_SIZE))
             .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_DECODER, new HttpContentDecompressor());
     }
 
@@ -964,7 +970,10 @@ public class ConnectionManager {
 
             Http2FrameCodec frameCodec = makeFrameCodec();
 
-            HttpClientCodec sourceCodec = new HttpClientCodec();
+            HttpClientCodec sourceCodec = new HttpClientCodec(
+                HttpClientConfiguration.DEFAULT_MAX_INITIAL_LINE_LENGTH,
+                configuration.getMaxHeaderSize(),
+                HttpClientConfiguration.DEFAULT_MAX_CHUNK_SIZE);
             Http2ClientUpgradeCodec upgradeCodec = new Http2ClientUpgradeCodec(frameCodec,
                 new ChannelInitializer<Channel>() {
                     @Override

--- a/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
@@ -37,6 +37,7 @@ class DefaultHttpClientConfigurationSpec extends Specification {
         'shutdown-timeout'          | 'shutdownTimeout'        | '100ms' | Optional.of(Duration.ofMillis(100))
         'shutdown-timeout'          | 'shutdownTimeout'        | '15s'   | Optional.of(Duration.ofSeconds(15))
         'follow-redirects'          | 'followRedirects'        | 'false' | false
+        'max-header-size'           | 'maxHeaderSize'          | '16384' | 16384
     }
 
     void "test pool config"() {


### PR DESCRIPTION
> Issue: [#11932](https://github.com/micronaut-projects/micronaut-core/issues/11932)

## Description
This PR adds configurable `maxHeaderSize` property to HTTP client configuration.
- Added `maxHeaderSize` configuration property with getter/setter methods.
- Updated all `HttpClientCodec` instantiations to use the configurable header size.

## Considerations
- Default values match Netty's `HttpObjectDecoder` constants ([Link](https://netty.io/4.1/api/io/netty/handler/codec/http/HttpObjectDecoder.html)).
- Can be configured via `micronaut.http.client.max-header-size` property.

## Test Case
Added test case to verify `max-header-size` configuration is being set as intended.