### PR TITLE
Fix event loop thread naming

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupRegistry.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupRegistry.java
@@ -131,6 +131,9 @@ public class DefaultEventLoopGroupRegistry implements EventLoopGroupRegistry {
         } else {
             ThreadFactory threadFactory = beanLocator.findBean(ThreadFactory.class, Qualifiers.byName(configuration.getName()))
                     .orElseGet(() ->  new DefaultThreadFactory(configuration.getName() + "-" + DefaultThreadFactory.toPoolName(NioEventLoopGroup.class)));
+            if (threadFactory instanceof NettyThreadFactory.EventLoopCustomizableThreadFactory custom) {
+                threadFactory = custom.customizeForEventLoop();
+            }
             executor = new ThreadPerTaskExecutor(threadFactory);
         }
 
@@ -149,6 +152,9 @@ public class DefaultEventLoopGroupRegistry implements EventLoopGroupRegistry {
     @BootstrapContextCompatible
     @Bean(typed = { EventLoopGroup.class })
     protected EventLoopGroup defaultEventLoopGroup(@Named(NettyThreadFactory.NAME) ThreadFactory threadFactory) {
+        if (threadFactory instanceof NettyThreadFactory.EventLoopCustomizableThreadFactory custom) {
+            threadFactory = custom.customizeForEventLoop();
+        }
         return createGroup(new DefaultEventLoopGroupConfiguration(), new ThreadPerTaskExecutor(threadFactory));
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FiltersSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FiltersSpec.groovy
@@ -51,28 +51,28 @@ class FiltersSpec extends Specification {
             def response = client."$method"()
         then:
             response == "OK"
-            filter1.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
-            filter1.mapExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter1.doFilterExecutedOn.startsWith "default-eventLoopGroup"
+            filter1.mapExecutedOn.startsWith "default-eventLoopGroup"
             filter1.filterOrder == 1
 
-            filter2.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
-            filter2.mapExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter2.doFilterExecutedOn.startsWith "default-eventLoopGroup"
+            filter2.mapExecutedOn.startsWith "default-eventLoopGroup"
             filter2.filterOrder == 2
 
-            filter4.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
-            filter4.mapExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter4.doFilterExecutedOn.startsWith "default-eventLoopGroup"
+            filter4.mapExecutedOn.startsWith "default-eventLoopGroup"
             filter4.filterOrder == 3
 
-            filter5.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
-            filter5.mapExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter5.doFilterExecutedOn.startsWith "default-eventLoopGroup"
+            filter5.mapExecutedOn.startsWith "default-eventLoopGroup"
             filter5.filterOrder == 4
 
-            filter6.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
-            filter6.mapExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter6.doFilterExecutedOn.startsWith "default-eventLoopGroup"
+            filter6.mapExecutedOn.startsWith "default-eventLoopGroup"
             filter6.filterOrder == 5
 
-            filter7.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
-            filter7.mapExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter7.doFilterExecutedOn.startsWith "default-eventLoopGroup"
+            filter7.mapExecutedOn.startsWith "default-eventLoopGroup"
             filter7.filterOrder == 6
 
         cleanup:
@@ -101,31 +101,31 @@ class FiltersSpec extends Specification {
             def response = client."$method"()
         then:
             response == "OK"
-            filter1.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter1.doFilterExecutedOn.startsWith "default-eventLoopGroup"
             filter1.mapExecutedOn.startsWith "io-executor"
             filter1.filterOrder == 1
 
-            filter2.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter2.doFilterExecutedOn.startsWith "default-eventLoopGroup"
             filter2.mapExecutedOn.startsWith "io-executor"
             filter2.filterOrder == 2
 
-            filter3.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter3.doFilterExecutedOn.startsWith "default-eventLoopGroup"
             filter3.mapExecutedOn.startsWith "io-executor"
             filter3.filterOrder == 3
 
-            filter4.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter4.doFilterExecutedOn.startsWith "default-eventLoopGroup"
             filter4.mapExecutedOn.startsWith "io-executor"
             filter4.filterOrder == 4
 
-            filter5.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter5.doFilterExecutedOn.startsWith "default-eventLoopGroup"
             filter5.mapExecutedOn.startsWith "io-executor"
             filter5.filterOrder == 5
 
-            filter6.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter6.doFilterExecutedOn.startsWith "default-eventLoopGroup"
             filter6.mapExecutedOn.startsWith "io-executor"
             filter6.filterOrder == 6
 
-            filter7.doFilterExecutedOn.startsWith "default-nioEventLoopGroup"
+            filter7.doFilterExecutedOn.startsWith "default-eventLoopGroup"
             filter7.mapExecutedOn.startsWith "io-executor"
             filter7.filterOrder == 7
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/threading/ThreadSelectionSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/threading/ThreadSelectionSpec.groovy
@@ -38,7 +38,7 @@ class ThreadSelectionSpec extends Specification {
 
     static final String IO = "io-executor-thread-"
     static final String VIRTUAL = "virtual-executor"
-    static final String LOOP = "default-nioEventLoopGroup"
+    static final String LOOP = "default-eventLoopGroup"
 
     private String jdkSwitch(String java17, String other) {
         Runtime.version().feature() == 17 ? java17 : other


### PR DESCRIPTION
To get separate thread names for each event loop group, we need separate ThreadFactories, but ours is a singleton. This PR makes the event loop registry create a new ThreadFactory with a new name where possible.