### PR TITLE
Make http header list size configurable in HTTP client for HTTP2

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -1274,11 +1274,19 @@ public abstract class HttpClientConfiguration {
          */
         public static final String PREFIX = "http2";
 
+        /**
+         * The default max header list size in bytes.
+         */
+        @SuppressWarnings("WeakerAccess")
+        public static final int DEFAULT_MAX_HEADER_LIST_SIZE = 8192;
+
         private Duration pingIntervalRead = null;
 
         private Duration pingIntervalWrite = null;
 
         private Duration pingIntervalIdle = null;
+
+        private int maxHeaderListSize = DEFAULT_MAX_HEADER_LIST_SIZE;
 
         /**
          * For HTTP/2 connections, the interval from the last inbound message to when an automated ping
@@ -1341,6 +1349,25 @@ public abstract class HttpClientConfiguration {
          */
         public void setPingIntervalIdle(@Nullable Duration pingIntervalIdle) {
             this.pingIntervalIdle = pingIntervalIdle;
+        }
+
+        /**
+         * [available in the Netty HTTP client].
+         *
+         * @return The maximum allowed compressed header list size (in bytes) after decompression
+         * using HPACK (the HTTP/2 header compression algorithm).
+         */
+        public int getMaxHeaderListSize() {
+            return maxHeaderListSize;
+        }
+
+        /**
+         * Sets the maximum header list size the client can handle. Default value ({@value io.micronaut.http.client.HttpClientConfiguration.Http2ClientConfiguration#DEFAULT_MAX_HEADER_LIST_SIZE}).
+         *
+         * @param maxHeaderListSize The maximum header list size the client can handle
+         */
+        public void setMaxHeaderListSize(@ReadableBytes int maxHeaderListSize) {
+            this.maxHeaderListSize = maxHeaderListSize;
         }
     }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -81,6 +81,7 @@ import io.netty.handler.codec.http2.Http2HeadersFrame;
 import io.netty.handler.codec.http2.Http2MultiplexActiveStreamsException;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2PingFrame;
+import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2SettingsAckFrame;
 import io.netty.handler.codec.http2.Http2SettingsFrame;
 import io.netty.handler.codec.http2.Http2StreamChannel;
@@ -654,7 +655,13 @@ public class ConnectionManager {
     }
 
     private Http2FrameCodec makeFrameCodec() {
-        Http2FrameCodecBuilder builder = Http2FrameCodecBuilder.forClient();
+        Http2Settings defaultSettings = Http2Settings.defaultSettings();
+
+        defaultSettings.maxHeaderListSize(configuration.getHttp2Configuration().getMaxHeaderListSize());
+
+        Http2FrameCodecBuilder builder = Http2FrameCodecBuilder.forClient()
+            .initialSettings(defaultSettings);
+
         configuration.getLogLevel().ifPresent(logLevel -> {
             try {
                 final LogLevel nettyLevel =


### PR DESCRIPTION
Description

This PR adds configurable maxHeaderListSize property to HTTP client configuration for HTTP2.

    Added maxHeaderListSize configuration property with getter/setter methods.
    Updated Http2FrameCodec instantiation to use the configurable header list size.

Considerations

    Can be configured via micronaut.http.client.http2.max-header-list-size property.