### PR TITLE
[Gen AI] Fix 11758:  Ensure @Replaces beans are detected globally 

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2032,6 +2032,20 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
                     throw new BeanInstantiationException(MSG_BEAN_DEFINITION + (ref == null ? "<ref discarded>" : ref.getName()) + MSG_COULD_NOT_BE_LOADED + e.getMessage(), e);
                 }
             }
+            // Prune eager beans that are replaced by any replacement bean in the application,
+            // regardless of the replacement scope.
+            List<BeanDefinition<Object>> replacementTypes = new ArrayList<>(4);
+            for (BeanDefinitionProducer producer : beanDefinitionsClasses) {
+                BeanDefinition<Object> def = producer.getDefinitionIfEnabled(this);
+                if (def != null && def.getAnnotationMetadata().hasStereotype(REPLACES_ANN)) {
+                    replacementTypes.add(def);
+                }
+            }
+            if (!replacementTypes.isEmpty()) {
+                //noinspection unchecked,rawtypes
+                eagerInit.removeIf(def -> checkIfReplacementExists(null, (List) replacementTypes, def));
+            }
+            // Also apply local replacement filtering amongst eager beans themselves.
             filterReplacedBeans(null, eagerInit);
             OrderUtil.sortOrdered(eagerInit);
             for (BeanDefinition eagerInitDefinition : eagerInit) {

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -248,7 +248,8 @@ final class SingletonScope {
                                                  @Nullable Qualifier<T> qualifier) {
         BeanRegistration<T> beanRegistration = singletonByBeanDefinition.get(BeanDefinitionIdentity.of(beanDefinition));
         if (beanRegistration == null) {
-            return findCachedSingletonBeanRegistration(beanType, qualifier);
+            // Do not fall back to cached registration by type/qualifier; we must respect the exact definition.
+            return null;
         }
         return beanRegistration;
     }

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/context/replacement/ContextBeanReplacementScopeTest.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/context/replacement/ContextBeanReplacementScopeTest.kt
@@ -1,0 +1,61 @@
+package io.micronaut.context.replacement
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Context
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+interface ReplacedApi
+
+@Context
+@Requires(property = "spec.name", value = "ContextBeanReplacementScopeTest")
+open class OriginalContextApi : ReplacedApi {
+    companion object {
+        @JvmField
+        val created = AtomicInteger(0)
+    }
+    init {
+        created.incrementAndGet()
+    }
+}
+
+@Singleton
+@Replaces(OriginalContextApi::class)
+@Requires(property = "spec.name", value = "ContextBeanReplacementScopeTest")
+open class ReplacementSingletonApi : ReplacedApi {
+    companion object {
+        @JvmField
+        val created = AtomicInteger(0)
+    }
+    init {
+        created.incrementAndGet()
+    }
+}
+
+class ContextBeanReplacementScopeTest {
+
+    @Test
+    fun replacingContextBeanWithSingletonShouldPreventOriginalInstantiation() {
+        // Reset counters for isolation
+        OriginalContextApi.created.set(0)
+        ReplacementSingletonApi.created.set(0)
+
+        val ctx = ApplicationContext.run(mapOf("spec.name" to "ContextBeanReplacementScopeTest"))
+        try {
+            // Expected: Replacing a @Context bean with a non-@Context bean should prevent eager instantiation
+            // Actual (bug): OriginalContextApi is still eagerly created at startup
+            assertEquals(0, OriginalContextApi.created.get(), "Original @Context bean should not be instantiated when replaced by a non-context bean")
+
+            val api = ctx.getBean(ReplacedApi::class.java)
+            assertTrue(api is ReplacementSingletonApi, "Injected bean should be the replacement")
+            assertEquals(1, ReplacementSingletonApi.created.get(), "Replacement bean should be constructed once on demand")
+            assertEquals(0, OriginalContextApi.created.get(), "Original bean must not be constructed at all")
+        } finally {
+            ctx.close()
+        }
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/micronaut-projects/micronaut-core/issues/11758

#### Bug description

The bug occurs because replacement beans (`@Replaces`) are only discovered among the candidate collection being considered, not across the global registry. As a result, replacements declared elsewhere in the registry (e.g., a non-`@Context` replacement for a `@Context bean`) can be missed, and already-cached singleton instances for the replaced bean can remain in singleton caches, leading to nondeterministic behavior.

#### Solution / fix
The test defines an @Context-scoped bean (`OriginalContextApi`) and a `@Singleton` replacement (`ReplacementSingletonApi`) annotated with `@Replaces(OriginalContextApi)`. It asserts that after starting the ApplicationContext, the original `@Context` bean is not instantiated and that injecting ReplacedApi yields the replacement. On the original code, the test fails because the original `@Context` bean is eagerly created, reproducing the reported issue where replacing a `@Context` bean with a non-@Context bean still instantiates the original. This is aligned with the issue description. 2) 

Patch effectiveness: The patch makes two key changes. In `DefaultBeanContext`, it scans all bean definitions for replacements and prunes any eager (`@Context`) beans from `eagerInit` if they are replaced, regardless of the replacement's scope. This ensures the original @Context bean is not eagerly created when there is any replacement, even if the replacement is not `@Context`. In `SingletonScope`, it removes the fallback from `findBeanRegistrationByExactDefinition` to the type/qualifier-based cache, preventing returning a previously created instance of a different bean definition. This addresses the nondeterministic case where an original singleton could be returned because it matched by type/qualifier. Together, these changes fix both parts of the issue: preventing unwanted eager instantiation and ensuring correct bean selection by exact definition. 


#### Steps to reproduce
```bash
./gradlew :test-suite-kotlin-ksp:test
```