### PR TITLE
Annotations referencing generated sources result in PostponeToNextRoundException

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -149,30 +149,36 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                         return Stream.of(typeElement);
                     })
                     .forEach(typeElement -> {
-                        if (typeElement.getKind() == ENUM) {
-                            final AnnotationMetadata am = annotationMetadataBuilder.lookupOrBuildForType(typeElement);
-                            if (BeanDefinitionCreatorFactory.isDeclaredBeanInMetadata(am)) {
-                                error(typeElement, "Enum types cannot be defined as beans");
-                            }
-                            return;
-                        }
-                        // skip Groovy code, handled by InjectTransform. Required for GroovyEclipse compiler
-                        if ((groovyObjectType != null && typeUtils.isAssignable(typeElement.asType(), groovyObjectType))) {
-                            return;
-                        }
-
                         String name = typeElement.getQualifiedName().toString();
-                        if (beanDefinitions.contains(name) || processed.contains(name) || name.endsWith(BeanDefinitionVisitor.PROXY_SUFFIX)) {
-                            return;
-                        }
-                        boolean isInterface = JavaModelUtils.resolveKind(typeElement, ElementKind.INTERFACE).isPresent();
-                        if (!isInterface) {
-                            beanDefinitions.add(name);
-                        } else {
-                            AnnotationMetadata annotationMetadata = annotationMetadataBuilder.lookupOrBuildForType(typeElement);
-                            if (BeanDefinitionCreatorFactory.isIntroduction(annotationMetadata) || annotationMetadata.hasStereotype(ConfigurationReader.class)) {
-                                beanDefinitions.add(name);
+                        try {
+                            if (typeElement.getKind() == ENUM) {
+                                final AnnotationMetadata am = annotationMetadataBuilder.lookupOrBuildForType(typeElement);
+                                if (BeanDefinitionCreatorFactory.isDeclaredBeanInMetadata(am)) {
+                                    error(typeElement, "Enum types cannot be defined as beans");
+                                }
+                                return;
                             }
+                            // skip Groovy code, handled by InjectTransform. Required for GroovyEclipse compiler
+                            if ((groovyObjectType != null && typeUtils.isAssignable(typeElement.asType(), groovyObjectType))) {
+                                return;
+                            }
+
+
+                            if (beanDefinitions.contains(name) || processed.contains(name) || name.endsWith(BeanDefinitionVisitor.PROXY_SUFFIX)) {
+                                return;
+                            }
+                            boolean isInterface = JavaModelUtils.resolveKind(typeElement, ElementKind.INTERFACE).isPresent();
+                            if (!isInterface) {
+                                beanDefinitions.add(name);
+                            } else {
+                                AnnotationMetadata annotationMetadata = annotationMetadataBuilder.lookupOrBuildForType(typeElement);
+                                if (BeanDefinitionCreatorFactory.isIntroduction(annotationMetadata) || annotationMetadata.hasStereotype(ConfigurationReader.class)) {
+                                    beanDefinitions.add(name);
+                                }
+                            }
+                        } catch (PostponeToNextRoundException e) {
+                            processed.remove(name);
+                            postponed.put(name, e);
                         }
                     }));
             }
@@ -181,6 +187,12 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
             for (String name : processed) {
                 beanDefinitions.remove(name);
                 postponed.remove(name);
+            }
+
+            if (!postponed.isEmpty()) {
+                System.out.println("postponed = " + postponed);
+
+//                beanDefinitions.addAll(postponed.keySet());
             }
 
             // process remaining

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -190,9 +190,8 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
             }
 
             if (!postponed.isEmpty()) {
-                System.out.println("postponed = " + postponed);
-
-//                beanDefinitions.addAll(postponed.keySet());
+                beanDefinitions.addAll(postponed.keySet());
+                postponed.clear();
             }
 
             // process remaining

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -278,8 +278,10 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                         extraClasses.addAll(VisitorUtils.collectImportedElements(javaClassElement, javaVisitorContext));
                         javaClassElements.addAll((Collection) extraClasses);
                     } catch (PostponeToNextRoundException e) {
+                        javaClassElements.remove(javaClassElement);
                         postponeElement(javaClassElement, e.getNativeErrorElement(), e);
                     } catch (ElementPostponedToNextRoundException e) {
+                        javaClassElements.remove(javaClassElement);
                         Element element = PostponeToNextRoundException.resolvedFailedElement(e.getOriginatingElement());
                         postponeElement(javaClassElement, element, e);
                     }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ConstantGen.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ConstantGen.java
@@ -1,0 +1,4 @@
+package io.micronaut.visitors;
+
+public @interface ConstantGen {
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ConstantGenVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ConstantGenVisitor.java
@@ -1,0 +1,39 @@
+package io.micronaut.visitors;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import org.intellij.lang.annotations.Language;
+
+import java.io.IOException;
+
+
+public class ConstantGenVisitor implements TypeElementVisitor<ConstantGen, Object> {
+
+    private static final @Language("java") String SOURCE_MODEL = """
+package test;
+
+class SomeInterfaceConstants {
+    public static final String PATH = "generated";
+}
+""";
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        if (element.hasDeclaredAnnotation(ConstantGen.class)) {
+            context.visitGeneratedSourceFile("test", "SomeInterfaceConstants", element)
+                .ifPresent(generatedFile -> {
+                    try {
+                        generatedFile.write(writer -> writer.write(SOURCE_MODEL));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        }
+    }
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTest.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/IntroductionTest.java
@@ -8,4 +8,5 @@ import java.lang.annotation.RetentionPolicy;
 @Introduction
 @Retention(RetentionPolicy.RUNTIME)
 public @interface IntroductionTest {
+    String value() default "";
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PostponedVisitorsSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.core.annotation.Introspected
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ProxyBeanDefinition
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.MethodElement
 import io.micronaut.inject.ast.UnresolvedTypeKind
@@ -17,6 +18,28 @@ import org.intellij.lang.annotations.Language
 import spock.lang.PendingFeature
 
 class PostponedVisitorsSpec extends AbstractTypeElementSpec {
+
+    void 'test postpone generation of annotation metadata on introduction'() {
+        when:
+        def definition = buildBeanDefinition('test.SomeInterface' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.visitors.*;
+import test.SomeInterfaceConstants;
+
+@IntroductionTest(SomeInterfaceConstants.PATH)
+interface SomeInterface {
+
+}
+
+@ConstantGen
+interface GenConstants {}
+''')
+        then:
+        definition != null
+        definition.stringValue(IntroductionTest).get() == 'generated'
+    }
+
     void 'test postpone introspection generation implementing generated interface'() {
         when:
             def definition = buildBeanIntrospection('test.Walrus', '''

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -1,4 +1,5 @@
 io.micronaut.visitors.InterfaceGenVisitor
+io.micronaut.visitors.ConstantGenVisitor
 io.micronaut.visitors.ControllerGetVisitor
 io.micronaut.visitors.IntroductionVisitor
 io.micronaut.visitors.AllElementsVisitor


### PR DESCRIPTION
Currently if you have an annotation that references a type generated by a source generator this causes `PostponeToNextRoundException` to be thrown by the compiler. 

There is a codepath that processes introduction advice annotations that does not handle `PostponeToNextRoundException`. This PR adjusts that code path to handle this exception and postpone the introduction advice to be handled in the next round of processing.