### PR TITLE
Add support for less buggy multipart decoder

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,7 @@ managed-kotlin-coroutines = "1.8.1"
 managed-methvin-directory-watcher = "0.19.1"
 managed-netty = "4.2.7.Final"
 managed-netty-tcnative = "2.0.74.Final"
+managed-netty-contrib-multipart = "1.0.0.Alpha1"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM
 managed-reactor = "3.7.12"
@@ -168,6 +169,7 @@ managed-netty-transport-native-iouring = { module = "io.netty:netty-transport-na
 managed-netty-transport-native-unix-common = { module = "io.netty:netty-transport-native-unix-common", version.ref = "managed-netty" }
 managed-netty-pkitesting = { module = "io.netty:netty-pkitesting", version.ref = "managed-netty" }
 managed-netty-tcnative-boringssl-static = { module = "io.netty:netty-tcnative-boringssl-static", version.ref = "managed-netty-tcnative" }
+managed-netty-contrib-multipart-vintage = { module = "io.netty.contrib:netty-codec-multipart-vintage", version.ref = "managed-netty-contrib-multipart" }
 
 managed-reactive-streams = { module = "org.reactivestreams:reactive-streams", version.ref = "managed-reactive-streams" }
 

--- a/http-server-netty/build.gradle.kts
+++ b/http-server-netty/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     compileOnly(projects.micronautWebsocket)
     compileOnly(libs.managed.kotlin.stdlib)
     compileOnly(libs.managed.netty.transport.native.unix.common)
+    compileOnly(libs.managed.netty.contrib.multipart.vintage)
     compileOnly(projects.micronautHttpNettyHttp3)
     compileOnly(libs.brotli4j)
 
@@ -125,6 +126,7 @@ dependencies {
         exclude(group = "io.micronaut")
     }
     testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.managed.netty.contrib.multipart.vintage)
 }
 
 tasks.withType<Test>().configureEach {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
@@ -24,6 +24,8 @@ import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.contrib.multipart.DecoderQuirk;
+import io.netty.contrib.multipart.FormDecoderException;
+import io.netty.contrib.multipart.TooManyFormFieldsException;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -178,20 +180,11 @@ public final class FormDataHttpContentProcessor {
                         postRequestDecoder.removeHttpDataFromClean(currentPartialHttpData);
                     }
 
-                } catch (HttpPostRequestDecoder.EndOfDataDecoderException e) {
-                    // ok, ignore
-                } catch (HttpPostRequestDecoder.ErrorDataDecoderException e) {
-                    Throwable cause = e.getCause();
-                    if (cause instanceof IOException && cause.getMessage().equals("Size exceed allowed maximum capacity")) {
-                        String partName = decoder.currentPartialHttpData().getName();
-                        throw new ContentLengthExceededException("The part named [" + partName + "] exceeds the maximum allowed content length [" + partMaxSize + "]");
-                    } else {
-                        throw e;
+                } catch (RuntimeException e) {
+                    RuntimeException mapped = mapFormException(e);
+                    if (mapped != null) {
+                        throw mapped;
                     }
-                } catch (HttpPostRequestDecoder.TooManyFormFieldsException e) {
-                    throw new ContentLengthExceededException("Number of form fields exceeds configured limit of [" + configuration.getFormMaxFields() + "]");
-                } catch (HttpPostRequestDecoder.TooLongFormFieldException e) {
-                    throw new ContentLengthExceededException("Length of buffered form field exceeds configured limit of [" + configuration.getFormMaxBufferedBytes() + "]");
                 } finally {
                     httpContent.release();
                 }
@@ -201,6 +194,31 @@ public final class FormDataHttpContentProcessor {
         } finally {
             inFlight = false;
             destroyIfRequested();
+        }
+    }
+
+    private RuntimeException mapFormException(RuntimeException original) {
+        if (original instanceof HttpPostRequestDecoder.EndOfDataDecoderException ||
+            (!contribCodecMissing && original instanceof io.netty.contrib.multipart.vintage.HttpPostRequestDecoder.EndOfDataDecoderException)) {
+            // ok, ignore
+            return null;
+        } else if (original instanceof HttpPostRequestDecoder.ErrorDataDecoderException ||
+            (!contribCodecMissing && original instanceof io.netty.contrib.multipart.vintage.HttpPostRequestDecoder.ErrorDataDecoderException)) {
+            Throwable cause = original.getCause();
+            if (cause instanceof IOException && cause.getMessage().equals("Size exceed allowed maximum capacity")) {
+                String partName = decoder.currentPartialHttpData().getName();
+                return new ContentLengthExceededException("The part named [" + partName + "] exceeds the maximum allowed content length [" + partMaxSize + "]");
+            } else {
+                return original;
+            }
+        } else if (original instanceof HttpPostRequestDecoder.TooManyFormFieldsException ||
+            (!contribCodecMissing && original instanceof TooManyFormFieldsException)) {
+            return new ContentLengthExceededException("Number of form fields exceeds configured limit of [" + configuration.getFormMaxFields() + "]");
+        } else if (original instanceof HttpPostRequestDecoder.TooLongFormFieldException ||
+            (!contribCodecMissing && original instanceof FormDecoderException && original.getMessage().equals("Undecoded data limit exceeded"))) {
+            return new ContentLengthExceededException("Length of buffered form field exceeds configured limit of [" + configuration.getFormMaxBufferedBytes() + "]");
+        } else {
+            return original;
         }
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 /**
  * <p>Decodes {@link MediaType#MULTIPART_FORM_DATA} in a non-blocking manner.</p>
@@ -199,11 +200,11 @@ public final class FormDataHttpContentProcessor {
 
     private RuntimeException mapFormException(RuntimeException original) {
         if (original instanceof HttpPostRequestDecoder.EndOfDataDecoderException ||
-            (!contribCodecMissing && original instanceof io.netty.contrib.multipart.vintage.HttpPostRequestDecoder.EndOfDataDecoderException)) {
+            instanceOfSafe(original, () -> io.netty.contrib.multipart.vintage.HttpPostRequestDecoder.EndOfDataDecoderException.class)) {
             // ok, ignore
             return null;
         } else if (original instanceof HttpPostRequestDecoder.ErrorDataDecoderException ||
-            (!contribCodecMissing && original instanceof io.netty.contrib.multipart.vintage.HttpPostRequestDecoder.ErrorDataDecoderException)) {
+            instanceOfSafe(original, () -> io.netty.contrib.multipart.vintage.HttpPostRequestDecoder.ErrorDataDecoderException.class)) {
             Throwable cause = original.getCause();
             if (cause instanceof IOException && cause.getMessage().equals("Size exceed allowed maximum capacity")) {
                 String partName = decoder.currentPartialHttpData().getName();
@@ -212,14 +213,24 @@ public final class FormDataHttpContentProcessor {
                 return original;
             }
         } else if (original instanceof HttpPostRequestDecoder.TooManyFormFieldsException ||
-            (!contribCodecMissing && original instanceof TooManyFormFieldsException)) {
+            instanceOfSafe(original, () -> TooManyFormFieldsException.class)) {
             return new ContentLengthExceededException("Number of form fields exceeds configured limit of [" + configuration.getFormMaxFields() + "]");
         } else if (original instanceof HttpPostRequestDecoder.TooLongFormFieldException ||
-            (!contribCodecMissing && original instanceof FormDecoderException && original.getMessage().equals("Undecoded data limit exceeded"))) {
+            (instanceOfSafe(original, () -> FormDecoderException.class) && original.getMessage().equals("Undecoded data limit exceeded"))) {
             return new ContentLengthExceededException("Length of buffered form field exceeds configured limit of [" + configuration.getFormMaxBufferedBytes() + "]");
         } else {
             return original;
         }
+    }
+
+    private static <B> boolean instanceOfSafe(B object, Supplier<Class<? extends B>> type) {
+        Class<? extends B> cl;
+        try {
+            cl = type.get();
+        } catch (LinkageError e) {
+            return false;
+        }
+        return cl.isInstance(object);
     }
 
     public void add(ByteBufHolder message, Collection<? super InterfaceHttpData> out) throws Throwable {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
@@ -15,12 +15,15 @@
  */
 package io.micronaut.http.server.netty;
 
+import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.exceptions.ContentLengthExceededException;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
 import io.netty.buffer.ByteBufHolder;
+import io.netty.contrib.multipart.DecoderQuirk;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -49,6 +52,8 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 @Internal
 public final class FormDataHttpContentProcessor {
+
+    private static boolean contribCodecMissing;
 
     protected final NettyHttpRequest<?> nettyHttpRequest;
     protected final long advertisedLength;
@@ -89,12 +94,38 @@ public final class FormDataHttpContentProcessor {
         HttpDataFactory factory = new MicronautHttpData.Factory(multipart, characterEncoding);
         // prevent the decoders from immediately parsing the content
         HttpRequest nativeRequest = nettyHttpRequest.toHttpRequestWithoutBody();
-        if (HttpPostRequestDecoder.isMultipart(nativeRequest)) {
-            this.decoder = new HttpPostMultipartRequestDecoder(factory, nativeRequest, characterEncoding, configuration.getFormMaxFields(), configuration.getFormMaxBufferedBytes());
-        } else {
-            this.decoder = new HttpPostStandardRequestDecoder(factory, nativeRequest, characterEncoding, configuration.getFormMaxFields(), configuration.getFormMaxBufferedBytes());
-        }
+        this.decoder = createDecoder(factory, nativeRequest, characterEncoding, configuration);
         this.partMaxSize = multipart.getMaxFileSize();
+    }
+
+    private static InterfaceHttpPostRequestDecoder createDecoder(HttpDataFactory factory, HttpRequest request, Charset charset, NettyHttpServerConfiguration configuration) {
+        if (!contribCodecMissing) {
+            try {
+                var builder = io.netty.contrib.multipart.vintage.HttpPostRequestDecoder.builder()
+                    .dataFactory(factory)
+                    .charset(charset)
+                    .maxFields(configuration.getFormMaxFields())
+                    .undecodedLimit(configuration.getFormMaxBufferedBytes())
+                    .enableQuirks(configuration.getFormDecoderQuirks().stream()
+                        .map(name -> ConversionService.SHARED.convertRequired(name, DecoderQuirk.class))
+                        .toArray(DecoderQuirk[]::new));
+                if (HttpPostRequestDecoder.isMultipart(request)) {
+                    return builder.buildMultipart(request);
+                } else {
+                    return builder.buildStandard(request);
+                }
+            } catch (LinkageError e) {
+                if (!configuration.getFormDecoderQuirks().isEmpty()) {
+                    throw new ConfigurationException("Configuration contained form-decoder-quirks, but failed to load new decoder implementation", e);
+                }
+                contribCodecMissing = true;
+            }
+        }
+        if (HttpPostRequestDecoder.isMultipart(request)) {
+            return new HttpPostMultipartRequestDecoder(factory, request, charset, configuration.getFormMaxFields(), configuration.getFormMaxBufferedBytes());
+        } else {
+            return new HttpPostStandardRequestDecoder(factory, request, charset, configuration.getFormMaxFields(), configuration.getFormMaxBufferedBytes());
+        }
     }
 
     protected void onData(ByteBufHolder message, Collection<? super InterfaceHttpData> out) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/MicronautHttpData.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/MicronautHttpData.java
@@ -280,6 +280,7 @@ public abstract sealed class MicronautHttpData<D extends HttpData> extends Abstr
             } catch (IOException e) {
                 LOG.warn("Failed to close temp file channel", e);
             }
+            channel = null;
         }
         if (path != null) {
             try {
@@ -287,21 +288,23 @@ public abstract sealed class MicronautHttpData<D extends HttpData> extends Abstr
             } catch (IOException e) {
                 LOG.warn("Failed to delete temp file", e);
             }
+            path = null;
         }
         for (Chunk chunk : chunks) {
             chunk.release();
         }
