### PR TITLE
test: reduce test pollution with spec.name

### DIFF
--- a/test-suite/src/test/groovy/io/micronaut/context/inject/CircularBeanResolutionWithPostConstructSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/context/inject/CircularBeanResolutionWithPostConstructSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.context.inject
 
+import io.micronaut.context.annotation.Property
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Issue
@@ -7,6 +8,7 @@ import spock.lang.Specification
 
 import jakarta.inject.Inject
 
+@Property(name = "spec.name", value = "CircularBeanResolutionWithPostConstructSpec")
 @MicronautTest
 class CircularBeanResolutionWithPostConstructSpec extends Specification {
 

--- a/test-suite/src/test/groovy/io/micronaut/context/inject/ExampleRepoImpl.java
+++ b/test-suite/src/test/groovy/io/micronaut/context/inject/ExampleRepoImpl.java
@@ -15,10 +15,12 @@
  */
 package io.micronaut.context.inject;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "CircularBeanResolutionWithPostConstructSpec")
 @Singleton
 public class ExampleRepoImpl implements ExampleRepo {
 

--- a/test-suite/src/test/java/io/micronaut/docs/client/ThirdPartyClientFilterSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/client/ThirdPartyClientFilterSpec.java
@@ -96,6 +96,7 @@ class ThirdPartyClientFilterSpec {
 
     }
 
+    @Requires(property = "spec.name", value = "ThirdPartyClientFilterSpec")
     @Controller("/repos")
     static class HeaderController {
 
@@ -106,6 +107,7 @@ class ThirdPartyClientFilterSpec {
     }
 }
 
+@Requires(property = "spec.name", value = "ThirdPartyClientFilterSpec")
 //tag::bintrayService[]
 @Singleton
 class BintrayService {

--- a/test-suite/src/test/java/io/micronaut/docs/config/builder/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/builder/Vehicle.java
@@ -15,9 +15,11 @@
  */
 package io.micronaut.docs.config.builder;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleBuilderSpec")
 // tag::class[]
 @Singleton
 class Vehicle {

--- a/test-suite/src/test/java/io/micronaut/docs/config/builder/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/builder/VehicleSpec.java
@@ -29,6 +29,7 @@ class VehicleSpec {
     void testStartVehicle() {
         // tag::start[]
         Map<String, Object> properties = new HashMap<>();
+        properties.put("spec.name", "VehicleBuilderSpec");
         properties.put("my.engine.cylinders"             ,"4");
         properties.put("my.engine.manufacturer"          , "Subaru");
         properties.put("my.engine.crank-shaft.rod-length", 4);
@@ -40,9 +41,9 @@ class VehicleSpec {
         Vehicle vehicle = applicationContext.getBean(Vehicle.class);
         System.out.println(vehicle.start());
         // end::start[]
-        
+
         assertEquals("Subaru Engine Starting V4 [rodLength=4.0, sparkPlug=Iridium(NGK 6619 LFR6AIX)]", vehicle.start());
-                
+
         applicationContext.close();
     }
 }

--- a/test-suite/src/test/java/io/micronaut/docs/config/immutable/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/immutable/Engine.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.config.immutable;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleImmutableSpec")
 // tag::class[]
 @Singleton
 public class Engine {

--- a/test-suite/src/test/java/io/micronaut/docs/config/immutable/EngineConfig.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/immutable/EngineConfig.java
@@ -16,6 +16,7 @@
 package io.micronaut.docs.config.immutable;
 
 // tag::imports[]
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.context.annotation.ConfigurationInject;
@@ -27,6 +28,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Optional;
 // end::imports[]
 
+@Requires(property = "spec.name", value = "VehicleImmutableSpec")
 // tag::class[]
 @ConfigurationProperties("my.engine") // <1>
 public class EngineConfig {

--- a/test-suite/src/test/java/io/micronaut/docs/config/immutable/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/immutable/Vehicle.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.config.immutable;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleImmutableSpec")
 @Singleton
 public class Vehicle {
     public Vehicle(Engine engine) {// <6>

--- a/test-suite/src/test/java/io/micronaut/docs/config/immutable/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/immutable/VehicleSpec.java
@@ -17,8 +17,9 @@ package io.micronaut.docs.config.immutable;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.exceptions.DependencyInjectionException;
-import io.micronaut.core.util.CollectionUtils;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +30,8 @@ class VehicleSpec {
     @Test
     void testStartVehicle() {
         // tag::start[]
-        ApplicationContext applicationContext = ApplicationContext.run(CollectionUtils.mapOf(
+        ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+            "spec.name", "VehicleImmutableSpec",
                 "my.engine.cylinders", "8",
                 "my.engine.crank-shaft.rod-length", "7.0"
         ));
@@ -44,8 +46,9 @@ class VehicleSpec {
 
     @Test
     void testStartWithInvalidValue() {
-        try (ApplicationContext applicationContext = ApplicationContext.run(CollectionUtils.mapOf(
-                "my.engine.cylinders", "-10",
+        try (ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+            "spec.name", "VehicleImmutableSpec",
+            "my.engine.cylinders", "-10",
                 "my.engine.crank-shaft.rod-length", "7.0"
         ))) {
             applicationContext.getBean(Vehicle.class);

--- a/test-suite/src/test/java/io/micronaut/docs/config/itfce/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/itfce/Engine.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.config.itfce;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleItfceSpec")
 @Singleton
 public class Engine {
     private final EngineConfig config;

--- a/test-suite/src/test/java/io/micronaut/docs/config/itfce/EngineConfig.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/itfce/EngineConfig.java
@@ -17,6 +17,7 @@ package io.micronaut.docs.config.itfce;
 
 // tag::imports[]
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.bind.annotation.Bindable;
 
 import jakarta.validation.constraints.Min;
@@ -25,6 +26,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Optional;
 // end::imports[]
 
+@Requires(property = "spec.name", value = "VehicleItfceSpec")
 // tag::class[]
 @ConfigurationProperties("my.engine") // <1>
 public interface EngineConfig {

--- a/test-suite/src/test/java/io/micronaut/docs/config/itfce/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/itfce/Vehicle.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.config.itfce;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleItfceSpec")
 @Singleton
 public class Vehicle {
     public Vehicle(Engine engine) {// <6>

--- a/test-suite/src/test/java/io/micronaut/docs/config/itfce/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/itfce/VehicleSpec.java
@@ -20,6 +20,8 @@ import io.micronaut.context.exceptions.BeanInstantiationException;
 import io.micronaut.core.util.CollectionUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -29,7 +31,8 @@ class VehicleSpec {
     @Test
     void testStartVehicle() {
         // tag::start[]
-        ApplicationContext applicationContext = ApplicationContext.run(CollectionUtils.mapOf(
+        ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+            "spec.name", "VehicleItfceSpec",
                 "my.engine.cylinders", "8",
                 "my.engine.crank-shaft.rod-length", "7.0"
         ));
@@ -47,7 +50,8 @@ class VehicleSpec {
         ApplicationContext applicationContext = null;
         try {
             applicationContext = ApplicationContext.run(CollectionUtils.mapOf(
-                    "my.engine.cylinders", "-10",
+                "spec.name", "VehicleItfceSpec",
+                "my.engine.cylinders", "-10",
                     "my.engine.crank-shaft.rod-length", "7.0"
             ));
 

--- a/test-suite/src/test/java/io/micronaut/docs/config/mapFormat/EngineConfig.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/mapFormat/EngineConfig.java
@@ -17,12 +17,14 @@ package io.micronaut.docs.config.mapFormat;
 
 // tag::imports[]
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.convert.format.MapFormat;
 
 import jakarta.validation.constraints.Min;
 import java.util.Map;
 // end::imports[]
 
+@Requires(property = "spec.name", value = "VehicleMapFormatSpec")
 // tag::class[]
 @ConfigurationProperties("my.engine")
 public class EngineConfig {

--- a/test-suite/src/test/java/io/micronaut/docs/config/mapFormat/EngineImpl.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/mapFormat/EngineImpl.java
@@ -15,10 +15,12 @@
  */
 package io.micronaut.docs.config.mapFormat;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.Map;
 
+@Requires(property = "spec.name", value = "VehicleMapFormatSpec")
 // tag::class[]
 @Singleton
 public class EngineImpl implements Engine {

--- a/test-suite/src/test/java/io/micronaut/docs/config/mapFormat/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/mapFormat/Vehicle.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.config.mapFormat;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleMapFormatSpec")
 @Singleton
 public class Vehicle {
     public Vehicle(Engine engine) {

--- a/test-suite/src/test/java/io/micronaut/docs/config/mapFormat/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/mapFormat/VehicleSpec.java
@@ -37,6 +37,8 @@ class VehicleSpec {
 
         map.put("my.engine.sensors", map1);
 
+        map.put( "spec.name", "VehicleMapFormatSpec");
+
         ApplicationContext applicationContext = ApplicationContext.run(map, "test");
 
         Vehicle vehicle = applicationContext.getBean(Vehicle.class);

--- a/test-suite/src/test/java/io/micronaut/docs/config/properties/EngineConfig.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/properties/EngineConfig.java
@@ -18,11 +18,13 @@ package io.micronaut.docs.config.properties;
 // tag::imports[]
 import io.micronaut.context.annotation.ConfigurationProperties;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Optional;
 // end::imports[]
 
+@Requires(property = "spec.name", value = "VehiclePropertiesSpec")
 // tag::class[]
 @ConfigurationProperties("my.engine") // <1>
 public class EngineConfig {

--- a/test-suite/src/test/java/io/micronaut/docs/config/properties/EngineImpl.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/properties/EngineImpl.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.config.properties;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehiclePropertiesSpec")
 // tag::class[]
 @Singleton
 public class EngineImpl implements Engine {

--- a/test-suite/src/test/java/io/micronaut/docs/config/properties/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/properties/Vehicle.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.config.properties;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehiclePropertiesSpec")
 @Singleton
 public class Vehicle {
     public Vehicle(Engine engine) {// <6>

--- a/test-suite/src/test/java/io/micronaut/docs/config/properties/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/properties/VehicleSpec.java
@@ -16,6 +16,7 @@
 package io.micronaut.docs.config.properties;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
@@ -30,6 +31,7 @@ class VehicleSpec {
         // tag::start[]
         Map<String, Object> map = new LinkedHashMap<>(1);
         map.put("my.engine.cylinders", "8");
+        map.put("spec.name", "VehiclePropertiesSpec");
         ApplicationContext applicationContext = ApplicationContext.run(map, "test");
 
         Vehicle vehicle = applicationContext.getBean(Vehicle.class);

--- a/test-suite/src/test/java/io/micronaut/docs/config/property/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/property/Engine.java
@@ -18,10 +18,12 @@ package io.micronaut.docs.config.property;
 // tag::imports[]
 import io.micronaut.context.annotation.Property;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 // end::imports[]
 
+@Requires(property = "spec.name", value = "VehicleConfigPropertySpec")
 // tag::class[]
 @Singleton
 public class Engine {

--- a/test-suite/src/test/java/io/micronaut/docs/config/property/EngineSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/property/EngineSpec.java
@@ -27,6 +27,7 @@ class EngineSpec {
     @Test
     void testStartVehicleWithConfiguration() {
         LinkedHashMap<String, Object> map = new LinkedHashMap<>(1);
+        map.put("spec.name", "VehicleConfigPropertySpec");
         map.put("my.engine.cylinders", "8");
         map.put("my.engine.manufacturer", "Honda");
         ApplicationContext ctx = ApplicationContext.run(map);

--- a/test-suite/src/test/java/io/micronaut/docs/config/value/EngineImpl.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/value/EngineImpl.java
@@ -16,12 +16,14 @@
 package io.micronaut.docs.config.value;
 
 // tag::imports[]
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.Nullable;
 
 import jakarta.inject.Singleton;
 // end::imports[]
 
+@Requires(property = "spec.name", value = "VehicleValueSpec")
 // tag::class[]
 @Singleton
 public class EngineImpl implements Engine {

--- a/test-suite/src/test/java/io/micronaut/docs/config/value/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/value/Vehicle.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.config.value;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleValueSpec")
 @Singleton
 public class Vehicle {
     public Vehicle(Engine engine) {// <6>

--- a/test-suite/src/test/java/io/micronaut/docs/config/value/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/value/VehicleSpec.java
@@ -16,21 +16,25 @@
 package io.micronaut.docs.config.value;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.PropertySource;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class VehicleSpec {
 
+    private final static Map<String, Object> CONFIG =Map.of("spec.name", "VehicleValueSpec");
+
     @Test
     void testStartVehicleWithConfiguration() {
         // tag::start[]
-        ApplicationContext applicationContext = ApplicationContext.builder("test").build();
+        ApplicationContext applicationContext = ApplicationContext.builder("test").properties(CONFIG).build();
         LinkedHashMap<String, Object> map = new LinkedHashMap(1);
         map.put("my.engine.cylinders", "8");
         applicationContext.getEnvironment().addPropertySource(PropertySource.of("test", map));
@@ -46,7 +50,7 @@ class VehicleSpec {
     @Test
     void testStartVehicleWithoutConfiguration() {
         // tag::start[]
-        ApplicationContext applicationContext = ApplicationContext.builder("test").build();
+        ApplicationContext applicationContext = ApplicationContext.builder("test").properties(CONFIG).build();
         applicationContext.start();
 
         Vehicle vehicle = applicationContext.getBean(Vehicle.class);
@@ -59,7 +63,7 @@ class VehicleSpec {
     @Test
     void testStartVehicleWithNonEmptyPlaceholder() {
         // tag::start[]
-        ApplicationContext applicationContext = ApplicationContext.builder("test").build();
+        ApplicationContext applicationContext = ApplicationContext.builder("test").properties(CONFIG).build();
         LinkedHashMap<String, Object> map = new LinkedHashMap(1);
         map.put("my.engine.description", "${DESCRIPTION}");
         map.put("DESCRIPTION", "V8 Engine");
@@ -75,7 +79,7 @@ class VehicleSpec {
     @Test
     void testStartVehicleWithEmptyPlaceholder() {
         // tag::start[]
-        ApplicationContext applicationContext = ApplicationContext.builder("test").build();
+        ApplicationContext applicationContext = ApplicationContext.builder("test").properties(CONFIG).build();
         LinkedHashMap<String, Object> map = new LinkedHashMap(1);
         map.put("my.engine.description", "${DESCRIPTION}");
         applicationContext.getEnvironment().addPropertySource(PropertySource.of("test", map));

--- a/test-suite/src/test/java/io/micronaut/docs/events/factory/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/events/factory/Vehicle.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.events.factory;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleEventsFactory")
 @Singleton
 public class Vehicle {
     public Vehicle(Engine engine) {

--- a/test-suite/src/test/java/io/micronaut/docs/events/factory/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/events/factory/VehicleSpec.java
@@ -17,7 +17,10 @@ package io.micronaut.docs.events.factory;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Requires;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,7 +29,7 @@ class VehicleSpec {
     @Test
     void testStartVehicle() {
         // tag::start[]
-        final ApplicationContext context = ApplicationContext.run();
+        final ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "VehicleEventsFactory"));
         Vehicle vehicle = context.getBean(Vehicle.class);
         System.out.println(vehicle.start());
         // end::start[]

--- a/test-suite/src/test/java/io/micronaut/docs/factories/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/factories/Vehicle.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.factories;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleFactoriesSpec")
 // tag::class[]
 @Singleton
 class Vehicle {

--- a/test-suite/src/test/java/io/micronaut/docs/factories/VehicleMockSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/factories/VehicleMockSpec.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 // end::imports[]
 
+@Property(name = "spec.name", value = "VehicleFactoriesSpec")
 // tag::class[]
 @MicronautTest
 public class VehicleMockSpec {

--- a/test-suite/src/test/java/io/micronaut/docs/factories/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/factories/VehicleSpec.java
@@ -18,13 +18,15 @@ package io.micronaut.docs.factories;
 import io.micronaut.context.ApplicationContext;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VehicleSpec {
 
     @Test
     void testStartVehicle() {
-        ApplicationContext context = ApplicationContext.run();
+        ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "VehicleFactoriesSpec"));
         Vehicle vehicle = context.getBean(Vehicle.class);
         System.out.println( vehicle.start() );
 

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/Vehicle.java
@@ -1,9 +1,11 @@
 package io.micronaut.docs.inject.generics;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.List;
 
+@Requires(property = "spec.name", value = "VehicleGenericsSpec")
 @Singleton
 public class Vehicle {
     private final Engine<V8> engine;

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/VehicleSpec.java
@@ -1,5 +1,6 @@
 package io.micronaut.docs.inject.generics;
 
+import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
+@Property(name = "spec.name", value = "VehicleGenericsSpec")
 @MicronautTest
 public class VehicleSpec {
     private final Vehicle vehicle;

--- a/test-suite/src/test/java/io/micronaut/docs/inject/intro/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/intro/Vehicle.java
@@ -15,8 +15,11 @@
  */
 package io.micronaut.docs.inject.intro;
 
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleIntroSpec")
 // tag::class[]
 @Singleton
 public class Vehicle {

--- a/test-suite/src/test/java/io/micronaut/docs/inject/intro/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/intro/VehicleSpec.java
@@ -16,7 +16,10 @@
 package io.micronaut.docs.inject.intro;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Property;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -25,7 +28,7 @@ class VehicleSpec {
     @Test
     void testStartVehicle() {
         // tag::start[]
-        final ApplicationContext context = ApplicationContext.run();
+        final ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "VehicleIntroSpec"));
         Vehicle vehicle = context.getBean(Vehicle.class);
         System.out.println(vehicle.start());
         // end::start[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/qualifiers/named/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/qualifiers/named/Vehicle.java
@@ -15,10 +15,12 @@
  */
 package io.micronaut.docs.inject.qualifiers.named;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleQualifiersNamedSpec")
 // tag::class[]
 @Singleton
 public class Vehicle {

--- a/test-suite/src/test/java/io/micronaut/docs/inject/qualifiers/named/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/qualifiers/named/VehicleSpec.java
@@ -19,6 +19,8 @@ import io.micronaut.context.ApplicationContext;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VehicleSpec {
@@ -26,7 +28,7 @@ class VehicleSpec {
     @Test
     void testStartVehicle() {
         // tag::start[]
-        final ApplicationContext context = ApplicationContext.run();
+        final ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "VehicleQualifiersNamedSpec"));
         Vehicle vehicle = context.getBean(Vehicle.class);
         DefaultGroovyMethods.println(this, vehicle.start());
         // end::start[]

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/Vehicle.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.injectionpoint;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleInjectinoPointSpec")
 // tag::class[]
 @Singleton
 class Vehicle {

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/VehicleSpec.java
@@ -18,13 +18,15 @@ package io.micronaut.docs.injectionpoint;
 import io.micronaut.context.ApplicationContext;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VehicleSpec {
 
     @Test
     void testStartVehicle() {
-        ApplicationContext context = ApplicationContext.run();
+        ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "VehicleInjectinoPointSpec"));
         Vehicle vehicle = context.getBean(Vehicle.class);
         System.out.println( vehicle.start() );
 

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/injection/optional/OptionalAutowiredTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/injection/optional/OptionalAutowiredTest.java
@@ -1,13 +1,15 @@
 package io.micronaut.docs.ioc.injection.optional;
 
+import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+@Property(name = "spec.name", value = "VehicleIocInjectionOptionalSpec")
 @MicronautTest(startApplication = false)
 @Disabled("optional injection is not supported")
-public class OptionalAutowiredTest {
+class OptionalAutowiredTest {
     @Test
     void testVehicle(Vehicle vehicle) {
         Assertions.assertEquals(6, vehicle.getEngine().cylinders());

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/injection/optional/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/injection/optional/Vehicle.java
@@ -1,9 +1,11 @@
 package io.micronaut.docs.ioc.injection.optional;
 
 //import io.micronaut.context.annotation.Autowired;
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleIocInjectionOptionalSpec")
 @Singleton
 class Vehicle {
     //@Autowired(required = false) // <1>

--- a/test-suite/src/test/java/io/micronaut/docs/lifecycle/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/lifecycle/Vehicle.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.docs.lifecycle;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleLifecycleSpec")
 // tag::class[]
 @Singleton
 public class Vehicle {

--- a/test-suite/src/test/java/io/micronaut/docs/lifecycle/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/lifecycle/VehicleSpec.java
@@ -16,7 +16,10 @@
 package io.micronaut.docs.lifecycle;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -25,7 +28,7 @@ class VehicleSpec {
     @Test
     void testStartVehicle() {
         // tag::start[]
-        final ApplicationContext context = ApplicationContext.run();
+        final ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "VehicleLifecycleSpec"));
         Vehicle vehicle = context.getBean(Vehicle.class);
 
         System.out.println(vehicle.start());

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/Vehicle.java
@@ -15,9 +15,11 @@
  */
 package io.micronaut.docs.qualifiers.annotation;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleQualifiersAnnotationSpec")
 // tag::class[]
 @Singleton
 public class Vehicle {

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/VehicleSpec.java
@@ -18,13 +18,15 @@ package io.micronaut.docs.qualifiers.annotation;
 import io.micronaut.context.ApplicationContext;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class VehicleSpec {
     @Test
     public void testStartVehicle() {
         // tag::start[]
-        final ApplicationContext context = ApplicationContext.run();
+        final ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "VehicleQualifiersAnnotationSpec"));
         Vehicle vehicle = context.getBean(Vehicle.class);
         System.out.println(vehicle.start());
         // end::start[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotationmember/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotationmember/Vehicle.java
@@ -1,8 +1,10 @@
 package io.micronaut.docs.qualifiers.annotationmember;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+@Requires(property = "spec.name", value = "VehicleAnnotationMemberSpec")
 // tag::class[]
 @Singleton
 public class Vehicle {

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotationmember/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotationmember/VehicleSpec.java
@@ -3,13 +3,15 @@ package io.micronaut.docs.qualifiers.annotationmember;
 import io.micronaut.context.ApplicationContext;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class VehicleSpec {
     @Test
     public void testStartVehicle() {
         // tag::start[]
-        final ApplicationContext context = ApplicationContext.run();
+        final ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "VehicleAnnotationMemberSpec"));
         Vehicle vehicle = context.getBean(Vehicle.class);
         System.out.println(vehicle.start());
         // end::start[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/any/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/any/Vehicle.java
@@ -1,5 +1,6 @@
 package io.micronaut.docs.qualifiers.any;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.docs.qualifiers.annotationmember.Engine;
 
 // tag::imports[]
@@ -8,6 +9,7 @@ import io.micronaut.context.annotation.Any;
 import jakarta.inject.Singleton;
 // end::imports[]
 
+@Requires(property = "spec.name", value = "VehicleAnySpec")
 // tag::clazz[]
 @Singleton
 public class Vehicle {

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/any/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/any/VehicleSpec.java
@@ -1,5 +1,6 @@
 package io.micronaut.docs.qualifiers.any;
 
+import io.micronaut.context.annotation.Property;
 import io.micronaut.docs.qualifiers.annotationmember.Engine;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Assertions;
@@ -10,6 +11,7 @@ import io.micronaut.context.annotation.Any;
 import jakarta.inject.Inject;
 // end::imports[]
 
+@Property(name = "spec.name", value = "VehicleAnySpec")
 @MicronautTest
 public class VehicleSpec {
 

--- a/test-suite/src/test/java/io/micronaut/docs/whatsNew/CacheFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/whatsNew/CacheFactory.java
@@ -25,7 +25,7 @@ import jakarta.inject.Singleton;
 // end::imports[]
 
 // tag::class[]
-@Factory
+//@Factory
 class CacheFactory {
 
     @Singleton

--- a/test-suite/src/test/java/io/micronaut/docs/whatsNew/CacheFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/whatsNew/CacheFactory.java
@@ -21,11 +21,14 @@ import io.micronaut.context.annotation.Factory;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.cache.configuration.MutableConfiguration;
+
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 // end::imports[]
 
+@Requires(property = "spec.name", value = "CacheFactoryTest")
 // tag::class[]
-//@Factory
+@Factory
 class CacheFactory {
 
     @Singleton


### PR DESCRIPTION
This commit reduces the test pollution in test-suite using spec.name property and @Requires