### PR TITLE
[GenAI] Fix 11755:  Providing a sensible default implementation in the base class that returns a new `ConnectionPoolConfiguration` instance

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -320,9 +320,13 @@ public abstract class HttpClientConfiguration {
     /**
      * Obtains the connection pool configuration.
      *
-     * @return The connection pool configuration.
+     * Subclasses may override to provide a specific ConnectionPoolConfiguration instance.
+     *
+     * @return The connection pool configuration. Defaults to a new ConnectionPoolConfiguration instance.
      */
-    public abstract ConnectionPoolConfiguration getConnectionPoolConfiguration();
+    public ConnectionPoolConfiguration getConnectionPoolConfiguration() {
+        return new ConnectionPoolConfiguration();
+    }
 
     /**
      * @return The {@link SslConfiguration} for the client

--- a/test-suite-kotlin-ksp/src/test/java/io/micronaut/reproduce/ReproduceIssueTest.java
+++ b/test-suite-kotlin-ksp/src/test/java/io/micronaut/reproduce/ReproduceIssueTest.java
@@ -1,0 +1,19 @@
+package io.micronaut.reproduce;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Trivial test whose only purpose is to ensure the test sources are compiled.
+ * If HttpClientConfiguration#getConnectionPoolConfiguration() is abstract,
+ * compilation will fail because TwitterHttpClientConfiguration does not
+ * implement that method (matching the user-guide example).
+ */
+public class ReproduceIssueTest {
+
+    @Test
+    void compileOnlySmoke() {
+        // Intentionally empty. Successful compilation of the test sources
+        // (which include TwitterHttpClientConfiguration) indicates the
+        // framework does not declare getConnectionPoolConfiguration() as abstract.
+    }
+}

--- a/test-suite-kotlin-ksp/src/test/java/io/micronaut/reproduce/TwitterHttpClientConfiguration.java
+++ b/test-suite-kotlin-ksp/src/test/java/io/micronaut/reproduce/TwitterHttpClientConfiguration.java
@@ -1,0 +1,25 @@
+package io.micronaut.reproduce;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import io.micronaut.http.client.HttpClientConfiguration;
+import io.micronaut.runtime.ApplicationConfiguration;
+
+/**
+ * Mirrors the user-guide example: a concrete subclass of
+ * io.micronaut.http.client.HttpClientConfiguration that does not
+ * override getConnectionPoolConfiguration().
+ *
+ * If HttpClientConfiguration#getConnectionPoolConfiguration() is declared
+ * abstract in the framework (as reported in the issue), this class will
+ * fail to compile because it does not implement that method.
+ */
+@Named("twitter")
+@Singleton
+public class TwitterHttpClientConfiguration extends HttpClientConfiguration {
+
+    public TwitterHttpClientConfiguration(ApplicationConfiguration configuration) {
+        super(configuration);
+    }
+}


### PR DESCRIPTION

Issue: https://github.com/micronaut-projects/micronaut-core/issues/11755

#### Bug description

`TwitterHttpClientConfiguration` does not compile because `getConnectionPoolConfiguration()` must be implemented. 

#### Root cause & Fix

The issue is that `HttpClientConfiguration.getConnectionPoolConfiguration()` is declared abstract, forcing subclasses (like user examples) to implement it. To fix this without changing the behavior of existing concrete classes, we can provide a sensible default implementation in the base class that returns a new `ConnectionPoolConfiguration` instance. Subclasses that already override the method (e.g. `DefaultHttpClientConfiguration`, `ServiceHttpClientConfiguration`) will continue to work unchanged. This is a minimal, backward-compatible change.

#### Steps to reproduce

Please use this command to see the test result:

```bash
./gradlew :test-suite-kotlin-ksp:test
```