+        chunks.clear();
         if (mmapSegments != null) {
             for (ByteBuf segment : mmapSegments) {
                 segment.release();
             }
+            mmapSegments = null;
         }
     }
 
     @Override
     public void setContent(ByteBuf buffer) throws IOException {
         dealloc0();
-        chunks.clear();
 
         Chunk ch = new Chunk(0);
         chunks.add(ch);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -23,6 +23,7 @@ import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NextMajorVersion;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.ReadableBytes;
@@ -45,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Allows configuring Netty within {@link io.micronaut.http.server.netty.NettyHttpServer}.
@@ -222,6 +224,8 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     private int formMaxFields = DEFAULT_FORM_MAX_FIELDS;
     private int formMaxBufferedBytes = DEFAULT_FORM_MAX_BUFFERED_BYTES;
     private boolean requestDecompressionEnabled = true;
+    @NextMajorVersion("Move to DecoderQuirk enum once it becomes mandatory")
+    private Set<String> formDecoderQuirks = Collections.emptySet();
 
     /**
      * Default empty constructor.
@@ -871,6 +875,30 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public void setFormMaxBufferedBytes(int formMaxBufferedBytes) {
         this.formMaxBufferedBytes = formMaxBufferedBytes;
+    }
+
+    /**
+     * The decoder quirks for the
+     * <a href="https://github.com/netty-contrib/codec-multipart/">next-generation multipart
+     * parser</a>, if present. No quirks by default.
+     *
+     * @return The decoder quirks
+     */
+    @Experimental
+    public Set<String> getFormDecoderQuirks() {
+        return formDecoderQuirks;
+    }
+
+    /**
+     * The decoder quirks for the
+     * <a href="https://github.com/netty-contrib/codec-multipart/">next-generation multipart
+     * parser</a>, if present. No quirks by default.
+     *
+     * @param formDecoderQuirks The decoder quirks
+     */
+    @Experimental
+    public void setFormDecoderQuirks(Set<String> formDecoderQuirks) {
+        this.formDecoderQuirks = formDecoderQuirks;
     }
 
     /**

--- a/http-server-netty/src/test/java/io/micronaut/http/server/netty/FormBodyQuirkTest.java
+++ b/http-server-netty/src/test/java/io/micronaut/http/server/netty/FormBodyQuirkTest.java
@@ -1,0 +1,117 @@
+package io.micronaut.http.server.netty;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Consumes;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Part;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.annotation.ServerFilter;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FormBodyQuirkTest {
+    // test the functioning of the new multipart parser api and its quirks.
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void test(boolean quirk) throws Exception {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            "spec.name", "FormBodyQuirkTest",
+            "micronaut.server.port", "0",
+            "micronaut.server.netty.form-decoder-quirks", quirk ? List.of("forward-chunk-cr") : List.of()
+        ));
+             EmbeddedServer server = ctx.getBean(EmbeddedServer.class)) {
+            server.start();
+
+            CompletableFuture<String> response = new CompletableFuture<>();
+            Channel channel = new Bootstrap()
+                .channel(NioSocketChannel.class)
+                .group(ctx.getBean(EventLoopGroup.class))
+                .handler(new ChannelInitializer<>() {
+                    @Override
+                    protected void initChannel(Channel ch) {
+                        ch.pipeline().addLast(new HttpClientCodec(), new HttpObjectAggregator(1024), new ChannelInboundHandlerAdapter() {
+                            @Override
+                            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                                try {
+                                    FullHttpResponse r = (FullHttpResponse) msg;
+                                    response.complete(r.content().toString(StandardCharsets.UTF_8));
+                                } catch (Exception e) {
+                                    response.completeExceptionally(e);
+                                } finally {
+                                    ReferenceCountUtil.release(msg);
+                                }
+                            }
+                        });
+                    }
+                })
+                .connect(server.getHost(), server.getPort()).sync().channel();
+
+            DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/quirk-echo");
+            request.headers().add(HttpHeaderNames.HOST, "example.com");
+            request.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=\"xyz\"");
+            request.headers().add(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+            channel.write(request, channel.voidPromise());
+            channel.writeAndFlush(new DefaultHttpContent(ByteBufUtil.writeUtf8(channel.alloc(), """
+                --xyz\r
+                Content-Disposition: form-data; name="foo"\r
+                \r
+                bar\r"""))).sync();
+            ctx.getBean(MyFilter.class).requestReceived.get();
+            channel.writeAndFlush(new DefaultLastHttpContent(ByteBufUtil.writeUtf8(channel.alloc(), "\n--xyz--"))).sync();
+
+            assertEquals(quirk ? "bar\r" : "bar", response.get());
+        }
+    }
+
+    @Controller
+    @Requires(property = "spec.name", value = "FormBodyQuirkTest")
+    public static class MyController {
+        @Post("/quirk-echo")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public String echo(@Part("foo") String foo) {
+            return foo;
+        }
+    }
+
+    @Singleton
+    @ServerFilter
+    @Requires(property = "spec.name", value = "FormBodyQuirkTest")
+    public static class MyFilter {
+        final CompletableFuture<?> requestReceived = new CompletableFuture<>();
+
+        @RequestFilter("/quirk-echo")
+        public void onRequest() {
+            requestReceived.complete(null);
+        }
+    }
+}


### PR DESCRIPTION
The standard netty multipart decoder is quite buggy. A new API is available at https://github.com/netty-contrib/codec-multipart . That implementation also has compatible drop-in replacement for the old netty APIs.

This PR checks whether the new implementation is available on the classpath, and if so, uses that instead of standard netty. There is also a config option to enable "quirks" that restore various bugs of the old implementation for compatibility.

This is experimental and undocumented because the new API is in alpha. I've added it to 4.10 to let people resolve long-standing issues with form data parsing.