### PR TITLE
[GenAI] Fix 11815:   Modifications on AbstractInitializableBeanDefinition.resolveBean

### DIFF
--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -2148,7 +2148,8 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
             if (isIterable() && getAnnotationMetadata().hasDeclaredAnnotation(EachBean.class)) {
                 throw new DisabledBeanException("Bean [" + getBeanType().getSimpleName() + "] disabled by parent: " + e.getMessage());
             } else {
-                throw new DependencyInjectionException(resolutionContext, e);
+                // Propagate DisabledBeanException as-is so upstream logic can handle disabled dependencies
+                throw e;
             }
         } catch (NoSuchBeanException e) {
             throw new DependencyInjectionException(resolutionContext, e);

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/disabledbean/DisabledBeanRequiresTest.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/disabledbean/DisabledBeanRequiresTest.kt
@@ -1,0 +1,41 @@
+package io.micronaut.disabledbean
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.exceptions.DisabledBeanException
+import jakarta.inject.Singleton
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DisabledBeanRequiresTest {
+    @Test
+    fun testConditionalMakeAnotherBeanUnavailable() {
+        val ctx = ApplicationContext.run()
+        try {
+            val opt = ctx.findBean(AnotherBean::class.java)
+            // Expected: AnotherBean should not be available because MyBean is disabled via DisabledBeanException
+            assertTrue(opt.isEmpty, "AnotherBean should not be available when MyBean is disabled")
+        } finally {
+            ctx.close()
+        }
+    }
+}
+
+class MyBean
+
+class AnotherBean(val myBean: MyBean)
+
+@Factory
+class MyFactory {
+    @Singleton
+    fun myBean(): MyBean {
+        throw DisabledBeanException("MyBean Disabled")
+    }
+
+    @Singleton
+    @Requires(bean = MyBean::class)
+    fun anotherBean(myBean: MyBean): AnotherBean {
+        return AnotherBean(myBean)
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/micronaut-projects/micronaut-core/issues/11815


#### Bug description

When a bean is conditionally disabled by throwing a DisabledBeanException from a factory method, other beans that @Require the disabled bean should also be considered unavailable.

#### Root Cause & Solutions
The test reproduces the reported issue: a factory method throws DisabledBeanException to disable a bean, and another bean annotated with `@Requires(bean = MyBean.class)` should therefore not be created.

In the original code, the `DisabledBeanException` thrown during dependency resolution was wrapped in a DependencyInjectionException, causing `ctx.findBean`(AnotherBean) to throw instead of returning an empty Optional, and the test failed as shown in the logs. 

The patch modifies `AbstractInitializableBeanDefinition.resolveBean` to rethrow `DisabledBeanException` directly (except for the special EachBean case which remains a `DisabledBeanException`), instead of wrapping it in `DependencyInjectionException`. This allows the upstream context to recognize the disabled dependency and honor @Requires, resulting in `findBean` returning an empty Optional and the test passing.

#### Steps to reproduce

Please use this command to execute the provided test:

```bash
./gradlew :test-suite-kotlin-ksp:test
```
