### PR TITLE
Remove server-specific event loop configuration

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -270,9 +270,12 @@ public class NettyHttpServer implements NettyEmbeddedServer {
             }
             //suppress unused
             //done here to prevent a blocking service loader in the event loop
-            EventLoopGroupConfiguration workerConfig = resolveWorkerConfiguration();
-            workerGroup = createWorkerEventLoopGroup(workerConfig);
-            parentGroup = createParentEventLoopGroup();
+            EventLoopGroupConfiguration workerConfig = nettyEmbeddedServices.getEventLoopGroupRegistry()
+                .getEventLoopGroupConfiguration(serverConfiguration.getWorkerLoopName()).orElse(null);
+            workerGroup = nettyEmbeddedServices.getEventLoopGroupRegistry().getEventLoopGroup(serverConfiguration.getWorkerLoopName())
+                .orElseThrow(() -> new ConfigurationException("No event loop with name '" + serverConfiguration.getWorkerLoopName() + "' available, but this name was configured as the worker-loop-name"));
+            parentGroup = nettyEmbeddedServices.getEventLoopGroupRegistry().getEventLoopGroup(serverConfiguration.getParentLoopName())
+                .orElseThrow(() -> new ConfigurationException("No event loop with name '" + serverConfiguration.getParentLoopName() + "' available, but this name was configured as the parent-loop-name"));
             Supplier<ServerBootstrap> serverBootstrap = SupplierUtil.memoized(() -> {
                 ServerBootstrap sb = createServerBootstrap();
                 processOptions(serverConfiguration.getOptions(), sb::option);
@@ -316,21 +319,6 @@ public class NettyHttpServer implements NettyEmbeddedServer {
         }
 
         return this;
-    }
-
-    private EventLoopGroupConfiguration resolveWorkerConfiguration() {
-        EventLoopGroupConfiguration workerConfig = serverConfiguration.getWorker();
-        if (workerConfig == null) {
-            workerConfig = nettyEmbeddedServices.getEventLoopGroupRegistry()
-                    .getEventLoopGroupConfiguration(EventLoopGroupConfiguration.DEFAULT).orElse(null);
-        } else {
-            final String eventLoopGroupName = workerConfig.getName();
-            if (!EventLoopGroupConfiguration.DEFAULT.equals(eventLoopGroupName)) {
-                workerConfig = nettyEmbeddedServices.getEventLoopGroupRegistry()
-                        .getEventLoopGroupConfiguration(eventLoopGroupName).orElse(workerConfig);
-            }
-        }
-        return workerConfig;
     }
 
     @Override
@@ -474,21 +462,6 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                 .filter(InetSocketAddress.class::isInstance)
                 .map(addr -> ((InetSocketAddress) addr).getPort())
                 .collect(Collectors.<Integer, Set<Integer>>toCollection(LinkedHashSet::new)));
