### PR TITLE
[GenAI] Fix 11799:  binding a list to endpoints.env.keys to ensure only 'activeEnvironments' remains.

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/env/EnvironmentEndpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/env/EnvironmentEndpoint.java
@@ -78,25 +78,43 @@ public class EnvironmentEndpoint {
     }
 
     /**
-     * Gets the keys to be displayed by the environment endpoint.
-     * Defaults to ["activeEnvironments", "packages", "propertySources"] if not configured.
-     * Configurable via {@code endpoints.env.active-keys}.
-     *
-     * @return The list of active sections.
-     */
-    public List<String> getActiveKeys() {
-        return activeKeys;
-    }
-
-    /**
-     * Sets the sections to be displayed by the environment endpoint.
-     * Example: {@code endpoints.env.active-keys=activeEnvironments,packages}
-     *
-     * @param activeKeys The list of sections. If an empty list is provided, no sections will be displayed.
-     */
-    public void setActiveKeys(List<String> activeKeys) {
-        this.activeKeys = activeKeys;
-    }
+      * Gets the keys to be displayed by the environment endpoint.
+      * Defaults to ["activeEnvironments", "packages", "propertySources"] if not configured.
+      * Configurable via {@code endpoints.env.active-keys} or {@code endpoints.env.keys}.
+      *
+      * @return The list of active sections.
+      */
+     public List<String> getActiveKeys() {
+         return activeKeys;
+     }
+ 
+     /**
+      * Alias accessor for configuration binding from {@code endpoints.env.keys}.
+      *
+      * @return The list of active sections.
+      */
+     public List<String> getKeys() {
+         return getActiveKeys();
+     }
+ 
+     /**
+      * Sets the sections to be displayed by the environment endpoint.
+      * Example: {@code endpoints.env.active-keys=activeEnvironments,packages}
+      *
+      * @param activeKeys The list of sections. If an empty list is provided, no sections will be displayed.
+      */
+     public void setActiveKeys(List<String> activeKeys) {
+         this.activeKeys = activeKeys;
+     }
+ 
+     /**
+      * Alias mutator for configuration binding from {@code endpoints.env.keys}.
+      *
+      * @param keys The list of sections. If an empty list is provided, no sections will be displayed.
+      */
+     public void setKeys(List<String> keys) {
+         setActiveKeys(keys);
+     }
 
     /**
      * @return The environment information as a map with the following keys: activeEnvironments, packages and

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/management/env/EnvironmentEndpointKeysFilterTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/management/env/EnvironmentEndpointKeysFilterTest.kt
@@ -1,0 +1,46 @@
+package io.micronaut.management.env
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.http.client.HttpClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EnvironmentEndpointKeysFilterTest {
+
+    @Test
+    fun `env endpoint respects endpoints_env_keys filter`() {
+        val props = mapOf(
+            // isolate config for this spec
+            "spec.name" to "EnvironmentEndpointKeysFilterTest",
+            // ensure server starts on random port
+            "micronaut.server.port" to -1,
+            // enable env endpoint and make it non-sensitive so it's accessible in test
+            "endpoints.all.enabled" to true,
+            "endpoints.all.sensitive" to false,
+            "endpoints.env.enabled" to true,
+            "endpoints.env.sensitive" to false,
+            // proposed configuration: expose only activeEnvironments
+            "endpoints.env.keys[0]" to "activeEnvironments"
+        )
+
+        val server = ApplicationContext.run(EmbeddedServer::class.java, props)
+        val client = HttpClient.create(server.url)
+        try {
+            val json = client.toBlocking().retrieve("/env")
+            val mapper = server.applicationContext.getBean(ObjectMapper::class.java)
+            val node = mapper.readTree(json)
+
+            assertTrue(node.has("activeEnvironments"), "Should contain 'activeEnvironments'")
+            assertFalse(node.has("packages"), "Should not contain 'packages' when filtered")
+            assertFalse(node.has("propertySources"), "Should not contain 'propertySources' when filtered")
+            assertEquals(1, node.size(), "Only 'activeEnvironments' should be present when filtered via endpoints.env.keys")
+        } finally {
+            client.close()
+            server.close()
+        }
+    }
+}


### PR DESCRIPTION
Issue:  https://github.com/micronaut-projects/micronaut-core/issues/11799


#### Bug description
To allow selective fields in env endpoint via endpoints.env.keys configuration

#### Solution
What the test file do is configuring the env endpoint via `endpoints.env.keys` to only include 'activeEnvironments' and exclude 'packages' and 'propertySources'. On the original code, the test failed because the implementation only honored endpoints.env.active-keys, not the new endpoints.env.keys alias. 

The patch adds `getKeys()/setKeys(List<String>)` as aliases to the existing activeKeys property, allowing Micronaut's configuration binding to map endpoints.env.keys to the same underlying list. This maintains backward compatibility with endpoints.env.active-keys and satisfies the new configuration option. 

#### Steps to reproduce

Please use this command to observe the output from  provided test case.
```
./gradlew :test-suite-kotlin-ksp:test
```