### PR TITLE
Fix NettyMutableHttpResponse Disabled Netty HTTP header validation

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyMutableHttpResponse.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyMutableHttpResponse.java
@@ -153,7 +153,7 @@ public final class NettyMutableHttpResponse<B> implements MutableHttpResponse<B>
 
         boolean hasHeaders = nettyHeaders != null;
         if (!hasHeaders) {
-            nettyHeaders = new DefaultHttpHeaders(false);
+            nettyHeaders = new DefaultHttpHeaders();
         }
         this.nettyHeaders = nettyHeaders;
         this.headers = new NettyHttpHeaders(nettyHeaders, conversionService);


### PR DESCRIPTION
fix the problem, we need to ensure Netty's HTTP header validation is enabled when creating `DefaultHttpHeaders` in the absence of provided headers. This can be accomplished simply by omitting the boolean argument (default is `true`), or explicitly passing `true` to indicate validation is on. Edit only the code shown: in file `http-netty/src/main/java/io/micronaut/http/netty/NettyMutableHttpResponse.java`, change the instantiation in line 156 from `new DefaultHttpHeaders(false)` to `new DefaultHttpHeaders()` (or `new DefaultHttpHeaders(true)`). No imports or auxiliary definitions are needed, as the constructor is part of Netty's public API.


#### References
SecLists.org: [HTTP response splitting](https://seclists.org/bugtraq/2005/Apr/187)
OWASP: [HTTP Response Splitting](https://www.owasp.org/index.php/HTTP_Response_Splitting)
Wikipedia: [HTTP response splitting](http://en.wikipedia.org/wiki/HTTP_response_splitting)
CAPEC: [CAPEC-105: HTTP Request Splitting](https://capec.mitre.org/data/definitions/105.html)