-    }
-
-    /**
-     * @return The parent event loop group
-     */
-    @SuppressWarnings("WeakerAccess")
-    protected EventLoopGroup createParentEventLoopGroup() {
-        final NettyHttpServerConfiguration.Parent parent = serverConfiguration.getParent();
-        return nettyEmbeddedServices.getEventLoopGroupRegistry()
-                .getEventLoopGroup(parent != null ? parent.getName() : NettyHttpServerConfiguration.Parent.NAME)
-                .orElseGet(() -> {
-                    final EventLoopGroup newGroup = newEventLoopGroup(parent);
-                    shutdownParent = true;
-                    return newGroup;
-                });
     }
 
     /**
@@ -703,7 +676,8 @@ public class NettyHttpServer implements NettyEmbeddedServer {
         List<Future<?>> futures = new ArrayList<>(2);
         try {
             if (shutdownParent) {
-                EventLoopGroupConfiguration parent = serverConfiguration.getParent();
+                EventLoopGroupConfiguration parent = nettyEmbeddedServices.getEventLoopGroupRegistry()
+                    .getEventLoopGroupConfiguration(serverConfiguration.getParentLoopName()).orElse(null);
                 if (parent != null) {
                     long quietPeriod = parent.getShutdownQuietPeriod().toMillis();
                     long timeout = parent.getShutdownTimeout().toMillis();
@@ -960,7 +934,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
         }
     }
 
-    private static class DomainSocketHolder {
+    private static final class DomainSocketHolder {
         @NonNull
         private static SocketAddress makeDomainSocketAddress(String path) {
             try {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -195,7 +195,6 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     private LogLevel logLevel;
     private int compressionThreshold = DEFAULT_COMPRESSIONTHRESHOLD;
     private int compressionLevel = DEFAULT_COMPRESSIONLEVEL;
-    private boolean useNativeTransport = DEFAULT_USE_NATIVE_TRANSPORT;
     private String fallbackProtocol = ApplicationProtocolNames.HTTP_1_1;
     private AccessLogger accessLogger;
     private Http2Settings http2Settings = new Http2Settings();
@@ -421,15 +420,6 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     }
 
     /**
-     * Whether to use netty's native transport (epoll or kqueue) if available.
-     *
-     * @return To use netty's native transport (epoll or kqueue) if available.
-     */
-    public boolean isUseNativeTransport() {
-        return useNativeTransport;
-    }
-
-    /**
      * Whether to validate headers.
      *
      * @return Whether to validate headers
@@ -609,14 +599,6 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public void setChunkedSupported(boolean chunkedSupported) {
         this.chunkedSupported = chunkedSupported;
-    }
-
-    /**
-     * Sets whether to use netty's native transport (epoll or kqueue) if available . Default value ({@value #DEFAULT_USE_NATIVE_TRANSPORT}).
-     * @param useNativeTransport True if netty's native transport should be use if available.
-     */
-    public void setUseNativeTransport(boolean useNativeTransport) {
-        this.useNativeTransport = useNativeTransport;
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -19,26 +19,21 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Replaces;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.ReadableBytes;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.netty.channel.ChannelPipelineListener;
-import io.micronaut.http.netty.channel.EventLoopGroupConfiguration;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.runtime.ApplicationConfiguration;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -185,8 +180,8 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
 
     private Map<ChannelOption, Object> childOptions = Collections.emptyMap();
     private Map<ChannelOption, Object> options = Collections.emptyMap();
-    private Worker worker;
-    private Parent parent;
+    private String workerLoopName = "default";
+    private String parentLoopName = "default";
     private FileTypeHandlerConfiguration fileTypeHandlerConfiguration = new FileTypeHandlerConfiguration();
     private int maxInitialLineLength = DEFAULT_MAXINITIALLINELENGTH;
     private int maxHeaderSize = DEFAULT_MAXHEADERSIZE;
@@ -489,13 +484,6 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     }
 
     /**
-     * @return Configuration for the worker {@link io.netty.channel.EventLoopGroup}
-     */
-    public Worker getWorker() {
-        return worker;
-    }
-
-    /**
      * @return The file type handler configuration.
      * @since 3.1.0
      */
@@ -516,10 +504,41 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     }
 
     /**
-     * @return Configuration for the parent {@link io.netty.channel.EventLoopGroup}
+     * The name of the worker event loop to use.
+     *
+     * @return The worker loop name
      */
