### PR TITLE
Remove @Experimental from BeanIntrospection.Builder

### DIFF
--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
@@ -413,7 +413,6 @@ public interface BeanIntrospection<T> extends AnnotationMetadataDelegate, BeanIn
      * @param <T> The bean type.
      * @since 4.1.0
      */
-    @Experimental
     interface Builder<T> {
         /**
          * All the arguments possible for creating the instance.


### PR DESCRIPTION
Support for using builder to create beans annotated with @Introspected has been introduced in 4.1.0 but the class BeanIntrospection.Builder is still marked @Experimental. Remove the annotation to signal that the API is now stable and reliable to use.\n\nFixes #12031