### PR TITLE
Isolate tests + fix looking for all beans

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/any/AnyProviderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/any/AnyProviderSpec.groovy
@@ -11,7 +11,7 @@ import spock.lang.Specification
 import java.util.stream.Collectors
 
 class AnyProviderSpec extends Specification {
-    @Shared @AutoCleanup ApplicationContext beanContext = ApplicationContext.run()
+    @Shared @AutoCleanup ApplicationContext beanContext = ApplicationContext.run(['spec.name':'AnyProviderSpec'])
 
     void 'test any injection'() {
         when:

--- a/inject-java/src/test/groovy/io/micronaut/inject/any/PetOwner.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/any/PetOwner.java
@@ -6,7 +6,9 @@ import io.micronaut.context.annotation.Any;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "AnyProviderSpec")
 @Singleton
 public class PetOwner {
     @Inject @Any Dog<?> dog;

--- a/inject-java/src/test/groovy/io/micronaut/inject/any/Poodle.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/any/Poodle.java
@@ -2,7 +2,9 @@ package io.micronaut.inject.any;
 
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "AnyProviderSpec")
 @Singleton
 @Named("poodle")
 public class Poodle implements Dog<Poodle> {

--- a/inject-java/src/test/groovy/io/micronaut/inject/any/Terrier.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/any/Terrier.java
@@ -2,7 +2,9 @@ package io.micronaut.inject.any;
 
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "AnyProviderSpec")
 @Singleton
 @Named("terrier")
 public class Terrier implements Dog<Terrier> {

--- a/inject-java/src/test/groovy/io/micronaut/inject/any/qualifier/AnyQualifierSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/any/qualifier/AnyQualifierSpec.groovy
@@ -7,7 +7,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class AnyQualifierSpec extends Specification {
-    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run(['spec.name':'AnyQualifierSpec'])
 
     void 'test singleton any injection'() {
         when:

--- a/inject-java/src/test/groovy/io/micronaut/inject/any/qualifier/MyAnyFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/any/qualifier/MyAnyFactory.java
@@ -5,10 +5,12 @@ import io.micronaut.context.annotation.Any;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.naming.Named;
 import jakarta.inject.Singleton;
 
 @Factory
+@Requires(property = "spec.name", value = "AnyQualifierSpec")
 public class MyAnyFactory {
 
     @Any

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/InjectionPointSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/InjectionPointSpec.groovy
@@ -9,7 +9,7 @@ import spock.lang.Specification
 class InjectionPointSpec extends Specification {
 
     @Shared @AutoCleanup ApplicationContext applicationContext =
-            ApplicationContext.run()
+            ApplicationContext.run(['spec.name':'InjectionPointSpec'])
 
     def "void test that the injection point can be used to construct the object"() {
         given:

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeBeanConsumer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeBeanConsumer.java
@@ -17,7 +17,9 @@ package io.micronaut.inject.injectionpoint;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @Singleton
 public class SomeBeanConsumer {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeClient.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeClient.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.inject.injectionpoint;
 
+import io.micronaut.context.annotation.Requires;
+
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @SomeAdvice
 public interface SomeClient {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeClientConsumer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeClientConsumer.java
@@ -17,7 +17,9 @@ package io.micronaut.inject.injectionpoint;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @Singleton
 public class SomeClientConsumer {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeFactory.java
@@ -18,8 +18,10 @@ package io.micronaut.inject.injectionpoint;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.inject.InjectionPoint;
+import io.micronaut.context.annotation.Requires;
 
 @Factory
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 public class SomeFactory {
 
     @Prototype

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeInterceptor.java
@@ -18,9 +18,11 @@ package io.micronaut.inject.injectionpoint;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.InjectionPoint;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @Prototype
 public class SomeInterceptor implements MethodInterceptor<Object, Object> {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeType.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeType.java
@@ -16,8 +16,10 @@
 package io.micronaut.inject.injectionpoint;
 
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.inject.InjectionPoint;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @Prototype
 public class SomeType {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/cacheablelazytarget/CustomScopeScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/cacheablelazytarget/CustomScopeScope.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.injectionpoint.cacheablelazytarget;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.scope.BeanCreationContext;
 import io.micronaut.context.scope.CustomScope;
 import io.micronaut.inject.BeanIdentifier;
@@ -22,6 +23,7 @@ import jakarta.inject.Singleton;
 
 import java.util.Optional;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @Singleton
 public class CustomScopeScope implements CustomScope<io.micronaut.inject.injectionpoint.cacheablelazytarget.CustomScope> {
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/cacheablelazytarget/ProxiedSomeBeanConsumer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/cacheablelazytarget/ProxiedSomeBeanConsumer.java
@@ -15,9 +15,11 @@
  */
 package io.micronaut.inject.injectionpoint.cacheablelazytarget;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.inject.injectionpoint.SomeAnn;
 import jakarta.inject.Inject;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @CustomScope
 public class ProxiedSomeBeanConsumer {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/cacheablelazytarget/ProxiedSomeFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/cacheablelazytarget/ProxiedSomeFactory.java
@@ -17,9 +17,11 @@ package io.micronaut.inject.injectionpoint.cacheablelazytarget;
 
 import io.micronaut.context.annotation.Any;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.inject.InjectionPoint;
 import io.micronaut.inject.injectionpoint.SomeAnn;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @Factory
 public class ProxiedSomeFactory {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/lazytarget/CustomScopeScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/lazytarget/CustomScopeScope.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.injectionpoint.lazytarget;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.scope.BeanCreationContext;
 import io.micronaut.context.scope.CustomScope;
 import io.micronaut.inject.BeanIdentifier;
@@ -22,6 +23,7 @@ import jakarta.inject.Singleton;
 
 import java.util.Optional;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @Singleton
 public class CustomScopeScope implements CustomScope<io.micronaut.inject.injectionpoint.lazytarget.CustomScope> {
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/lazytarget/ProxiedSomeBeanConsumer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/lazytarget/ProxiedSomeBeanConsumer.java
@@ -15,9 +15,11 @@
  */
 package io.micronaut.inject.injectionpoint.lazytarget;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.inject.injectionpoint.SomeAnn;
 import jakarta.inject.Inject;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @CustomScope
 public class ProxiedSomeBeanConsumer {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/lazytarget/ProxiedSomeFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/lazytarget/ProxiedSomeFactory.java
@@ -17,9 +17,11 @@ package io.micronaut.inject.injectionpoint.lazytarget;
 
 import io.micronaut.context.annotation.Any;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.inject.InjectionPoint;
 import io.micronaut.inject.injectionpoint.SomeAnn;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @Factory
 public class ProxiedSomeFactory {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/notlazytarget/CustomScopeScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/notlazytarget/CustomScopeScope.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.injectionpoint.notlazytarget;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.scope.BeanCreationContext;
 import io.micronaut.context.scope.CustomScope;
 import io.micronaut.inject.BeanIdentifier;
@@ -22,6 +23,7 @@ import jakarta.inject.Singleton;
 
 import java.util.Optional;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @Singleton
 public class CustomScopeScope implements CustomScope<io.micronaut.inject.injectionpoint.notlazytarget.CustomScope> {
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/notlazytarget/ProxiedSomeBeanConsumer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/notlazytarget/ProxiedSomeBeanConsumer.java
@@ -15,9 +15,11 @@
  */
 package io.micronaut.inject.injectionpoint.notlazytarget;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.inject.injectionpoint.SomeAnn;
 import jakarta.inject.Inject;
 
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 @CustomScope
 public class ProxiedSomeBeanConsumer {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/notlazytarget/ProxiedSomeFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/notlazytarget/ProxiedSomeFactory.java
@@ -19,8 +19,10 @@ import io.micronaut.context.annotation.Any;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.inject.InjectionPoint;
 import io.micronaut.inject.injectionpoint.SomeAnn;
+import io.micronaut.context.annotation.Requires;
 
 @Factory
+@Requires(property = "spec.name", value = "InjectionPointSpec")
 public class ProxiedSomeFactory {
 
     @Any

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/A1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/A1.java
@@ -16,6 +16,8 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 public class A1 implements A {}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/A2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/A2.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Replaces(A1.class)
 @Singleton
 public class A2 implements A {}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AnotherIntroductionReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AnotherIntroductionReplacement.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Replaces(IntroductionB.class)
 public class AnotherIntroductionReplacement  implements IntroductionB {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AroundA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AroundA.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.aop.simple.Mutating;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Mutating("name")
 @Singleton
 public class AroundA implements AroundOps {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AroundReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AroundReplacement.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Replaces(AroundA.class)
 public class AroundReplacement implements AroundOps {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/B.java
@@ -15,9 +15,11 @@
  */
 package io.micronaut.inject.qualifiers.replaces;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import java.util.List;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 public class B {
     @Inject
     private List<A> all;

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/CFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/CFactory.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Factory
 public class CFactory {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/CFactoryReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/CFactoryReplacement.java
@@ -17,9 +17,10 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Replaces;
-
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Factory
 @Replaces(factory = CFactory.class)
 public class CFactoryReplacement {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DFactory.java
@@ -16,9 +16,10 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Factory;
-
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Factory
 public class DFactory {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DFactoryMethodReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DFactoryMethodReplacement.java
@@ -17,9 +17,9 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Replaces;
-
 import jakarta.inject.Singleton;
 
+@Replaces(value = D.class, factory = DFactory.class)
 @Factory
 public class DFactoryMethodReplacement {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DSecondFactoryMethodReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DSecondFactoryMethodReplacement.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Factory
 @Requires(env = "factory-replacement-chain")
 public class DSecondFactoryMethodReplacement {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E1.java
@@ -17,7 +17,9 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Named("E1")
 public class E1 implements E {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E1Replacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E1Replacement.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Replaces(bean = E.class, named = "E1")
 public class E1Replacement implements E {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E2.java
@@ -17,7 +17,9 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Named("E2")
 public class E2 implements E {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E2Replacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E2Replacement.java
@@ -16,8 +16,10 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Replaces(bean = E.class, named = "E2")
 public class E2Replacement implements E {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/E3.java
@@ -17,7 +17,9 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Named("E3")
 public class E3 implements E {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/FFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/FFactory.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Factory
 public class FFactory {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/FReplacesSelf.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/FReplacesSelf.java
@@ -18,9 +18,10 @@ package io.micronaut.inject.qualifiers.replaces;
 import io.micronaut.aop.simple.Mutating;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Replaces;
-
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Factory
 public class FReplacesSelf {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G1Qualifier.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G1Qualifier.java
@@ -17,7 +17,9 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.inject.qualifiers.replaces.qualifier.One;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @One
 public class G1Qualifier implements G {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G1QualifierReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G1QualifierReplacement.java
@@ -18,7 +18,9 @@ package io.micronaut.inject.qualifiers.replaces;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.inject.qualifiers.replaces.qualifier.One;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Replaces(bean = E.class, qualifier = One.class)
 @One

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G2Qualifier.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G2Qualifier.java
@@ -17,7 +17,9 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.inject.qualifiers.replaces.qualifier.Two;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Two
 public class G2Qualifier implements G {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G2QualifierReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G2QualifierReplacement.java
@@ -18,7 +18,9 @@ package io.micronaut.inject.qualifiers.replaces;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.inject.qualifiers.replaces.qualifier.Two;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Replaces(bean = E.class, qualifier = Two.class)
 @Two

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G3Qualifier.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/G3Qualifier.java
@@ -17,7 +17,9 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.inject.qualifiers.replaces.qualifier.Three;
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Three
 public class G3Qualifier implements G {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/HFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/HFactory.java
@@ -17,9 +17,10 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Replaces;
-
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Factory
 public class HFactory {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/HImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/HImpl.java
@@ -16,7 +16,9 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.aop.simple.Mutating;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Mutating("name")
 public class HImpl implements H {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/IntroductionA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/IntroductionA.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.aop.introduction.Stub;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Stub
 @Singleton
 public interface IntroductionA extends IntroductionOperations {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/IntroductionB.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/IntroductionB.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.aop.introduction.Stub;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Stub
 @Singleton
 public interface IntroductionB {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/IntroductionReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/IntroductionReplacement.java
@@ -17,8 +17,10 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Replaces;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesSpec")
 @Singleton
 @Replaces(IntroductionA.class)
 public class IntroductionReplacement implements IntroductionOperations {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/ReplacesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/ReplacesSpec.groovy
@@ -17,16 +17,14 @@ package io.micronaut.inject.qualifiers.replaces
 
 import io.micronaut.context.ApplicationContext
 import spock.lang.Specification
-
 /**
  * Created by graemerocher on 26/05/2017.
  */
 class ReplacesSpec extends Specification {
 
-//    @Ignore
     void "test that a bean can be marked to replace another bean"() {
         given:
-        ApplicationContext context = ApplicationContext.run()
+        ApplicationContext context = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         when:"A bean has a dependency on an interface with multiple impls"
         B b = context.getBean(B)
@@ -43,7 +41,7 @@ class ReplacesSpec extends Specification {
 
     void "test that a bean that has AOP advice applied can be replaced"() {
         given:
-        ApplicationContext context = ApplicationContext.run()
+        ApplicationContext context = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         expect:
         context.getBeansOfType(H).size() == 1
@@ -55,7 +53,7 @@ class ReplacesSpec extends Specification {
 
     void "test that named beans can be replaced"() {
         given:
-        ApplicationContext context = ApplicationContext.run()
+        ApplicationContext context = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         expect:
         context.containsBean(E1Replacement)
@@ -73,7 +71,7 @@ class ReplacesSpec extends Specification {
 
     void "test that qualified beans can be replaced"() {
         given:
-        ApplicationContext context = ApplicationContext.run()
+        ApplicationContext context = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         expect:
         context.containsBean(G1QualifierReplacement)
@@ -92,7 +90,7 @@ class ReplacesSpec extends Specification {
 
     void "test that introduction advice can be replaced with inheritance"() {
         given:
-        def ctx = ApplicationContext.run()
+        def ctx = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         when:
         IntroductionOperations ops = ctx.getBean(IntroductionOperations)
@@ -108,7 +106,7 @@ class ReplacesSpec extends Specification {
 
     void "test that introduction advice can be replaced"() {
         given:
-        def ctx = ApplicationContext.run()
+        def ctx = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         when:
         IntroductionB ops = ctx.getBean(IntroductionB)
@@ -124,7 +122,7 @@ class ReplacesSpec extends Specification {
 
     void "test that classes with around advice can be replaced"() {
         given:
-        def ctx = ApplicationContext.run()
+        def ctx = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         when:
         AroundOps ops = ctx.getBean(AroundOps)
@@ -140,7 +138,7 @@ class ReplacesSpec extends Specification {
 
     void "test replacing an entire factory"() {
         given:
-        def ctx = ApplicationContext.run()
+        def ctx = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         when:
         C c = ctx.getBean(C)
@@ -154,7 +152,7 @@ class ReplacesSpec extends Specification {
 
     void "test replacing a factory method"() {
         given:
-        def ctx = ApplicationContext.run()
+        def ctx = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         when:
         D d = ctx.getBean(D)
@@ -168,7 +166,7 @@ class ReplacesSpec extends Specification {
 
     void "test replacing a bean with AOP bean of the same type"() {
         given:
-        def ctx = ApplicationContext.run()
+        def ctx = ApplicationContext.run(['spec.name':'ReplacesSpec'])
 
         when:
         F f = ctx.getBean(F)
@@ -182,7 +180,7 @@ class ReplacesSpec extends Specification {
 
     void "test replacing a chain of factory methods"() {
         given:
-        def ctx = ApplicationContext.run("factory-replacement-chain")
+        def ctx = ApplicationContext.run(['spec.name':'ReplacesSpec'], "factory-replacement-chain")
 
         when:
         D d = ctx.getBean(D)

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A1.java
@@ -16,7 +16,9 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 public class A1 implements A {
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A2.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 @Replaces(A.class)
 public class A2 implements A {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B1.java
@@ -16,7 +16,9 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 public class B1 implements B {
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B2.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 @Replaces(B.class)
 public class B2 implements B {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B3.java
@@ -16,7 +16,9 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 public class B3 implements B {
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C1.java
@@ -16,7 +16,9 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 public class C1 implements C {
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C2.java
@@ -16,7 +16,9 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 public class C2 implements C {
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C3.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 @Replaces(C2.class)
 public class C3 implements C {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E1.java
@@ -17,6 +17,9 @@ package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import jakarta.inject.Singleton;
 
+import io.micronaut.context.annotation.Requires;
+
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 public class E1 implements E {
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E2.java
@@ -18,7 +18,9 @@ package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 import io.micronaut.context.annotation.Replaces;
 
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 @Replaces(E.class)
 public class E2 implements E {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F1.java
@@ -16,7 +16,9 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.Requires;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 public class F1 implements F {
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F2.java
@@ -16,9 +16,11 @@
 package io.micronaut.inject.qualifiers.replaces.defaultimpl;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
 
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "ReplacesDefaultImplSpec")
 @Singleton
 @Replaces(F.class)
 public class F2 implements F {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/ReplacesDefaultImplSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/ReplacesDefaultImplSpec.groovy
@@ -8,7 +8,7 @@ class ReplacesDefaultImplSpec extends Specification {
 
     void "test A replacement"() {
         given:
-        ApplicationContext context = ApplicationContext.run()
+        ApplicationContext context = ApplicationContext.run(['spec.name':'ReplacesDefaultImplSpec'])
 
         when:"retrieve the interface"
         A a = context.getBean(A)
@@ -23,7 +23,7 @@ class ReplacesDefaultImplSpec extends Specification {
 
     void "test B replacement"() {
         given:
-        ApplicationContext context = ApplicationContext.run()
+        ApplicationContext context = ApplicationContext.run(['spec.name':'ReplacesDefaultImplSpec'])
 
         when:"retrieve the interface"
         List<B> bs = context.getBeansOfType(B).toList()
@@ -39,7 +39,7 @@ class ReplacesDefaultImplSpec extends Specification {
 
     void "test nested default impls"() {
         given:
-        ApplicationContext context = ApplicationContext.run()
+        ApplicationContext context = ApplicationContext.run(['spec.name':'ReplacesDefaultImplSpec'])
 
         when:
         F f = context.getBean(F)
@@ -68,7 +68,7 @@ class ReplacesDefaultImplSpec extends Specification {
 
     void "test normal replacement still works"() {
         given:
-        ApplicationContext context = ApplicationContext.run()
+        ApplicationContext context = ApplicationContext.run(['spec.name':'ReplacesDefaultImplSpec'])
 
         when:"retrieve the interface"
         List<C> cs = context.getBeansOfType(C).toList()


### PR DESCRIPTION
Used AI to add Requires to some of the tests to isolate them. That detected a problem where `@Replaces` would eliminate BeanProvider definitions and cause for `AnyProviderSpec` to pass.