### PR TITLE
Support deserializing json via jackson into kotlin classes that have default properties and use the default property values if missing

### DIFF
--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -54,6 +54,7 @@ import com.fasterxml.jackson.databind.deser.NullValueProvider;
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.deser.impl.MethodProperty;
+import com.fasterxml.jackson.databind.deser.impl.PropertyValueBuffer;
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator;
 import com.fasterxml.jackson.databind.introspect.AccessorNamingStrategy;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
@@ -646,6 +647,28 @@ public class BeanIntrospectionModule extends SimpleModule {
                     public boolean canCreateUsingDefault() {
                         return constructorArguments.length == 0;
                     }
+
+                    @Override
+                    public Object createFromObjectWith(DeserializationContext ctxt,
+                                                       SettableBeanProperty[] props, PropertyValueBuffer buffer) throws IOException {
+
+                        List<Object> args = new ArrayList<>();
+
+                        for (var prop : props ) {
+                            var isOptionalConstructorArg = Arrays.stream(constructorArguments)
+                                .anyMatch(introspectionProp ->
+                                    introspectionProp.getName().equals(prop.getName())
+                                        && introspectionProp.findAnnotation(jakarta.annotation.Nullable.class).isPresent()
+                                );
+                            if (!buffer.hasParameter(prop) && isOptionalConstructorArg) {
+                                args.add(null);
+                            } else {
+                                args.add(buffer.getParameter(prop));
+                            }
+                        }
+                        return createFromObjectWith(ctxt, args.toArray());
+                    }
+
 
                     @Override
                     public boolean canCreateFromObjectWith() {

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -1073,6 +1073,61 @@ class BeanIntrospectionModuleSpec extends Specification {
         // without reflection we only see JsonIgnore on the whole property
         ignoreReflectiveProperties << [false]
     }
+    @Introspected
+    static class BeanWithDefaults {
+        String foo = "bar"
+        List<Integer> fizz = [4]
+        int buzz
+    }
+
+
+    void "class uses default value if missing when serializing"() {
+
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+        def values = objectMapper.readValue('{"fizz":[7], "buzz": null}', BeanWithDefaults)
+
+        then:
+        values.foo == "bar"
+        values.fizz == [7]
+        values.buzz == 0
+
+        cleanup:
+        ctx.close()
+    }
+    @Introspected
+    @EqualsAndHashCode
+    static class IntrospectionCreatorWithDefaults {
+        String name = "example"
+        int age
+
+        @Creator
+        public IntrospectionCreatorWithDefaults(String name, int age) {
+            this.name = name
+            this.age = age
+        }
+    }
+
+
+    void "class uses default value of primitive constructor arg for introspected class if missing when serializing"() {
+
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+        def values = objectMapper.readValue('{}', IntrospectionCreatorWithDefaults)
+
+        then:
+        values.name == null
+        values.age == 0
+
+        cleanup:
+        ctx.close()
+    }
 
     @Introspected
     static class IgnoreBean2 {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/DefaultConstructorDto.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/DefaultConstructorDto.kt
@@ -1,0 +1,14 @@
+
+package io.micronaut.jackson
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+data class DefaultConstructorDto(
+    val longField: Long = 22,
+)
+
+@Introspected
+data class RequireConstructorParamDto(
+    val longField: Long
+)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/JacksonDefaultTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/JacksonDefaultTest.kt
@@ -1,0 +1,60 @@
+package io.micronaut.jackson
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class JacksonDefaultTest {
+
+    @Test
+    fun testValueMissingOnDefaultField(objectMapper: ObjectMapper) {
+        val json = """{}"""
+        val bean = objectMapper.readValue(json, DefaultConstructorDto::class.java)
+        Assertions.assertEquals(22, bean.longField)
+    }
+
+    @Test
+    fun defaultPrimitiveIsUsedIfMissingOnRequiredField(objectMapper: ObjectMapper) {
+        val json = """{}"""
+        val bean = objectMapper.readValue(json, RequireConstructorParamDto::class.java)
+        Assertions.assertEquals(0, bean.longField)
+    }
+
+    @Test
+    fun throwExceptionWhenFailOnNullForPrimitiveIsEnabledAndPrimitiveFieldIsMissing(objectMapper: ObjectMapper) {
+        val configuredObjectMapper =
+            objectMapper.copy().configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true)
+        val json = """{}"""
+        val exception = Assertions.assertThrows(
+            MismatchedInputException::class.java,
+            { configuredObjectMapper.readValue(json, RequireConstructorParamDto::class.java) })
+        Assertions.assertTrue(exception.message!!.contains("Cannot map `null` into type `long`"))
+    }
+}
+// @Override
+//                    public Object createFromObjectWith(DeserializationContext ctxt,
+//                                                       SettableBeanProperty[] props, PropertyValueBuffer buffer) throws IOException {
+//
+////                        var isKotlinClass = introspection.hasAnnotation("kotlin.Metadata"); //Arrays.stream(introspection.getBeanType().getAnnotations()).anyMatch(annotation -> annotation.getName().equals("kotlin.Metadata"));
+////                        if (false && isKotlinClass == false) {
+////                            var values = buffer.getParameters(props);
+////                            return createFromObjectWith(ctxt, values);
+////                        }
+//                        Object[] args = new Object[props.length];
+//
+//                        for (int i = 0; i < props.length; i++) {
+//
+//                            var prop = props[i];
+//                            var isOptionalConstructorArg = Arrays.stream(constructorArguments).anyMatch(introspectionProp -> introspectionProp.getName().equals(prop.getName()) && introspectionProp.findAnnotation(jakarta.annotation.Nullable.class).isPresent());
+//                            if (!buffer.hasParameter(prop) && isOptionalConstructorArg) {
+//                                args[i] = null;
+//                            } else {
+//                                args[i] = buffer.getParameter(prop);
+//                            }
+//                        }
+//                        return createFromObjectWith(ctxt, args);
+//                    }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/JacksonDefaultTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/JacksonDefaultTest.kt
@@ -35,26 +35,3 @@ class JacksonDefaultTest {
         Assertions.assertTrue(exception.message!!.contains("Cannot map `null` into type `long`"))
     }
 }
-// @Override
-//                    public Object createFromObjectWith(DeserializationContext ctxt,
-//                                                       SettableBeanProperty[] props, PropertyValueBuffer buffer) throws IOException {
-//
-////                        var isKotlinClass = introspection.hasAnnotation("kotlin.Metadata"); //Arrays.stream(introspection.getBeanType().getAnnotations()).anyMatch(annotation -> annotation.getName().equals("kotlin.Metadata"));
-////                        if (false && isKotlinClass == false) {
-////                            var values = buffer.getParameters(props);
-////                            return createFromObjectWith(ctxt, values);
-////                        }
-//                        Object[] args = new Object[props.length];
-//
-//                        for (int i = 0; i < props.length; i++) {
-//
-//                            var prop = props[i];
-//                            var isOptionalConstructorArg = Arrays.stream(constructorArguments).anyMatch(introspectionProp -> introspectionProp.getName().equals(prop.getName()) && introspectionProp.findAnnotation(jakarta.annotation.Nullable.class).isPresent());
-//                            if (!buffer.hasParameter(prop) && isOptionalConstructorArg) {
-//                                args[i] = null;
-//                            } else {
-//                                args[i] = buffer.getParameter(prop);
-//                            }
-//                        }
-//                        return createFromObjectWith(ctxt, args);
-//                    }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/JacksonDefaultTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/JacksonDefaultTest.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 
 @MicronautTest
 class JacksonDefaultTest {
@@ -22,6 +23,18 @@ class JacksonDefaultTest {
         val json = """{}"""
         val bean = objectMapper.readValue(json, RequireConstructorParamDto::class.java)
         Assertions.assertEquals(0, bean.longField)
+    }
+
+    @Test
+    fun noExceptionIsThrownWhenFailOnNullForPrimitiveIsEnabledAndPrimitiveFieldHasDefault(objectMapper: ObjectMapper) {
+        val configuredObjectMapper =
+            objectMapper.copy().configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true)
+        val json = """{}"""
+
+        val bean: DefaultConstructorDto = assertDoesNotThrow {
+            configuredObjectMapper.readValue(json, DefaultConstructorDto::class.java)
+        }
+        Assertions.assertEquals(22, bean.longField)
     }
 
     @Test


### PR DESCRIPTION
I found an bug recently in a Micronaut application I was writing where I was using the custom Micronaut object mapper, if a Kotlin class is annotated with `@Introspected` and the json payload is missing a primitive field, the class property's default value is ignored and the Jackson default primitive value is used. The Micronaut bean instantiation feature already supports instantiating a Kotlin class that has optional/default properties which this fix uses. If the parameter's constructor argument is not required and there is no value from the json payload in the value buffer, instead of having Jackson determine the default the primitive value, we just use null and have the bean instantiation functionality take over and use the default property value.

This is my first pr to the project and I wasnt sure if I needed to create an issue before submitting a pr. If that is required, I can totally do that! Thanks!