### PR TITLE
Introduce TaskQueueInterceptor

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/TaskQueueInterceptor.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/TaskQueueInterceptor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.netty.channel;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+
+import java.util.Queue;
+
+/**
+ * An interceptor that wraps a task queue for a netty event loop.
+ *
+ * @author Jonas Konrad
+ */
+@BootstrapContextCompatible
+@Experimental
+public interface TaskQueueInterceptor {
+    /**
+     * Wrap a task queue.
+     *
+     * @param groupName The event loop group name
+     * @param original  The original queue
+     * @return The wrapped queue
+     */
+    @NonNull
+    Queue<Runnable> wrapTaskQueue(@NonNull String groupName, @NonNull Queue<Runnable> original);
+}

--- a/http-netty/src/test/java/io/micronaut/http/netty/channel/TaskQueueInterceptorTest.java
+++ b/http-netty/src/test/java/io/micronaut/http/netty/channel/TaskQueueInterceptorTest.java
@@ -1,0 +1,73 @@
+package io.micronaut.http.netty.channel;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.Promise;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskQueueInterceptorTest {
+    @Test
+    public void test() throws ExecutionException, InterruptedException {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of("spec.name", "TaskQueueInterceptorTest"))) {
+            AtomicInteger started = ctx.getBean(MyTaskQueueInterceptor.class).started;
+            EventLoopGroup group = ctx.getBean(EventLoopGroup.class);
+            EventLoop loop = group.next();
+            Promise<String> promise = loop.newPromise();
+            int before = started.get();
+            loop.execute(() -> promise.setSuccess("foo"));
+            assertEquals("foo", promise.get());
+            assertNotEquals(before, started.get());
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "TaskQueueInterceptorTest")
+    static final class MyTaskQueueInterceptor implements TaskQueueInterceptor {
+        final AtomicInteger started = new AtomicInteger(0);
+
+        @Override
+        public Queue<Runnable> wrapTaskQueue(String groupName, Queue<Runnable> original) {
+            return new AbstractQueue<>() {
+                @Override
+                public Iterator<Runnable> iterator() {
+                    return original.iterator();
+                }
+
+                @Override
+                public int size() {
+                    return original.size();
+                }
+
+                @Override
+                public boolean offer(Runnable runnable) {
+                    return original.offer(() -> {
+                        started.incrementAndGet();
+                        runnable.run();
+                    });
+                }
+
+                @Override
+                public Runnable poll() {
+                    return original.poll();
+                }
+
+                @Override
+                public Runnable peek() {
+                    return original.peek();
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
With the new Netty event loop APIs, we need a new approach for intercepting the event loop task queue.

This is required to fix #12157, so the PR is against 4.10.x