### PR TITLE
Add explicit event loop transport configuration

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupRegistry.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupRegistry.java
@@ -73,6 +73,7 @@ public class DefaultEventLoopGroupRegistry implements EventLoopGroupRegistry {
      *
      * @param eventLoopGroupFactory The event loop group factory
      * @param beanLocator           The bean locator
+     * @param loomCarrierGroupFactory Factory for the loom carrier group
      */
     public DefaultEventLoopGroupRegistry(EventLoopGroupFactory eventLoopGroupFactory, BeanLocator beanLocator, BeanProvider<LoomCarrierGroup.Factory> loomCarrierGroupFactory) {
         this.eventLoopGroupFactory = eventLoopGroupFactory;

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollEventLoopGroupFactory.java
@@ -42,10 +42,11 @@ import org.slf4j.LoggerFactory;
 @Singleton
 @Requires(classes = Epoll.class, condition = EpollAvailabilityCondition.class)
 @Internal
-@Named(EventLoopGroupFactory.NATIVE)
+@Named(EpollEventLoopGroupFactory.NAME)
 @BootstrapContextCompatible
 @Order(100)
 public class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
+    public static final String NAME = "epoll";
     private static final Logger LOG = LoggerFactory.getLogger(EpollEventLoopGroupFactory.class);
 
     @Override

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupConfiguration.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupConfiguration.java
@@ -16,9 +16,12 @@
 package io.micronaut.http.netty.channel;
 
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NextMajorVersion;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.Named;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -87,7 +90,25 @@ public interface EventLoopGroupConfiguration extends Named {
     /**
      * @return Whether to prefer the native transport
      */
+    @Deprecated(since = "4.10.0", forRemoval = true)
     boolean isPreferNativeTransport();
+
+    /**
+     * The transports to use for this event loop, in order of preference. Supported values are
+     * {@code io_uring,epoll,kqueue,nio}. The first available transport out of those listed will
+     * be used (nio is always available). If no listed transport is available, an exception will be
+     * thrown.
+     * <p>By default, only {@code nio} is used, even if native transports are available. If the
+     * legacy {@link #isPreferNativeTransport() prefer-native-transport} property is set to
+     * {@code true}, this defaults to {@code io_uring,epoll,kqueue,nio}.
+     *
+     * @return The available transports, in order of preference
+     */
+    @NonNull
+    @NextMajorVersion("Change default to all transports")
+    default List<String> getTransport() {
+        return isPreferNativeTransport() ? DefaultEventLoopGroupFactory.FACTORY_PRIORITY : List.of(NioEventLoopGroupFactory.NAME);
+    }
 
     /**
      * @return The shutdown quiet period

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
@@ -57,8 +57,10 @@ public interface EventLoopGroupFactory {
      *
      * @return The handler factory
      * @since 4.9
+     * @deprecated Please {@link #createIoHandlerFactory(EventLoopGroupConfiguration) pass a configuration}
      */
     @NonNull
+    @Deprecated(forRemoval = true)
     default IoHandlerFactory createIoHandlerFactory() {
         throw new UnsupportedOperationException();
     }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/IoUringEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/IoUringEventLoopGroupFactory.java
@@ -39,11 +39,12 @@ import jakarta.inject.Singleton;
 @Singleton
 @Requires(classes = IoUring.class, condition = IoUringAvailabilityCondition.class)
 @Internal
-@Named(EventLoopGroupFactory.NATIVE)
+@Named(IoUringEventLoopGroupFactory.NAME)
 @BootstrapContextCompatible
 // avoid collision with epoll. we prefer epoll because it supports more features (domain socket).
 @Order(200)
 public class IoUringEventLoopGroupFactory implements EventLoopGroupFactory {
+    public static final String NAME = "io_uring";
 
     @Override
     public IoHandlerFactory createIoHandlerFactory() {

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/KQueueEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/KQueueEventLoopGroupFactory.java
@@ -41,9 +41,10 @@ import org.slf4j.LoggerFactory;
 @Singleton
 @Internal
 @Requires(classes = KQueue.class, condition = KQueueAvailabilityCondition.class)
-@Named(EventLoopGroupFactory.NATIVE)
+@Named(KQueueEventLoopGroupFactory.NAME)
 @BootstrapContextCompatible
 public class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
+    public static final String NAME = "kqueue";
     private static final Logger LOG = LoggerFactory.getLogger(KQueueEventLoopGroupFactory.class);
 
     @Override

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/NioEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/NioEventLoopGroupFactory.java
@@ -27,6 +27,7 @@ import io.netty.channel.socket.nio.NioDomainSocketChannel;
 import io.netty.channel.socket.nio.NioServerDomainSocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 import java.io.IOException;
@@ -38,8 +39,10 @@ import java.io.IOException;
  */
 @Internal
 @Singleton
+@Named(NioEventLoopGroupFactory.NAME)
 @BootstrapContextCompatible
 public class NioEventLoopGroupFactory implements EventLoopGroupFactory {
+    public static final String NAME = "nio";
 
     @Override
     public IoHandlerFactory createIoHandlerFactory() {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -1302,6 +1302,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
         private Integer ioRatio;
         private String executor;
         private boolean preferNativeTransport = false;
+        private List<String> transport;
         private Duration shutdownQuietPeriod = Duration.ofSeconds(DEFAULT_SHUTDOWN_QUIET_PERIOD);
         private Duration shutdownTimeout = Duration.ofSeconds(DEFAULT_SHUTDOWN_TIMEOUT);
         private String name;
@@ -1436,6 +1437,26 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
         @Override
         public boolean isPreferNativeTransport() {
             return preferNativeTransport;
+        }
+
+        @Override
+        public @NonNull List<String> getTransport() {
+            return transport == null ? EventLoopGroupConfiguration.super.getTransport() : transport;
+        }
+
+        /**
+         * The transports to use for this event loop, in order of preference. Supported values are
+         * {@code io_uring,epoll,kqueue,nio}. The first available transport out of those listed will
+         * be used (nio is always available). If no listed transport is available, an exception will be
+         * thrown.
+         * <p>By default, only {@code nio} is used, even if native transports are available. If the
+         * legacy {@link #isPreferNativeTransport() prefer-native-transport} property is set to
+         * {@code true}, this defaults to {@code io_uring,epoll,kqueue,nio}.
+         *
+         * @param transport The available transports, in order of preference
+         */
+        public void setTransport(@NonNull List<String> transport) {
+            this.transport = transport;
         }
 
         @Override

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/ListenerConfigurationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/ListenerConfigurationSpec.groovy
@@ -169,8 +169,8 @@ class ListenerConfigurationSpec extends Specification {
         def server = (NettyEmbeddedServer) ApplicationContext.run(
                 EmbeddedServer,
                 [
-                        'micronaut.netty.event-loops.default.prefer-native-transport': true,
-                        'micronaut.netty.event-loops.parent.prefer-native-transport': true,
+                        'micronaut.netty.event-loops.default.transport': 'epoll',
+                        'micronaut.netty.event-loops.parent.transport': 'epoll',
                         'micronaut.server.netty.listeners.a.family': 'UNIX',
                         'micronaut.server.netty.listeners.a.path': bindPath,
                 ])
@@ -229,8 +229,8 @@ class ListenerConfigurationSpec extends Specification {
         def server = (NettyEmbeddedServer) ApplicationContext.run(
                 EmbeddedServer,
                 [
-                        'micronaut.netty.event-loops.default.prefer-native-transport': false,
-                        'micronaut.netty.event-loops.parent.prefer-native-transport': false,
+                        'micronaut.netty.event-loops.default.transport': 'epoll',
+                        'micronaut.netty.event-loops.parent.transport': 'epoll',
                         'micronaut.server.netty.listeners.a.family': 'UNIX',
                         'micronaut.server.netty.listeners.a.path': bindPath,
                 ])
@@ -295,8 +295,8 @@ class ListenerConfigurationSpec extends Specification {
         def server = (NettyEmbeddedServer) ApplicationContext.run(
                 EmbeddedServer,
                 [
-                        'micronaut.netty.event-loops.default.prefer-native-transport': true,
-                        'micronaut.netty.event-loops.parent.prefer-native-transport': true,
+                        'micronaut.netty.event-loops.default.transport': 'epoll',
+                        'micronaut.netty.event-loops.parent.transport': 'epoll',
                         'micronaut.server.netty.listeners.a.bind': false,
                         'micronaut.server.netty.listeners.a.fd': sock.intValue(),
                 ])

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/NewLinuxNativeTransportSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/NewLinuxNativeTransportSpec.groovy
@@ -9,7 +9,7 @@ import spock.lang.Requires
 import spock.util.environment.OperatingSystem
 
 @Requires({ os.family == OperatingSystem.Family.LINUX })
-class LinuxNativeTransportSpec extends AbstractMicronautSpec {
+class NewLinuxNativeTransportSpec extends AbstractMicronautSpec {
 
     void "test a basic request works with epoll"() {
         when:
@@ -26,7 +26,7 @@ class LinuxNativeTransportSpec extends AbstractMicronautSpec {
     @Override
     Map<String, Object> getConfiguration() {
         super.getConfiguration() << [
-                'micronaut.server.netty.use-native-transport': true,
+                'micronaut.server.netty.transport': 'epoll',
                 'spec': 'TransportSpec']
     }
 }

--- a/http-server-netty/src/test/java/io/micronaut/http/server/netty/nativetransport/TransportConfigTest.java
+++ b/http-server-netty/src/test/java/io/micronaut/http/server/netty/nativetransport/TransportConfigTest.java
@@ -1,0 +1,46 @@
+package io.micronaut.http.server.netty.nativetransport;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.netty.channel.DefaultEventLoopGroupConfiguration;
+import io.micronaut.http.netty.channel.EventLoopGroupFactory;
+import io.micronaut.http.netty.channel.NettyChannelType;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TransportConfigTest {
+    @Test
+    public void unavailable() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            "micronaut.netty.event-loops.default.transport", "unavailable"
+        ))) {
+            EventLoopGroupFactory factory = ctx.getBean(EventLoopGroupFactory.class);
+            assertThrows(NoSuchElementException.class, () -> factory.channelClass(NettyChannelType.SERVER_SOCKET, ctx.getBean(DefaultEventLoopGroupConfiguration.class)));
+        }
+    }
+
+    @Test
+    public void single() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            "micronaut.netty.event-loops.default.transport", "nio"
+        ))) {
+            EventLoopGroupFactory factory = ctx.getBean(EventLoopGroupFactory.class);
+            assertEquals(NioServerSocketChannel.class, factory.channelClass(NettyChannelType.SERVER_SOCKET, ctx.getBean(DefaultEventLoopGroupConfiguration.class)));
+        }
+    }
+
+    @Test
+    public void multi() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            "micronaut.netty.event-loops.default.transport", "nio,foo1,foo2"
+        ))) {
+            EventLoopGroupFactory factory = ctx.getBean(EventLoopGroupFactory.class);
+            assertEquals(NioServerSocketChannel.class, factory.channelClass(NettyChannelType.SERVER_SOCKET, ctx.getBean(DefaultEventLoopGroupConfiguration.class)));
+        }
+    }
+}

--- a/src/main/docs/guide/httpClient/lowLevelHttpClient/clientConfiguration.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelHttpClient/clientConfiguration.adoc
@@ -124,7 +124,6 @@ micronaut:
     event-loops:
       default:
         num-threads: 10
-        prefer-native-transport: true
 ----
 
 You can also use the `micronaut.netty.event-loops` setting to configure one or more additional event loops. The following table summarizes the properties:
@@ -143,7 +142,6 @@ micronaut:
     event-loops:
       other:
         num-threads: 10
-        prefer-native-transport: true
 ----
 
 Once an additional event loop has been configured you can alter the HTTP client configuration to use it:

--- a/src/main/docs/guide/httpServer/serverConfiguration.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration.adoc
@@ -41,9 +41,17 @@ For Linux on x86:
 
 dependency:netty-transport-native-epoll[groupId="io.netty",scope="runtimeOnly",classifier="linux-x86_64"]
 
+or
+
+dependency:netty-transport-native-io_uring[groupId="io.netty",scope="runtimeOnly",classifier="linux-x86_64"]
+
 For Linux on ARM64:
 
 dependency:netty-transport-native-epoll[groupId="io.netty",scope="runtimeOnly",classifier="linux-aarch_64"]
+
+or
+
+dependency:netty-transport-native-io_uring[groupId="io.netty",scope="runtimeOnly",classifier="linux-aarch_64"]
 
 Then configure the default event loop group to prefer native transports:
 
@@ -54,15 +62,9 @@ micronaut:
   netty:
     event-loops:
       default:
-        prefer-native-transport: true
+        transport: io_uring,epoll,kqueue,nio
 ----
 
-On Linux, Netty also offers an io_uring-based transport in incubator status. On x86_64:
-
-dependency:netty-transport-native-io_uring[groupId="io.netty",scope="runtimeOnly",classifier="linux-x86_64"]
-
-On ARM64:
-
-dependency:netty-transport-native-io_uring[groupId="io.netty",scope="runtimeOnly",classifier="linux-aarch_64"]
+The first available transport out of those listed will be used. If you want to make sure native transports will be used in all environments, remove the `nio` entry. An exception will be thrown if no native transport is available.
 
 NOTE: Netty enables simplistic sampling resource leak detection which reports there is a leak or not, at the cost of small overhead. You can enable it by setting property `netty.resource-leak-detector-level` to one of: `DISABLED` (default), `SIMPLE`, `PARANOID` or `ADVANCED`.

--- a/src/main/docs/guide/httpServer/serverConfiguration/listener.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/listener.adoc
@@ -53,11 +53,11 @@ The HTTP server can be configured to use an existing file descriptor. With this 
 micronaut:
   netty:
     event-loops:
-      # use epoll
+      # use epoll transport
       parent:
-        prefer-native-transport: true
+        transport: epoll
       default:
-        prefer-native-transport: true
+        transport: epoll
     listeners:
       systemd:
         fd: 3 # systemd passes the server socket as fd 3


### PR DESCRIPTION
prefer-native-transport only sets a preference. If the native transport fails to load for any reason (e.g. wrong architecture), the event loop silently falls back to nio.

This PR adds a new property to set an explicit preference list of transports to use. If the user wants to be sure they aren't using nio by accident, they can simply remove the nio entry from the list and there will be an exception.