### PR TITLE
test: isolate ConstantPropertySourceSpec in its own module

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -86,6 +86,7 @@ include "test-suite-kotlin-graalvm"
 include "test-utils"
 include "test-suite-annotation-remapper"
 include "test-suite-annotation-remapper-visitor"
+include "test-suite-property-source"
 
 // benchmarks
 include "benchmarks"

--- a/test-suite-property-source/build.gradle.kts
+++ b/test-suite-property-source/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    id("io.micronaut.build.internal.convention-test-library")
+}
+
+micronautBuild {
+    core {
+        usesMicronautTestSpock()
+    }
+}
+
+dependencies {
+    testImplementation(projects.micronautInjectGroovy)
+    testImplementation(projects.micronautInjectGroovyTest)
+    testImplementation(projects.micronautRuntime)
+    testImplementation(projects.micronautInject)
+}

--- a/test-suite-property-source/gradle.properties
+++ b/test-suite-property-source/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/test-suite-property-source/src/test/groovy/io/micronaut/context/env/ConstantPropertySourceSpec.groovy
+++ b/test-suite-property-source/src/test/groovy/io/micronaut/context/env/ConstantPropertySourceSpec.groovy
@@ -36,7 +36,6 @@ class ConstantPropertySourceSpec extends Specification {
         "default" | 'application'
         "dev"     | "application-dev"
         "cloud"   | "application-cloud"
-
     }
 
     private static TestPropertySource propertySource(String name, Map<String, String> values = [:]) {


### PR DESCRIPTION
test `ConstantPropertySourceSpec` passes when run on isolation. It fails when run in a suite. This PR moves the test to its own module. Not ideal but at least we remove the flakiness of the test:

https://ge.micronaut.io/scans/tests?search.relativeStartTime=P90D&search.timeZoneId=Europe%2FMadrid&tests.container=io.micronaut.context.env.ConstantPropertySourceSpec&tests.help=tags