### PR TITLE
feat(http-server-netty): make server request decompression configurable

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -755,6 +755,7 @@ final class HttpPipelineBuilder {
             PipeliningServerHandler pipeliningServerHandler = new PipeliningServerHandler(requestHandler);
             pipeliningServerHandler.setCompressionStrategy(embeddedServices.getHttpCompressionStrategy());
             pipeliningServerHandler.setBodySizeLimits(bodySizeLimits());
+            pipeliningServerHandler.setRequestDecompressionEnabled(server.getServerConfiguration().isRequestDecompressionEnabled());
             pipeline.addLast(ChannelPipelineCustomizer.HANDLER_MICRONAUT_INBOUND, pipeliningServerHandler);
             return pipeliningServerHandler;
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -221,6 +221,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     private boolean legacyMultiplexHandlers = false;
     private int formMaxFields = DEFAULT_FORM_MAX_FIELDS;
     private int formMaxBufferedBytes = DEFAULT_FORM_MAX_BUFFERED_BYTES;
+    private boolean requestDecompressionEnabled = true;
 
     /**
      * Default empty constructor.
@@ -772,6 +773,29 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public void setJsonBufferMaxComponents(int jsonBufferMaxComponents) {
         this.jsonBufferMaxComponents = jsonBufferMaxComponents;
+    }
+
+    /**
+     * Whether request content decompression is enabled in the Netty HTTP server.
+     * When disabled, the server will not decode Content-Encoding or Transfer-Encoding on requests
+     * and will pass the compressed body and headers through unchanged.
+     * Default: true.
+     *
+     * @return true if automatic request content decompression is enabled
+     */
+    public boolean isRequestDecompressionEnabled() {
+        return requestDecompressionEnabled;
+    }
+
+    /**
+     * Enable or disable automatic request content decompression in the Netty HTTP server.
+     * Disabling this can be useful for proxy or testing scenarios where the compressed payload
+     * and Content-Encoding header need to be observed.
+     *
+     * @param requestDecompressionEnabled true to enable decompression, false to disable it
+     */
+    public void setRequestDecompressionEnabled(boolean requestDecompressionEnabled) {
+        this.requestDecompressionEnabled = requestDecompressionEnabled;
     }
 
     /**

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/RequestDecompressionConfigSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/RequestDecompressionConfigSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.ByteBufUtil
+import io.netty.buffer.Unpooled
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.compression.SnappyFrameEncoder
+import io.netty.handler.codec.compression.ZlibCodecFactory
+import io.netty.handler.codec.compression.ZlibWrapper
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpHeaderValues
+import spock.lang.Specification
+
+import java.util.concurrent.ThreadLocalRandom
+
+class RequestDecompressionConfigSpec extends Specification {
+
+    def 'server request decompression can be disabled'(CharSequence contentEncoding, Object compressor) {
+        given: 'an embedded server with request decompression disabled'
+        Map<String, Object> cfg = [
+            'spec.name'                                           : 'RequestDecompressionConfigSpec',
+            'micronaut.server.netty.request-decompression-enabled': false
+        ]
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, cfg)
+        def client = server.applicationContext.createBean(HttpClient, server.URI).toBlocking()
+
+        and: 'some random payload and a compressed variant we send to the server'
+        byte[] uncompressed = new byte[1024]
+        ThreadLocalRandom.current().nextBytes(uncompressed)
+
+        def compChannel = (compressor instanceof ZlibWrapper)
+            ? new EmbeddedChannel(ZlibCodecFactory.newZlibEncoder((ZlibWrapper) compressor))
+            : new EmbeddedChannel((io.netty.channel.ChannelHandler) compressor)
+        compChannel.writeOutbound(Unpooled.copiedBuffer(uncompressed))
+        compChannel.finish()
+        ByteBuf compressedBuf = Unpooled.buffer()
+        while (true) {
+            ByteBuf o = compChannel.readOutbound()
+            if (o == null) {
+                break
+            }
+            compressedBuf.writeBytes(o)
+            o.release()
+        }
+        byte[] compressed = ByteBufUtil.getBytes(compressedBuf)
+
+        when: 'we POST compressed data with Content-Encoding'
+        client.exchange(
+            HttpRequest.POST("/rdc/decompress", compressed)
+                      .header(HttpHeaderNames.CONTENT_ENCODING, contentEncoding),
+            byte[]
+        )
+
+        then: 'controller receives the compressed bytes unchanged (no server-side decompression)'
+        server.applicationContext.getBean(Ctrl).data == compressed
+
+        cleanup:
+        client.close()
+        server.stop()
+
+        where:
+        contentEncoding            | compressor
+        HttpHeaderValues.GZIP      | ZlibWrapper.GZIP
+        HttpHeaderValues.X_GZIP    | ZlibWrapper.GZIP
+        // deflate can mean raw (NONE) or zlib wrapper; ensure both do not get decompressed by server
+        HttpHeaderValues.DEFLATE   | ZlibWrapper.NONE
+        HttpHeaderValues.X_DEFLATE | ZlibWrapper.NONE
+        HttpHeaderValues.DEFLATE   | ZlibWrapper.ZLIB
+        HttpHeaderValues.X_DEFLATE | ZlibWrapper.ZLIB
+        HttpHeaderValues.SNAPPY    | new SnappyFrameEncoder()
+    }
+
+    @Requires(property = "spec.name", value = "RequestDecompressionConfigSpec")
+    @Controller("/rdc")
+    static class Ctrl {
+        byte[] data
+
+        @Post("/decompress")
+        void receive(@Body byte[] data) {
+            this.data = data
+        }
+    }
+}


### PR DESCRIPTION
Add netty request-decompression-enabled option (default true) to allow disabling automatic decoding of Content-Encoding/Transfer-Encoding on incoming requests.

- NettyHttpServerConfiguration: requestDecompressionEnabled property + getters/setter
- HttpPipelineBuilder: propagate config to PipeliningServerHandler
- PipeliningServerHandler: gate decompression based on config
- Tests: RequestDecompressionConfigSpec verifies disabling preserves compressed body

Relates-to: #12018