### PR TITLE
feat(http-client-netty): configurable response decompression

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -176,6 +176,7 @@ public abstract class HttpClientConfiguration {
     private boolean followRedirects = DEFAULT_FOLLOW_REDIRECTS;
 
     private boolean exceptionOnErrorStatus = DEFAULT_EXCEPTION_ON_ERROR_STATUS;
+    private boolean decompressionEnabled = true;
 
     private SslConfiguration sslConfiguration = new ClientSslConfiguration();
 
@@ -371,6 +372,29 @@ public abstract class HttpClientConfiguration {
      */
     public void setExceptionOnErrorStatus(boolean exceptionOnErrorStatus) {
         this.exceptionOnErrorStatus = exceptionOnErrorStatus;
+    }
+
+    /**
+     * Whether response content decompression is enabled in the Netty HTTP client.
+     * When disabled, the client will not add the HttpContentDecompressor to the pipeline
+     * and will receive the raw compressed response body and headers (e.g. Content-Encoding).
+     * Default: true.
+     *
+     * @return true if automatic content decompression is enabled
+     */
+    public boolean isDecompressionEnabled() {
+        return decompressionEnabled;
+    }
+
+    /**
+     * Enable or disable automatic response content decompression in the Netty HTTP client.
+     * Disabling this can be useful for proxy or testing scenarios where the compressed payload
+     * and Content-Encoding header need to be observed.
+     *
+     * @param decompressionEnabled true to enable decompression, false to disable it
+     */
+    public void setDecompressionEnabled(boolean decompressionEnabled) {
+        this.decompressionEnabled = decompressionEnabled;
     }
 
     /**

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/DecompressionConfigTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/DecompressionConfigTest.java
@@ -6,6 +6,12 @@
  * You may obtain a copy of the License at
  *
  * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.micronaut.http.client.tck.tests;
 

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/DecompressionConfigTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/DecompressionConfigTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.micronaut.http.client.tck.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.ByteBodyHttpResponse;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.RawHttpClient;
+import io.micronaut.http.tck.ServerUnderTest;
+import io.micronaut.http.tck.ServerUnderTestProviderUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+
+class DecompressionConfigTest {
+    static final String SPEC_NAME = "DecompressionConfigTest";
+
+    private static final byte[] UNCOMPRESSED = "Hello, gzip!".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] GZIPPED = gzip(UNCOMPRESSED);
+
+    @Test
+    void gzipPreservedWhenDecompressionDisabled() throws Exception {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider()
+                 .getServer(SPEC_NAME, Map.of("micronaut.http.client.decompression-enabled", "false"));
+             RawHttpClient client = server.getApplicationContext().createBean(RawHttpClient.class);
+             ByteBodyHttpResponse<?> response = Mono.from(
+                     client.exchange(HttpRequest.GET(server.getURL().get() + "/decompression/gzip"), null, null))
+                 .cast(ByteBodyHttpResponse.class)
+                 .block()) {
+
+            // Body should still be compressed
+            byte[] body = response.byteBody().buffer().get().toByteArray();
+            Assertions.assertArrayEquals(GZIPPED, body);
+
+            // Header should be preserved
+            Assertions.assertEquals("gzip", response.getHeaders().get(HttpHeaders.CONTENT_ENCODING));
+        }
+    }
+
+    @Test
+    void gzipIsDecompressedByDefault() throws Exception {
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME);
+             RawHttpClient client = server.getApplicationContext().createBean(RawHttpClient.class);
+             ByteBodyHttpResponse<?> response = Mono.from(
+                     client.exchange(HttpRequest.GET(server.getURL().get() + "/decompression/gzip"), null, null))
+                 .cast(ByteBodyHttpResponse.class)
+                 .block()) {
+
+            // Body should be decompressed to the original content
+            byte[] body = response.byteBody().buffer().get().toByteArray();
+            Assertions.assertArrayEquals(UNCOMPRESSED, body);
+
+            // Content-Encoding header should be removed by the decompressor
+            Assertions.assertFalse(response.getHeaders().contains(HttpHeaders.CONTENT_ENCODING));
+        }
+    }
+
+    @Controller("/decompression")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class DecompressionController {
+        @Get("/gzip")
+        HttpResponse<byte[]> gzip() {
+            return HttpResponse.ok(GZIPPED)
+                .header(HttpHeaders.CONTENT_ENCODING, "gzip")
+                .contentLength(GZIPPED.length);
+        }
+    }
+
+    private static byte[] gzip(byte[] data) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+                gzip.write(data);
+            }
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -675,12 +675,14 @@ public class ConnectionManager {
     private void initHttp1(Channel ch) {
         addLogHandler(ch);
 
-        ch.pipeline()
-            .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, new HttpClientCodec(
-                HttpClientConfiguration.DEFAULT_MAX_INITIAL_LINE_LENGTH,
-                configuration.getMaxHeaderSize(),
-                HttpClientConfiguration.DEFAULT_MAX_CHUNK_SIZE))
-            .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_DECODER, new HttpContentDecompressor());
+        ChannelPipeline pipeline = ch.pipeline();
+        pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, new HttpClientCodec(
+            HttpClientConfiguration.DEFAULT_MAX_INITIAL_LINE_LENGTH,
+            configuration.getMaxHeaderSize(),
+            HttpClientConfiguration.DEFAULT_MAX_CHUNK_SIZE));
+        if (configuration.isDecompressionEnabled()) {
+            pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_DECODER, new HttpContentDecompressor());
+        }
     }
 
     private void addLogHandler(Channel ch) {
@@ -1619,7 +1621,8 @@ public class ConnectionManager {
                 withPropagation(openStreamChannel(), (Future<Channel> future) -> {
                     if (future.isSuccess()) {
                         Channel streamChannel = future.get();
-                        streamChannel.pipeline()
+                        ChannelPipeline streamPipeline = streamChannel.pipeline();
+                        streamPipeline
                             .addLast(new ChannelOutboundHandlerAdapter() {
                                 @Override
                                 public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
@@ -1627,8 +1630,10 @@ public class ConnectionManager {
                                     super.write(ctx, msg, promise);
                                 }
                             })
-                            .addLast(createFrameToHttpObjectCodec())
-                            .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_DECOMPRESSOR, new HttpContentDecompressor());
+                            .addLast(createFrameToHttpObjectCodec());
+                        if (configuration.isDecompressionEnabled()) {
+                            streamPipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_DECOMPRESSOR, new HttpContentDecompressor());
+                        }
                         NettyClientCustomizer streamCustomizer = connectionCustomizer.specializeForChannel(streamChannel, NettyClientCustomizer.ChannelRole.HTTP2_STREAM);
                         PoolHandle ph = new PoolHandle(true, streamChannel) {
                             @Override

--- a/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
+++ b/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
@@ -19,7 +19,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.client.tck.tests.ContinueTest", // Unsupported body type errors
     "io.micronaut.http.client.tck.tests.RawTest", // There's no raw client for the JDK client
     "io.micronaut.http.client.tck.tests.StreamTest", // There's no streaming client for the JDK client
+    "io.micronaut.http.client.tck.tests.DecompressionConfigTest", // Netty-specific decompression behavior; not applicable to JDK client
 })
 public class JdkHttpMethodTests {
 }
-


### PR DESCRIPTION
- Add HttpClientConfiguration.decompressionEnabled (default: true)
- Netty client: only add HttpContentDecompressor for HTTP/1 and HTTP/2 when enabled
- TCK: add DecompressionConfigTest covering default behavior and disabled mode
- JDK TCK: exclude DecompressionConfigTest from JdkHttpMethodTests

Use-case: allow proxies/tests to observe raw compressed payloads and preserve Content-Encoding.

Fixes #11995