### PR TITLE
Properly adapt streaming body in RawHttpClient

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -104,7 +104,6 @@ import io.micronaut.http.netty.body.NettyByteBodyFactory;
 import io.micronaut.http.netty.body.NettyByteBufMessageBodyHandler;
 import io.micronaut.http.netty.body.NettyJsonHandler;
 import io.micronaut.http.netty.body.NettyJsonStreamHandler;
-import io.micronaut.http.netty.body.StreamingNettyByteBody;
 import io.micronaut.http.netty.channel.ChannelPipelineCustomizer;
 import io.micronaut.http.netty.stream.DefaultStreamedHttpResponse;
 import io.micronaut.http.netty.stream.JsonSubscriber;
@@ -1714,7 +1713,7 @@ public class DefaultHttpClient implements
             byteBuf = NettyByteBodyFactory.toByteBuf(available);
             streamWriter = null;
         } else {
-            streamWriter = new StreamWriter((StreamingNettyByteBody) byteBody, e -> {
+            streamWriter = new StreamWriter(new NettyByteBodyFactory(poolHandle.channel()).toStreaming(byteBody), e -> {
                 poolHandle.taint();
                 completeExceptionallySafe(sink, e);
             });


### PR DESCRIPTION
With the migration to ReadBuffer, this code lost a NettyByteBody adapt call. That means casting to StreamingNettyByteBody is not safe anymore, and we need a proper adapt call to handle other implementations (InputStreamByteBody).