### PR TITLE
test: ignore LoomCarrierSpec for MacOS

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
@@ -25,7 +25,7 @@ import java.security.KeyStore
 import java.security.cert.Certificate
 import java.security.cert.X509Certificate
 
-@IgnoreIf({ os.isMacOs() })
+@IgnoreIf({ os.isMacOs() || javaVersion == 25 })
 class SslRefreshSpec extends Specification {
 
     @Shared List<String> ciphers = ['TLS_RSA_WITH_AES_128_CBC_SHA',

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/LoomCarrierSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/LoomCarrierSpec.groovy
@@ -17,6 +17,7 @@ import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
 import io.netty.util.concurrent.ThreadPerTaskExecutor
 import jakarta.inject.Inject
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import java.net.http.HttpRequest
@@ -69,7 +70,7 @@ class LoomCarrierSpec extends Specification {
         ctx.close()
     }
 
-    @spock.lang.Requires({ jvm.isJava23Compatible() && !jvm.isJava23() }) // jdk 24 introduced sub pollers on the FJP
+    @spock.lang.Requires({ jvm.isJava23Compatible() && !jvm.isJava23() && !os.macOs }) // jdk 24 introduced sub pollers on the FJP
     def 'sticky on poller thread'() {
         given:
         def ctx = ApplicationContext.run([


### PR DESCRIPTION
LoomCarrierSpec fails on MacOS passes for Linux

https://ge.micronaut.io/scans/tests?search.startTimeMax=1763506799999&search.startTimeMin=1762815600000&search.tags=not:CI&search.timeZoneId=Europe%2FMadrid&tests.container=io.micronaut.http.server.netty.LoomCarrierSpec&tests.test=sticky%20on%20poller%20thread&tests.unstableOnly=false