### PR TITLE
[GenAI] Fixing 11656:  Handling the issue with @PostConstruct annotated bean

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -199,7 +199,10 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
     private final Map<Argument, Collection<BeanDefinition>> beanCandidateCache = new ConcurrentLinkedHashMap.Builder<Argument, Collection<BeanDefinition>>().maximumWeightedCapacity(30).build();
 
     private final Map<Class<?>, Collection<BeanDefinitionProducer>> beanIndex = new ConcurrentHashMap<>(12);
-
+    
+    // Tracks instances that have already been initialized (e.g., via createBean) to avoid double @PostConstruct on registration
+    private final Set<Object> initializedInstances = Collections.newSetFromMap(new IdentityHashMap<>());
+    
     private final ClassLoader classLoader;
     private final Set<Class<?>> thisInterfaces = CollectionUtils.setOf(
             BeanDefinitionRegistry.class,
@@ -691,7 +694,18 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
         if (beanDefinition != null && !(beanDefinition instanceof RuntimeBeanDefinition<T>) && beanDefinition.getBeanType().isInstance(singleton)) {
             try (BeanResolutionContext context = newResolutionContext(beanDefinition, null)) {
                 if (inject) {
-                    doInjectAndInitialize(context, singleton, beanDefinition);
+                    // If the instance was already created (and initialized) by this context, avoid initializing twice.
+                    if (initializedInstances.contains(singleton)) {
+                        if (beanDefinition instanceof InjectableBeanDefinition<T> injectableBeanDefinition) {
+                            injectableBeanDefinition.inject(context, this, singleton);
+                        } else {
+                            // Fallback to the existing behavior if we cannot inject explicitly
+                            doInjectAndInitialize(context, singleton, beanDefinition);
+                        }
+                    } else {
+                        doInjectAndInitialize(context, singleton, beanDefinition);
+                        initializedInstances.add(singleton);
+                    }
                 }
                 DefaultBeanContext.BeanKey<T> key = new DefaultBeanContext.BeanKey<>(beanDefinition.asArgument(), qualifier);
                 singletonScope.registerSingletonBean(BeanRegistration.of(this, key, beanDefinition, singleton), qualifier);
@@ -1039,7 +1053,10 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
             try (BeanResolutionContext resolutionContext = newResolutionContext(beanDefinition, null)) {
                 if (beanDefinition instanceof InstantiatableBeanDefinition<T> instantiatableBeanDefinition) {
                     T bean = resolveByBeanFactory(resolutionContext, instantiatableBeanDefinition, qualifier, argumentValues);
-                    return postBeanCreated(resolutionContext, beanDefinition, beanArg, qualifier, bean);
+                    bean = postBeanCreated(resolutionContext, beanDefinition, beanArg, qualifier, bean);
+                    // Mark as initialized to prevent duplicate initialization on registerSingleton
+                    initializedInstances.add(bean);
+                    return bean;
                 }
             }
         }
@@ -1083,7 +1100,10 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
         }
         if (definition instanceof InstantiatableBeanDefinition<T> instantiatableBeanDefinition) {
             T bean = resolveByBeanFactory(resolutionContext, instantiatableBeanDefinition, qualifier, argumentValues);
-            return postBeanCreated(resolutionContext, definition, beanType, qualifier, bean);
+            bean = postBeanCreated(resolutionContext, definition, beanType, qualifier, bean);
+            // Mark as initialized to prevent duplicate initialization on registerSingleton
+            initializedInstances.add(bean);
+            return bean;
         } else {
             throw new BeanInstantiationException("BeanDefinition doesn't support creating a new instance of the bean");
         }
@@ -1409,7 +1429,10 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
             try (BeanResolutionContext context = newResolutionContext(candidate, resolutionContext)) {
                 if (candidate instanceof InstantiatableBeanDefinition<T> instantiatableBeanDefinition) {
                     T bean = resolveByBeanFactory(context, instantiatableBeanDefinition, qualifier, Collections.emptyMap());
-                    return postBeanCreated(context, candidate, Argument.of(beanType), qualifier, bean);
+                    bean = postBeanCreated(context, candidate, Argument.of(beanType), qualifier, bean);
+                    // Mark as initialized to prevent duplicate initialization on registerSingleton
+                    initializedInstances.add(bean);
+                    return bean;
                 } else {
                     throw new BeanInstantiationException("BeanDefinition doesn't support creating a new instance of the bean");
                 }

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/repro/PostConstructDoubleInvocationKspTest.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/repro/PostConstructDoubleInvocationKspTest.kt
@@ -1,0 +1,45 @@
+package io.micronaut.repro
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import jakarta.annotation.PostConstruct
+import jakarta.inject.Singleton
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class PostConstructDoubleInvocationKspTest {
+
+    @Test
+    fun postConstructCalledOnceWhenCreateThenRegister() {
+        val ctx = ApplicationContext.run(mapOf("spec.name" to "PostConstructDoubleInvocationKspTest"))
+        try {
+            val bean = ctx.createBean(MyBean::class.java)
+            // createBean should invoke @PostConstruct exactly once
+            assertEquals(1, bean.initCount, "createBean should call @PostConstruct exactly once")
+
+            // Register the same instance as a singleton in the context
+            ctx.registerSingleton(MyBean::class.java, bean)
+
+            // registerSingleton should NOT invoke @PostConstruct again for the same instance
+            assertEquals(1, bean.initCount, "registerSingleton should not invoke @PostConstruct again for the same instance")
+
+            // Ensure the registered instance is the one available from the context
+            assertSame(bean, ctx.getBean(MyBean::class.java))
+        } finally {
+            ctx.close()
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "PostConstructDoubleInvocationKspTest")
+    class MyBean {
+        var initCount: Int = 0
+            private set
+
+        @PostConstruct
+        fun init() {
+            initCount++
+        }
+    }
+}


### PR DESCRIPTION
**Issue link**:  https://github.com/micronaut-projects/micronaut-core/issues/11656

### Issue description

1) The test reproduces the issue: it creates a bean via `ApplicationContext.createBean` (which should invoke `@PostConstruct once`), then registers the same instance via r`egisterSingleton` and asserts that `@PostConstruct` is not invoked a second time. On the original code, the test failed with initCount=2, confirming the double @PostConstruct invocation. 

2) The patch resolves the issue by tracking instances created by the context (via `createBean`) in an identity-based set. When registerSingleton is called with `inject=true`, it checks this set: if the instance was already initialized by the context, it performs injection only (without initialization), avoiding a second `@PostConstruct` call. The test passes after the patch, and the full test suite builds successfully. 

**Note**: this approach introduces a global set of initialized instances, which may have implications (e.g., strong references and non-concurrent collection); 

### Solution
please run the command 

```bash
./gradlew :test-suite-kotlin-ksp:test
```




