### PR TITLE
[GenAI] Fix 11819: updating SimpleHttpRequest.updateCookies to remove existing cookie headers

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientHttpRequest.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientHttpRequest.java
@@ -131,7 +131,7 @@ public class NettyClientHttpRequest<B> implements MutableHttpRequest<B>, NettyHt
                 String value = ClientCookieEncoder.INSTANCE.encode(cookie);
                 this.cookies.put(cookie.getName(), value);
             }
-            headers.set(HttpHeaderNames.COOKIE, String.join(";", this.cookies.values()));
+            headers.set(HttpHeaderNames.COOKIE, String.join("; ", this.cookies.values()));
         } else if (!cookies.isEmpty()) {
             cookie(cookies.iterator().next());
         }

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
@@ -77,8 +77,20 @@ public class SimpleHttpRequest<B> implements MutableHttpRequest<B> {
 
     private void updateCookies() {
         headers.remove(HttpHeaders.COOKIE);
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
         for (Cookie cookie : cookies.getAll()) {
-            headers.add(HttpHeaders.COOKIE, ClientCookieEncoder.INSTANCE.encode(cookie));
+            String encoded = ClientCookieEncoder.INSTANCE.encode(cookie);
+            if (encoded != null && !encoded.isEmpty()) {
+                if (!first) {
+                    sb.append("; ");
+                }
+                sb.append(encoded);
+                first = false;
+            }
+        }
+        if (sb.length() > 0) {
+            headers.set(HttpHeaders.COOKIE, sb.toString());
         }
     }
 

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/repro/http/CookieHeaderSingleValueReproTest.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/repro/http/CookieHeaderSingleValueReproTest.kt
@@ -1,0 +1,68 @@
+package io.micronaut.repro.http
+
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.client.netty.NettyClientHttpRequestFactory
+import io.micronaut.http.cookie.Cookie
+import io.micronaut.http.simple.SimpleHttpRequestFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CookieHeaderSingleValueReproTest {
+
+    private val cookies = linkedSetOf(
+        Cookie.of("a", "1"),
+        Cookie.of("b", "2"),
+        Cookie.of("a", "3") // latest value for 'a' should win
+    )
+
+    // Simple request factory
+    @Test
+    fun simpleRequest_addCookies_oneByOne_resultsInSingleCookieHeader() {
+        val request: MutableHttpRequest<Any> = SimpleHttpRequestFactory().get<Any>("/")
+        assertSingleCookieHeaderAfterAddingCookiesIndividually(request)
+    }
+
+    @Test
+    fun simpleRequest_addCookies_bulk_resultsInSingleCookieHeader() {
+        val request: MutableHttpRequest<Any> = SimpleHttpRequestFactory().get<Any>("/")
+        assertSingleCookieHeaderAfterAddingCookiesBulk(request)
+    }
+
+    // Netty client request factory
+    @Test
+    fun nettyClientRequest_addCookies_oneByOne_resultsInSingleCookieHeader() {
+        val request: MutableHttpRequest<Any> = NettyClientHttpRequestFactory().get<Any>("/")
+        assertSingleCookieHeaderAfterAddingCookiesIndividually(request)
+    }
+
+    @Test
+    fun nettyClientRequest_addCookies_bulk_resultsInSingleCookieHeader() {
+        val request: MutableHttpRequest<Any> = NettyClientHttpRequestFactory().get<Any>("/")
+        assertSingleCookieHeaderAfterAddingCookiesBulk(request)
+    }
+
+    private fun assertSingleCookieHeaderAfterAddingCookiesIndividually(request: MutableHttpRequest<*>) {
+        cookies.forEach { request.cookie(it) }
+        assertSingleCookieHeaderAndValues(request)
+    }
+
+    private fun assertSingleCookieHeaderAfterAddingCookiesBulk(request: MutableHttpRequest<*>) {
+        request.cookies(cookies)
+        assertSingleCookieHeaderAndValues(request)
+    }
+
+    private fun assertSingleCookieHeaderAndValues(request: MutableHttpRequest<*>) {
+        val cookieHeaders = request.headers.getAll(HttpHeaders.COOKIE)
+        assertEquals(1, cookieHeaders.size, "Expected a single Cookie header value")
+
+        val value = cookieHeaders[0]
+        // Validate semantics (latest value wins, all expected cookies present)
+        val parts = value.split(";".toRegex()).map { it.trim() }.filter { it.isNotEmpty() }
+        assertTrue(parts.contains("a=3"), "Expected latest value for cookie 'a' to be present")
+        assertTrue(parts.contains("b=2"), "Expected cookie 'b' to be present")
+        assertFalse(parts.contains("a=1"), "Expected old value for cookie 'a' to be replaced")
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/micronaut-projects/micronaut-core/issues/11819


#### Bug description

`Calling MutableHttpRequest.cookie(s)` is expected to keep a single Cookie header updated. However, multiple Cookie headers are created depending on the request implementation. 

#### Root cause & Fix
The test reproduces the problem for `SimpleHttpRequest` by  adding cookies, it expects exactly one Cookie header value with the latest value for duplicate names and correct semantics. 
On the original code, `SimpleHttpRequest.updateCookies used headers.add(...)` per cookie, which produced multiple Cookie header entries (one per cookie), causing the test to fail. 

The patch fixes this by building a single combined Cookie header string (joined with \"; \") and setting it once via `headers.set(...)`, thus preventing multiple header entries. 



#### Steps to reproduce

Please use this command to see the output from provided test:
```bash
./gradlew :test-suite-kotlin-ksp:test
```