-    public Parent getParent() {
-        return parent;
+    @NonNull
+    public String getWorkerLoopName() {
+        return workerLoopName;
+    }
+
+    /**
+     * The name of the worker event loop to use.
+     *
+     * @param workerLoopName The worker loop name
+     */
+    public void setWorkerLoopName(@NonNull String workerLoopName) {
+        this.workerLoopName = workerLoopName;
+    }
+
+    /**
+     * The name of the parent event loop to use.
+     *
+     * @return The parent loop name
+     */
+    @NonNull
+    public String getParentLoopName() {
+        return parentLoopName;
+    }
+
+    /**
+     * The name of the parent event loop to use.
+     *
+     * @param parentLoopName The parent loop name
+     */
+    public void setParentLoopName(@NonNull String parentLoopName) {
+        this.parentLoopName = parentLoopName;
     }
 
     /**
@@ -544,22 +563,6 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public void setOptions(Map<ChannelOption, Object> options) {
         this.options = options;
-    }
-
-    /**
-     * Sets the worker event loop configuration.
-     * @param worker The worker config
-     */
-    public void setWorker(Worker worker) {
-        this.worker = worker;
-    }
-
-    /**
-     * Sets the parent event loop configuration.
-     * @param parent The parent config
-     */
-    public void setParent(Parent parent) {
-        this.parent = parent;
     }
 
     /**
@@ -1133,38 +1136,6 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     }
 
     /**
-     * Configuration for Netty worker.
-     */
-    @ConfigurationProperties("worker")
-    @Named("netty-server-worker-event-loop")
-    public static class Worker extends EventLoopConfig {
-        /**
-         * Default constructor.
-         */
-        Worker() {
-            super(DEFAULT);
-        }
-    }
-
-    /**
-     * Configuration for Netty parent.
-     */
-    @ConfigurationProperties(Parent.NAME)
-    @Requires(missingProperty = EventLoopGroupConfiguration.EVENT_LOOPS + ".parent")
-    @Named("netty-server-parent-event-loop")
-    public static class Parent extends EventLoopConfig {
-
-        public static final String NAME = "parent";
-
-        /**
-         * Default constructor.
-         */
-        Parent() {
-            super(NAME);
-        }
-    }
-
-    /**
      * Allows configuration of properties for the {@link io.micronaut.http.server.netty.body.AbstractFileBodyWriter}.
      *
      * @author James Kleeh
@@ -1266,145 +1237,6 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
             public boolean getPublic() {
                 return publicCache;
             }
-        }
-    }
-
-    /**
-     * Abstract class for configuring the Netty event loop.
-     */
-    public abstract static class EventLoopConfig implements EventLoopGroupConfiguration {
-        private int threads;
-        private Integer ioRatio;
-        private String executor;
-        private boolean preferNativeTransport = false;
-        private Duration shutdownQuietPeriod = Duration.ofSeconds(DEFAULT_SHUTDOWN_QUIET_PERIOD);
-        private Duration shutdownTimeout = Duration.ofSeconds(DEFAULT_SHUTDOWN_TIMEOUT);
-        private String name;
-
-        /**
-         * @param name The name;
-         */
-        EventLoopConfig(String name) {
-            this.name = name;
-        }
-
-        @NonNull
-        @Override
-        public String getName() {
-            return name;
-        }
-
-        /**
-         * Sets the name to use.
-         * @param name The name
-         */
-        public void setEventLoopGroup(String name) {
-            if (StringUtils.isNotEmpty(name)) {
-                this.name = name;
-            }
-        }
-
-        /**
-         * Sets the number of threads for the event loop group.
-         * @param threads The number of threads
-         */
-        public void setThreads(int threads) {
-            this.threads = threads;
-        }
-
-        /**
-         * Sets the I/O ratio.
-         * @param ioRatio The I/O ratio
-         */
-        public void setIoRatio(Integer ioRatio) {
-            this.ioRatio = ioRatio;
-        }
-
-        /**
-         * A named executor service to use for event loop threads
-         * (optional). This property is very specialized. In particular,
-         * it will <i>not</i> solve read timeouts or fix blocking
-         * operations on the event loop, in fact it may do the opposite.
-         * Don't use unless you really know what this does.
-         *
-         * @param executor The executor
-         */
-        public void setExecutor(String executor) {
-            this.executor = executor;
-        }
-
-        /**
-         * @param preferNativeTransport Set whether to prefer the native transport if available
-         */
-        public void setPreferNativeTransport(boolean preferNativeTransport) {
-            this.preferNativeTransport = preferNativeTransport;
-        }
-
-        /**
-         * @param shutdownQuietPeriod Set the shutdown quiet period
-         */
-        public void setShutdownQuietPeriod(Duration shutdownQuietPeriod) {
-            if (shutdownQuietPeriod != null) {
-                this.shutdownQuietPeriod = shutdownQuietPeriod;
-            }
-        }
-
-        /**
-         * @param shutdownTimeout Set the shutdown timeout (must be >= shutdownQuietPeriod)
-         */
-        public void setShutdownTimeout(Duration shutdownTimeout) {
-            if (shutdownTimeout != null) {
-                this.shutdownTimeout = shutdownTimeout;
-            }
-        }
-
-        /**
-         * @return The number of threads to use
-         */
-        public int getNumOfThreads() {
-            return threads;
-        }
-
-        /**
-         * @return The I/O ratio to use
-         */
-        @Override
-        public Optional<Integer> getIoRatio() {
-            if (ioRatio != null) {
-                return Optional.of(ioRatio);
-            }
-            return Optional.empty();
-        }
-
-        /**
-         * @return The name of the configured executor to use
-         */
-        @Override
-        public Optional<String> getExecutorName() {
-            if (executor != null) {
-                return Optional.of(executor);
-            }
-            return Optional.empty();
-        }
-
-        @Override
-        public int getNumThreads() {
-            return threads;
-        }
-
-        @Override
-        public boolean isPreferNativeTransport() {
-            return preferNativeTransport;
-        }
-
-        @Override
-        public Duration getShutdownQuietPeriod() {
-            return shutdownQuietPeriod;
-        }
-
-        @Override
-        public Duration getShutdownTimeout() {
-            return shutdownTimeout;
         }
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/ListenerConfigurationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/ListenerConfigurationSpec.groovy
@@ -170,7 +170,6 @@ class ListenerConfigurationSpec extends Specification {
                 EmbeddedServer,
                 [
                         'micronaut.netty.event-loops.default.prefer-native-transport': true,
-                        'micronaut.netty.event-loops.parent.prefer-native-transport': true,
                         'micronaut.server.netty.listeners.a.family': 'UNIX',
                         'micronaut.server.netty.listeners.a.path': bindPath,
                 ])
@@ -230,7 +229,6 @@ class ListenerConfigurationSpec extends Specification {
                 EmbeddedServer,
                 [
                         'micronaut.netty.event-loops.default.prefer-native-transport': false,
-                        'micronaut.netty.event-loops.parent.prefer-native-transport': false,
                         'micronaut.server.netty.listeners.a.family': 'UNIX',
                         'micronaut.server.netty.listeners.a.path': bindPath,
                 ])
@@ -296,7 +294,6 @@ class ListenerConfigurationSpec extends Specification {
                 EmbeddedServer,
                 [
                         'micronaut.netty.event-loops.default.prefer-native-transport': true,
-                        'micronaut.netty.event-loops.parent.prefer-native-transport': true,
                         'micronaut.server.netty.listeners.a.bind': false,
                         'micronaut.server.netty.listeners.a.fd': sock.intValue(),
                 ])

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
@@ -186,8 +186,7 @@ class NettyHttpServerConfigurationSpec extends Specification {
         given:
         ApplicationContext beanContext = new DefaultApplicationContext("test")
         beanContext.environment.addPropertySource(PropertySource.of("test",
-              ['micronaut.server.netty.use-native-transport': true,
-               'micronaut.server.netty.childOptions.tcpQuickack': true]
+              ['micronaut.server.netty.childOptions.tcpQuickack': true]
 
         ))
         beanContext.start()
@@ -196,7 +195,6 @@ class NettyHttpServerConfigurationSpec extends Specification {
         NettyHttpServerConfiguration config = beanContext.getBean(NettyHttpServerConfiguration)
 
         then:
-        config.useNativeTransport
         config.childOptions.size() == 1
 
         when:
@@ -230,7 +228,6 @@ class NettyHttpServerConfigurationSpec extends Specification {
         EventLoopGroupFactory eventLoopGroupFactory = beanContext.getBean(EventLoopGroupFactory)
 
         then:
-        config.useNativeTransport
         config.childOptions.size() == 1
 
         when:
@@ -284,7 +281,6 @@ class NettyHttpServerConfigurationSpec extends Specification {
         NettyHttpServerConfiguration config = beanContext.getBean(NettyHttpServerConfiguration)
 
         then:
-        !config.useNativeTransport
         config.maxRequestSize == 2097152
         config.multipart.maxFileSize == 2048
         config.childOptions.size() == 2

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
@@ -76,26 +76,6 @@ class NettyHttpServerConfigurationSpec extends Specification {
         'idle-timeout'       | 'idleTimeout'      | '-1s' | Duration.ofSeconds(-1)
     }
 
-    @Unroll
-    void "test config for worker #key"() {
-        given:
-        def ctx = ApplicationContext.run(
-                ("micronaut.server.netty.worker.$key".toString()): value
-        )
-        NettyHttpServerConfiguration config = ctx.getBean(NettyHttpServerConfiguration)
-
-        expect:
-        config.worker[property] == expected
-
-        cleanup:
-        ctx.close()
-
-        where:
-        key                     | property              | value     | expected
-        'shutdown-quiet-period' | 'shutdownQuietPeriod' | '500ms'   | Duration.ofMillis(500)
-        'shutdown-timeout'      | 'shutdownTimeout'     | '2s'      | Duration.ofSeconds(2)
-    }
-
     void "test netty server epoll native channel option conversion"() {
         given:
         ChannelOptionFactory epollChannelOptionFactory = new EpollChannelOptionFactory()
@@ -291,10 +271,6 @@ class NettyHttpServerConfigurationSpec extends Specification {
         ApplicationContext beanContext = new DefaultApplicationContext("test")
         beanContext.environment.addPropertySource(PropertySource.of("test",
                 ['micronaut.server.netty.childOptions.autoRead'         : 'true',
-                 'micronaut.server.netty.worker.threads'                : 8,
-                 'micronaut.server.netty.worker.shutdown-quiet-period'  : '500ms',
-                 'micronaut.server.netty.worker.shutdown-timeout'       : '2s',
-                 'micronaut.server.netty.parent.threads'                : 8,
                  'micronaut.server.multipart.maxFileSize'               : 2048,
                  'micronaut.server.maxRequestSize'                      : '2MB',
                  'micronaut.server.netty.childOptions.write_buffer_water_mark.high': 262143,
@@ -317,10 +293,6 @@ class NettyHttpServerConfigurationSpec extends Specification {
         config.childOptions.get(ChannelOption.WRITE_BUFFER_WATER_MARK).high == 262143
         config.childOptions.get(ChannelOption.WRITE_BUFFER_WATER_MARK).low == 65535
         !config.host.isPresent()
-        config.parent.numThreads == 8
-        config.worker.numThreads == 8
-        config.worker.shutdownQuietPeriod == Duration.ofMillis(500)
-        config.worker.shutdownTimeout == Duration.ofSeconds(2)
 
         then:
         NettyEmbeddedServer server = beanContext.getBean(NettyEmbeddedServer)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogSpec.groovy
@@ -638,7 +638,6 @@ class AccessLogSpec extends Specification {
         def ctx = ApplicationContext.run([
                 'spec.name': 'AccessLogSpec',
                 'micronaut.netty.event-loops.default.prefer-native-transport': true,
-                'micronaut.netty.event-loops.parent.prefer-native-transport': true,
                 'micronaut.server.netty.listeners.main.family': 'UNIX',
                 'micronaut.server.netty.listeners.main.path': sock.toString(),
                 'micronaut.server.netty.access-logger.enabled': true,

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesParseSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesParseSpec.groovy
@@ -13,8 +13,6 @@ import io.micronaut.inject.InstantiatableBeanDefinition
 import io.micronaut.inject.configuration.Engine
 import spock.lang.Issue
 
-import java.time.Duration
-
 class ConfigPropertiesParseSpec extends AbstractTypeElementSpec {
 
     void "test configuration properties implementing interface"() {
@@ -96,70 +94,6 @@ class ParentConfiguration {
         then:
         bean != null
         bean.properties() as Map == [url_escaping_charset:'UTF-8']
-    }
-
-    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/8480")
-    void "test configuration properties inheritance for compiled classes - inherited props"() {
-        when:
-        def context = buildContext('''
-package test;
-
-import io.micronaut.context.annotation.ConfigurationProperties;
-import io.micronaut.http.server.HttpServerConfiguration;
-
-@ConfigurationProperties("netty")
-class NettyHttpServerConfiguration extends
- HttpServerConfiguration {
-    private Parent parent;
-    private Child child;
-    public test.NettyHttpServerConfiguration.Parent getParent() {
-        return parent;
-    }
-
-    public void setParent(test.NettyHttpServerConfiguration.Parent parent) {
-        this.parent = parent;
-    }
-
-    public void setChild(test.NettyHttpServerConfiguration.Child child) {
-        this.child = child;
-    }
-    public test.NettyHttpServerConfiguration.Child getChild() {
-        return child;
-    }
-    @ConfigurationProperties("child")
-    public static class Child extends EventLoopConfig {
-
-    }
-    @ConfigurationProperties("parent")
-    public static class Parent extends EventLoopConfig {
-
-    }
-    public abstract static class EventLoopConfig {
-        private Integer ioRatio;
-        private int threads;
-        public void setIoRatio(Integer ioRatio) {
-            this.ioRatio = ioRatio;
-        }
-        public Integer getIoRatio() {
-            return ioRatio;
-        }
-        public void setThreads(int threads) {
-            this.threads = threads;
-        }
-        public int getNumOfThreads() {
-            return threads;
-        }
-    }
-}
-''')
-        def config = getBean(context, "test.NettyHttpServerConfiguration")
-
-        then:
-        config.idleTimeout == Duration.ofSeconds(2)
-        config.parent.ioRatio == 10
-        config.parent.numOfThreads == 5
-        config.child.ioRatio == 15
-        config.child.numOfThreads == 55
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/8480")
@@ -254,8 +188,6 @@ class MyConfig {
                 "micronaut.session.http.test.uri": "http://localhost:9999",
                 "micronaut.session.http.test.uris": "http://localhost:9999",
                 "micronaut.server.idle-timeout": "2s",
-                "micronaut.server.netty.parent.io-ratio": "10",
-                "micronaut.server.netty.parent.threads": "5",
                 "micronaut.server.netty.child.io-ratio": "15",
                 "micronaut.server.netty.child.threads": "55",
                 "freemarker.settings.urlEscapingCharset": 'UTF-8'

--- a/src/main/docs/guide/httpServer/serverConfiguration.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration.adoc
@@ -11,15 +11,12 @@ micronaut:
     host: localhost
     netty:
       maxHeaderSize: 500KB
-      worker:
-        threads: 8
       childOptions:
-        autoRead: true
+        tcpQuickack: true
 ----
 - By default, Micronaut framework binds to all network interfaces. Use `localhost` to bind only to loopback network interface
 - `maxHeaderSize` sets the maximum size for headers
-- `worker.threads` specifies the number of Netty worker threads
-- `autoRead` enables request body auto read
+- `tcpQuickack` enables TCP quick acks
 
 include::{includedir}configurationProperties/io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration.adoc[]
 

--- a/src/main/docs/guide/httpServer/serverConfiguration/listener.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/listener.adoc
@@ -54,8 +54,6 @@ micronaut:
   netty:
     event-loops:
       # use epoll
-      parent:
-        prefer-native-transport: true
       default:
         prefer-native-transport: true
     listeners:

--- a/src/main/docs/guide/httpServer/serverConfiguration/threadPools.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/threadPools.adoc
@@ -1,14 +1,8 @@
 The HTTP server is built on https://netty.io[Netty] which is designed as a non-blocking I/O toolkit in an event loop model.
 
-The Netty worker event loop uses the "default" named event loop group. This can be configured through `micronaut.netty.event-loops.default`.
+The Netty worker event loop uses the "default" named event loop group. This loop can be configured through `micronaut.netty.event-loops.default`.
 
-IMPORTANT: The event loop configuration under `micronaut.server.netty.worker` is only used if the `event-loop-group` is set to a name which doesn't correspond to any `micronaut.netty.event-loops` configuration. This behavior is deprecated and will be removed in a future version. Use `micronaut.netty.event-loops.*` for any event loop group configuration beyond setting the name through `event-loop-group`. This does not apply to the parent event loop configuration (`micronaut.server.netty.parent`).
-
-include::{includedir}configurationProperties/io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration$Worker.adoc[]
-
-TIP: The parent event loop can be configured with `micronaut.server.netty.parent` with the same configuration options.
-
-The server can also be configured to use a different named worker event loop:
+The server can also be configured to use a different named event loop:
 
 .Using a different event loop for the server
 [configuration]
@@ -16,8 +10,8 @@ The server can also be configured to use a different named worker event loop:
 micronaut:
   server:
     netty:
-      worker:
-        event-loop-group: other
+      worker-loop-name: other
+      parent-loop-name: other
   netty:
     event-loops:
       other:


### PR DESCRIPTION
* Use the same (default) event loop as the server worker and parent groups. This is usually preferable anyway, and is documented as such in netty. It also makes transport config simpler.
* Instead of having an EventLoopGroupConfiguration under the `micronaut.server` key, only add an event loop name there. All event loop config now happens through the `micronaut.netty.event-loops` key.