### PR TITLE
Collection of enum types not converting with ConfigurationBuilder

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -1447,7 +1447,7 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
                                                         ConfigurationBuilderPropertyDefinition builderPoint) {
         boolean isDurationWithTimeUnit = builderPoint.parameter() == null && builderPoint.type().getName().equals(Duration.class.getName());
         ClassElement paramType = builderPoint.type();
-        Map<String, ClassElement> generics = builderPoint.method().getTypeArguments();
+        Map<String, ClassElement> generics = paramType.getTypeArguments();
 
         boolean zeroArgs = builderPoint.parameter() == null && !isDurationWithTimeUnit;
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesParseSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesParseSpec.groovy
@@ -297,9 +297,47 @@ class MyConfig {
         config.host.get() == 'bar'
     }
 
+    void "test configuration properties with sets of enum"() {
+        when:
+        def context = buildContext('''
+package test;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.core.annotation.Nullable;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+
+@ConfigurationProperties("more.stuff")
+class MyConfig {
+    java.util.Set<Foo> foos = Set.of();
+
+    public void setFoos(Set<Foo> foos) {
+        this.foos = foos;
+    }
+
+    public Set<Foo> getFoos() {
+        return foos;
+    }
+}
+
+enum Foo {
+    BAR,
+    BAZ
+}
+
+''')
+        def config = getBean(context, 'test.MyConfig')
+
+        then:
+        config.foos.size() == 1
+        config.foos.first() instanceof Enum
+    }
+
     @Override
     protected void configureContext(ApplicationContextBuilder contextBuilder) {
         contextBuilder.properties(
+                'more.stuff.foos': ["BAR"],
                 'foo.bar.host':'bar',
                 'jdbc.url':'test',
                 'jdbc.username':'foo',


### PR DESCRIPTION
When using `@ConfigurationBuilder` with a `Set<SomeNum>` types are not converted from strings for the elements types.