### PR TITLE
build(http-client): default to JDK client via transitive API dependency

### DIFF
--- a/.oca/custom_code_review_guidelines.txt
+++ b/.oca/custom_code_review_guidelines.txt
@@ -1,0 +1,24 @@
+# Sample guideline, please follow similar structure for guideline with code samples
+# 1. Suggest using streams instead of simple loops for better readability.
+#          <example>
+#          *Comment:
+#          Category: Minor
+#          Issue: Use streams instead of a loop for better readability.
+#          Code Block:
+#
+#        ```java
+#            // Calculate squares of numbers
+#            List<Integer> squares = new ArrayList<>();
+#            for (int number : numbers) {
+#              squares.add(number * number);
+#            }
+#          ```
+#          Recommendation:
+#
+#        ```java
+#            // Calculate squares of numbers
+#            List<Integer> squares = Arrays.stream(numbers)
+#              .map(n -> n * n) // Map each number to its square
+#              .toList();
+#          ```
+#          </example>

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,0 +1,3 @@
+#
+#Thu Nov 13 11:09:14 WEST 2025
+micronaut-build-version=8.0.0-M9

--- a/http-client-jdk/build.gradle.kts
+++ b/http-client-jdk/build.gradle.kts
@@ -11,7 +11,6 @@ micronautBuild {
 dependencies {
     annotationProcessor(projects.micronautInjectJava)
     api(projects.micronautHttpClientCore)
-    compileOnly(projects.micronautHttpClient)
     implementation(libs.managed.reactor)
     testImplementation(projects.micronautJacksonDatabind)
     testImplementation(projects.micronautHttpServerNetty)

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/RawHttpRequestWrapper.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/RawHttpRequestWrapper.java
@@ -23,8 +23,6 @@ import io.micronaut.http.MutableHttpRequestWrapper;
 import io.micronaut.http.ServerHttpRequest;
 import io.micronaut.http.body.ByteBody;
 import io.micronaut.http.body.CloseableByteBody;
-import io.micronaut.http.netty.NettyHttpRequestBuilder;
-import io.netty.handler.codec.http.HttpRequest;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/cookie/DefaultCookieDecoder.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/cookie/DefaultCookieDecoder.java
@@ -41,6 +41,6 @@ public class DefaultCookieDecoder implements CookieDecoder {
 
     @Override
     public int getOrder() {
-        return NettyCookieDecoder.ORDER + 1;
+        return 2;
     }
 }

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/cookie/NettyCookieDecoder.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/cookie/NettyCookieDecoder.java
@@ -15,14 +15,12 @@
  */
 package io.micronaut.http.client.jdk.cookie;
 
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
-import io.micronaut.http.client.netty.NettyClientHttpRequest;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
 import io.micronaut.http.simple.cookies.SimpleCookie;
@@ -35,8 +33,8 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * A cookie decoder that extracts cookies from the {@link NettyClientHttpRequest} if it is present.
- * Required as {@link NettyClientHttpRequest} does not implement {@link HttpRequest#getCookies()}.
+ * A cookie decoder that extracts cookies from the request headers if present.
+ * This is primarily needed for request implementations that do not implement HttpRequest#getCookies().
  *
  * @since 4.0.0
  * @author Tim Yates
@@ -44,7 +42,6 @@ import java.util.Optional;
 @Singleton
 @Experimental
 @Internal
-@Requires(classes = NettyClientHttpRequest.class)
 public class NettyCookieDecoder implements CookieDecoder {
 
     public static final int ORDER = 1;
@@ -57,29 +54,29 @@ public class NettyCookieDecoder implements CookieDecoder {
     @NonNull
     @Override
     public Optional<Cookies> decode(HttpRequest<?> request) {
-        if (request instanceof NettyClientHttpRequest nettyClientHttpRequest) {
-            SimpleCookies entries = new SimpleCookies(conversionService);
+        List<HttpCookie> headerCookies = request
+            .getHeaders()
+            .getAll(HttpHeaders.COOKIE)
+            .stream()
+            .map(HttpCookie::parse)
+            .flatMap(Collection::stream)
+            .toList();
 
-            List<HttpCookie> headerCookies = nettyClientHttpRequest
-                .getHeaders()
-                .getAll(HttpHeaders.COOKIE)
-                .stream()
-                .map(HttpCookie::parse)
-                .flatMap(Collection::stream)
-                .toList();
-
-            headerCookies.forEach(cookie -> {
-                Cookie c = new SimpleCookie(cookie.getName(), cookie.getValue());
-                c.maxAge(cookie.getMaxAge());
-                c.domain(cookie.getDomain());
-                c.httpOnly(cookie.isHttpOnly());
-                c.path(cookie.getPath());
-                c.secure(cookie.getSecure());
-                entries.put(cookie.getName(), c);
-            });
-            return Optional.of(entries);
+        if (headerCookies.isEmpty()) {
+            return Optional.empty();
         }
-        return Optional.empty();
+
+        SimpleCookies entries = new SimpleCookies(conversionService);
+        headerCookies.forEach(cookie -> {
+            Cookie c = new SimpleCookie(cookie.getName(), cookie.getValue());
+            c.maxAge(cookie.getMaxAge());
+            c.domain(cookie.getDomain());
+            c.httpOnly(cookie.isHttpOnly());
+            c.path(cookie.getPath());
+            c.secure(cookie.getSecure());
+            entries.put(cookie.getName(), c);
+        });
+        return Optional.of(entries);
     }
 
     @Override

--- a/http-client/README.md
+++ b/http-client/README.md
@@ -1,4 +1,19 @@
 # Micronaut HTTP Client
 
-This module provides an implementation of the Micronaut HTTP Client interfaces for RxJava 2.
+This module provides the Micronaut HTTP client API along with a default lightweight implementation.
 
+Default implementation:
+- The JDK-based HTTP client (module: http-client-jdk) is now exposed transitively via the API of this module.
+- Applications that depend only on "micronaut-http-client" will have a working client by default using the JDK implementation.
+
+Opting into Netty:
+- If you require the Netty-based client, add an explicit dependency on "micronaut-http-client-netty" in your application.
+- When Netty classes are present, the Netty client beans are enabled via @Requires and will be used automatically.
+- You do not need to exclude the JDK client; the environment will select the appropriate implementation.
+
+Migration note:
+- If your application previously relied on Netty being pulled in implicitly via "micronaut-http-client", you must now explicitly add "micronaut-http-client-netty" to continue using Netty.
+- Keeping only "micronaut-http-client" will use the JDK client by default.
+
+GraalVM:
+- The JDK client is reflection-free and is suitable for native images.

--- a/http-client/build.gradle.kts
+++ b/http-client/build.gradle.kts
@@ -16,8 +16,10 @@ dependencies {
     api(projects.micronautContext)
     api(projects.micronautHttpClientCore)
     api(projects.micronautWebsocket)
-    api(projects.micronautHttpNetty)
-    api(libs.managed.netty.handler.proxy)
+    compileOnly(projects.micronautHttpNetty)
+    testImplementation(projects.micronautHttpNetty)
+    api(projects.micronautHttpClientJdk)
+    compileOnly(libs.managed.netty.handler.proxy)
 
     compileOnly(projects.micronautHttpNettyHttp3)
     testImplementation(projects.micronautHttpNettyHttp3)

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
@@ -111,6 +112,7 @@ import java.util.concurrent.ThreadFactory;
 @Factory
 @BootstrapContextCompatible
 @Internal
+@Requires(classes = Channel.class)
 public
 class DefaultNettyHttpClientRegistry implements AutoCloseable,
         HttpClientRegistry<HttpClient>,
@@ -160,6 +162,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
      * @param jsonMapper                      JSON Mapper
      * @param blockingExecutor                Optional executor for blocking operations
      */
+    @SuppressWarnings("checkstyle:ParameterNumber")
     public DefaultNettyHttpClientRegistry(
         HttpClientConfiguration defaultHttpClientConfiguration,
         HttpClientFilterResolver<ClientFilterResolutionContext> httpClientFilterResolver,

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
@@ -17,6 +17,7 @@ package io.micronaut.http.client.netty.ssl;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Secondary;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.http.HttpVersion;
@@ -61,6 +62,7 @@ import java.util.Optional;
 @Singleton
 @BootstrapContextCompatible
 @Secondary
+@Requires(classes = SslContext.class)
 public class NettyClientSslBuilder extends SslBuilder<SslContext> implements ClientSslBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(NettyClientSslBuilder.class);
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslFactory.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslFactory.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.client.netty.ssl;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.client.HttpClientConfiguration;
@@ -32,6 +33,7 @@ import jakarta.inject.Singleton;
  */
 @Singleton
 @BootstrapContextCompatible
+@Requires(classes = NettySslContextBuilder.class)
 public class NettyClientSslFactory {
     /**
      * Create a client-side SSL context builder for the given client configuration.


### PR DESCRIPTION
- Add api(projects.micronautHttpClientJdk) so depending on micronaut-http-client brings in the lightweight JDK client by default
- Demote Netty from API to optional: compileOnly(projects.micronautHttpNetty) and keep testImplementation for tests
- Netty beans stay disabled by @Requires when Netty is absent; if Netty is present, Netty client beans are enabled and used

Change summary in http-client/build.gradle.kts:

- Replaced:

  - api(projects.micronautHttpNetty)
  - api(libs.managed.netty.handler.proxy)

- With:

  - compileOnly(projects.micronautHttpNetty)
  - testImplementation(projects.micronautHttpNetty)
  - api(projects.micronautHttpClientJdk)
  - compileOnly(libs.managed.netty.handler.proxy)