### PR TITLE
Pass HttpRequest to getLoadBalancerDiscriminator()

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1288,10 +1288,11 @@ public class DefaultHttpClient implements
     }
 
     /**
-     * @return The discriminator to use when selecting a server for the purposes of load balancing (defaults to null)
+     * @param request The request object
+     * @return The discriminator to use when selecting a server for the purposes of load balancing (defaults to {@link io.micronaut.http.HttpRequest})
      */
-    protected Object getLoadBalancerDiscriminator() {
-        return null;
+    protected Object getLoadBalancerDiscriminator(io.micronaut.http.HttpRequest<?> request) {
+        return request;
     }
 
     /**
@@ -1469,7 +1470,7 @@ public class DefaultHttpClient implements
         if (loadBalancer instanceof FixedLoadBalancer fixed) {
             selected = ExecutionFlow.just(fixed.getServiceInstance());
         } else {
-            selected = ReactiveExecutionFlow.fromPublisher(loadBalancer.select(getLoadBalancerDiscriminator()));
+            selected = ReactiveExecutionFlow.fromPublisher(loadBalancer.select(getLoadBalancerDiscriminator(request)));
         }
 
         return selected.map(server -> {


### PR DESCRIPTION
Closes #8823. 

Changes:
1. Modified `getLoadBalancerDiscriminator()` to accept `HttpRequest` parameter.
2. Default implementation now passes the request as the discriminator.
3. Applied to both `DefaultHttpClient` and `AbstractJdkHttpClient`

This provides users with the flexibility to:
1. Override `getLoadBalancerDiscriminator(HttpRequest)` to create custom discriminator values using the request.
2. Implement custom `LoadBalancer.select()` logic that routes based on request properties, rather than receiving null.

Existing LoadBalancer implementations that ignore the discriminator parameter continue to work as before.