### PR TITLE
Bean context improvements

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/chain/DefaultInterceptorRegistry.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/DefaultInterceptorRegistry.java
@@ -29,6 +29,7 @@ import io.micronaut.context.EnvironmentConfigurable;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.beans.BeanConstructor;
 import io.micronaut.core.naming.Described;
@@ -51,8 +52,9 @@ import java.util.List;
  * @author graemerocher
  * @since 3.0.0
  */
-public class DefaultInterceptorRegistry implements InterceptorRegistry {
-    protected static final Logger LOG = LoggerFactory.getLogger(InterceptorChain.class);
+@Internal
+public final class DefaultInterceptorRegistry implements InterceptorRegistry {
+    private static final Logger LOG = LoggerFactory.getLogger(InterceptorChain.class);
     private static final MethodInterceptor<?, ?>[] ZERO_METHOD_INTERCEPTORS = new MethodInterceptor[0];
     private static final Interceptor[] ZERO_INTERCEPTORS = new Interceptor[0];
     private final BeanContext beanContext;

--- a/aop/src/main/java/io/micronaut/aop/internal/InterceptorRegistryBean.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/InterceptorRegistryBean.java
@@ -30,6 +30,7 @@ import io.micronaut.inject.InstantiatableBeanDefinition;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 
 import java.util.Collections;
+import java.util.Set;
 
 /**
  * Registers the {@link InterceptorRegistry} instance.
@@ -45,6 +46,29 @@ public final class InterceptorRegistryBean implements InstantiatableBeanDefiniti
         MutableAnnotationMetadata metadata = new MutableAnnotationMetadata();
         metadata.addDeclaredAnnotation(BootstrapContextCompatible.class.getName(), Collections.emptyMap());
         ANNOTATION_METADATA = metadata;
+    }
+
+    @Override
+    public @NonNull Class<?>[] getIndexes() {
+        return new Class[]{InterceptorRegistry.class};
+    }
+
+    @Override
+    public Set<Class<?>> getExposedTypes() {
+        return Set.of(
+            InterceptorRegistry.class,
+            DefaultInterceptorRegistry.class
+        );
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+
+    @Override
+    public boolean isParallel() {
+        return false;
     }
 
     @Override

--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -400,6 +400,9 @@ public class AopProxyWriter implements ProxyingBeanDefinitionVisitor, ClassOutpu
         } else {
             proxyBeanDefinitionWriter.setInterceptedType(targetClassFullName);
         }
+        if (interfaceTypes != null && interfaceTypes.length > 0) {
+            proxyBeanDefinitionWriter.setExposes(Set.of(interfaceTypes));
+        }
 
         proxyBuilder = ClassDef.builder(proxyFullName).synthetic();
 
@@ -491,6 +494,11 @@ public class AopProxyWriter implements ProxyingBeanDefinitionVisitor, ClassOutpu
     @Override
     public void setInterceptedType(String typeName) {
         proxyBeanDefinitionWriter.setInterceptedType(typeName);
+    }
+
+    @Override
+    public void setExposes(Set<ClassElement> exposes) {
+        proxyBeanDefinitionWriter.setExposes(exposes);
     }
 
     @Override

--- a/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.TypeInformation;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataGenUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
@@ -118,6 +119,21 @@ public final class ArgumentExpUtils {
         AnnotationMetadata.class,
         Class[].class
     );
+
+    private static final Method METHOD_ARGUMENT_GET_TYPE = ReflectionUtils.getRequiredInternalMethod(
+        TypeInformation.class,
+        "getType"
+    );
+
+    /**
+     * Extract the argument's type.
+     *
+     * @param argument The argument expression
+     * @return The type expression
+     */
+    public static ExpressionDef getTypeExp(ExpressionDef argument) {
+        return argument.invoke(METHOD_ARGUMENT_GET_TYPE);
+    }
 
     /**
      * Creates an argument.

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Interface for {@link BeanDefinitionVisitor} implementations such as {@link BeanDefinitionWriter}.
@@ -170,6 +171,12 @@ public interface BeanDefinitionVisitor extends OriginatingElements, Toggleable {
      * @param typeName The type name
      */
     void setInterceptedType(String typeName);
+
+    /**
+     * @param exposes The exposed types
+     * @since 5.0
+     */
+    void setExposes(Set<ClassElement> exposes);
 
     /**
      * @return The intercepted type

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -26,6 +26,7 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanLocator;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.context.LifeCycle;
 import io.micronaut.context.Qualifier;
 import io.micronaut.context.RequiresCondition;
 import io.micronaut.context.annotation.Any;
@@ -83,7 +84,9 @@ import io.micronaut.core.beans.BeanConstructor;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.ConversionServiceProvider;
 import io.micronaut.core.expressions.EvaluatedExpressionReference;
+import io.micronaut.core.naming.Described;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.naming.Named;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.reflect.ReflectionUtils;
@@ -147,8 +150,10 @@ import io.micronaut.sourcegen.model.VariableDef;
 import jakarta.inject.Singleton;
 
 import javax.lang.model.element.Modifier;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -591,6 +596,7 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
     private static final Method IS_INNER_CONFIGURATION_METHOD = ReflectionUtils.getRequiredMethod(AbstractInitializableBeanDefinition.class, "isInnerConfiguration", Class.class);
     private static final Method CONTAINS_METHOD = ReflectionUtils.getRequiredMethod(Collection.class, "contains", Object.class);
     private static final Method GET_EXPOSED_TYPES_METHOD = ReflectionUtils.getRequiredMethod(AbstractInitializableBeanDefinition.class, "getExposedTypes");
+    private static final Method IS_CANDIDATE_BEAN_METHOD = ReflectionUtils.getRequiredMethod(BeanDefinition.class, "isCandidateBean", Argument.class);
     private static final Method GET_ORDER_METHOD = ReflectionUtils.getRequiredMethod(Ordered.class, "getOrder");
     private static final Constructor<HashSet> HASH_SET_COLLECTION_CONSTRUCTOR = ReflectionUtils.getRequiredInternalConstructor(HashSet.class, Collection.class);
     private static final Method ARRAYS_AS_LIST_METHOD = ReflectionUtils.getRequiredMethod(Arrays.class, "asList", Object[].class);
@@ -606,6 +612,14 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
     private static final Method ARGUMENT_OF_METHOD = ReflectionUtils.getRequiredInternalMethod(Argument.class, "of", Class.class);
     private static final Method GET_INDEXES_METHOD = ReflectionUtils.getRequiredMethod(BeanDefinitionReference.class, "getIndexes");
     private static final Method IS_PARALLEL_METHOD = ReflectionUtils.getRequiredMethod(BeanDefinitionReference.class, "isParallel");
+    private static final Method IS_ASSIGNABLE_METHOD = ReflectionUtils.getRequiredMethod(Class.class, "isAssignableFrom", Class.class);
+
+    private static final Set<String> IGNORED_EXPOSED_INTERFACES = Set.of(
+        AutoCloseable.class.getName(), LifeCycle.class.getName(), Ordered.class.getName(), Closeable.class.getName(),
+        Named.class.getName(), Described.class.getName(),
+        Record.class.getName(), Enum.class.getName(), Toggleable.class.getName(), Iterable.class.getName(),
+        Serializable.class.getName()
+    );
 
     private final String beanFullClassName;
     private final String beanDefinitionName;
@@ -631,7 +645,8 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
     private Map<String, Map<String, ClassElement>> typeArguments;
     @Nullable
     private String interceptedType;
-
+    @Nullable
+    private Set<ClassElement> exposes;
     private final List<FieldVisitData> fieldInjectionPoints = new ArrayList<>(2);
     private final List<MethodVisitData> methodInjectionPoints = new ArrayList<>(2);
     private final List<MethodVisitData> postConstructMethodVisits = new ArrayList<>(2);
@@ -701,10 +716,10 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
         this.originatingElements = originatingElements;
         this.beanProducingElement = beanProducingElement;
         if (beanProducingElement instanceof ClassElement classElement) {
-            autoApplyNamedToBeanProducingElement(classElement);
             if (classElement.isPrimitive()) {
                 throw new IllegalArgumentException("Primitive beans can only be created from factories");
             }
+            autoApplyNamedToBeanProducingElement(classElement);
             this.beanTypeElement = classElement;
             this.packageName = classElement.getPackageName();
             this.isInterface = classElement.isInterface();
@@ -713,8 +728,8 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
             this.beanSimpleClassName = classElement.getSimpleName();
             this.beanDefinitionName = getBeanDefinitionName(packageName, beanSimpleClassName);
         } else if (beanProducingElement instanceof MethodElement factoryMethodElement) {
-            autoApplyNamedToBeanProducingElement(beanProducingElement);
             final ClassElement producedElement = factoryMethodElement.getGenericReturnType();
+            autoApplyNamedToBeanProducingElement(beanProducingElement);
             this.beanTypeElement = producedElement;
             this.packageName = producedElement.getPackageName();
             this.isInterface = producedElement.isInterface();
@@ -728,8 +743,8 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
             final ClassElement declaringType = factoryMethodElement.getOwningType();
             this.beanDefinitionName = declaringType.getPackageName() + "." + prefixClassName(declaringType.getSimpleName()) + "$" + upperCaseMethodName + uniqueIdentifier + CLASS_SUFFIX;
         } else if (beanProducingElement instanceof PropertyElement factoryPropertyElement) {
-            autoApplyNamedToBeanProducingElement(beanProducingElement);
             final ClassElement producedElement = factoryPropertyElement.getGenericType();
+            autoApplyNamedToBeanProducingElement(beanProducingElement);
             this.beanTypeElement = producedElement;
             this.packageName = producedElement.getPackageName();
             this.isInterface = producedElement.isInterface();
@@ -743,8 +758,8 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
             final ClassElement declaringType = factoryPropertyElement.getOwningType();
             this.beanDefinitionName = declaringType.getPackageName() + "." + prefixClassName(declaringType.getSimpleName()) + "$" + upperCaseMethodName + uniqueIdentifier + CLASS_SUFFIX;
         } else if (beanProducingElement instanceof FieldElement factoryMethodElement) {
-            autoApplyNamedToBeanProducingElement(beanProducingElement);
             final ClassElement producedElement = factoryMethodElement.getGenericField();
+            autoApplyNamedToBeanProducingElement(beanProducingElement);
             this.beanTypeElement = producedElement;
             this.packageName = producedElement.getPackageName();
             this.isInterface = producedElement.isInterface();
@@ -979,6 +994,11 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
             classDefBuilder.addSuperinterface(TypeDef.of(AdvisedBeanType.class));
         }
         this.interceptedType = typeName;
+    }
+
+    @Override
+    public void setExposes(Set<ClassElement> exposes) {
+        this.exposes = exposes;
     }
 
     @Override
@@ -2079,7 +2099,14 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
                 )
         );
 
-        List<AnnotationValue<Indexed>> indexes = annotationMetadata.getAnnotationValuesByType(Indexed.class);
+        AnnotationMetadata declaredAnnotationMetadata;
+        if (beanProducingElement instanceof MethodElement methodElement) {
+            declaredAnnotationMetadata = methodElement.getMethodAnnotationMetadata();
+        } else {
+            declaredAnnotationMetadata = annotationMetadata;
+        }
+
+        List<AnnotationValue<Indexed>> indexes = declaredAnnotationMetadata.getAnnotationValuesByType(Indexed.class);
         if (!indexes.isEmpty()) {
             TypeDef.Array arrayOfClasses = TypeDef.Primitive.CLASS.array();
             FieldDef indexesField = FieldDef.builder("$INDEXES")
@@ -2369,24 +2396,109 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
     }
 
     private StatementDef addGetExposedTypes() {
-        if (annotationMetadata.hasDeclaredAnnotation(Bean.class.getName())) {
-            final String[] exposedTypes = annotationMetadata.stringValues(Bean.class.getName(), "typed");
-            if (exposedTypes.length > 0) {
-                FieldDef exposedTypesField = FieldDef.builder(FIELD_EXPOSED_TYPES, Set.class)
-                    .addModifiers(Modifier.PRIVATE, Modifier.FINAL, Modifier.STATIC)
-                    .build();
-
-                classDefBuilder.addField(exposedTypesField);
-
-                classDefBuilder.addMethod(
-                    MethodDef.override(GET_EXPOSED_TYPES_METHOD)
-                        .build((aThis, methodParameters) -> aThis.type().getStaticField(exposedTypesField).returning())
-                );
-
-                return beanDefinitionTypeDef.getStaticField(exposedTypesField).put(getClassesAsSetExpression(exposedTypes));
+        AnnotationMetadata producingAnnotationMetadata;
+        if (beanProducingElement instanceof MethodElement methodElement) {
+            producingAnnotationMetadata = methodElement.getMethodAnnotationMetadata();
+        } else {
+            producingAnnotationMetadata = annotationMetadata;
+        }
+        String[] exposedTypes = producingAnnotationMetadata.stringValues(Bean.class.getName(), "typed");
+        Set<String> exposedTypeNames;
+        if (exposedTypes.length != 0) {
+            exposedTypeNames = Set.of(exposedTypes);
+        } else {
+            exposedTypeNames = new HashSet<>();
+            if (interceptedType != null) {
+                collectExposedTypes(exposedTypeNames, visitorContext.getClassElement(interceptedType).orElseThrow(() -> new IllegalStateException("Intercepted type not found: " + interceptedType)));
+                exposedTypeNames.add(beanProducingElement.getName()); // Allow finding the proxy by it's name
+            } else if (exposes != null) {
+                exposes.forEach(name -> exposedTypeNames.add(name.getName()));
+            } else if (isContainerType()) {
+                if (beanTypeElement.isArray()) {
+                    collectExposedTypes(exposedTypeNames, beanTypeElement.fromArray());
+                } else {
+                    collectExposedTypes(exposedTypeNames, beanTypeElement.getFirstTypeArgument()
+                        .orElseThrow(() -> new IllegalStateException("No type argument found for array type: " + beanTypeElement.getType())));
+                }
+                collectExposedTypes(exposedTypeNames, beanTypeElement);
+            } else {
+                collectExposedTypes(exposedTypeNames, beanTypeElement);
             }
         }
-        return StatementDef.multi();
+        if (exposedTypeNames.isEmpty()) {
+            // This should never happen
+            return StatementDef.multi();
+        }
+        FieldDef exposedTypesField = FieldDef.builder(FIELD_EXPOSED_TYPES, TypeDef.parameterized(Set.class, TypeDef.Primitive.CLASS))
+            .addModifiers(Modifier.PRIVATE, Modifier.FINAL, Modifier.STATIC)
+            .build();
+
+        List<StatementDef> statements = new ArrayList<>();
+
+        classDefBuilder.addField(exposedTypesField);
+
+        VariableDef.StaticField staticFieldExposes = beanDefinitionTypeDef.getStaticField(exposedTypesField);
+        statements.add(StatementDef.doTry(
+                staticFieldExposes.put(getClassesAsSetExpression(exposedTypeNames))
+            ).doCatch(Throwable.class,
+                exceptionVar -> staticFieldExposes.put(GenUtils.setOf(List.of())))
+        );
+
+        classDefBuilder.addMethod(
+            MethodDef.override(GET_EXPOSED_TYPES_METHOD)
+                .build((aThis, methodParameters) ->
+                    aThis.type().getStaticField(exposedTypesField).returning())
+        );
+
+        if (!hasTypeArguments() && !isContainerType()) {
+
+            classDefBuilder.addMethod(
+                MethodDef.override(IS_CANDIDATE_BEAN_METHOD)
+                    .build((aThis, methodParameters) -> {
+                            if (exposedTypes.length != 0) { // User-defined exposed types
+                                if (exposedTypeNames.size() == 1) {
+                                    return methodParameters.get(0).newLocal("type", variableDef ->
+                                        variableDef.isNonNull()
+                                            .and(
+                                                ArgumentExpUtils.getTypeExp(variableDef).equalsReferentially(
+                                                    ExpressionDef.constant(TypeDef.of(exposedTypeNames.iterator().next()))
+                                                )
+                                            )
+                                            .returning()
+                                    );
+                                } else {
+                                    return methodParameters.get(0).newLocal("type", variableDef ->
+                                        variableDef.isNonNull().and(
+                                            staticFieldExposes.invoke(CONTAINS_METHOD, ArgumentExpUtils.getTypeExp(variableDef)).isTrue()
+                                        ).returning()
+                                    );
+                                }
+                            } else {
+                                return ArgumentExpUtils.getTypeExp(methodParameters.get(0))
+                                    .invoke(IS_ASSIGNABLE_METHOD, ExpressionDef.constant(beanTypeDef))
+                                    .returning();
+                            }
+                        }
+                    )
+            );
+        }
+        return StatementDef.multi(statements);
+    }
+
+    private void collectExposedTypes(Set<String> exposedTypeNames, ClassElement element) {
+        String className = getClassName(element);
+        if (!exposedTypeNames.add(className) || IGNORED_EXPOSED_INTERFACES.contains(className)) {
+            return;
+        }
+        element.getSuperType().ifPresent(superType -> collectExposedTypes(exposedTypeNames, superType));
+        element.getInterfaces().forEach(iface -> collectExposedTypes(exposedTypeNames, iface));
+    }
+
+    private String getClassName(ClassElement element) {
+        if (element.isArray()) {
+            return getClassName(element.fromArray()) + "[]";
+        }
+        return element.getName();
     }
 
     @Nullable
@@ -2420,6 +2532,10 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
 
                 asClassExpression(classes[0])
             );
+    }
+
+    private ExpressionDef getClassesAsSetExpression(Collection<String> classes) {
+        return GenUtils.setOf(classes.stream().<ExpressionDef>map(this::asClassExpression).toList());
     }
 
     private boolean hasTypeArguments() {
@@ -3174,7 +3290,11 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
     }
 
     private ExpressionDef getArrayOfClasses(String[] byType) {
-        return TypeDef.CLASS.array().instantiate(Arrays.stream(byType).map(this::asClassExpression).toList());
+        return getArrayOfClasses(List.of(byType));
+    }
+
+    private ExpressionDef getArrayOfClasses(Collection<String> byType) {
+        return TypeDef.CLASS.array().instantiate(byType.stream().map(this::asClassExpression).toList());
     }
 
     private ExpressionDef.Constant asClassExpression(String type) {

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -165,6 +165,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -2407,7 +2408,7 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
         if (exposedTypes.length != 0) {
             exposedTypeNames = Set.of(exposedTypes);
         } else {
-            exposedTypeNames = new HashSet<>();
+            exposedTypeNames = new LinkedHashSet<>();
             if (interceptedType != null) {
                 collectExposedTypes(exposedTypeNames, visitorContext.getClassElement(interceptedType).orElseThrow(() -> new IllegalStateException("Intercepted type not found: " + interceptedType)));
                 exposedTypeNames.add(beanProducingElement.getName()); // Allow finding the proxy by it's name

--- a/core-processor/src/main/java/io/micronaut/inject/writer/GenUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/GenUtils.java
@@ -45,6 +45,7 @@ public final class GenUtils {
     private static final ClassTypeDef MAP_TYPE = ClassTypeDef.of(Map.class);
     private static final ClassTypeDef MAP_ENTRY_TYPE = ClassTypeDef.of(Map.Entry.class);
     private static final ClassTypeDef LIST_TYPE = ClassTypeDef.of(List.class);
+    private static final ClassTypeDef SET_TYPE = ClassTypeDef.of(Set.class);
 
     private GenUtils() {
     }
@@ -169,6 +170,41 @@ public final class GenUtils {
                 TypeDef.OBJECT.array().instantiate(values)
             );
         }
+    }
+
+    /**
+     * The set of expression.
+     * @param values The values
+     * @return the expression
+     */
+    public static ExpressionDef setOf(List<ExpressionDef> values) {
+        if (values != null) {
+            values = values.stream().filter(Objects::nonNull).toList();
+        }
+        if (values == null || values.isEmpty()) {
+            return SET_TYPE.invokeStatic("of", SET_TYPE);
+        }
+        if (values.size() < 11) {
+            List<TypeDef> parameterTypes = new ArrayList<>(values.size());
+            for (ExpressionDef ignore : values) {
+                parameterTypes.add(TypeDef.OBJECT);
+            }
+            return SET_TYPE.invokeStatic("of", parameterTypes, SET_TYPE, values);
+        } else {
+            return setOfArray(TypeDef.OBJECT.array().instantiate(values));
+        }
+    }
+
+    /**
+     * The set of expression.
+     * @param array The array
+     * @return the expression
+     */
+    public static ExpressionDef setOfArray(ExpressionDef array) {
+        if (!array.type().isArray()) {
+            throw new IllegalArgumentException("Argument must be an array");
+        }
+        return SET_TYPE.invokeStatic("of", List.of(TypeDef.OBJECT.array()), SET_TYPE, array);
     }
 
 }

--- a/core-processor/src/main/java/io/micronaut/inject/writer/GenUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/GenUtils.java
@@ -143,7 +143,8 @@ public final class GenUtils {
      * @param strings The strings
      * @return the expression
      */
-    public static ExpressionDef listOfString(List<String> strings) {
+    @NonNull
+    public static ExpressionDef listOfString(@NonNull List<String> strings) {
         return listOf(strings.stream().<ExpressionDef>map(ExpressionDef::constant).toList());
     }
 
@@ -152,7 +153,8 @@ public final class GenUtils {
      * @param values The values
      * @return the expression
      */
-    public static ExpressionDef listOf(List<ExpressionDef> values) {
+    @NonNull
+    public static ExpressionDef listOf(@NonNull List<ExpressionDef> values) {
         if (values != null) {
             values = values.stream().filter(Objects::nonNull).toList();
         }
@@ -177,7 +179,8 @@ public final class GenUtils {
      * @param values The values
      * @return the expression
      */
-    public static ExpressionDef setOf(List<ExpressionDef> values) {
+    @NonNull
+    public static ExpressionDef setOf(@NonNull List<ExpressionDef> values) {
         if (values != null) {
             values = values.stream().filter(Objects::nonNull).toList();
         }
@@ -200,7 +203,8 @@ public final class GenUtils {
      * @param array The array
      * @return the expression
      */
-    public static ExpressionDef setOfArray(ExpressionDef array) {
+    @NonNull
+    public static ExpressionDef setOfArray(@NonNull ExpressionDef array) {
         if (!array.type().isArray()) {
             throw new IllegalArgumentException("Argument must be an array");
         }

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -276,7 +276,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
                                                        Predicate<String> lineCondition,
                                                        ClassLoader classLoader,
                                                        Function<String, S> transformer) {
-        return new ServiceScanner<>(classLoader, serviceName, lineCondition, transformer).new DefaultServiceCollector();
+        return new ServiceScanner<>(classLoader, serviceName, lineCondition, transformer).createCollector();
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/reflect/ReflectionUtils.java
+++ b/core/src/main/java/io/micronaut/core/reflect/ReflectionUtils.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -84,6 +85,34 @@ public class ReflectionUtils {
         m.put(Short.class, short.class);
         m.put(Void.class, void.class);
         WRAPPER_TO_PRIMITIVE = Collections.unmodifiableMap(m);
+    }
+
+    /**
+     * Retrieves all classes, interfaces, and superclasses in the hierarchy of the given class.
+     *
+     * @param aClass The class whose hierarchy is to be retrieved. Must not be null.
+     * @return A set of classes and interfaces representing the entire hierarchy of the given class,
+     *         including the provided class itself.
+     * @since 5.0
+     */
+    public static Set<Class<?>> getAllClassesInHierarchy(Class<?> aClass) {
+        ClassUtils.REFLECTION_LOGGER.debug("Reflectively retrieving hierarchy for class: {}", aClass);
+        Set<Class<?>> set = new LinkedHashSet<>();
+        collectAllClassesInHierarchy(set, aClass);
+        return set;
+    }
+
+    private static void collectAllClassesInHierarchy(Set<Class<?>> classes, Class<?> aClass) {
+        if (!classes.add(aClass)) {
+            return;
+        }
+        Class<?> superclass = aClass.getSuperclass();
+        if (superclass != null && superclass != Object.class && superclass != Record.class && superclass != Enum.class) {
+            collectAllClassesInHierarchy(classes, superclass);
+        }
+        for (Class<?> interfaceClass : aClass.getInterfaces()) {
+            collectAllClassesInHierarchy(classes, interfaceClass);
+        }
     }
 
     /**

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
@@ -65,7 +65,7 @@ class ClientIntroductionAdviceSpec extends Specification {
 
     void "service id appears in exceptions"() {
         given:
-        server.applicationContext.registerSingleton(new TestServiceInstanceList(server.getURI()))
+        server.applicationContext.registerSingleton(ServiceInstanceList.class, new TestServiceInstanceList(server.getURI()))
         PolicyClient myService = server.applicationContext.getBean(PolicyClient)
 
         when:
@@ -79,7 +79,7 @@ class ClientIntroductionAdviceSpec extends Specification {
 
     void "test multiple clients with the same id and different paths"() {
         given:
-        server.applicationContext.registerSingleton(new TestServiceInstanceList(server.getURI()))
+        server.applicationContext.registerSingleton(ServiceInstanceList.class, new TestServiceInstanceList(server.getURI()))
 
         expect:
         server.applicationContext.getBean(PolicyClient).index() == 'policy'
@@ -88,7 +88,7 @@ class ClientIntroductionAdviceSpec extends Specification {
 
     void "test a client with a body and header"() {
         given:
-        server.applicationContext.registerSingleton(new TestServiceInstanceList(server.getURI()))
+        server.applicationContext.registerSingleton(ServiceInstanceList.class, new TestServiceInstanceList(server.getURI()))
 
         when:
         OfferClient client = server.applicationContext.getBean(OfferClient)
@@ -99,7 +99,7 @@ class ClientIntroductionAdviceSpec extends Specification {
 
     void "test a client that auto encodes basic auth header"() {
         given:
-        server.applicationContext.registerSingleton(new TestServiceInstanceList(server.getURI()))
+        server.applicationContext.registerSingleton(ServiceInstanceList.class, new TestServiceInstanceList(server.getURI()))
 
         when:
         BasicAuthHeaderAutoEncodingClient client = server.applicationContext.getBean(BasicAuthHeaderAutoEncodingClient)
@@ -158,7 +158,7 @@ class ClientIntroductionAdviceSpec extends Specification {
 
     void "test client interface definition type"() {
         given:
-        server.applicationContext.registerSingleton(new TestServiceInstanceList(server.getURI()))
+        server.applicationContext.registerSingleton(ServiceInstanceList.class, new TestServiceInstanceList(server.getURI()))
 
         when:
         var inverseClient = server.applicationContext.getBean(SingleInterfaceClient)

--- a/inject-java/src/test/groovy/io/micronaut/annotation/NullabilityAnnotationsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/NullabilityAnnotationsSpec.groovy
@@ -5,7 +5,7 @@ import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.beans.BeanMethod
 import io.micronaut.inject.ast.ElementQuery
 
-class NullabilityAnnotationsSpec extends AbstractTypeElementSpec {
+class kNullabilityAnnotationsSpec extends AbstractTypeElementSpec {
 
     void "test map nullable annotation for #packageName in beans"() {
         given:

--- a/inject-java/src/test/groovy/io/micronaut/aop/factory/mapped/FactoryMappedAdviceReflectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/factory/mapped/FactoryMappedAdviceReflectionSpec.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.aop.factory.mapped
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+class FactoryMappedAdviceReflectionSpec extends AbstractTypeElementSpec {
+
+    void "test configuration mapping"() {
+        given:
+        ApplicationContext applicationContext = buildContext('test.MyConfiguration', '''
+package test;
+
+
+@io.micronaut.aop.factory.mapped.TestConfiguration
+public class MyConfiguration {
+
+    @io.micronaut.context.annotation.Bean
+    public MyBean myBean() {
+        return new MyBean("default");
+    }
+
+}
+
+class MyBean {
+        private final String name;
+
+        MyBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+''')
+
+        applicationContext.registerSingleton(new TestSingletonInterceptor())
+        def type = applicationContext.classLoader.loadClass('test.MyBean')
+        def config = applicationContext.classLoader.loadClass('test.MyConfiguration')
+
+        expect:
+        applicationContext.getBean(type) == applicationContext.getBean(type)
+        applicationContext.getBean(config).myBean() == applicationContext.getBean(config).myBean()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/factory/mapped/FactoryMappedAdviceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/factory/mapped/FactoryMappedAdviceSpec.groovy
@@ -2,9 +2,11 @@ package io.micronaut.aop.factory.mapped
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
+import spock.lang.PendingFeature
 
 class FactoryMappedAdviceSpec extends AbstractTypeElementSpec {
 
+    @PendingFeature
     void "test configuration mapping"() {
         given:
         ApplicationContext applicationContext = buildContext('test.MyConfiguration', '''
@@ -14,7 +16,7 @@ package test;
 @io.micronaut.aop.factory.mapped.TestConfiguration
 public class MyConfiguration {
 
-    @io.micronaut.context.annotation.Bean    
+    @io.micronaut.context.annotation.Bean
     public MyBean myBean() {
         return new MyBean("default");
     }

--- a/inject-java/src/test/groovy/io/micronaut/aop/factory/mapped/FactoryMappedAdviceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/factory/mapped/FactoryMappedAdviceSpec.groovy
@@ -1,12 +1,12 @@
 package io.micronaut.aop.factory.mapped
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.Interceptor
 import io.micronaut.context.ApplicationContext
-import spock.lang.PendingFeature
+import io.micronaut.context.RuntimeBeanDefinition
 
 class FactoryMappedAdviceSpec extends AbstractTypeElementSpec {
 
-    @PendingFeature
     void "test configuration mapping"() {
         given:
         ApplicationContext applicationContext = buildContext('test.MyConfiguration', '''
@@ -36,7 +36,12 @@ class MyBean {
     }
 ''')
 
-        applicationContext.registerSingleton(new TestSingletonInterceptor())
+        applicationContext.registerBeanDefinition(
+                RuntimeBeanDefinition.builder(new TestSingletonInterceptor())
+                    .singleton(true)
+                    .exposedTypes(Interceptor.class, TestSingletonInterceptor.class)
+                    .build()
+        )
         def type = applicationContext.classLoader.loadClass('test.MyBean')
         def config = applicationContext.classLoader.loadClass('test.MyConfiguration')
 

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
@@ -19,9 +19,11 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.context.event.StartupEvent
+import spock.lang.PendingFeature
 
 class MappedIntroductionOnConcreteClassSpec extends AbstractTypeElementSpec {
 
+    @PendingFeature(reason = "This test should fail because ListenerAdviceMarker convert the class to be an Application listener which should fail on startup because if the missing interceptor")
     void "test mapped introduction of new interface on concrete class"() {
         given:
             ApplicationContext applicationContext = buildContext('test.MyBeanWithMappedIntroduction', '''

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
@@ -16,14 +16,14 @@
 package io.micronaut.aop.introduction
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.Interceptor
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.RuntimeBeanDefinition
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.context.event.StartupEvent
-import spock.lang.PendingFeature
 
 class MappedIntroductionOnConcreteClassSpec extends AbstractTypeElementSpec {
 
-    @PendingFeature(reason = "This test should fail because ListenerAdviceMarker convert the class to be an Application listener which should fail on startup because if the missing interceptor")
     void "test mapped introduction of new interface on concrete class"() {
         given:
             ApplicationContext applicationContext = buildContext('test.MyBeanWithMappedIntroduction', '''
@@ -38,7 +38,12 @@ public class MyBeanWithMappedIntroduction {
 }
 
 ''')
-            applicationContext.registerSingleton(new ListenerAdviceInterceptor())
+            applicationContext.registerBeanDefinition(
+                RuntimeBeanDefinition.builder(new ListenerAdviceInterceptor())
+                    .singleton(true)
+                    .exposedTypes(ListenerAdviceInterceptor.class, Interceptor.class)
+                    .build()
+            )
 
         when:
             def beanClass = applicationContext.classLoader.loadClass('test.MyBeanWithMappedIntroduction')

--- a/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
@@ -24,12 +24,14 @@ import io.micronaut.inject.qualifiers.Qualifiers
 import jakarta.inject.Named
 import jakarta.inject.Singleton
 import spock.lang.Issue
+import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import java.lang.reflect.Proxy
 
 class RegisterSingletonSpec extends Specification {
 
+    @PendingFeature
     void "test register singleton with generic types"() {
         given:
         ApplicationContext context = ApplicationContext.run()
@@ -44,6 +46,7 @@ class RegisterSingletonSpec extends Specification {
         context.close()
     }
 
+    @PendingFeature
     void "test register singleton and exposed type"() {
         given:
         ApplicationContext context = ApplicationContext.run()

--- a/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
@@ -24,20 +24,23 @@ import io.micronaut.inject.qualifiers.Qualifiers
 import jakarta.inject.Named
 import jakarta.inject.Singleton
 import spock.lang.Issue
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import java.lang.reflect.Proxy
 
 class RegisterSingletonSpec extends Specification {
 
-    @PendingFeature
     void "test register singleton with generic types"() {
         given:
         ApplicationContext context = ApplicationContext.run()
 
         when:
-        context.registerSingleton(new TestReporter())
+        context.registerBeanDefinition(
+                RuntimeBeanDefinition.builder(new TestReporter())
+                        .exposedTypes(TestReporter.class, Reporter.class)
+                        .typeArguments(Reporter, Argument.of(Span))
+                        .build()
+        )
 
         then:
         context.containsBean(Argument.of(Reporter, Span))
@@ -46,7 +49,6 @@ class RegisterSingletonSpec extends Specification {
         context.close()
     }
 
-    @PendingFeature
     void "test register singleton and exposed type"() {
         given:
         ApplicationContext context = ApplicationContext.run()
@@ -61,7 +63,9 @@ class RegisterSingletonSpec extends Specification {
         ) // replaces ToBeReplacedCodec
         context.registerSingleton(Codec, {  } as Codec) // adds a new codec
         context.registerSingleton(Codec, new FooCodec()) // adds another codec
-        context.registerSingleton(new BarCodec()) // should be registered with bean type BarCodec
+            context.registerBeanDefinition(RuntimeBeanDefinition.builder(new BarCodec())
+                    .exposedTypes(BarCodec.class, Codec.class)
+                    .build()) // should be registered with bean type BarCodec
         context.registerSingleton(Codec, new BazCodec(), Qualifiers.byName("baz"))
 
         then:

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
@@ -3,12 +3,14 @@ package io.micronaut.kotlin.processing.aop.introduction
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.context.event.StartupEvent
+import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import static io.micronaut.annotation.processing.test.KotlinCompiler.*
 
 class MappedIntroductionOnConcreteClassSpec extends Specification {
 
+    @PendingFeature(reason = "This test should fail because ListenerAdviceMarker convert the class to be an Application listener which should fail on startup because if the missing interceptor")
     void "test mapped introduction of new interface on concrete class"() {
         given:
             ApplicationContext applicationContext = buildContext('''

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
@@ -1,16 +1,16 @@
 package io.micronaut.kotlin.processing.aop.introduction
 
+import io.micronaut.aop.Interceptor
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.RuntimeBeanDefinition
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.context.event.StartupEvent
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import static io.micronaut.annotation.processing.test.KotlinCompiler.*
 
 class MappedIntroductionOnConcreteClassSpec extends Specification {
 
-    @PendingFeature(reason = "This test should fail because ListenerAdviceMarker convert the class to be an Application listener which should fail on startup because if the missing interceptor")
     void "test mapped introduction of new interface on concrete class"() {
         given:
             ApplicationContext applicationContext = buildContext('''
@@ -22,7 +22,11 @@ import jakarta.inject.Singleton
 @Singleton
 open class MyBeanWithMappedIntroduction
 ''')
-        applicationContext.registerSingleton(new ListenerAdviceInterceptor())
+        applicationContext.registerBeanDefinition(
+                RuntimeBeanDefinition.builder(new ListenerAdviceInterceptor())
+                .exposedTypes(ListenerAdviceInterceptor.class, Interceptor.class)
+                .build()
+        )
 
         when:
         def beanClass = applicationContext.classLoader.loadClass('test.MyBeanWithMappedIntroduction')

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanConfiguration.java
@@ -18,7 +18,6 @@ package io.micronaut.context;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.BeanConfiguration;
 import io.micronaut.inject.BeanDefinitionReference;
-import java.util.function.Predicate;
 
 /**
  * An abstract implementation of the {@link BeanConfiguration} method. Not typically used directly from user code,
@@ -56,7 +55,7 @@ public abstract class AbstractBeanConfiguration extends AbstractBeanContextCondi
     }
 
     @Override
-    public boolean isWithin(BeanDefinitionReference beanDefinitionReference) {
+    public boolean isWithin(BeanDefinitionReference<?> beanDefinitionReference) {
         String beanTypeName = beanDefinitionReference.getBeanDefinitionName();
         return isWithin(beanTypeName);
     }

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -542,10 +542,6 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         return Optional.empty();
     }
 
-    protected void onNewSegment(Segment<?, ?> segment) {
-        //no-op
-    }
-
     @NonNull
     private Map<CharSequence, Object> getAttributesOrCreate() {
         if (attributes == null) {
@@ -859,12 +855,6 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
             } else {
                 push(constructorSegment);
             }
-        }
-
-        @Override
-        public void push(Segment<?, ?> segment) {
-            super.push(segment);
-            AbstractBeanResolutionContext.this.onNewSegment(segment);
         }
 
         @Override

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -837,7 +837,7 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
                 }
             }
         }
-        if (bean instanceof LifeCycle lifeCycle) {
+        if (bean instanceof LifeCycle<?> lifeCycle) {
             bean = lifeCycle.start();
         }
         return bean;
@@ -855,7 +855,7 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
     @Internal
     @UsedByGeneratedCode
     protected Object preDestroy(BeanResolutionContext resolutionContext, BeanContext context, Object bean) {
-        if (bean instanceof LifeCycle lifeCycle) {
+        if (bean instanceof LifeCycle<?> lifeCycle) {
             bean = lifeCycle.stop();
         }
         return bean;

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextLifeCycle.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextLifeCycle.java
@@ -22,7 +22,7 @@ import io.micronaut.core.annotation.NonNull;
  *
  * @param <T> The concrete type
  */
-public interface ApplicationContextLifeCycle<T extends ApplicationContextLifeCycle> extends ApplicationContextProvider, LifeCycle {
+public interface ApplicationContextLifeCycle<T extends ApplicationContextLifeCycle<T>> extends ApplicationContextProvider, LifeCycle<T> {
 
     @SuppressWarnings("unchecked")
     @Override

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
@@ -75,6 +75,11 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
         this.typeArgumentsMap = typeArgumentsMap;
     }
 
+    @Override
+    public int getOrder() {
+        return definition.getOrder();
+    }
+
     public Optional<ConfigurationPath> getConfigurationPath() {
         return Optional.ofNullable(configurationPath);
     }

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -277,21 +277,21 @@ public interface BeanDefinitionRegistry {
      * @param qualifier The qualifier
      * @return The bean definitions
      */
-    @NonNull Collection<BeanDefinition<?>> getBeanDefinitions(@NonNull Qualifier<Object> qualifier);
+    @NonNull Collection<BeanDefinition<Object>> getBeanDefinitions(@NonNull Qualifier<Object> qualifier);
 
     /**
      * Get all registered {@link BeanDefinition}.
      *
      * @return The bean definitions
      */
-    @NonNull Collection<BeanDefinition<?>> getAllBeanDefinitions();
+    @NonNull Collection<BeanDefinition<Object>> getAllBeanDefinitions();
 
     /**
      * Get all enabled {@link BeanDefinitionReference}.
      *
      * @return The bean definitions
      */
-    @NonNull Collection<BeanDefinitionReference<?>> getBeanDefinitionReferences();
+    @NonNull Collection<BeanDefinitionReference<Object>> getBeanDefinitionReferences();
 
     /**
      * Get all disabled {@link DisabledBean}.

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -17,14 +17,13 @@ package io.micronaut.context;
 
 import io.micronaut.context.exceptions.NoSuchBeanException;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.inject.BeanConfiguration;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
-
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.ProxyBeanDefinition;
 
 import java.util.Collection;
@@ -443,10 +442,11 @@ public interface BeanDefinitionRegistry {
      */
     default @NonNull <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(@NonNull BeanDefinition<T> proxyBeanDefinition) {
         Objects.requireNonNull(proxyBeanDefinition, "Proxy bean definition cannot be null");
-        if (proxyBeanDefinition instanceof ProxyBeanDefinition) {
-            Class<T> targetType = ((ProxyBeanDefinition<T>) proxyBeanDefinition).getTargetType();
-            Qualifier<T> targetQualifier = proxyBeanDefinition.getDeclaredQualifier();
-            return findProxyTargetBeanDefinition(targetType, targetQualifier);
+        if (proxyBeanDefinition instanceof ProxyBeanDefinition<T> beanDefinition) {
+            return findProxyTargetBeanDefinition(
+                beanDefinition.getTargetType(),
+                proxyBeanDefinition.getDeclaredQualifier()
+            );
         }
         return Optional.empty();
     }
@@ -461,7 +461,9 @@ public interface BeanDefinitionRegistry {
      * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible bean definitions exist
      *                                                                for the given type
      */
-    @NonNull <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier);
+    default @NonNull <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return findProxyBeanDefinition(Argument.of(beanType), qualifier);
+    }
 
     /**
      * Obtain the proxy {@link BeanDefinition} for the bean of type and qualifier.
@@ -489,12 +491,11 @@ public interface BeanDefinitionRegistry {
      * @param qualifier The bean qualifier
      * @param <T>       The concrete type
      * @return This bean context
+     * @deprecated Use {@link #registerBeanDefinition(RuntimeBeanDefinition)}
      */
-    default @NonNull <T> BeanDefinitionRegistry registerSingleton(
-        @NonNull Class<T> type,
-        @NonNull T singleton,
-        @Nullable Qualifier<T> qualifier
-    ) {
+    @NonNull
+    @Deprecated(forRemoval = true, since = "5.0")
+    default <T> BeanDefinitionRegistry registerSingleton(@NonNull Class<T> type, @NonNull T singleton, @Nullable Qualifier<T> qualifier) {
         return registerSingleton(type, singleton, qualifier, true);
     }
 
@@ -511,12 +512,60 @@ public interface BeanDefinitionRegistry {
      * @param singleton The singleton bean
      * @param <T>       The concrete type
      * @return This bean context
+     * @deprecated Use {@link #registerBeanDefinition(RuntimeBeanDefinition)}
      */
-    default <T> BeanDefinitionRegistry registerSingleton(
-        @NonNull Class<T> type,
-        @NonNull T singleton
-    ) {
+    @NonNull
+    @Deprecated(forRemoval = true, since = "5.0")
+    default <T> BeanDefinitionRegistry registerSingleton(@NonNull Class<T> type, @NonNull T singleton) {
         return registerSingleton(type, singleton, null);
+    }
+
+    /**
+     * <p>Registers a new singleton bean at runtime. This method expects that the bean definition data will have been
+     * compiled ahead of time.</p>
+     *
+     * <p>If bean definition data is found the method will perform dependency injection on the instance followed by
+     * invoking any {@link jakarta.annotation.PostConstruct} hooks.</p>
+     *
+     * <p>If no bean definition data is found the bean is registered as is.</p>
+     *
+     * @param singleton The singleton bean
+     * @return This bean context
+     * @deprecated Use {@link #registerBeanDefinition(RuntimeBeanDefinition)}
+     */
+    @NonNull
+    @Deprecated(forRemoval = true, since = "5.0")
+    default BeanDefinitionRegistry registerSingleton(@NonNull Object singleton) {
+        ArgumentUtils.requireNonNull("singleton", singleton);
+        Class type = singleton.getClass();
+        return registerSingleton(type, singleton);
+    }
+
+    /**
+     * <p>Registers a new singleton bean at runtime. This method expects that the bean definition data will have been
+     * compiled ahead of time.</p>
+     *
+     * <p>If bean definition data is found the method will perform dependency injection on the instance followed by
+     * invoking any {@link jakarta.annotation.PostConstruct} hooks.</p>
+     *
+     * <p>If no bean definition data is found the bean is registered as is.</p>
+     *
+     * @param singleton The singleton bean
+     * @param inject    Whether the singleton should be injected (defaults to true)
+     * @return This bean context
+     * @deprecated Use {@link #registerBeanDefinition(RuntimeBeanDefinition)}
+     */
+    @NonNull
+    @Deprecated(forRemoval = true, since = "5.0")
+    default BeanDefinitionRegistry registerSingleton(@NonNull Object singleton, boolean inject) {
+        ArgumentUtils.requireNonNull("singleton", singleton);
+        Class type = singleton.getClass();
+        return registerSingleton(
+            type,
+            singleton,
+            null,
+            inject
+        );
     }
 
     /**
@@ -621,48 +670,6 @@ public interface BeanDefinitionRegistry {
      */
     default @NonNull <T> Optional<BeanDefinition<T>> findBeanDefinition(@NonNull Class<T> beanType) {
         return findBeanDefinition(beanType, null);
-    }
-
-    /**
-     * <p>Registers a new singleton bean at runtime. This method expects that the bean definition data will have been
-     * compiled ahead of time.</p>
-     *
-     * <p>If bean definition data is found the method will perform dependency injection on the instance followed by
-     * invoking any {@link jakarta.annotation.PostConstruct} hooks.</p>
-     *
-     * <p>If no bean definition data is found the bean is registered as is.</p>
-     *
-     * @param singleton The singleton bean
-     * @return This bean context
-     */
-    default @NonNull BeanDefinitionRegistry registerSingleton(@NonNull Object singleton) {
-        ArgumentUtils.requireNonNull("singleton", singleton);
-        Class type = singleton.getClass();
-        return registerSingleton(type, singleton);
-    }
-
-    /**
-     * <p>Registers a new singleton bean at runtime. This method expects that the bean definition data will have been
-     * compiled ahead of time.</p>
-     *
-     * <p>If bean definition data is found the method will perform dependency injection on the instance followed by
-     * invoking any {@link jakarta.annotation.PostConstruct} hooks.</p>
-     *
-     * <p>If no bean definition data is found the bean is registered as is.</p>
-     *
-     * @param singleton The singleton bean
-     * @param inject    Whether the singleton should be injected (defaults to true)
-     * @return This bean context
-     */
-    default @NonNull BeanDefinitionRegistry registerSingleton(@NonNull Object singleton, boolean inject) {
-        ArgumentUtils.requireNonNull("singleton", singleton);
-        Class type = singleton.getClass();
-        return registerSingleton(
-            type,
-            singleton,
-            null,
-            inject
-        );
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionTracer.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionTracer.java
@@ -38,7 +38,7 @@ sealed interface BeanResolutionTracer permits ConsoleBeanResolutionTracer {
      */
     default void traceInitialConfiguration(
         @NonNull Environment environment,
-        @NonNull Collection<BeanDefinitionReference<?>> beanReferences,
+        @NonNull Collection<BeanDefinitionReference<Object>> beanReferences,
         @NonNull Collection<DisabledBean<?>> disabledBeans) {
         // no-op
     }

--- a/inject/src/main/java/io/micronaut/context/ConsoleBeanResolutionTracer.java
+++ b/inject/src/main/java/io/micronaut/context/ConsoleBeanResolutionTracer.java
@@ -29,6 +29,9 @@ import io.micronaut.core.util.AnsiColour;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -36,8 +39,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 abstract sealed class ConsoleBeanResolutionTracer
     implements BeanResolutionTracer {
@@ -54,7 +55,7 @@ abstract sealed class ConsoleBeanResolutionTracer
 
 
     @Override
-    public void traceInitialConfiguration(Environment environment, Collection<BeanDefinitionReference<?>> beanReferences, Collection<DisabledBean<?>> disabledBeans) {
+    public void traceInitialConfiguration(Environment environment, Collection<BeanDefinitionReference<Object>> beanReferences, Collection<DisabledBean<?>> disabledBeans) {
         Collection<PropertySource> propertySources = environment.getPropertySources();
         Set<String> activeNames = environment.getActiveNames();
         StringWriter sw = new StringWriter();
@@ -84,7 +85,7 @@ abstract sealed class ConsoleBeanResolutionTracer
             writer.newLine();
             writer.write(AnsiColour.brightBlue("Configurable Beans: "));
             writer.newLine();
-            List<BeanDefinitionReference<?>> configRefs = beanReferences.stream()
+            List<BeanDefinitionReference<Object>> configRefs = beanReferences.stream()
                 .filter(ref -> ref.hasStereotype(ConfigurationReader.class) &&
                     ref.stringValue(ConfigurationReader.class, "prefix").isPresent())
                 .sorted((b1, b2) ->

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -25,11 +25,12 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Secondary;
+import io.micronaut.context.beans.BeanDefinitionProvider;
+import io.micronaut.context.beans.DefaultBeanDefinitionProvider;
 import io.micronaut.context.condition.ConditionContext;
 import io.micronaut.context.condition.Failure;
 import io.micronaut.context.env.CachedEnvironment;
 import io.micronaut.context.env.PropertyPlaceholderResolver;
-import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
@@ -59,7 +60,6 @@ import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationMetadataResolver;
-import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NextMajorVersion;
@@ -68,10 +68,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.convert.DefaultMutableConversionService;
 import io.micronaut.core.convert.MutableConversionService;
-import io.micronaut.core.convert.TypeConverter;
-import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
-import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
 import io.micronaut.core.io.service.MicronautMetaServiceLoaderUtils;
 import io.micronaut.core.naming.NameResolver;
@@ -116,7 +113,6 @@ import io.micronaut.inject.qualifiers.Qualified;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.inject.qualifiers.TypeArgumentQualifier;
 import io.micronaut.inject.validation.BeanDefinitionValidator;
-import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,17 +138,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static io.micronaut.core.util.StringUtils.EMPTY_STRING_ARRAY;
+import java.util.stream.StreamSupport;
 
 /**
  * The default context implementations.
@@ -161,7 +154,7 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING_ARRAY;
  * @since 1.0
  */
 @Internal
-@NextMajorVersion("Remove public")
+@NextMajorVersion("Remove public in v6")
 @SuppressWarnings("MagicNumber")
 public sealed class DefaultBeanContext implements ConfigurableBeanContext permits DefaultApplicationContext {
 
@@ -170,14 +163,6 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     private static final String SCOPED_PROXY_ANN = "io.micronaut.runtime.context.scope.ScopedProxy";
     private static final String INTRODUCTION_TYPE = "io.micronaut.aop.Introduction";
     private static final String REPLACES_ANN = Replaces.class.getName();
-    private static final List<Class<?>> KNOWN_INDEX_TYPE = List.of(
-        ResourceLoader.class,
-        TypeConverter.class,
-        TypeConverterRegistrar.class,
-        ApplicationEventListener.class,
-        BeanCreatedEventListener.class,
-        BeanInitializedEventListener.class
-    );
 
     private static final String MSG_COULD_NOT_BE_LOADED = "] could not be loaded: ";
     public static final String MSG_BEAN_DEFINITION = "Bean definition [";
@@ -195,71 +180,53 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     private final BeanContextConfiguration beanContextConfiguration;
 
-    // The collection should be modified only when new bean definition is added
-    // That shouldn't happen that often, so we can use CopyOnWriteArrayList
-    private final Collection<BeanDefinitionProducer> beanDefinitionsClasses = new CopyOnWriteArrayList<>();
-    private final Collection<BeanDefinitionProducer> proxyTargetBeans = new CopyOnWriteArrayList<>();
-
-    private final Map<BeanKey<?>, BeanDefinitionProducer> disabledBeans = new ConcurrentHashMap<>(20);
     private final Map<String, List<String>> disabledConfigurations = new ConcurrentHashMap<>(5);
     private final Map<String, BeanConfiguration> beanConfigurations = new HashMap<>(10);
+
     private final Map<BeanKey, Boolean> containsBeanCache = new ConcurrentHashMap<>(30);
     private final Map<CharSequence, Object> attributes = Collections.synchronizedMap(new HashMap<>(5));
 
     private final Map<BeanKey, CollectionHolder> singletonBeanRegistrations = new ConcurrentHashMap<>(50);
 
     private final Map<BeanCandidateKey, Optional<BeanDefinition>> beanConcreteCandidateCache =
-            new ConcurrentLinkedHashMap.Builder<BeanCandidateKey, Optional<BeanDefinition>>().maximumWeightedCapacity(30).build();
+        new ConcurrentLinkedHashMap.Builder<BeanCandidateKey, Optional<BeanDefinition>>().maximumWeightedCapacity(30).build();
 
     private final Map<BeanCandidateKey, Optional<BeanDefinition>> beanProxyTargetCache =
         new ConcurrentLinkedHashMap.Builder<BeanCandidateKey, Optional<BeanDefinition>>().maximumWeightedCapacity(30).build();
 
     private final Map<Argument, Collection<BeanDefinition>> beanCandidateCache = new ConcurrentLinkedHashMap.Builder<Argument, Collection<BeanDefinition>>().maximumWeightedCapacity(30).build();
 
-    private final Map<Class<?>, Collection<BeanDefinitionProducer>> beanIndex = new ConcurrentHashMap<>(12);
-
     private final ClassLoader classLoader;
     private final Set<Class<?>> thisInterfaces = CollectionUtils.setOf(
-            BeanDefinitionRegistry.class,
-            BeanContext.class,
-            AnnotationMetadataResolver.class,
-            BeanLocator.class,
-            ExecutionHandleLocator.class,
-            ApplicationContext.class,
-            PropertyResolver.class,
-            ValueResolver.class,
-            PropertyPlaceholderResolver.class
+        BeanDefinitionRegistry.class,
+        BeanContext.class,
+        AnnotationMetadataResolver.class,
+        BeanLocator.class,
+        ExecutionHandleLocator.class,
+        ApplicationContext.class,
+        PropertyResolver.class,
+        ValueResolver.class,
+        PropertyPlaceholderResolver.class
     );
-    private final Function<Class<?>, Collection<BeanDefinitionProducer>> COMPUTE_INDEXES_FN = new Function<Class<?>, Collection<BeanDefinitionProducer>>() {
-        // Keep an anonymous class for performance
-        @Override
-        public Collection<BeanDefinitionProducer> apply(Class<?> indexedType) {
-            return new ArrayList<>(20);
-        }
-    };
+
     private final CustomScopeRegistry customScopeRegistry;
-    private final String[] eagerInitStereotypes;
-    private final boolean eagerInitStereotypesPresent;
-    private final boolean eagerInitSingletons;
 
     private BeanDefinitionValidator beanValidator;
-    private List<BeanDefinitionReference> beanDefinitionReferences;
     private List<BeanConfiguration> beanConfigurationsList;
-
-    private StartupBeans startupBeans;
 
     List<Map.Entry<Class<?>, ListenersSupplier<BeanInitializedEventListener>>> beanInitializedEventListeners;
     private List<Map.Entry<Class<?>, ListenersSupplier<BeanCreatedEventListener>>> beanCreationEventListeners;
     private List<Map.Entry<Class<?>, ListenersSupplier<BeanPreDestroyEventListener>>> beanPreDestroyEventListeners;
     private List<Map.Entry<Class<?>, ListenersSupplier<BeanDestroyedEventListener>>> beanDestroyedEventListeners;
 
-    private final BeanDefinitionsProvider beanDefinitionReferencesProvider;
-    @Nullable
-    private final Predicate<QualifiedBeanType<?>> beansPredicate;
     private final boolean eventsEnabled;
     private final boolean eagerBeansEnabled;
 
+    private ForkJoinTask<?> checkEnabledBeans;
+
     protected MutableConversionService conversionService;
+
+    protected final BeanDefinitionProvider beanDefinitionProvider;
 
     /**
      * Construct a new bean context using the same classloader that loaded this DefaultBeanContext class.
@@ -316,19 +283,15 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         for (Class<? extends Annotation> ann : eagerInitAnnotated) {
             configuredEagerSingletonAnnotations.add(ann.getName());
         }
-        this.eagerInitStereotypes = configuredEagerSingletonAnnotations.toArray(EMPTY_STRING_ARRAY);
-        this.eagerInitStereotypesPresent = !configuredEagerSingletonAnnotations.isEmpty();
-        this.eagerInitSingletons = eagerInitStereotypesPresent && (configuredEagerSingletonAnnotations.contains(AnnotationUtil.SINGLETON) || configuredEagerSingletonAnnotations.contains(Singleton.class.getName()));
         this.beanContextConfiguration = contextConfiguration;
         BeanResolutionTraceConfiguration traceConfiguration = beanContextConfiguration
             .getTraceConfiguration();
         this.traceMode = traceConfiguration.mode();
         this.tracePatterns = traceConfiguration.classPatterns();
-        this.beansPredicate = contextConfiguration.beansPredicate();
         this.eventsEnabled = contextConfiguration.eventsEnabled();
         this.eagerBeansEnabled = contextConfiguration.eagerBeansEnabled();
-        this.beanDefinitionReferencesProvider = contextConfiguration.getBeanDefinitionsProvider();
         this.conversionService = new DefaultMutableConversionService();
+        beanDefinitionProvider = new DefaultBeanDefinitionProvider(beanContextConfiguration);
     }
 
     /**
@@ -371,11 +334,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 configureAndStartContext();
                 if (LOG.isDebugEnabled()) {
                     String activeConfigurations = beanConfigurations
-                            .values()
-                            .stream()
-                            .filter(config -> config.isEnabled(this))
-                            .map(BeanConfiguration::getName)
-                            .collect(Collectors.joining(","));
+                        .values()
+                        .stream()
+                        .filter(config -> config.isEnabled(this))
+                        .map(BeanConfiguration::getName)
+                        .collect(Collectors.joining(","));
                     if (StringUtils.isNotEmpty(activeConfigurations)) {
                         LOG.debug("Loaded active configurations: {}", activeConfigurations);
                     }
@@ -396,33 +359,21 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
      */
     protected void registerConversionService() {
         //noinspection resource
-        registerSingleton(MutableConversionService.class, conversionService,  null, false);
+        registerSingleton(MutableConversionService.class, conversionService, null, false);
     }
 
     /**
      * Tracks when a bean or configuration is disabled.
+     *
      * @param conditionContext The conditional context
-     * @param <C> The component type
+     * @param <C>              The component type
      */
     @Internal
     <C extends AnnotationMetadataProvider> void trackDisabledComponent(@NonNull ConditionContext<C> conditionContext) {
         C component = conditionContext.getComponent();
         List<String> reasons = conditionContext.getFailures().stream().map(Failure::getMessage).toList();
         if (component instanceof QualifiedBeanType<?> beanType) {
-            try {
-                @SuppressWarnings("unchecked")
-                Argument<Object> argument = (Argument<Object>) beanType.getGenericBeanType();
-                @SuppressWarnings("unchecked")
-                Qualifier<Object> declaredQualifier = (Qualifier<Object>) beanType.getDeclaredQualifier();
-                this.disabledBeans.put(new BeanKey<>(argument, declaredQualifier), new BeanDefinitionProducer(new DisabledBean<>(
-                    argument,
-                    declaredQualifier,
-                    reasons
-                )));
-            } catch (Exception | NoClassDefFoundError e) {
-                // it is theoretically possible that resolving the generic type results in an error
-                // in this case just ignore this as the maps built here are purely to aid error diagnosis
-            }
+            beanDefinitionProvider.trackDisabled(beanType, reasons);
         } else if (component instanceof BeanConfiguration configuration) {
             this.disabledConfigurations.put(configuration.getName(), reasons);
         }
@@ -445,7 +396,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             List<BeanRegistration> objects = topologicalSort(singletonScope.getBeanRegistrations());
 
             Map<Boolean, List<BeanRegistration>> result = objects.stream().collect(Collectors.groupingBy(br -> br.bean != null
-                    && (br.bean instanceof BeanPreDestroyEventListener || br.bean instanceof BeanDestroyedEventListener)));
+                && (br.bean instanceof BeanPreDestroyEventListener || br.bean instanceof BeanDestroyedEventListener)));
 
             List<BeanRegistration> listeners = result.get(true);
             if (listeners != null) {
@@ -477,6 +428,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 }
             }
 
+            if (checkEnabledBeans != null) {
+                checkEnabledBeans.cancel(true);
+            }
+
             singlesInCreation.clear();
             singletonBeanRegistrations.clear();
             beanConcreteCandidateCache.clear();
@@ -486,18 +441,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             beanConfigurations.clear();
             disabledConfigurations.clear();
             singletonScope.clear();
-            beanDefinitionsClasses.clear();
-            disabledBeans.clear();
-            proxyTargetBeans.clear();
             attributes.clear();
-            beanIndex.clear();
-            beanConfigurationsList = null;
-            beanDefinitionReferences = null;
             beanInitializedEventListeners = null;
             beanCreationEventListeners = null;
             beanPreDestroyEventListeners = null;
             beanDestroyedEventListeners = null;
-            startupBeans = null;
             terminating.set(false);
             running.set(false);
             configured.set(false);
@@ -506,6 +454,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                     tracer.traceContextShutdown(this);
                 });
             }
+            beanDefinitionProvider.reset();
         }
         return this;
     }
@@ -517,8 +466,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             return AnnotationMetadata.EMPTY_METADATA;
         }
         return findBeanDefinitionInternal(Argument.of(type), null)
-                .map(AnnotationMetadataProvider::getAnnotationMetadata)
-                .orElse(AnnotationMetadata.EMPTY_METADATA);
+            .map(AnnotationMetadataProvider::getAnnotationMetadata)
+            .orElse(AnnotationMetadata.EMPTY_METADATA);
     }
 
     @Override
@@ -586,18 +535,18 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     @Override
     public <T> Collection<BeanRegistration<T>> getBeanRegistrations(Argument<T> beanType, Qualifier<T> qualifier) {
         return getBeanRegistrations(
-                null,
-                Objects.requireNonNull(beanType, "Bean type cannot be null"),
-                qualifier
+            null,
+            Objects.requireNonNull(beanType, "Bean type cannot be null"),
+            qualifier
         );
     }
 
     @Override
     public <T> BeanRegistration<T> getBeanRegistration(Argument<T> beanType, Qualifier<T> qualifier) {
         return getBeanRegistration(
-                null,
-                Objects.requireNonNull(beanType, "Bean type cannot be null"),
-                qualifier
+            null,
+            Objects.requireNonNull(beanType, "Bean type cannot be null"),
+            qualifier
         );
     }
 
@@ -681,18 +630,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     @Override
     public <T, R> Optional<MethodExecutionHandle<T, R>> findExecutionHandle(T bean, String method, Class<?>[] arguments) {
         if (bean != null) {
-            Optional<? extends BeanDefinition<?>> foundBean = findBeanDefinition(bean.getClass());
-            if (foundBean.isPresent()) {
-                BeanDefinition<?> beanDefinition = foundBean.get();
-                Optional<? extends ExecutableMethod<?, Object>> foundMethod = beanDefinition.findMethod(method, arguments);
-                if (foundMethod.isPresent()) {
-                    return foundMethod.map((ExecutableMethod executableMethod) -> new ObjectExecutionHandle<>(bean, executableMethod));
-                } else {
-                    return beanDefinition.findPossibleMethods(method)
-                            .findFirst()
-                            .map((ExecutableMethod executableMethod) -> new ObjectExecutionHandle<>(bean, executableMethod));
-                }
-            }
+            Class<T> aClass = (Class<T>) bean.getClass();
+            return findExecutionHandle(aClass, method, arguments);
         }
         return Optional.empty();
     }
@@ -717,7 +656,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 if (inject) {
                     doInjectAndInitialize(context, singleton, beanDefinition);
                 }
-                DefaultBeanContext.BeanKey<T> key = new DefaultBeanContext.BeanKey<>(beanDefinition.asArgument(), qualifier);
+                BeanKey<T> key = new BeanKey<>(beanDefinition.asArgument(), qualifier);
                 singletonScope.registerSingletonBean(BeanRegistration.of(this, key, beanDefinition, singleton), qualifier);
             }
         } else {
@@ -769,7 +708,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     @Override
     public Optional<BeanConfiguration> findBeanConfiguration(String configurationName) {
-        BeanConfiguration configuration = this.beanConfigurations.get(configurationName);
+        BeanConfiguration configuration = beanConfigurations.get(configurationName);
         if (configuration != null) {
             return Optional.of(configuration);
         } else {
@@ -780,7 +719,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     @Override
     public <T> BeanDefinition<T> getBeanDefinition(Argument<T> beanType, Qualifier<T> qualifier) {
         return findBeanDefinition(beanType, qualifier)
-                .orElseThrow(() -> newNoSuchBeanException(null, beanType, qualifier, null));
+            .orElseThrow(() -> newNoSuchBeanException(null, beanType, qualifier, null));
     }
 
     @Override
@@ -842,7 +781,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             return containsBeanCache.get(beanKey);
         } else {
             boolean result = singletonScope.containsBean(beanType, qualifier) ||
-                    isCandidatePresent(beanKey.beanType, qualifier);
+                isCandidatePresent(beanKey.beanType, qualifier);
 
             containsBeanCache.put(beanKey, result);
             return result;
@@ -942,10 +881,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     /**
      * Obtains a map of beans of the given type and qualifier.
-     * @param resolutionContext  The resolution context
-     * @param beanType           The bean type
-     * @param qualifier          The qualifier
-     * @param <V>                The bean type
+     *
+     * @param resolutionContext The resolution context
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param <V>               The bean type
      * @return A map of beans, never {@code null}.
      * @since 4.0.0
      */
@@ -1010,7 +950,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     public <T> Stream<T> streamOfType(BeanResolutionContext resolutionContext, Argument<T> beanType, Qualifier<T> qualifier) {
         Objects.requireNonNull(beanType, "Bean type cannot be null");
         return getBeanRegistrations(resolutionContext, beanType, qualifier).stream()
-                .map(BeanRegistration::getBean);
+            .map(BeanRegistration::getBean);
     }
 
     @NonNull
@@ -1138,7 +1078,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                             argumentValues.put(requiredArgument.getName(), val);
                         } else {
                             argumentValues.put(requiredArgument.getName(), conversionService.convert(val, requiredArgument).orElseThrow(() ->
-                                    new BeanInstantiationException(resolutionContext, "Invalid bean @Argument [" + requiredArgument + "]. Cannot convert object [" + val + "] to required type: " + argumentType)
+                                new BeanInstantiationException(resolutionContext, "Invalid bean @Argument [" + requiredArgument + "]. Cannot convert object [" + val + "] to required type: " + argumentType)
                             ));
                         }
                     } else if (!requiredArgument.isDeclaredNullable()) {
@@ -1163,8 +1103,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     public <T> T destroyBean(@NonNull Argument<T> beanType, Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         return findBeanDefinition(beanType, qualifier)
-                .map(this::destroyBean)
-                .orElse(null);
+            .map(this::destroyBean)
+            .orElse(null);
     }
 
     @Override
@@ -1266,9 +1206,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     /**
      * Destroy a lifecycle bean.
-     * @param cycle The cycle
+     *
+     * @param cycle      The cycle
      * @param definition The definition
-     * @param <T> The bean type
+     * @param <T>        The bean type
      */
     @Internal
     protected <T> void destroyLifeCycleBean(LifeCycle<?> cycle, BeanDefinition<T> definition) {
@@ -1279,7 +1220,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
     }
 
-    @SuppressWarnings("unchecked") @NonNull
+    @SuppressWarnings("unchecked")
+    @NonNull
     private <T> T triggerPreDestroyListeners(@NonNull BeanDefinition<T> beanDefinition, @NonNull T bean) {
         if (beanPreDestroyEventListeners == null) {
             beanPreDestroyEventListeners = loadBeanEventListeners(BeanPreDestroyEventListener.class);
@@ -1324,7 +1266,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             }
         }
         BeanDefinition<T> proxyTargetBeanDefinition = findProxyTargetBeanDefinition(registration.beanDefinition)
-                .orElseThrow(() -> new IllegalStateException("Cannot find a proxy target bean definition for: " + registration.beanDefinition));
+            .orElseThrow(() -> new IllegalStateException("Cannot find a proxy target bean definition for: " + registration.beanDefinition));
         Optional<CustomScope<?>> declaredScope = customScopeRegistry.findDeclaredScope(proxyTargetBeanDefinition);
         if (declaredScope.isEmpty()) {
             if (proxyTargetBeanDefinition.isSingleton()) {
@@ -1339,10 +1281,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                         return;
                     }
                     destroyBean(BeanRegistration.of(this,
-                            new BeanKey<>(proxyTargetBeanDefinition, proxyTargetBeanDefinition.getDeclaredQualifier()),
-                            proxyTargetBeanDefinition,
-                            interceptedTarget,
-                            registration instanceof BeanDisposingRegistration ? ((BeanDisposingRegistration<T>) registration).getDependents() : null
+                        new BeanKey<>(proxyTargetBeanDefinition, proxyTargetBeanDefinition.getDeclaredQualifier()),
+                        proxyTargetBeanDefinition,
+                        interceptedTarget,
+                        registration instanceof BeanDisposingRegistration ? ((BeanDisposingRegistration<T>) registration).getDependents() : null
                     ));
                 }
             }
@@ -1609,123 +1551,70 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         return beanDefinition;
     }
 
-    @SuppressWarnings("unchecked")
     @NonNull
     @Override
-    public Collection<BeanDefinition<?>> getBeanDefinitions(@Nullable Qualifier<Object> qualifier) {
+    public Collection<BeanDefinition<Object>> getBeanDefinitions(@Nullable Qualifier<Object> qualifier) {
         if (qualifier == null) {
             return Collections.emptyList();
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finding candidate beans for qualifier: {}", qualifier);
         }
-        // first traverse component definition classes and load candidates
-        if (beanDefinitionsClasses.isEmpty()) {
-            return Collections.emptyList();
-        }
         Collection<BeanDefinition<Object>> candidates;
         if (qualifier instanceof FilteringQualifier<Object> filteringQualifier) {
-            List<BeanDefinition<Object>> bdCandidates = new ArrayList<>(20);
-            for (BeanDefinitionProducer producer : beanDefinitionsClasses) {
-                BeanDefinitionReference<Object> reference = producer.getReferenceIfEnabled(this);
-                if (reference == null) {
-                    continue;
+            // Keep anonymous
+            Predicate<BeanDefinitionReference<Object>> predicate = new Predicate<>() {
+                @Override
+                public boolean test(BeanDefinitionReference<Object> qbt) {
+                    return filteringQualifier.doesQualify(Object.class, qbt);
                 }
-                if (!filteringQualifier.doesQualify(Object.class, reference)) {
-                    continue;
-                }
-                BeanDefinition<Object> beanDefinition = reference.load(this);
-                if (!beanDefinition.isEnabled(this)) {
-                    continue;
-                }
-                if (!filteringQualifier.doesQualify(Object.class, beanDefinition)) {
-                    continue;
-                }
-                bdCandidates.add(beanDefinition);
-            }
-            candidates = bdCandidates;
+            };
+            candidates = beanDefinitionProvider.getBeanDefinitions(this, predicate, null);
         } else {
-            Stream<BeanDefinitionReference<Object>> reduced = qualifier.reduce(Object.class, beanDefinitionsClasses.stream()
-                .map(p -> p.getReferenceIfEnabled(this))
-                .filter(Objects::nonNull));
-            Stream<BeanDefinition<Object>> candidateStream = qualifier.reduce(Object.class,
-                reduced
-                    .map(ref -> ref.load(this))
-                    .filter(candidate -> candidate.isEnabled(this))
-            );
-            candidates = candidateStream.collect(Collectors.toList());
+            Stream<BeanDefinition<Object>> beanDefinitionsClasses = StreamSupport.stream(
+                beanDefinitionProvider.getBeanDefinitions(this, Argument.OBJECT_ARGUMENT, null, null).spliterator(),
+                false);
+            candidates = qualifier.reduce(Object.class, beanDefinitionsClasses)
+                .toList();
         }
 
-        if (!candidates.isEmpty()) {
-            filterReplacedBeans(null, candidates);
-        }
-        return (Collection) candidates;
+        filterReplacedBeans(null, candidates);
+        return candidates;
     }
 
-    @SuppressWarnings("unchecked")
     @NonNull
     @Override
-    public Collection<BeanDefinition<?>> getAllBeanDefinitions() {
+    public Collection<BeanDefinition<Object>> getAllBeanDefinitions() {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finding all bean definitions");
         }
-
-        if (!beanDefinitionsClasses.isEmpty()) {
-            return beanDefinitionsClasses
-                    .stream()
-                    .map(p -> p.getDefinitionIfEnabled(this))
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
-        }
-
-        return (Collection<BeanDefinition<?>>) Collections.emptyMap();
+        return beanDefinitionProvider.getBeanDefinitions(this, null);
     }
 
     @Override
     public Collection<DisabledBean<?>> getDisabledBeans() {
-        return disabledBeans.values().stream()
-            .map(producer -> (DisabledBean<?>) producer.reference)
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+        return beanDefinitionProvider.getDisabledBeans(this);
     }
 
-    @SuppressWarnings("unchecked")
     @NonNull
     @Override
-    public Collection<BeanDefinitionReference<?>> getBeanDefinitionReferences() {
-        if (!beanDefinitionsClasses.isEmpty()) {
-            final List refs = beanDefinitionsClasses.stream()
-                    .map(p -> p.getReferenceIfEnabled(this))
-                    .filter(Objects::nonNull)
-                    .toList();
-
-            return refs;
-        }
-        return Collections.emptyList();
+    public Collection<BeanDefinitionReference<Object>> getBeanDefinitionReferences() {
+        return beanDefinitionProvider.getBeanReferences();
     }
 
     @Override
     public BeanContext registerBeanConfiguration(BeanConfiguration configuration) {
         Objects.requireNonNull(configuration, "Configuration cannot be null");
         this.beanConfigurations.put(configuration.getName(), configuration);
+        beanDefinitionProvider.registerConfiguration(configuration);
         return this;
     }
 
     @Override
     @NonNull
     public <B> BeanContext registerBeanDefinition(@NonNull RuntimeBeanDefinition<B> definition) {
-        Objects.requireNonNull(definition, "Bean definition cannot be null");
-        Class<B> beanType = definition.getBeanType();
-        BeanDefinitionProducer producer = new BeanDefinitionProducer(definition);
-        this.beanDefinitionsClasses.add(producer);
-        for (Class<?> indexedType : beanIndex.keySet()) {
-            if (indexedType == beanType || indexedType.isAssignableFrom(beanType)) {
-                final Collection<BeanDefinitionProducer> indexed = resolveTypeIndex(indexedType);
-                indexed.add(producer);
-                break;
-            }
-        }
-        purgeCacheForBeanType(beanType);
+        beanDefinitionProvider.addBeanDefinition(definition);
+        purgeCacheForBeanType(definition.getBeanType());
         return this;
     }
 
@@ -1734,24 +1623,6 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         beanConcreteCandidateCache.entrySet().removeIf(entry -> entry.getKey().beanType.isAssignableFrom(beanType));
         singletonBeanRegistrations.entrySet().removeIf(entry -> entry.getKey().beanType.isAssignableFrom(beanType));
         containsBeanCache.entrySet().removeIf(entry -> entry.getKey().beanType.isAssignableFrom(beanType));
-    }
-
-    /**
-     * The definition to remove.
-     * @param definition The definition to remove
-     * @param <B> The bean type
-     */
-    @Internal
-    <B> void removeBeanDefinition(RuntimeBeanDefinition<B> definition) {
-        Class<B> beanType = definition.getBeanType();
-        for (Class<?> indexedType : beanIndex.keySet()) {
-            if (indexedType == beanType || indexedType.isAssignableFrom(beanType)) {
-                resolveTypeIndex(indexedType).forEach(p -> p.disableIfMatch(definition));
-                break;
-            }
-        }
-        beanDefinitionsClasses.forEach(p -> p.disableIfMatch(definition));
-        purgeCacheForBeanType(definition.getBeanType());
     }
 
     /**
@@ -1938,29 +1809,6 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     }
 
     /**
-     * Resolves the {@link BeanDefinitionReference} class instances. Default implementation uses ServiceLoader pattern.
-     *
-     * @return The bean definition classes
-     */
-    @NonNull
-    protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
-        if (beanDefinitionReferences == null) {
-            List<BeanDefinitionReference<?>> refs = beanDefinitionReferencesProvider.provide(classLoader);
-            if (beansPredicate != null) {
-                List<BeanDefinitionReference<?>> list = new ArrayList<>(refs.size());
-                for (BeanDefinitionReference<?> ref : refs) {
-                    if (beansPredicate.test(ref)) {
-                        list.add(ref);
-                    }
-                }
-                refs = list;
-            }
-            beanDefinitionReferences = (List) refs;
-        }
-        return beanDefinitionReferences;
-    }
-
-    /**
      * Resolves the {@link BeanConfiguration} class instances. Default implementation uses ServiceLoader pattern.
      *
      * @return The bean definition classes
@@ -2015,31 +1863,28 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 argument = Argument.OBJECT_ARGUMENT;
             }
             typeToListener.computeIfAbsent(argument.getType(), aClass -> new ArrayList<>(10))
-                    .add(beanCreatedDefinition);
+                .add(beanCreatedDefinition);
         }
         return typeToListener;
     }
 
-    private void initializeContext(
-            @NonNull List<BeanDefinitionProducer> eagerInitBeans,
-            @NonNull List<BeanDefinitionProducer> processedBeans,
-            @NonNull List<BeanDefinitionProducer> parallelBeans) {
+    private void initializeContext() {
         if (!eagerBeansEnabled) {
             return;
         }
-        if (CollectionUtils.isNotEmpty(eagerInitBeans)) {
-            final List<BeanDefinition<Object>> eagerInit = new ArrayList<>(eagerInitBeans.size());
-            for (BeanDefinitionProducer contextScopeBean : eagerInitBeans) {
+        Iterable<BeanDefinition<Object>> eagerInitBeans = beanDefinitionProvider.getEagerInitBeans(this);
+        if (eagerInitBeans.iterator().hasNext()) {
+            final List<BeanDefinition<Object>> eagerInit = new ArrayList<>(20);
+            for (BeanDefinition<Object> contextScopeBean : eagerInitBeans) {
                 try {
                     loadEagerBeans(contextScopeBean, eagerInit);
                 } catch (Throwable e) {
-                    BeanDefinitionReference<?> ref = contextScopeBean.getReferenceBestEffort();
-                    throw new BeanInstantiationException(MSG_BEAN_DEFINITION + (ref == null ? "<ref discarded>" : ref.getName()) + MSG_COULD_NOT_BE_LOADED + e.getMessage(), e);
+                    throw new BeanInstantiationException(MSG_BEAN_DEFINITION + (contextScopeBean.getName()) + MSG_COULD_NOT_BE_LOADED + e.getMessage(), e);
                 }
             }
             filterReplacedBeans(null, eagerInit);
             OrderUtil.sortOrdered(eagerInit);
-            for (BeanDefinition eagerInitDefinition : eagerInit) {
+            for (BeanDefinition<Object> eagerInitDefinition : eagerInit) {
                 try {
                     initializeEagerBean(eagerInitDefinition);
                 } catch (DisabledBeanException e) {
@@ -2052,13 +1897,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             }
         }
 
-        if (!processedBeans.isEmpty()) {
+        Iterable<BeanDefinition<Object>> processedBeans = beanDefinitionProvider.getProcessedBeans(this);
+        if (processedBeans.iterator().hasNext()) {
             List<BeanDefinitionMethodReference<Object, Object>> methodsToProcess = new ArrayList<>();
-            for (BeanDefinitionProducer processedBeanProducer : processedBeans) {
-                BeanDefinition<Object> definition = processedBeanProducer.getDefinitionIfEnabled(this);
-                if (definition == null) {
-                    continue;
-                }
+            for (BeanDefinition<Object> definition : processedBeans) {
                 for (ExecutableMethod<Object, ?> method : definition.getExecutableMethods()) {
                     if (method.hasStereotype(Executable.class)) {
                         methodsToProcess.add(BeanDefinitionMethodReference.of(definition, (ExecutableMethod<Object, Object>) method));
@@ -2125,10 +1967,28 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             }
         }
 
-        if (CollectionUtils.isNotEmpty(parallelBeans)) {
-            processParallelBeans(parallelBeans);
-        }
-        ForkJoinPool.commonPool().execute(() -> beanDefinitionsClasses.forEach(p -> p.getReferenceIfEnabled(this)));
+        processParallelBeans();
+        checkEnabledBeans = ForkJoinPool.commonPool().submit(new ForkJoinTask<>() {
+
+            @Override
+            public Object getRawResult() {
+                return null;
+            }
+
+            @Override
+            protected void setRawResult(Object value) {
+            }
+
+            @Override
+            protected boolean exec() {
+                for (BeanDefinitionReference<Object> ignore : beanDefinitionProvider.getBeanReferences(DefaultBeanContext.this)) {
+                    if (isCancelled()) {
+                        return true;
+                    }
+                }
+                return true;
+            }
+        });
     }
 
     /**
@@ -2143,8 +2003,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     @NonNull
     @Internal
     public final <T> Collection<BeanDefinition<T>> findBeanCandidates(@Nullable BeanResolutionContext resolutionContext,
-                                                                   @NonNull Argument<T> beanType,
-                                                                   @Nullable BeanDefinition<?> filter) {
+                                                                      @NonNull Argument<T> beanType,
+                                                                      @Nullable BeanDefinition<?> filter) {
         Predicate<BeanDefinition<T>> predicate = filter == null ? null : definition -> !definition.equals(filter);
         return findBeanCandidates(resolutionContext, beanType, true, predicate);
     }
@@ -2168,13 +2028,17 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finding candidate beans for type: {}", beanType);
         }
-
+        Iterable<BeanDefinition<T>> beanDefinitions;
+        if (resolutionContext == null) {
+            beanDefinitions = beanDefinitionProvider.getBeanDefinitions(this, beanType, null, predicate);
+        } else {
+            beanDefinitions = beanDefinitionProvider.getBeanDefinitions(resolutionContext, beanType, null, predicate);
+        }
         return collectBeanCandidates(
             resolutionContext,
             beanType,
             collectIterables,
-            predicate,
-            beanIndex.getOrDefault(beanType.getType(), beanDefinitionsClasses)
+            beanDefinitions
         );
     }
 
@@ -2183,32 +2047,21 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         BeanResolutionContext resolutionContext,
         Argument<T> beanType,
         boolean collectIterables,
-        @Nullable
-        Predicate<BeanDefinition<T>> predicate,
-        Collection<BeanDefinitionProducer> beanDefinitionProducers) {
+        Iterable<BeanDefinition<T>> beanDefinitions) {
+
+        Iterator<BeanDefinition<T>> iterator = beanDefinitions.iterator();
         Set<BeanDefinition<T>> candidates;
-        if (!beanDefinitionProducers.isEmpty()) {
-
+        if (iterator.hasNext()) {
             candidates = new HashSet<>();
-            for (BeanDefinitionProducer producer : beanDefinitionProducers) {
-                if (producer.isDisabledOptimistic() || !producer.isReferenceCandidateBean(beanType)) {
-                    continue;
-                }
-                BeanDefinition<T> loadedBean = producer.getDefinitionIfEnabled(this, null, beanType, predicate);
-                if (loadedBean == null) {
-                    continue;
-                }
-
-                if (collectIterables && loadedBean.isConfigurationProperties()) {
-                    collectIterableBeans(resolutionContext, loadedBean, candidates, beanType);
+            while (iterator.hasNext()) {
+                BeanDefinition<T> candidate = iterator.next();
+                if (collectIterables && candidate.isConfigurationProperties()) {
+                    collectIterableBeans(resolutionContext, candidate, candidates, beanType);
                 } else {
-                    candidates.add(loadedBean);
+                    candidates.add(candidate);
                 }
             }
-
-            if (!candidates.isEmpty()) {
-                filterReplacedBeans(resolutionContext, candidates);
-            }
+            filterReplacedBeans(resolutionContext, candidates);
         } else {
             candidates = Collections.emptySet();
         }
@@ -2227,11 +2080,12 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     /**
      * Collects iterable beans from a given iterable.
+     *
      * @param resolutionContext The resolution context
-     * @param iterableBean The iterable
-     * @param targetSet The target set
-     * @param beanType The bean type
-     * @param <T> The bean type
+     * @param iterableBean      The iterable
+     * @param targetSet         The target set
+     * @param beanType          The bean type
+     * @param <T>               The bean type
      */
     protected <T> void collectIterableBeans(@Nullable BeanResolutionContext resolutionContext,
                                             @NonNull BeanDefinition<T> iterableBean,
@@ -2253,57 +2107,44 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finding candidate beans for instance: {}", instance);
         }
-        Collection<BeanDefinitionProducer> beanProducers = this.beanDefinitionsClasses;
         final Class<?> beanClass = instance.getClass();
         Argument<?> beanType = Argument.of(beanClass);
         Collection<BeanDefinition<T>> beanDefinitions = (Collection<BeanDefinition<T>>) ((Map) beanCandidateCache).get(beanType);
         if (beanDefinitions != null) {
             return beanDefinitions;
         }
-        // first traverse component definition classes and load candidates
-        if (!beanDefinitionsClasses.isEmpty()) {
-            List<BeanDefinition<T>> candidates = new ArrayList<>();
-            for (BeanDefinitionProducer producer : beanProducers) {
-                if (producer.isDisabledOptimistic()) {
-                    continue;
+        java.lang.Iterable<BeanDefinition<Object>> iterable = beanDefinitionProvider.getBeanDefinitions(
+            this,
+            Argument.OBJECT_ARGUMENT,
+            ref -> ref.getBeanType().isInstance(instance),
+            null
+        );
+        Iterator<BeanDefinition<Object>> iterator = iterable.iterator();
+        List<BeanDefinition<T>> candidates;
+        if (iterator.hasNext()) {
+            // try narrow to exact type
+            List<BeanDefinition<T>> list = new ArrayList<>(2);
+            while (iterator.hasNext()) {
+                BeanDefinition<Object> beanDefinition = iterator.next();
+                if (beanDefinition.getBeanType() == beanClass) {
+                    list.add((BeanDefinition<T>) beanDefinition);
                 }
-                BeanDefinitionReference<T> reference = producer.getReferenceIfEnabled(this);
-                if (reference == null) {
-                    continue;
-                }
-                Class<?> candidateType = reference.getBeanType();
-                if (candidateType == null || !candidateType.isInstance(instance)) {
-                    continue;
-                }
-                BeanDefinition<T> candidate = producer.getDefinitionIfEnabled(this);
-                if (candidate == null) {
-                    continue;
-                }
-                candidates.add(candidate);
             }
-
-            if (candidates.size() > 1) {
-                // try narrow to exact type
-                List<BeanDefinition<T>> list = new ArrayList<>(2);
-                for (BeanDefinition<T> candidate : candidates) {
-                    if (candidate.getBeanType() == beanClass) {
-                        list.add(candidate);
-                    }
-                }
-                candidates = list;
-            }
+            candidates = list;
+        } else {
+            candidates = List.of();
+        }
+        if (!candidates.isEmpty()) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Resolved bean candidates {} for instance: {}", candidates, instance);
             }
-            beanDefinitions = candidates;
         } else {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("No bean candidates found for instance: {}", instance);
             }
-            beanDefinitions = Collections.emptySet();
         }
-        beanCandidateCache.put(beanType, (Collection) beanDefinitions);
-        return beanDefinitions;
+        beanCandidateCache.put(beanType, (Collection) candidates);
+        return candidates;
     }
 
     /**
@@ -2314,6 +2155,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     protected synchronized void registerConfiguration(@NonNull BeanConfiguration configuration) {
         ArgumentUtils.requireNonNull("configuration", configuration);
         beanConfigurations.put(configuration.getName(), configuration);
+        beanDefinitionProvider.registerConfiguration(configuration);
     }
 
     @NonNull
@@ -2342,7 +2184,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 qualified.$withBeanQualifier(declaredQualifier);
             }
             return bean;
-        } catch (DependencyInjectionException | DisabledBeanException | BeanInstantiationException e) {
+        } catch (DependencyInjectionException | DisabledBeanException |
+                 BeanInstantiationException e) {
             throw e;
         } catch (Throwable e) {
             if (!resolutionContext.getPath().isEmpty()) {
@@ -2434,7 +2277,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                     convertedValue = val;
                 } else {
                     convertedValue = conversionService.convert(val, requiredArgument).orElseThrow(() ->
-                            new BeanInstantiationException(resolutionContext, "Invalid bean argument [" + requiredArgument + "]. Cannot convert object [" + val + "] to required type: " + requiredArgument.getType())
+                        new BeanInstantiationException(resolutionContext, "Invalid bean argument [" + requiredArgument + "]. Cannot convert object [" + val + "] to required type: " + requiredArgument.getType())
                     );
                 }
                 convertedValues.put(argumentName, convertedValue);
@@ -2463,47 +2306,41 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
     }
 
-    private void processParallelBeans(List<BeanDefinitionProducer> parallelBeans) {
-        if (!eagerBeansEnabled || parallelBeans.isEmpty()) {
+    private void processParallelBeans() {
+        if (!eagerBeansEnabled) {
             return;
         }
-        List<BeanDefinitionProducer> finalParallelBeans = parallelBeans.stream()
-                .filter(p -> p.getReferenceIfEnabled(this) != null)
-                .toList();
-        if (!finalParallelBeans.isEmpty()) {
-            new Thread(() -> {
-                Collection<BeanDefinition<Object>> parallelDefinitions = new ArrayList<>();
-                finalParallelBeans.forEach(producer -> {
-                    try {
-                        loadEagerBeans(producer, parallelDefinitions);
-                    } catch (Throwable e) {
-                        BeanDefinitionReference<?> beanDefinitionReference = producer.getReferenceBestEffort();
-                        LOG.error("Parallel Bean definition [{}{}{}]", beanDefinitionReference == null ? "<ref discarded>" : beanDefinitionReference.getName(), MSG_COULD_NOT_BE_LOADED, e.getMessage(), e);
-                        boolean shutdownOnError = beanDefinitionReference != null &&
-                            beanDefinitionReference.getAnnotationMetadata().booleanValue(Parallel.class, "shutdownOnError").orElse(true);
-                        if (shutdownOnError) {
-                            stop();
-                        }
+        new Thread(() -> {
+            Iterable<BeanDefinition<Object>> parallelBeans = beanDefinitionProvider.getParallelBeans(this);
+            Collection<BeanDefinition<Object>> parallelDefinitions = new ArrayList<>(20);
+            parallelBeans.forEach(beanDefinition -> {
+                try {
+                    loadEagerBeans(beanDefinition, parallelDefinitions);
+                } catch (Throwable e) {
+                    LOG.error("Parallel Bean definition [{}{}{}]", beanDefinition.getName(), MSG_COULD_NOT_BE_LOADED, e.getMessage(), e);
+                    boolean shutdownOnError = beanDefinition.getAnnotationMetadata().booleanValue(Parallel.class, "shutdownOnError").orElse(true);
+                    if (shutdownOnError) {
+                        stop();
                     }
-                });
+                }
+            });
 
-                filterReplacedBeans(null, parallelDefinitions);
+            filterReplacedBeans(null, parallelDefinitions);
 
-                parallelDefinitions.forEach(beanDefinition -> ForkJoinPool.commonPool().execute(() -> {
-                    try {
-                        initializeEagerBean(beanDefinition);
-                    } catch (Throwable e) {
-                        LOG.error("Parallel Bean definition [{}{}{}]", beanDefinition.getName(), MSG_COULD_NOT_BE_LOADED, e.getMessage(), e);
-                        Boolean shutdownOnError = beanDefinition.getAnnotationMetadata().booleanValue(Parallel.class, "shutdownOnError").orElse(true);
-                        if (shutdownOnError) {
-                            stop();
-                        }
+            parallelDefinitions.forEach(beanDefinition -> ForkJoinPool.commonPool().execute(() -> {
+                try {
+                    initializeEagerBean(beanDefinition);
+                } catch (Throwable e) {
+                    LOG.error("Parallel Bean definition [{}{}{}]", beanDefinition.getName(), MSG_COULD_NOT_BE_LOADED, e.getMessage(), e);
+                    Boolean shutdownOnError = beanDefinition.getAnnotationMetadata().booleanValue(Parallel.class, "shutdownOnError").orElse(true);
+                    if (shutdownOnError) {
+                        stop();
                     }
-                }));
-                parallelDefinitions.clear();
+                }
+            }));
+            parallelDefinitions.clear();
 
-            }).start();
-        }
+        }).start();
     }
 
     private <T> void filterReplacedBeans(BeanResolutionContext resolutionContext, Collection<BeanDefinition<T>> candidates) {
@@ -2532,8 +2369,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
         for (BeanDefinition<T> replacementType : replacementTypes) {
             if (isNotTheSameDefinition(replacementType, definitionToBeReplaced) &&
-                    isNotProxy(replacementType, definitionToBeReplaced) &&
-                    checkIfReplaces(replacementType, definitionToBeReplaced, annotationMetadata)) {
+                isNotProxy(replacementType, definitionToBeReplaced) &&
+                checkIfReplaces(replacementType, definitionToBeReplaced, annotationMetadata)) {
                 return true;
             }
         }
@@ -2552,7 +2389,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     private <T> boolean isNotProxy(BeanDefinition<T> replacingCandidate, BeanDefinition<T> definitionToBeReplaced) {
         return !(replacingCandidate instanceof ProxyBeanDefinition &&
-                ((ProxyBeanDefinition<T>) replacingCandidate).getTargetDefinitionType() == definitionToBeReplaced.getClass());
+            ((ProxyBeanDefinition<T>) replacingCandidate).getTargetDefinitionType() == definitionToBeReplaced.getClass());
     }
 
     private <T> boolean checkIfReplaces(BeanDefinition<T> replacingCandidate, BeanDefinition<T> definitionToBeReplaced, AnnotationMetadata annotationMetadata) {
@@ -2570,7 +2407,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             if (qualifiedByNamed(definitionToBeReplaced, replacedBeanType, name)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Bean [{}] replaces existing bean of type [{}] qualified by name [{}]",
-                            replacingCandidate.getBeanType(), definitionToBeReplaced.getBeanType(), name);
+                        replacingCandidate.getBeanType(), definitionToBeReplaced.getBeanType(), name);
                 }
                 return true;
             }
@@ -2582,7 +2419,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             if (qualifiedByQualifier(definitionToBeReplaced, replacedBeanType, qualifierClassValue)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Bean [{}] replaces existing bean of type [{}] qualified by qualifier [{}]",
-                            replacingCandidate.getBeanType(), definitionToBeReplaced.getBeanType(), qualifierClassValue);
+                        replacingCandidate.getBeanType(), definitionToBeReplaced.getBeanType(), qualifierClassValue);
                 }
                 return true;
             }
@@ -2595,11 +2432,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             if (declaringType.isPresent()) {
                 Class<?> factoryClass = factory.get();
                 final boolean factoryReplaces = factoryClass == declaringType.get() &&
-                        checkIfTypeMatches(definitionToBeReplaced, annotationMetadata, replacedBeanType);
+                    checkIfTypeMatches(definitionToBeReplaced, annotationMetadata, replacedBeanType);
                 if (factoryReplaces) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Bean [{}] replaces existing bean of type [{}] in factory type [{}]",
-                                replacingCandidate.getBeanType(), replacedBeanType, factoryClass);
+                            replacingCandidate.getBeanType(), replacedBeanType, factoryClass);
                     }
                     return true;
                 }
@@ -2618,7 +2455,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                                              Class<T> replacedBeanType,
                                              AnnotationClassValue<?> qualifier) {
         @SuppressWarnings("unchecked") final Class<? extends Annotation> qualifierClass =
-                (Class<? extends Annotation>) qualifier.getType().orElse(null);
+            (Class<? extends Annotation>) qualifier.getType().orElse(null);
         if (qualifierClass != null && !qualifierClass.isAssignableFrom(Annotation.class)) {
             return Qualifiers.<T>byStereotype(qualifierClass).doesQualify(replacedBeanType, definitionToBeReplaced);
         } else {
@@ -2672,14 +2509,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
     }
 
-    private void loadEagerBeans(BeanDefinitionProducer producer, Collection<BeanDefinition<Object>> collector) {
-        BeanDefinitionReference<Object> reference = producer.getReferenceIfEnabled(this, null);
-        if (reference != null) {
-            BeanDefinition<Object> beanDefinition = reference.load(this);
-            try (BeanResolutionContext resolutionContext = newResolutionContext(beanDefinition, null)) {
-                if (beanDefinition.isEnabled(this, resolutionContext)) {
-                    collector.add(beanDefinition);
-                }
+    private void loadEagerBeans(BeanDefinition<Object> beanDefinition, Collection<BeanDefinition<Object>> collector) {
+        try (BeanResolutionContext resolutionContext = newResolutionContext(beanDefinition, null)) {
+            if (beanDefinition.isEnabled(this, resolutionContext)) {
+                collector.add(beanDefinition);
             }
         }
     }
@@ -2696,10 +2529,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             );
             for (BeanDefinition beanCandidate : beanCandidates) {
                 intializeEagerBean(
-                        null,
-                        beanCandidate,
-                        beanCandidate.asArgument(),
-                        beanCandidate.hasAnnotation(Context.class) ? null : beanDefinition.getDeclaredQualifier()
+                    null,
+                    beanCandidate,
+                    beanCandidate.asArgument(),
+                    beanCandidate.hasAnnotation(Context.class) ? null : beanDefinition.getDeclaredQualifier()
                 );
             }
 
@@ -2814,11 +2647,12 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     /**
      * Resolves the message to use for a disabled bean.
+     *
      * @param resolutionContext The resolution context
-     * @param beanType The bean type
-     * @param qualifier The qualifier
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param <T>               The bean type
      * @return The message or null if none exists
-     * @param <T> The bean type
      */
     @Nullable
     protected <T> String resolveDisabledBeanMessage(BeanResolutionContext resolutionContext, Argument<T> beanType, Qualifier<T> qualifier) {
@@ -2866,8 +2700,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             resolutionContext,
             beanType,
             false,
-            null,
-            disabledBeans.values()
+            beanDefinitionProvider.getDisabledBeans(this).stream().<BeanDefinition<T>>mapMulti((disabledBean, consumer) -> {
+                if (disabledBean.isCandidateBean(beanType)) {
+                    consumer.accept((BeanDefinition<T>) disabledBean);
+                }
+            }).toList()
         ).stream()
             .sorted(Comparator.comparing(BeanDefinition::getName))
             .toList();
@@ -2900,11 +2737,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                                 .ifPresent(beanClass -> {
                                     messageBuilder.setLength(messageBuilder.length() - lineSeparator.length());
                                     resolveDisabledBeanMessage(linePrefix + " ",
-                                            messageBuilder,
-                                            lineSeparator,
-                                            resolutionContext,
-                                            Argument.of(beanClass),
-                                            null);
+                                        messageBuilder,
+                                        lineSeparator,
+                                        resolutionContext,
+                                        Argument.of(beanClass),
+                                        null);
                                     messageBuilder.append(lineSeparator);
                                 });
                         }
@@ -3069,9 +2906,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
         if (resolutionContext != null) {
             BeanResolutionContext.Segment<?, ?> currentSegment = resolutionContext
-                    .getPath()
-                    .currentSegment()
-                    .orElse(null);
+                .getPath()
+                .currentSegment()
+                .orElse(null);
             if (currentSegment != null) {
                 Argument<?> argument = currentSegment.getArgument();
                 CustomScope<?> customScope = customScopeRegistry.findDeclaredScope(argument).orElse(null);
@@ -3095,25 +2932,25 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                                                                   @NonNull BeanDefinition<T> definition) {
         BeanKey<T> beanKey = new BeanKey<>(definition.asArgument(), qualifier);
         T bean = registeredScope.getOrCreate(
-                new BeanCreationContext<T>() {
-                    @NonNull
-                    @Override
-                    public BeanDefinition<T> definition() {
-                        return definition;
-                    }
-
-                    @NonNull
-                    @Override
-                    public BeanIdentifier id() {
-                        return beanKey;
-                    }
-
-                    @NonNull
-                    @Override
-                    public CreatedBean<T> create() throws BeanCreationException {
-                        return createRegistration(resolutionContext == null ? null : resolutionContext.copy(), beanKey.beanType, qualifier, definition, true);
-                    }
+            new BeanCreationContext<T>() {
+                @NonNull
+                @Override
+                public BeanDefinition<T> definition() {
+                    return definition;
                 }
+
+                @NonNull
+                @Override
+                public BeanIdentifier id() {
+                    return beanKey;
+                }
+
+                @NonNull
+                @Override
+                public CreatedBean<T> create() throws BeanCreationException {
+                    return createRegistration(resolutionContext == null ? null : resolutionContext.copy(), beanKey.beanType, qualifier, definition, true);
+                }
+            }
         );
         return BeanRegistration.of(this, beanKey, definition, bean);
     }
@@ -3193,10 +3030,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         Optional beanDefinition = beanConcreteCandidateCache.get(bk);
         if (beanDefinition == null) {
             beanDefinition = findConcreteCandidateNoCache(
-                    resolutionContext,
-                    beanType,
-                    qualifier,
-                    throwNonUnique);
+                resolutionContext,
+                beanType,
+                qualifier,
+                throwNonUnique);
             beanConcreteCandidateCache.put(bk, beanDefinition);
         }
         return beanDefinition;
@@ -3216,12 +3053,17 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                                                                    @NonNull Argument<T> beanType,
                                                                    @Nullable Qualifier<T> qualifier) {
 
+        // TODO: Improve
+        List<BeanDefinition<Object>> targetProxyBeans = CollectionUtils.iterableToList(beanDefinitionProvider.getTargetProxyBeans(this));
         Collection<BeanDefinition<T>> candidates = collectBeanCandidates(
             resolutionContext,
             beanType,
             true,
-            null,
-            proxyTargetBeans
+            targetProxyBeans.stream().<BeanDefinition<T>>mapMulti((beanDefinition, consumer) -> {
+                if (beanDefinition.isCandidateBean(beanType)) {
+                    consumer.accept((BeanDefinition<T>) beanDefinition);
+                }
+            }).toList()
         );
         return pickOneBean(beanType, qualifier, false, candidates);
     }
@@ -3348,95 +3190,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         registerConversionService();
         initializeEventListeners();
         initializeTypeConverters();
-        initializeContext(
-            startupBeans.eagerInitBeans,
-            startupBeans.processedBeans,
-            startupBeans.parallelBeans
-        );
+        initializeContext();
     }
 
     protected void initializeTypeConverters() {
-    }
-
-    @NonNull
-    private StartupBeans readBeanDefinitionReferences() {
-        if (startupBeans == null) {
-
-            List<BeanDefinitionProducer> eagerInitBeans = new ArrayList<>(20);
-            List<BeanDefinitionProducer> processedBeans = new ArrayList<>(10);
-            List<BeanDefinitionProducer> parallelBeans = new ArrayList<>(10);
-
-            List<BeanDefinitionReference> beanDefinitionReferences = resolveBeanDefinitionReferences();
-
-            List<BeanDefinitionProducer> producers = new ArrayList<>(beanDefinitionReferences.size());
-            List<BeanDefinitionProducer> proxyTargetBeans = new ArrayList<>(beanDefinitionReferences.size());
-            for (BeanDefinitionReference beanDefinitionReference : beanDefinitionReferences) {
-                producers.add(new BeanDefinitionProducer(beanDefinitionReference));
-            }
-            beanDefinitionsClasses.addAll(producers);
-
-            Collection<BeanConfiguration> allConfigurations = beanConfigurations.values();
-            List<BeanConfiguration> configurationsDisabled = new ArrayList<>(allConfigurations.size());
-            for (BeanConfiguration bc : allConfigurations) {
-                if (!bc.isEnabled(this)) {
-                    configurationsDisabled.add(bc);
-                }
-            }
-
-            reference:
-            for (BeanDefinitionProducer beanDefinitionProducer : producers) {
-                if (beanDefinitionProducer.isDisabledOptimistic()) {
-                    continue;
-                }
-                BeanDefinitionReference beanDefinitionReference = beanDefinitionProducer.reference;
-                for (BeanConfiguration disableConfiguration : configurationsDisabled) {
-                    if (disableConfiguration.isWithin(beanDefinitionReference)) {
-                        beanDefinitionProducer.disable();
-                        continue reference;
-                    }
-                }
-
-                if (beanDefinitionReference.isProxiedBean()) {
-                    beanDefinitionProducer.disable();
-                    BeanDefinitionProducer proxyBeanProducer = new BeanDefinitionProducer(beanDefinitionReference);
-                    // retain only if proxy target otherwise the target is never used
-                    if (beanDefinitionReference.isProxyTarget()) {
-                        proxyTargetBeans.add(proxyBeanProducer);
-                    }
-                    continue;
-                }
-
-                for (Class<?> indexedType : beanDefinitionReference.getIndexes()) {
-                    resolveTypeIndex(indexedType).add(beanDefinitionProducer);
-                }
-                if (isEagerInit(beanDefinitionReference)) {
-                    eagerInitBeans.add(beanDefinitionProducer);
-                } else if (beanDefinitionReference.isParallel()) {
-                    parallelBeans.add(beanDefinitionProducer);
-                }
-                if (beanDefinitionReference.requiresMethodProcessing()) {
-                    processedBeans.add(beanDefinitionProducer);
-                }
-            }
-
-            this.beanDefinitionReferences = null;
-            this.beanConfigurationsList = null;
-
-            this.proxyTargetBeans.addAll(proxyTargetBeans);
-            startupBeans = new StartupBeans(eagerInitBeans, processedBeans, parallelBeans);
-        }
-        return startupBeans;
-    }
-
-    private boolean isEagerInit(BeanDefinitionReference<?> beanDefinitionReference) {
-        return beanDefinitionReference.isContextScope() ||
-                (eagerInitSingletons && beanDefinitionReference.isSingleton()) ||
-                (eagerInitStereotypesPresent && beanDefinitionReference.getAnnotationMetadata().hasDeclaredStereotype(eagerInitStereotypes));
-    }
-
-    @NonNull
-    private Collection<BeanDefinitionProducer> resolveTypeIndex(Class<?> indexedType) {
-        return beanIndex.computeIfAbsent(indexedType, COMPUTE_INDEXES_FN);
     }
 
     @SuppressWarnings("unchecked")
@@ -3658,8 +3415,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     private List<BeanRegistration> topologicalSort(Collection<BeanRegistration> beans) {
         Map<Boolean, List<BeanRegistration>> initial = beans.stream()
-                .sorted(Comparator.comparing(s -> s.getBeanDefinition().getRequiredComponents().size()))
-                .collect(Collectors.groupingBy(b -> b.getBeanDefinition().getRequiredComponents().isEmpty()));
+            .sorted(Comparator.comparing(s -> s.getBeanDefinition().getRequiredComponents().size()))
+            .collect(Collectors.groupingBy(b -> b.getBeanDefinition().getRequiredComponents().isEmpty()));
         List<BeanRegistration> sorted = new ArrayList<>(nullSafe(initial.get(true)));
         List<BeanRegistration> unsorted = new ArrayList<>(nullSafe(initial.get(false)));
         // Optimization which knows about types which are already in the sorted list
@@ -3686,9 +3443,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                         continue;
                     }
                     if (unsatisfied.contains(clazz) || unsorted.stream()
-                            .map(BeanRegistration::getBeanDefinition)
-                            .map(BeanDefinition::getBeanType)
-                            .anyMatch(clazz::isAssignableFrom)) {
+                        .map(BeanRegistration::getBeanDefinition)
+                        .map(BeanDefinition::getBeanType)
+                        .anyMatch(clazz::isAssignableFrom)) {
                         found = true;
                         unsatisfied.add(clazz);
                         break;
@@ -3795,10 +3552,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     void configureContextInternal() {
         if (configured.compareAndSet(false, true)) {
             readAllBeanConfigurations();
-            readBeanDefinitionReferences();
-        }
-        for (Class<?> indexType : KNOWN_INDEX_TYPE) {
-            resolveTypeIndex(indexType);
+            beanDefinitionProvider.initialize(this);
         }
     }
 
@@ -3979,7 +3733,6 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
      * Internal supplier of listeners.
      *
      * @param <T> The listener type
-     *
      * @author Denis Stepanov
      * @since 4.0.0
      */
@@ -3996,7 +3749,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         Iterable<ListenerAndOrder<T>> get(@Nullable BeanResolutionContext beanResolutionContext);
 
         record ListenerAndOrder<T>(T bean, int order) implements Ordered {
-            @Override public int getOrder() {
+            @Override
+            public int getOrder() {
                 return order;
             }
         }
@@ -4074,7 +3828,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             }
             BeanKey<?> beanKey = (BeanKey<?>) o;
             return beanType.equalsType(beanKey.beanType) &&
-                    Objects.equals(qualifier, beanKey.qualifier);
+                Objects.equals(qualifier, beanKey.qualifier);
         }
 
         @Override
@@ -4126,7 +3880,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             }
             BeanCandidateKey<?> beanKey = (BeanCandidateKey<?>) o;
             return beanType.equalsType(beanKey.beanType) &&
-                    Objects.equals(qualifier, beanKey.qualifier) && throwNonUnique == beanKey.throwNonUnique;
+                Objects.equals(qualifier, beanKey.qualifier) && throwNonUnique == beanKey.throwNonUnique;
         }
 
         @Override
@@ -4226,190 +3980,6 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     private static final class CollectionHolder<T> {
         Collection<BeanRegistration<T>> registrations;
-    }
-
-    /**
-     * Holds references to the startup beans.
-     * @param eagerInitBeans Eager init beans
-     * @param processedBeans Processed beans
-     * @param parallelBeans Parallel startup beans
-     */
-    private record StartupBeans(
-        List<BeanDefinitionProducer> eagerInitBeans,
-        List<BeanDefinitionProducer> processedBeans,
-        List<BeanDefinitionProducer> parallelBeans) {
-    }
-
-
-    /**
-     * The class adds the caching of the enabled decision + the definition instance.
-     * NOTE: The class can be accessed in multiple threads, we do allow for the fields to be possibly initialized concurrently - multiple times.
-     *
-     * @since 4.0.0
-     */
-    @Internal
-    static final class BeanDefinitionProducer {
-        private static final AtomicReferenceFieldUpdater<BeanDefinitionProducer, Object> DEFINITION_UPDATER =
-            AtomicReferenceFieldUpdater.newUpdater(BeanDefinitionProducer.class, Object.class, "definition");
-        private static final Object DEFINITION_DISABLED_SENTINEL = "";
-
-        /**
-         * Initially the reference, may be set to {@code null} by {@link #disable()} or if
-         * {@link #getReferenceIfEnabled} determines the ref is disabled.
-         */
-        @Nullable
-        @SuppressWarnings("java:S3077")
-        private volatile BeanDefinitionReference reference;
-        /**
-         * Initially {@code null}. If the {@link #reference} is enabled, and the definition from it
-         * is also enabled, this is set to the {@link BeanDefinition}. If the definition is
-         * disabled (either through conditions or explicitly by {@link #disable()}), this is set to
-         * {@link #DEFINITION_DISABLED_SENTINEL}.
-         */
-        @Nullable
-        @SuppressWarnings("java:S3077")
-        private volatile Object definition;
-
-        BeanDefinitionProducer(@NonNull BeanDefinitionReference reference) {
-            this.reference = reference;
-        }
-
-        private static boolean isReferenceEnabled(BeanDefinitionReference<?> ref, DefaultBeanContext context, BeanResolutionContext resolutionContext) {
-            if (ref == null) {
-                return false;
-            }
-            if (ref instanceof io.micronaut.context.AbstractInitializableBeanDefinitionAndReference<?> referenceAndDefinition) {
-                return referenceAndDefinition.isEnabled(context, resolutionContext, true);
-            }
-            return ref.isEnabled(context);
-        }
-
-        private static boolean isDefinitionEnabled(@NonNull DefaultBeanContext context,
-                                                   @Nullable BeanResolutionContext resolutionContext,
-                                                   @Nullable BeanDefinition<?> def) {
-            if (def == null) {
-                return false;
-            }
-            if (def instanceof io.micronaut.context.AbstractInitializableBeanDefinitionAndReference<?> definitionAndReference) {
-                return definitionAndReference.isEnabled(context, resolutionContext, false);
-            }
-            return def.isEnabled(context, resolutionContext);
-        }
-
-        /**
-         * Returns {@code true} if we know for sure that the definition is disabled
-         * ({@link #getDefinitionIfEnabled} is {@code null}). Note that even if this returns
-         * {@code false}, {@link #getDefinitionIfEnabled} may still return {@code null} in some
-         * cases.
-         *
-         * @return {@code true} if we know for sure that this definition is disabled
-         */
-        boolean isDisabledOptimistic() {
-            return reference == null || definition == DEFINITION_DISABLED_SENTINEL;
-        }
-
-        @Nullable
-        <T> BeanDefinitionReference<T> getReferenceIfEnabled(DefaultBeanContext context) {
-            return getReferenceIfEnabled(context, null);
-        }
-
-        @Nullable
-        <T> BeanDefinitionReference<T> getReferenceIfEnabled(DefaultBeanContext context, @Nullable BeanResolutionContext resolutionContext) {
-            BeanDefinitionReference ref = reference;
-            if (ref == null) {
-                return null;
-            }
-            if (isReferenceEnabled(ref, context, resolutionContext)) {
-                return ref;
-            } else {
-                this.reference = null;
-                return null;
-            }
-        }
-
-        /**
-         * Get the reference if it hasn't been discarded yet. It might still be disabled, though.
-         * This is used for logging.
-         *
-         * @return The reference, if it's still available
-         */
-        @Nullable
-        BeanDefinitionReference<?> getReferenceBestEffort() {
-            return reference;
-        }
-
-        @Nullable
-        <T> BeanDefinition<T> getDefinitionIfEnabled(DefaultBeanContext context) {
-            return getDefinitionIfEnabled(context, null, null, null);
-        }
-
-        /**
-         * Get the bean definition for this producer, if it's enabled.
-         *
-         * @param context           The context
-         * @param resolutionContext The resolution context (optional)
-         * @param beanType          The bean type this definition must match. This is checked before {@link BeanDefinition#isEnabled}, to avoid infinite loops
-         * @param predicate         The predicate this definition must match. This is checked before {@link BeanDefinition#isEnabled}, to avoid infinite loops
-         * @return The definition or {@code null} if it's disabled (or {@code beanType} or {@code predicate} did not match)
-         */
-        @Nullable
-        <T> BeanDefinition<T> getDefinitionIfEnabled(DefaultBeanContext context,
-                                                     @Nullable BeanResolutionContext resolutionContext,
-                                                     @Nullable Argument<T> beanType,
-                                                     @Nullable Predicate<BeanDefinition<T>> predicate) {
-            Object defObject = this.definition;
-            if (defObject != DEFINITION_DISABLED_SENTINEL && defObject != null) {
-                BeanDefinition<T> def = (BeanDefinition<T>) defObject;
-                if (beanType != null && !def.isCandidateBean(beanType)) {
-                    return null;
-                }
-                if (predicate != null && !predicate.test(def)) {
-                    return null;
-                }
-                return def;
-            }
-            BeanDefinitionReference<T> ref = getReferenceIfEnabled(context, resolutionContext);
-            if (ref == null) {
-                // shortcut for future calls
-                this.definition = DEFINITION_DISABLED_SENTINEL;
-                return null;
-            }
-            BeanDefinition def = ref.load(context);
-            if (beanType != null && !def.isCandidateBean(beanType)) {
-                return null;
-            }
-            if (predicate != null && !predicate.test(def)) {
-                return null;
-            }
-            if (isDefinitionEnabled(context, resolutionContext, def)) {
-                if (DEFINITION_UPDATER.compareAndSet(this, null, def)) {
-                    return def;
-                } else {
-                    defObject = this.definition;
-                    return defObject != DEFINITION_DISABLED_SENTINEL && defObject != null ? (BeanDefinition<T>) defObject : null;
-                }
-            } else {
-                this.definition = DEFINITION_DISABLED_SENTINEL;
-                return null;
-            }
-        }
-
-        <T> boolean isReferenceCandidateBean(Argument<T> beanType) {
-            // The reference needs to be assigned to a new variable as it can change between checks
-            BeanDefinitionReference ref = reference;
-            return ref != null && ref.isCandidateBean(beanType);
-        }
-
-        void disableIfMatch(BeanDefinitionReference<?> toDisable) {
-            if (Objects.equals(toDisable, this.reference)) {
-                disable();
-            }
-        }
-
-        void disable() {
-            this.reference = null;
-            this.definition = DEFINITION_DISABLED_SENTINEL;
-        }
     }
 
     private final class BeanContextUnsafeExecutionHandle extends BeanContextExecutionHandle implements UnsafeExecutionHandle<Object, Object> {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1782,13 +1782,6 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     @NonNull
     @Override
-    public <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
-        ArgumentUtils.requireNonNull("beanType", beanType);
-        return findProxyBeanDefinition(Argument.of(beanType), qualifier);
-    }
-
-    @NonNull
-    @Override
     public <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         for (BeanDefinition<T> beanDefinition : getBeanDefinitions(beanType, qualifier)) {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -25,8 +25,8 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Secondary;
-import io.micronaut.context.beans.BeanDefinitionProvider;
-import io.micronaut.context.beans.DefaultBeanDefinitionProvider;
+import io.micronaut.context.beans.BeanDefinitionService;
+import io.micronaut.context.beans.DefaultBeanDefinitionService;
 import io.micronaut.context.condition.ConditionContext;
 import io.micronaut.context.condition.Failure;
 import io.micronaut.context.env.CachedEnvironment;
@@ -226,7 +226,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     protected MutableConversionService conversionService;
 
-    protected final BeanDefinitionProvider beanDefinitionProvider;
+    protected final BeanDefinitionService beanDefinitionProvider;
 
     /**
      * Construct a new bean context using the same classloader that loaded this DefaultBeanContext class.
@@ -291,7 +291,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         this.eventsEnabled = contextConfiguration.eventsEnabled();
         this.eagerBeansEnabled = contextConfiguration.eagerBeansEnabled();
         this.conversionService = new DefaultMutableConversionService();
-        beanDefinitionProvider = new DefaultBeanDefinitionProvider(beanContextConfiguration);
+        beanDefinitionProvider = new DefaultBeanDefinitionService(beanContextConfiguration);
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -77,6 +77,7 @@ import io.micronaut.core.naming.Named;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.type.UnsafeExecutable;
@@ -652,28 +653,28 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             beanDefinition = null;
         }
         if (beanDefinition != null && !(beanDefinition instanceof RuntimeBeanDefinition<T>) && beanDefinition.getBeanType().isInstance(singleton)) {
-            try (BeanResolutionContext context = newResolutionContext(beanDefinition, null)) {
-                if (inject) {
+            if (inject) {
+                try (BeanResolutionContext context = newResolutionContext(beanDefinition, null)) {
                     doInjectAndInitialize(context, singleton, beanDefinition);
                 }
-                BeanKey<T> key = new BeanKey<>(beanDefinition.asArgument(), qualifier);
-                singletonScope.registerSingletonBean(BeanRegistration.of(this, key, beanDefinition, singleton), qualifier);
             }
         } else {
             RuntimeBeanDefinition<T> runtimeBeanDefinition = RuntimeBeanDefinition.builder(type, () -> singleton)
                 .singleton(true)
+                .exposedTypes(ReflectionUtils.getAllClassesInHierarchy(type).toArray(Class<?>[]::new))
                 .qualifier(qualifier)
                 .build();
 
-            var registration = BeanRegistration.of(
-                this,
-                new BeanKey<>(runtimeBeanDefinition, qualifier),
-                runtimeBeanDefinition,
-                singleton
-            );
-            singletonScope.registerSingletonBean(registration, qualifier);
             registerBeanDefinition(runtimeBeanDefinition);
+            beanDefinition = runtimeBeanDefinition;
         }
+        var registration = BeanRegistration.of(
+            this,
+            new BeanKey<>(beanDefinition, qualifier),
+            beanDefinition,
+            singleton
+        );
+        singletonScope.registerSingletonBean(registration, qualifier);
         return this;
     }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -23,6 +23,7 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.naming.Named;
+import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
@@ -65,6 +66,7 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
     private final Class<? extends Annotation> scope;
     private final Class<?>[] exposedTypes;
     private Map<Class<?>, List<Argument<?>>> typeArguments;
+    private int order;
 
     DefaultRuntimeBeanDefinition(
         @NonNull Argument<T> beanType,
@@ -87,6 +89,12 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
         this.scope = scope;
         this.exposedTypes = exposedTypes;
         this.typeArguments = typeArguments;
+        this.order = annotationMetadata == null ? 0 : OrderUtil.getOrder(this.annotationMetadata);
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -318,7 +318,7 @@ final class SingletonScope {
      * @author Denis Stepanov
      * @since 3.5.0
      */
-    interface BeanDefinitionIdentity {
+    private interface BeanDefinitionIdentity {
 
         static BeanDefinitionIdentity of(BeanDefinition<?> beanDefinition) {
             if (beanDefinition instanceof BeanDefinitionDelegate<?> definitionDelegate) {
@@ -336,7 +336,7 @@ final class SingletonScope {
      *
      * @since 3.5.0
      */
-    static final class BeanDefinitionDelegatedIdentity implements BeanDefinitionIdentity {
+    private static final class BeanDefinitionDelegatedIdentity implements BeanDefinitionIdentity {
 
         private final BeanDefinitionDelegate<?> beanDefinitionDelegate;
 
@@ -370,7 +370,7 @@ final class SingletonScope {
      *
      * @since 3.5.0
      */
-    static final class RuntimeBeanDefinitionIdentity implements BeanDefinitionIdentity {
+    private static final class RuntimeBeanDefinitionIdentity implements BeanDefinitionIdentity {
 
         private final RuntimeBeanDefinition<?> beanDefinition;
 
@@ -405,7 +405,7 @@ final class SingletonScope {
      *
      * @since 3.5.0
      */
-    static final class SimpleBeanDefinitionIdentity implements BeanDefinitionIdentity {
+    private static final class SimpleBeanDefinitionIdentity implements BeanDefinitionIdentity {
 
         private final Class<?> beanDefinitionClass;
 

--- a/inject/src/main/java/io/micronaut/context/beans/BeanDefinitionProvider.java
+++ b/inject/src/main/java/io/micronaut/context/beans/BeanDefinitionProvider.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.beans;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.context.DisabledBean;
+import io.micronaut.context.RuntimeBeanDefinition;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanConfiguration;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanDefinitionReference;
+import io.micronaut.inject.QualifiedBeanType;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * The API to access bean definitions and bean references.
+ * Internal implementation is responsible for loading bean definitions and checking if it's enabled.
+ *
+ * @author Denis Stepanov
+ * @since 5.0
+ */
+public interface BeanDefinitionProvider {
+
+    /**
+     * Registers a runtime bean definition so it becomes visible to the provider alongside precompiled definitions.
+     *
+     * @param definition the runtime definition to register, never null
+     */
+    void addBeanDefinition(@NonNull RuntimeBeanDefinition<?> definition);
+
+    /**
+     * Unregisters a runtime bean definition that was previously added.
+     *
+     * @param definition the runtime definition to remove, never null
+     */
+    void removeBeanDefinition(@NonNull RuntimeBeanDefinition<?> definition);
+
+    /**
+     * Records that a qualified bean type has been disabled, along with human-readable reasons.
+     *
+     * @param beanType the qualified bean type that has been disabled
+     * @param reasons  the reasons explaining why the bean is disabled
+     */
+    void trackDisabled(QualifiedBeanType<?> beanType, List<String> reasons);
+
+    /**
+     * Returns bean definitions that should be initialized eagerly.
+     *
+     * @param beanContext the bean context to eliminate disabled beans
+     * @return an iterable of bean definitions that should be eagerly instantiated
+     */
+    Iterable<BeanDefinition<Object>> getEagerInitBeans(@NonNull BeanContext beanContext);
+
+    /**
+     * Returns bean definitions that require contextual processing during startup.
+     *
+     * @param beanContext the bean context to eliminate disabled beans
+     * @return an iterable of bean definitions that require processing at startup
+     */
+    Iterable<BeanDefinition<Object>> getProcessedBeans(@NonNull BeanContext beanContext);
+
+    /**
+     * Returns bean definitions that are safe to be instantiated in parallel during startup.
+     *
+     * @param beanContext the bean context to eliminate disabled beans
+     * @return an iterable of bean definitions eligible for parallel creation
+     */
+    Iterable<BeanDefinition<Object>> getParallelBeans(@NonNull BeanContext beanContext);
+
+    /**
+     * Returns target proxy bean definitions.
+     *
+     * @param beanContext the bean context to eliminate disabled beans
+     * @return an iterable of bean definitions that should be treated as target proxy candidates
+     */
+    Iterable<BeanDefinition<Object>> getTargetProxyBeans(@NonNull BeanContext beanContext);
+
+    /**
+     * Returns a disabled beans.
+     *
+     * @param beanContext the bean context to eliminate disabled beans
+     * @return a list of disabled beans with their associated reasons
+     */
+    List<DisabledBean<?>> getDisabledBeans(@NonNull BeanContext beanContext);
+
+    /**
+     * Returns whether at least one bean definition exists for the given raw type.
+     * This is a lightweight existence check and does not consider qualifiers.
+     *
+     * @param beanType the raw type to check
+     * @return true if at least one definition of the given type is known; false otherwise
+     */
+    @NonNull
+    boolean exists(Class<?> beanType);
+
+    /**
+     * Resolves enabled bean definitions.
+     *
+     * @param beanContext  the bean context to eliminate disabled beans
+     * @param defPredicate optional filter applied to definitions
+     * @return a list of loaded bean definitions matching the filter
+     */
+    @NonNull
+    default List<BeanDefinition<Object>> getBeanDefinitions(
+        @NonNull BeanContext beanContext,
+        @Nullable Predicate<BeanDefinition<Object>> defPredicate
+    ) {
+        return getBeanDefinitions(beanContext, null, defPredicate);
+    }
+
+    /**
+     * Resolves enabled bean definitions.
+     *
+     * @param beanContext  the bean context to eliminate disabled beans
+     * @param refPredicate optional filter applied to references
+     * @param defPredicate optional filter applied to definitions
+     * @return a list of loaded bean definitions matching the filters
+     */
+    @NonNull
+    default List<BeanDefinition<Object>> getBeanDefinitions(
+        @NonNull BeanContext beanContext,
+        @Nullable Predicate<BeanDefinitionReference<Object>> refPredicate,
+        @Nullable Predicate<BeanDefinition<Object>> defPredicate
+    ) {
+        List<BeanDefinition<Object>> beanDefinitions = new java.util.ArrayList<>(20);
+        for (BeanDefinition<Object> beanDefinition : getBeanDefinitions(beanContext, Argument.OBJECT_ARGUMENT, refPredicate, defPredicate)) {
+            beanDefinitions.add(beanDefinition);
+        }
+        return beanDefinitions;
+    }
+
+    /**
+     * Resolves enabled bean definitions.
+     *
+     * @param beanContext  the bean context to eliminate disabled beans
+     * @param beanType     the bean type to resolve
+     * @param refPredicate optional filter applied to references
+     * @param defPredicate optional filter applied to definitions
+     * @param <B>          the bean generic type
+     * @return an iterable over matching bean definitions; iteration may trigger loading
+     */
+    @NonNull
+    <B> Iterable<BeanDefinition<B>> getBeanDefinitions(
+        @NonNull BeanContext beanContext,
+        @NonNull Argument<B> beanType,
+        @Nullable Predicate<BeanDefinitionReference<B>> refPredicate,
+        @Nullable Predicate<BeanDefinition<B>> defPredicate
+    );
+
+    /**
+     * Resolves enabled bean definitions.
+     *
+     * @param beanResolutionContext the resolution context to eliminate disabled beans
+     * @param beanType              the bean context to eliminate disabled beans
+     * @param refPredicate          optional filter applied to references prior to loading; may be null
+     * @param defPredicate          optional filter applied to loaded definitions; may be null
+     * @param <B>                   the bean generic type
+     * @return an iterable over matching bean definitions]]
+     */
+    @NonNull
+    <B> Iterable<BeanDefinition<B>> getBeanDefinitions(
+        @NonNull BeanResolutionContext beanResolutionContext,
+        @NonNull Argument<B> beanType,
+        @Nullable Predicate<BeanDefinitionReference<B>> refPredicate,
+        @Nullable Predicate<BeanDefinition<B>> defPredicate
+    );
+
+    /**
+     * Returns all enabled bean references.
+     *
+     * @param beanContext the context for which references are requested
+     * @return an iterable of bean definition references
+     */
+    @NonNull
+    Iterable<BeanDefinitionReference<Object>> getBeanReferences(
+        @NonNull BeanContext beanContext
+    );
+
+    /**
+     * Returns all bean references.
+     *
+     * @return a list of all known bean definition references
+     */
+    @NonNull
+    List<BeanDefinitionReference<Object>> getBeanReferences();
+
+    /**
+     * Registers a bean configuration.
+     *
+     * @param configuration the configuration to register
+     */
+    void registerConfiguration(@NonNull BeanConfiguration configuration);
+
+    /**
+     * Resets the provider by clearing internal caches and runtime registrations.
+     * Intended for container lifecycle management and test scenarios.
+     */
+    void reset();
+
+    /**
+     * Initializes the provider for use with the given context.
+     * Implementations may perform warm-up and indexing.
+     *
+     * @param beanContext the bean context
+     */
+    void initialize(BeanContext beanContext);
+
+}

--- a/inject/src/main/java/io/micronaut/context/beans/BeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/BeanDefinitionService.java
@@ -19,6 +19,7 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.DisabledBean;
 import io.micronaut.context.RuntimeBeanDefinition;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
@@ -37,7 +38,8 @@ import java.util.function.Predicate;
  * @author Denis Stepanov
  * @since 5.0
  */
-public interface BeanDefinitionProvider {
+@Internal
+public sealed interface BeanDefinitionService permits DefaultBeanDefinitionService {
 
     /**
      * Registers a runtime bean definition so it becomes visible to the provider alongside precompiled definitions.

--- a/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionProvider.java
+++ b/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionProvider.java
@@ -1,0 +1,744 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.beans;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanContextConfiguration;
+import io.micronaut.context.BeanDefinitionsProvider;
+import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.context.DisabledBean;
+import io.micronaut.context.Qualifier;
+import io.micronaut.context.RuntimeBeanDefinition;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import io.micronaut.context.event.BeanInitializedEventListener;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.TypeConverter;
+import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.BeanConfiguration;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanDefinitionReference;
+import io.micronaut.inject.QualifiedBeanType;
+import jakarta.inject.Singleton;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * The default implementation of {@link BeanDefinitionProvider}.
+ *
+ * @author Denis Stepanov
+ * @since 5.0
+ */
+@Internal
+public final class DefaultBeanDefinitionProvider implements BeanDefinitionProvider {
+
+    private static final List<Class<?>> KNOWN_INDEX_TYPES = List.of(
+        ResourceLoader.class,
+        TypeConverter.class,
+        TypeConverterRegistrar.class,
+        ApplicationEventListener.class,
+        BeanCreatedEventListener.class,
+        BeanInitializedEventListener.class,
+        BeanPreDestroyEventListener.class,
+        BeanDestroyedEventListener.class,
+        ConversionService.class
+    );
+
+    private final String[] eagerInitStereotypes;
+    private final boolean eagerInitStereotypesPresent;
+    private final boolean eagerInitSingletons;
+
+    // The collection should be modified only when new bean definition is added
+    // That shouldn't happen that often, so we can use CopyOnWriteArrayList
+
+    private final CopyOnWriteArrayList<BeanDefinitionProducer> disabledBeans = new CopyOnWriteArrayList<>();
+
+    private static final Function<Class<?>, List<BeanDefinitionProducer>> COMPUTE_INDEXES_FN = new Function<Class<?>, List<BeanDefinitionProducer>>() {
+        // Keep an anonymous class for performance
+        @Override
+        public List<BeanDefinitionProducer> apply(Class<?> indexedType) {
+            return new ArrayList<>(20);
+        }
+    };
+
+    private final BeanDefinitionsProvider beanDefinitionReferencesProvider;
+    @Nullable
+    private final Predicate<QualifiedBeanType<?>> beansPredicate;
+
+    private final ClassLoader classLoader;
+    private Beans beans;
+
+    private final List<BeanDefinitionProducer> additionalBeanDefinitions = new ArrayList<>();
+    private final List<BeanConfiguration> additionalBeanConfigurations = new ArrayList<>();
+
+    /**
+     * Creates a new bean context with the given configuration.
+     *
+     * @param contextConfiguration The context configuration
+     */
+    public DefaultBeanDefinitionProvider(@NonNull BeanContextConfiguration contextConfiguration) {
+        Set<Class<? extends Annotation>> eagerInitAnnotated = contextConfiguration.getEagerInitAnnotated();
+        List<String> configuredEagerSingletonAnnotations = new ArrayList<>(eagerInitAnnotated.size());
+        for (Class<? extends Annotation> ann : eagerInitAnnotated) {
+            configuredEagerSingletonAnnotations.add(ann.getName());
+        }
+        this.eagerInitStereotypes = configuredEagerSingletonAnnotations.toArray(StringUtils.EMPTY_STRING_ARRAY);
+        this.eagerInitStereotypesPresent = !configuredEagerSingletonAnnotations.isEmpty();
+        this.eagerInitSingletons = eagerInitStereotypesPresent && (configuredEagerSingletonAnnotations.contains(AnnotationUtil.SINGLETON) || configuredEagerSingletonAnnotations.contains(Singleton.class.getName()));
+        this.beansPredicate = contextConfiguration.beansPredicate();
+        this.beanDefinitionReferencesProvider = contextConfiguration.getBeanDefinitionsProvider();
+        this.classLoader = contextConfiguration.getClassLoader();
+        if (beans == null) {
+            beans = createBeans(resolveBeanDefinitionReferences(), List.of());
+        }
+    }
+
+    /**
+     * Configures the context reading all bean definitions.
+     */
+    @Internal
+    public void initialize(BeanContext beanContext) {
+        readBeanDefinitionReferences(beanContext);
+        for (Class<?> indexType : KNOWN_INDEX_TYPES) {
+            resolveTypeIndex(indexType);
+        }
+    }
+
+    @Override
+    public void registerConfiguration(BeanConfiguration configuration) {
+        additionalBeanConfigurations.add(configuration);
+    }
+
+    @Override
+    @NonNull
+    public void addBeanDefinition(@NonNull RuntimeBeanDefinition<?> definition) {
+        Objects.requireNonNull(definition, "Bean definition cannot be null");
+        BeanDefinitionProducer producer = new BeanDefinitionProducer(definition);
+        if (beans == null) {
+            additionalBeanDefinitions.add(producer);
+        } else {
+            addBeanDefinition(producer);
+        }
+    }
+
+    private void addBeanDefinition(BeanDefinitionProducer producer) {
+        beans.all.add(producer);
+        BeanDefinitionReference<?> reference = producer.reference;
+        Class<?> beanType = producer.reference.getBeanType();
+        boolean beanTypeIndexAdded = false;
+        for (Class<?> exposedType : reference.getExposedTypes()) {
+            resolveTypeIndex(exposedType).add(producer);
+            if (beanType.equals(exposedType)) {
+                beanTypeIndexAdded = true;
+            }
+        }
+        if (!beanTypeIndexAdded) {
+            resolveTypeIndex(beanType).add(producer);
+        }
+    }
+
+    @Override
+    public <B> Iterable<BeanDefinition<B>> getBeanDefinitions(BeanContext beanContext,
+                                                              Argument<B> beanType,
+                                                              Predicate<BeanDefinitionReference<B>> refPredicate,
+                                                              Predicate<BeanDefinition<B>> defPredicate) {
+        return getBeanDefinitions(resolveProducersForBeanType(beanType), beanContext, null, beanType, refPredicate, defPredicate);
+    }
+
+    @Override
+    public List<BeanDefinitionReference<Object>> getBeanReferences() {
+        if (beans == null) {
+            return List.of();
+        }
+        List<BeanDefinitionProducer> all = beans.all;
+        List<BeanDefinitionReference<Object>> references = new ArrayList<>(all.size());
+        for (BeanDefinitionProducer producer : all) {
+            BeanDefinitionReference<?> reference = producer.reference;
+            if (reference != null) {
+                references.add((BeanDefinitionReference<Object>) reference);
+            }
+        }
+        return references;
+    }
+
+    @Override
+    public <B> Iterable<BeanDefinition<B>> getBeanDefinitions(BeanResolutionContext beanResolutionContext, Argument<B> beanType, Predicate<BeanDefinitionReference<B>> refPredicate, Predicate<BeanDefinition<B>> defPredicate) {
+        return getBeanDefinitions(resolveProducersForBeanType(beanType), null, beanResolutionContext, beanType, refPredicate, defPredicate);
+    }
+
+    private <B> Iterable<BeanDefinition<B>> getBeanDefinitions(Collection<BeanDefinitionProducer> producers,
+                                                               BeanContext beanContext,
+                                                               Argument<B> beanType,
+                                                               Predicate<BeanDefinitionReference<B>> refPredicate,
+                                                               Predicate<BeanDefinition<B>> defPredicate) {
+        return getBeanDefinitions(producers, beanContext, null, beanType, refPredicate, defPredicate);
+    }
+
+    private <B> Iterable<BeanDefinition<B>> getBeanDefinitions(Collection<BeanDefinitionProducer> producers,
+                                                               @Nullable
+                                                               BeanContext beanContext,
+                                                               @Nullable
+                                                               BeanResolutionContext beanResolutionContext,
+                                                               Argument<B> beanType,
+                                                               Predicate<BeanDefinitionReference<B>> refPredicate,
+                                                               Predicate<BeanDefinition<B>> defPredicate) {
+        return new Iterable<>() {
+
+            @Override
+            public Iterator<BeanDefinition<B>> iterator() {
+                Iterator<BeanDefinitionProducer> iterator = producers.iterator();
+                return new Iterator<>() {
+
+                    private BeanDefinition<B> next;
+
+                    private void advance() {
+                        while (next == null && iterator.hasNext()) {
+                            next = iterator.next().getDefinitionIfEnabled(
+                                beanResolutionContext != null ? beanResolutionContext.getContext() : beanContext,
+                                beanResolutionContext,
+                                beanType,
+                                refPredicate,
+                                defPredicate
+                            );
+                        }
+                    }
+
+                    @Override
+                    public boolean hasNext() {
+                        advance();
+                        return next != null;
+                    }
+
+                    @Override
+                    public BeanDefinition<B> next() {
+                        advance();
+                        if (next == null) {
+                            throw new NoSuchElementException();
+                        }
+                        BeanDefinition<B> value = next;
+                        next = null;
+                        return value;
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    public Iterable<BeanDefinitionReference<Object>> getBeanReferences(BeanContext beanContext) {
+        return new Iterable<>() {
+
+            @Override
+            public Iterator<BeanDefinitionReference<Object>> iterator() {
+                Iterator<BeanDefinitionProducer> iterator = beans.all.iterator();
+                return new Iterator<>() {
+
+                    private BeanDefinitionReference<Object> next;
+
+                    private void advance() {
+                        while (next == null && iterator.hasNext()) {
+                            next = iterator.next().getReferenceIfEnabled(beanContext);
+                        }
+                    }
+
+                    @Override
+                    public boolean hasNext() {
+                        advance();
+                        return next != null;
+                    }
+
+                    @Override
+                    public BeanDefinitionReference<Object> next() {
+                        advance();
+                        if (next == null) {
+                            throw new NoSuchElementException();
+                        }
+                        BeanDefinitionReference<Object> value = next;
+                        next = null;
+                        return value;
+                    }
+                };
+            }
+        };
+    }
+
+    private List<BeanDefinitionProducer> resolveProducersForBeanType(Argument<?> beanType) {
+        Class<?> type = beanType.getType();
+        if (type == Object.class) {
+            return beans.all;
+        }
+        List<BeanDefinitionProducer> producers = beans.beanIndex.get(type);
+        if (producers == null) {
+            return List.of();
+        }
+        return producers;
+    }
+
+    @Override
+    public void reset() {
+        beans = null;
+        disabledBeans.clear();
+        additionalBeanDefinitions.clear();
+        additionalBeanConfigurations.clear();
+    }
+
+    /**
+     * The definition to remove.
+     *
+     * @param definition The definition to remove
+     */
+    @Internal
+    public void removeBeanDefinition(RuntimeBeanDefinition<?> definition) {
+        Class<?> beanType = definition.getBeanType();
+        for (Class<?> indexedType : beans.beanIndex.keySet()) {
+            if (indexedType == beanType || indexedType.isAssignableFrom(beanType)) {
+                resolveTypeIndex(indexedType).forEach(p -> p.disableIfMatch(definition));
+                break;
+            }
+        }
+        beans.all.forEach(p -> p.disableIfMatch(definition));
+    }
+
+    @Override
+    public void trackDisabled(QualifiedBeanType<?> beanType, List<String> reasons) {
+        try {
+            @SuppressWarnings("unchecked")
+            Argument<Object> argument = (Argument<Object>) beanType.getGenericBeanType();
+            @SuppressWarnings("unchecked")
+            Qualifier<Object> declaredQualifier = (Qualifier<Object>) beanType.getDeclaredQualifier();
+            this.disabledBeans.add(new BeanDefinitionProducer(new DisabledBean<>(
+                argument,
+                declaredQualifier,
+                reasons
+            )));
+        } catch (Exception | NoClassDefFoundError e) {
+            // it is theoretically possible that resolving the generic type results in an error
+            // in this case just ignore this as the maps built here are purely to aid error diagnosis
+        }
+    }
+
+    @Override
+    public Iterable<BeanDefinition<Object>> getEagerInitBeans(BeanContext beanContext) {
+        return getBeanDefinitions(beans.eagerInitBeans, beanContext, Argument.OBJECT_ARGUMENT, null, null);
+    }
+
+    @Override
+    public Iterable<BeanDefinition<Object>> getProcessedBeans(BeanContext beanContext) {
+        return getBeanDefinitions(beans.processedBeans, beanContext, Argument.OBJECT_ARGUMENT, null, null);
+    }
+
+    @Override
+    public Iterable<BeanDefinition<Object>> getParallelBeans(BeanContext beanContext) {
+        return getBeanDefinitions(beans.parallelBeans, beanContext, Argument.OBJECT_ARGUMENT, null, null);
+    }
+
+    @Override
+    public Iterable<BeanDefinition<Object>> getTargetProxyBeans(BeanContext beanContext) {
+        return getBeanDefinitions(beans.proxyTargetBeans, beanContext, Argument.OBJECT_ARGUMENT, null, null);
+    }
+
+    @Override
+    public List<DisabledBean<?>> getDisabledBeans(BeanContext beanContext) {
+        return disabledBeans.stream()
+            .map(producer -> (DisabledBean<?>) producer.reference)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    }
+
+    @NonNull
+    private Collection<BeanDefinitionProducer> resolveTypeIndex(Class<?> indexedType) {
+        return beans.beanIndex.computeIfAbsent(indexedType, COMPUTE_INDEXES_FN);
+    }
+
+    @Override
+    public boolean exists(Class<?> beanType) {
+        if (beans == null) {
+            for (BeanDefinitionReference<?> beanDefinitionReference : resolveBeanDefinitionReferences()) {
+                if (beanType.isAssignableFrom(beanDefinitionReference.getBeanType())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        List<BeanDefinitionProducer> refs = beans.beanIndex.get(beanType);
+        return refs != null && !refs.isEmpty();
+    }
+
+    @NonNull
+    private void readBeanDefinitionReferences(BeanContext beanContext) {
+        if (beans == null) {
+            beans = createBeans(resolveBeanDefinitionReferences(), additionalBeanConfigurations);
+            additionalBeanConfigurations.clear();
+        }
+        if (!additionalBeanDefinitions.isEmpty()) {
+            for (BeanDefinitionProducer additionalBeanDefinition : additionalBeanDefinitions) {
+                BeanDefinitionReference<?> reference = additionalBeanDefinition.reference;
+                if (reference == null) {
+                    continue;
+                }
+                addBeanDefinition(additionalBeanDefinition);
+                for (Map.Entry<BeanConfiguration, List<BeanDefinitionProducer>> e : beans.byConfiguration) {
+                    BeanConfiguration configuration = e.getKey();
+                    if (!configuration.isEnabled(beanContext) && configuration.isWithin(reference)) {
+                        additionalBeanDefinition.disable();
+                    }
+                }
+                for (BeanConfiguration additionalBeanConfiguration : additionalBeanConfigurations) {
+                    if (!additionalBeanConfiguration.isEnabled(beanContext) && additionalBeanConfiguration.isWithin(reference)) {
+                        additionalBeanDefinition.disable();
+                    }
+                }
+            }
+        }
+
+        if (!beans.byConfiguration.isEmpty()) {
+            for (Map.Entry<BeanConfiguration, List<BeanDefinitionProducer>> e : beans.byConfiguration) {
+                List<BeanDefinitionProducer> producers = e.getValue();
+                BeanConfiguration configuration = e.getKey();
+                if (!producers.isEmpty() && !configuration.isEnabled(beanContext)) {
+                    for (BeanDefinitionProducer producer : producers) {
+                        producer.disable();
+                    }
+                }
+            }
+        }
+        for (BeanConfiguration additionalBeanConfiguration : additionalBeanConfigurations) {
+            if (!additionalBeanConfiguration.isEnabled(beanContext)) {
+                for (BeanDefinitionProducer producer : beans.all) {
+                    BeanDefinitionReference<?> reference = producer.reference;
+                    if (reference != null && additionalBeanConfiguration.isWithin(reference)) {
+                        producer.disable();
+                    }
+                }
+            }
+        }
+        if (eagerInitSingletons || eagerInitStereotypesPresent) {
+            for (BeanDefinitionProducer beanDefinitionProducer : beans.all) {
+                BeanDefinitionReference<?> reference = beanDefinitionProducer.reference;
+                if (reference != null && isEagerInit(reference)) {
+                    beans.eagerInitBeans.add(beanDefinitionProducer);
+                }
+            }
+        }
+    }
+
+
+    private boolean isEagerInit(BeanDefinitionReference<?> beanDefinitionReference) {
+        return eagerInitSingletons && beanDefinitionReference.isSingleton() ||
+            eagerInitStereotypesPresent && beanDefinitionReference.getAnnotationMetadata().hasDeclaredStereotype(eagerInitStereotypes);
+    }
+
+    private static Beans createBeans(List<BeanDefinitionReference<?>> beanDefinitionReferences, List<BeanConfiguration> beanConfigurations) {
+        List<BeanDefinitionProducer> eagerInitBeans = new ArrayList<>(20);
+        List<BeanDefinitionProducer> processedBeans = new ArrayList<>(10);
+        List<BeanDefinitionProducer> parallelBeans = new ArrayList<>(10);
+
+        Map<Class<?>, List<BeanDefinitionProducer>> indexByType = CollectionUtils.newHashMap(beanDefinitionReferences.size());
+        List<BeanDefinitionProducer> all = new ArrayList<>(beanDefinitionReferences.size());
+        List<BeanDefinitionProducer> proxyTargetBeans = new ArrayList<>(beanDefinitionReferences.size());
+        for (BeanDefinitionReference<?> beanDefinitionReference : beanDefinitionReferences) {
+            all.add(new BeanDefinitionProducer(beanDefinitionReference));
+        }
+
+        List<Map.Entry<BeanConfiguration, List<BeanDefinitionProducer>>> byConfiguration = new ArrayList<>(beanConfigurations.size());
+        for (BeanConfiguration beanConfiguration : beanConfigurations) {
+            byConfiguration.add(Map.entry(beanConfiguration, new ArrayList<>()));
+        }
+
+        for (BeanDefinitionProducer beanDefinitionProducer : all) {
+            BeanDefinitionReference<?> beanDefinitionReference = beanDefinitionProducer.reference;
+            for (Map.Entry<BeanConfiguration, List<BeanDefinitionProducer>> e : byConfiguration) {
+                BeanConfiguration configuration = e.getKey();
+                if (configuration.isWithin(beanDefinitionReference)) {
+                    e.getValue().add(beanDefinitionProducer);
+                }
+            }
+            if (beanDefinitionReference.isProxiedBean()) {
+                beanDefinitionProducer.disable();
+                indexDisabledBean(indexByType, beanDefinitionReference);
+                // retain only if proxy target otherwise the target is never used
+                if (beanDefinitionReference.isProxyTarget()) {
+                    proxyTargetBeans.add(new BeanDefinitionProducer(beanDefinitionReference));
+                }
+                continue;
+            }
+
+            if (beanDefinitionReference.isContextScope()) {
+                eagerInitBeans.add(beanDefinitionProducer);
+            } else if (beanDefinitionReference.isParallel()) {
+                parallelBeans.add(beanDefinitionProducer);
+            }
+            if (beanDefinitionReference.requiresMethodProcessing()) {
+                processedBeans.add(beanDefinitionProducer);
+            }
+
+            indexBean(indexByType, beanDefinitionProducer);
+        }
+
+        return new Beans(
+            eagerInitBeans,
+            processedBeans,
+            parallelBeans,
+            new CopyOnWriteArrayList<>(all),
+            proxyTargetBeans,
+            new ConcurrentHashMap<>(indexByType),
+            byConfiguration
+        );
+    }
+
+    private static void indexBean(Map<Class<?>, List<BeanDefinitionProducer>> indexByType, BeanDefinitionProducer beanDefinitionProducer) {
+        BeanDefinitionReference<?> reference = beanDefinitionProducer.reference;
+        Set<Class<?>> exposedTypes = reference.getExposedTypes();
+        if (exposedTypes.isEmpty()) {
+            // The reference must be compiled prior to v5, use reflection to find exposed types till it's recompiled
+            exposedTypes = findExposedClassesUsingReflection(reference.getBeanType());
+        }
+        for (Class<?> indexedType : exposedTypes) {
+            indexByType.computeIfAbsent(indexedType, COMPUTE_INDEXES_FN).add(beanDefinitionProducer);
+        }
+    }
+
+    private static Set<Class<?>> findExposedClassesUsingReflection(Class<?> aClass) {
+        Set<Class<?>> set = new HashSet<>();
+        collectExposedClassesUsingReflection(set, aClass);
+        return set;
+    }
+
+    private static void collectExposedClassesUsingReflection(Set<Class<?>> classes, Class<?> aClass) {
+        if (!classes.add(aClass)) {
+            return;
+        }
+        Class<?> superclass = aClass.getSuperclass();
+        if (superclass != null && superclass != Object.class && superclass != Record.class && superclass != Enum.class) {
+            collectExposedClassesUsingReflection(classes, superclass);
+        }
+        for (Class<?> interfaceClass : aClass.getInterfaces()) {
+            collectExposedClassesUsingReflection(classes, interfaceClass);
+        }
+    }
+
+    private static void indexDisabledBean(Map<Class<?>, List<BeanDefinitionProducer>> indexByType, BeanDefinitionReference<?> reference) {
+        // For disabled beans we want to initialize the index collection, otherwise MISS will cause N search
+        for (Class<?> indexedType : reference.getExposedTypes()) {
+            indexByType.computeIfAbsent(indexedType, COMPUTE_INDEXES_FN);
+        }
+    }
+
+    @NonNull
+    private List<BeanDefinitionReference<?>> resolveBeanDefinitionReferences() {
+        List<BeanDefinitionReference<?>> refs = beanDefinitionReferencesProvider.provide(classLoader);
+        if (beansPredicate != null) {
+            List<BeanDefinitionReference<?>> list = new ArrayList<>(refs.size());
+            for (BeanDefinitionReference<?> ref : refs) {
+                if (beansPredicate.test(ref)) {
+                    list.add(ref);
+                }
+            }
+            refs = list;
+        }
+        return refs;
+    }
+
+    private record Beans(
+        List<BeanDefinitionProducer> eagerInitBeans,
+        List<BeanDefinitionProducer> processedBeans,
+        List<BeanDefinitionProducer> parallelBeans,
+        List<BeanDefinitionProducer> all,
+        List<BeanDefinitionProducer> proxyTargetBeans,
+        Map<Class<?>, List<BeanDefinitionProducer>> beanIndex,
+        List<Map.Entry<BeanConfiguration, List<BeanDefinitionProducer>>> byConfiguration
+    ) {
+    }
+
+    /**
+     * The class adds the caching of the enabled decision + the definition instance.
+     * NOTE: The class can be accessed in multiple threads, we do allow for the fields to be possibly initialized concurrently - multiple times.
+     *
+     * @since 4.0.0
+     */
+    @Internal
+    private static final class BeanDefinitionProducer {
+        private static final AtomicReferenceFieldUpdater<BeanDefinitionProducer, Object> DEFINITION_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(BeanDefinitionProducer.class, Object.class, "definition");
+        private static final Object DEFINITION_DISABLED_SENTINEL = "";
+
+        /**
+         * Initially the reference, may be set to {@code null} by {@link #disable()} or if
+         * {@link #getReferenceIfEnabled} determines the ref is disabled.
+         */
+        @Nullable
+        @SuppressWarnings("java:S3077")
+        private volatile BeanDefinitionReference<?> reference;
+        /**
+         * Initially {@code null}. If the {@link #reference} is enabled, and the definition from it
+         * is also enabled, this is set to the {@link BeanDefinition}. If the definition is
+         * disabled (either through conditions or explicitly by {@link #disable()}), this is set to
+         * {@link #DEFINITION_DISABLED_SENTINEL}.
+         */
+        @Nullable
+        @SuppressWarnings("java:S3077")
+        private volatile Object definition;
+
+        BeanDefinitionProducer(@NonNull BeanDefinitionReference<?> reference) {
+            this.reference = reference;
+        }
+
+        private static boolean isReferenceEnabled(BeanDefinitionReference<?> ref, BeanContext context, BeanResolutionContext resolutionContext) {
+            if (ref == null) {
+                return false;
+            }
+            if (ref instanceof io.micronaut.context.AbstractInitializableBeanDefinitionAndReference<?> referenceAndDefinition) {
+                return referenceAndDefinition.isEnabled(context, resolutionContext, true);
+            }
+            return ref.isEnabled(context);
+        }
+
+        static boolean isDefinitionEnabled(@NonNull BeanContext context,
+                                           @Nullable BeanResolutionContext resolutionContext,
+                                           @Nullable BeanDefinition<?> def) {
+            if (def == null) {
+                return false;
+            }
+            if (def instanceof io.micronaut.context.AbstractInitializableBeanDefinitionAndReference<?> definitionAndReference) {
+                return definitionAndReference.isEnabled(context, resolutionContext, false);
+            }
+            return def.isEnabled(context, resolutionContext);
+        }
+
+        @Nullable
+        <T> BeanDefinitionReference<T> getReferenceIfEnabled(BeanContext context) {
+            return getReferenceIfEnabled(context, null);
+        }
+
+        @Nullable
+        <T> BeanDefinitionReference<T> getReferenceIfEnabled(BeanContext context, @Nullable BeanResolutionContext resolutionContext) {
+            BeanDefinitionReference ref = reference;
+            if (ref == null) {
+                return null;
+            }
+            if (isReferenceEnabled(ref, context, resolutionContext)) {
+                return ref;
+            } else {
+                this.reference = null;
+                return null;
+            }
+        }
+
+        @Nullable
+        <T> BeanDefinition<T> getDefinitionIfEnabled(BeanContext context,
+                                                     @Nullable BeanResolutionContext resolutionContext,
+                                                     @Nullable Argument<T> beanType,
+                                                     @Nullable Predicate<BeanDefinitionReference<T>> refPredicate,
+                                                     @Nullable Predicate<BeanDefinition<T>> defPredicate) {
+            Object defObject = this.definition;
+            if (defObject != DEFINITION_DISABLED_SENTINEL && defObject != null) {
+                if (refPredicate != null) {
+                    BeanDefinitionReference<T> ref = (BeanDefinitionReference<T>) reference;
+                    if (ref == null || !refPredicate.test(ref)) {
+                        return null;
+                    }
+                }
+                BeanDefinition<T> def = (BeanDefinition<T>) defObject;
+                if (beanType != null && !(beanType.getType().equals(Object.class) || def.isCandidateBean(beanType))) {
+                    return null;
+                }
+                if (defPredicate != null && !defPredicate.test(def)) {
+                    return null;
+                }
+                return def;
+            }
+            BeanDefinitionReference<T> ref = getReferenceIfEnabled(context, resolutionContext);
+            if (ref == null) {
+                // shortcut for future calls
+                this.definition = DEFINITION_DISABLED_SENTINEL;
+                return null;
+            }
+            if (beanType != null && !(beanType.getType().equals(Object.class) || ref.isCandidateBean(beanType))) {
+                return null;
+            }
+            if (refPredicate != null && !refPredicate.test(ref)) {
+                return null;
+            }
+            BeanDefinition<T> def = ref.load(context);
+            if (def == null) {
+                return null;
+            }
+            if (defPredicate != null && !defPredicate.test(def)) {
+                return null;
+            }
+            if (isDefinitionEnabled(context, resolutionContext, def)) {
+                if (DEFINITION_UPDATER.compareAndSet(this, null, def)) {
+                    return def;
+                } else {
+                    defObject = this.definition;
+                    return defObject != DEFINITION_DISABLED_SENTINEL && defObject != null ? (BeanDefinition<T>) defObject : null;
+                }
+            } else {
+                this.definition = DEFINITION_DISABLED_SENTINEL;
+                return null;
+            }
+        }
+
+        void disableIfMatch(BeanDefinitionReference<?> toDisable) {
+            if (Objects.equals(toDisable, this.reference)) {
+                disable();
+            }
+        }
+
+        void disable() {
+            this.reference = null;
+            this.definition = DEFINITION_DISABLED_SENTINEL;
+        }
+
+        @Override
+        public String toString() {
+            Object def = definition;
+            if (def != null) {
+                return def.toString();
+            }
+            BeanDefinitionReference ref = reference;
+            if (ref == null) {
+                return "BeanDefinitionProducer{disabled}";
+            }
+            return ref.toString();
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
@@ -62,13 +62,13 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * The default implementation of {@link BeanDefinitionProvider}.
+ * The default implementation of {@link BeanDefinitionService}.
  *
  * @author Denis Stepanov
  * @since 5.0
  */
 @Internal
-public final class DefaultBeanDefinitionProvider implements BeanDefinitionProvider {
+public final class DefaultBeanDefinitionService implements BeanDefinitionService {
 
     private static final List<Class<?>> KNOWN_INDEX_TYPES = List.of(
         ResourceLoader.class,
@@ -114,7 +114,7 @@ public final class DefaultBeanDefinitionProvider implements BeanDefinitionProvid
      *
      * @param contextConfiguration The context configuration
      */
-    public DefaultBeanDefinitionProvider(@NonNull BeanContextConfiguration contextConfiguration) {
+    public DefaultBeanDefinitionService(@NonNull BeanContextConfiguration contextConfiguration) {
         Set<Class<? extends Annotation>> eagerInitAnnotated = contextConfiguration.getEagerInitAnnotated();
         List<String> configuredEagerSingletonAnnotations = new ArrayList<>(eagerInitAnnotated.size());
         for (Class<? extends Annotation> ann : eagerInitAnnotated) {

--- a/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
@@ -35,6 +35,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
@@ -47,7 +48,6 @@ import jakarta.inject.Singleton;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -529,29 +529,10 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
         Set<Class<?>> exposedTypes = reference.getExposedTypes();
         if (exposedTypes.isEmpty()) {
             // The reference must be compiled prior to v5, use reflection to find exposed types till it's recompiled
-            exposedTypes = findExposedClassesUsingReflection(reference.getBeanType());
+            exposedTypes = ReflectionUtils.getAllClassesInHierarchy(reference.getBeanType());
         }
         for (Class<?> indexedType : exposedTypes) {
             indexByType.computeIfAbsent(indexedType, COMPUTE_INDEXES_FN).add(beanDefinitionProducer);
-        }
-    }
-
-    private static Set<Class<?>> findExposedClassesUsingReflection(Class<?> aClass) {
-        Set<Class<?>> set = new HashSet<>();
-        collectExposedClassesUsingReflection(set, aClass);
-        return set;
-    }
-
-    private static void collectExposedClassesUsingReflection(Set<Class<?>> classes, Class<?> aClass) {
-        if (!classes.add(aClass)) {
-            return;
-        }
-        Class<?> superclass = aClass.getSuperclass();
-        if (superclass != null && superclass != Object.class && superclass != Record.class && superclass != Enum.class) {
-            collectExposedClassesUsingReflection(classes, superclass);
-        }
-        for (Class<?> interfaceClass : aClass.getInterfaces()) {
-            collectExposedClassesUsingReflection(classes, interfaceClass);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -314,16 +314,16 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
     @NonNull
     @Override
     public Collection<String> getPropertyEntries(@NonNull String name) {
-        return getPropertyEntries(name, io.micronaut.core.value.PropertyCatalog.NORMALIZED);
+        return getPropertyEntries(name, PropertyCatalog.NORMALIZED);
     }
 
     @NonNull
     @Override
-    public Collection<String> getPropertyEntries(@NonNull String name, @NonNull io.micronaut.core.value.PropertyCatalog propertyCatalog) {
+    public Collection<String> getPropertyEntries(@NonNull String name, @NonNull PropertyCatalog propertyCatalog) {
         if (StringUtils.isEmpty(name)) {
             return Collections.emptySet();
         }
-        Map<String, DefaultPropertyEntry> entries = resolveEntriesForKey(name, false, PropertyCatalog.valueOf(propertyCatalog.name()));
+        Map<String, DefaultPropertyEntry> entries = resolveEntriesForKey(name, false, propertyCatalog);
         if (entries == null) {
             return Collections.emptySet();
         }
@@ -880,21 +880,20 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
         if (name.isEmpty()) {
             return null;
         }
-        final Map<String, DefaultPropertyEntry>[] catalog = getCatalog(propertyCatalog);
-
-        Map<String, DefaultPropertyEntry> entries = null;
         char firstChar = name.charAt(0);
         if (Character.isLetter(firstChar)) {
+            final Map<String, DefaultPropertyEntry>[] catalog = getCatalog(propertyCatalog);
             int index = firstChar - 65;
             if (index < catalog.length && index >= 0) {
-                entries = catalog[index];
+                Map<String, DefaultPropertyEntry> entries = catalog[index];
                 if (allowCreate && entries == null) {
                     entries = new LinkedHashMap<>(5);
                     catalog[index] = entries;
                 }
+                return entries;
             }
         }
-        return entries;
+        return null;
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -74,6 +75,26 @@ public final class ApplicationEventPublisherFactory<T>
             // ignore, might happen if jakarta.inject is not the classpath
         }
         annotationMetadata = metadata;
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+
+    @Override
+    public boolean isParallel() {
+        return false;
+    }
+
+    @Override
+    public @NonNull Class<?>[] getIndexes() {
+        return new Class<?>[]{getBeanType()};
+    }
+
+    @Override
+    public Set<Class<?>> getExposedTypes() {
+        return Set.of(getBeanType());
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/BeanConfiguration.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanConfiguration.java
@@ -18,7 +18,7 @@ package io.micronaut.inject;
 import io.micronaut.context.BeanContext;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.NonNull;
-import java.util.Objects;
+
 import java.util.function.Predicate;
 
 /**
@@ -52,7 +52,7 @@ public interface BeanConfiguration extends AnnotationMetadataProvider, BeanConte
      * @param beanDefinitionReference The bean definition class
      * @return True if it is
      */
-    default boolean isWithin(BeanDefinitionReference beanDefinitionReference) {
+    default boolean isWithin(BeanDefinitionReference<?> beanDefinitionReference) {
         return isWithin(beanDefinitionReference.getBeanType());
     }
 

--- a/inject/src/main/java/io/micronaut/inject/BeanType.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanType.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.inject;
 
-import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Primary;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationUtil;

--- a/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
@@ -42,6 +42,7 @@ import io.micronaut.inject.qualifiers.Qualifiers;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Abstract bean definition for other providers to extend from.
@@ -73,6 +74,11 @@ public abstract class AbstractProviderDefinition<T> implements InstantiatableBea
     }
 
     @Override
+    public int getOrder() {
+        return 0;
+    }
+
+    @Override
     @NonNull
     public Class<?>[] getIndexes() {
         try {
@@ -81,6 +87,16 @@ public abstract class AbstractProviderDefinition<T> implements InstantiatableBea
             // ignore, might happen if jakarta.inject is not the classpath
         }
         return new Class<?>[]{};
+    }
+
+    @Override
+    public Set<Class<?>> getExposedTypes() {
+        return Set.of(getBeanType());
+    }
+
+    @Override
+    public boolean isParallel() {
+        return false;
     }
 
     @Override

--- a/management/src/main/java/io/micronaut/management/endpoint/beans/impl/DefaultBeanDefinitionDataCollector.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/beans/impl/DefaultBeanDefinitionDataCollector.java
@@ -63,7 +63,7 @@ public class DefaultBeanDefinitionDataCollector implements BeanDefinitionDataCol
         List<BeanDefinition<?>> beanDefinitions = beanContext.getAllBeanDefinitions()
             .stream()
             .sorted(Comparator.comparing((BeanDefinition<?> bd) -> bd.getClass().getName()))
-            .toList();
+            .collect(Collectors.toUnmodifiableList());
 
         beanData.put("beans", getBeans(beanDefinitions));
         beanData.put("disabled", getDisabledBeans());

--- a/management/src/test/groovy/io/micronaut/management/endpoint/health/HealthEndpointSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/health/HealthEndpointSpec.groovy
@@ -49,7 +49,7 @@ class HealthEndpointSpec extends Specification {
     void "test the beans are available"() {
         given:
         ApplicationContext context = ApplicationContext.builder("test").build()
-        context.registerSingleton(Mock(DataSource))
+        context.registerSingleton(DataSource.class, Mock(DataSource))
         context.start()
 
         expect:

--- a/messaging/src/main/java/io/micronaut/messaging/MessagingApplication.java
+++ b/messaging/src/main/java/io/micronaut/messaging/MessagingApplication.java
@@ -104,7 +104,7 @@ public class MessagingApplication implements EmbeddedApplication<MessagingApplic
 
     @Override
     public @NonNull String getDescription() {
-        Collection<BeanDefinition<?>> beanDefinitions = applicationContext.getBeanDefinitions(Qualifiers.byStereotype(MessageListener.class));
+        Collection<BeanDefinition<Object>> beanDefinitions = applicationContext.getBeanDefinitions(Qualifiers.byStereotype(MessageListener.class));
         return beanDefinitions.size() + " active message listeners.";
     }
 }

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -37,6 +37,13 @@ ApplicationContext customApplicationContext = ApplicationContext.create(myEnv);
 
 ----
 
+==== Bean context performance improvements
+
+The bean context in v5 tries to avoid scanning all available beans as much as possible.
+The bean definitions are now generated with all posible exposed types (if not explicitly defined by `@Bean(typed=..)`).
+Beans added at the runtime require all the exposed types (supertypes and interfaces) explicitly defined.
+
+TODO: Example with the new API
 
 == 4.0.0
 

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -41,9 +41,26 @@ ApplicationContext customApplicationContext = ApplicationContext.create(myEnv);
 
 The bean context in v5 tries to avoid scanning all available beans as much as possible.
 The bean definitions are now generated with all posible exposed types (if not explicitly defined by `@Bean(typed=..)`).
-Beans added at the runtime require all the exposed types (supertypes and interfaces) explicitly defined.
 
-TODO: Example with the new API
+Beans added at the runtime require all the exposed types (supertypes and interfaces) explicitly defined:
+
+[source,java]
+----
+class FooBar extends Abc implements Resolver<String> {
+}
+
+// In v4 this registration will resolve beans by class FooBar, Abc and Resolver
+beanContext.registerSingleton(new FooBar());
+
+// In v5 it is necessary to register it in the following way:
+context.registerBeanDefinition(
+    RuntimeBeanDefinition.builder(new FooBar())
+        .singleton(true)
+        .exposedTypes(FooBar.class, Abc.class, Resolver.class)
+        .typeArguments(Resolver, Argument.of(String))
+        .build()
+)
+----
 
 == 4.0.0
 

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -59,7 +59,7 @@ context.registerBeanDefinition(
         .exposedTypes(FooBar.class, Abc.class, Resolver.class)
         .typeArguments(Resolver, Argument.of(String))
         .build()
-)
+);
 ----
 
 == 4.0.0

--- a/test-inject-kotlin2-ksp2/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
+++ b/test-inject-kotlin2-ksp2/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
@@ -3,12 +3,14 @@ package io.micronaut.kotlin.processing.aop.introduction
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.context.event.StartupEvent
+import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import static io.micronaut.annotation.processing.test.KotlinCompiler.*
 
 class MappedIntroductionOnConcreteClassSpec extends Specification {
 
+    @PendingFeature(reason = "This test should fail because ListenerAdviceMarker convert the class to be an Application listener which should fail on startup because if the missing interceptor")
     void "test mapped introduction of new interface on concrete class"() {
         given:
             ApplicationContext applicationContext = buildContext('''

--- a/test-inject-kotlin2-ksp2/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
+++ b/test-inject-kotlin2-ksp2/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MappedIntroductionOnConcreteClassSpec.groovy
@@ -1,16 +1,16 @@
 package io.micronaut.kotlin.processing.aop.introduction
 
+import io.micronaut.aop.Interceptor
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.RuntimeBeanDefinition
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.context.event.StartupEvent
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import static io.micronaut.annotation.processing.test.KotlinCompiler.*
 
 class MappedIntroductionOnConcreteClassSpec extends Specification {
 
-    @PendingFeature(reason = "This test should fail because ListenerAdviceMarker convert the class to be an Application listener which should fail on startup because if the missing interceptor")
     void "test mapped introduction of new interface on concrete class"() {
         given:
             ApplicationContext applicationContext = buildContext('''
@@ -22,7 +22,11 @@ import jakarta.inject.Singleton
 @Singleton
 open class MyBeanWithMappedIntroduction
 ''')
-        applicationContext.registerSingleton(new ListenerAdviceInterceptor())
+        applicationContext.registerBeanDefinition(
+                RuntimeBeanDefinition.builder(new ListenerAdviceInterceptor())
+                .exposedTypes(ListenerAdviceInterceptor.class, Interceptor.class)
+                .build()
+        )
 
         when:
         def beanClass = applicationContext.classLoader.loadClass('test.MyBeanWithMappedIntroduction')


### PR DESCRIPTION
Now we always generate exposed types - all the subclasses and interfaces that a bean can be accessed by. Indexes are not needed at this moment, maybe we can deprecate them.

For the backwards compatibility - for bean definitions compiled with v4 - reflection is used to access all posible types.

There are some tests that only worked becase application listeners were not initialized.

Breaking change is that we require all the possible exposed types for runtime registered beans / definitions, I will review the current API to make it more clear. I didn't want to include those changes in this PR.

PR extracts most of the code that was dealing with bean definitions / references and moves it to a new helper class.
It also includes small optimalizations and a bit of refactoring of the service loading.