### PR TITLE
Prepare JsonMapper for Jackson 3 and ReadBuffer

### DIFF
--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBuffer.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBuffer.java
@@ -16,16 +16,18 @@
 package io.micronaut.buffer.netty;
 
 import io.micronaut.core.annotation.Internal;
-import org.jspecify.annotations.NonNull;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ReadBuffer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.util.function.Function;
 
 /**
  * Netty {@link ReadBuffer} implementation.
@@ -108,6 +110,17 @@ final class NettyReadBuffer extends ReadBuffer {
         ByteBuf b = getBuf();
         buf = null;
         return new ByteBufInputStream(b, true);
+    }
+
+    @Override
+    public <R> @Nullable R useFastHeapBuffer(@NonNull Function<java.nio.ByteBuffer, @NonNull R> function) {
+        ByteBuf b = getBuf();
+        if (b.hasArray()) {
+            buf = null;
+            return function.apply(java.nio.ByteBuffer.wrap(b.array(), b.arrayOffset() + b.readerIndex(), b.readableBytes()));
+        } else {
+            return super.useFastHeapBuffer(function);
+        }
     }
 
     @Override

--- a/buffer-netty/src/test/java/io/micronaut/buffer/netty/AbstractReadBufferTest.java
+++ b/buffer-netty/src/test/java/io/micronaut/buffer/netty/AbstractReadBufferTest.java
@@ -143,6 +143,20 @@ abstract class AbstractReadBufferTest {
     }
 
     @Test
+    public void transferToNio() throws IOException {
+        ByteBuffer nio = ByteBuffer.allocateDirect(3);
+        nio.put((byte) 1);
+        nio.put((byte) 2);
+        nio.put((byte) 3);
+        nio.flip();
+        try (ReadBuffer rb = factory.adapt(nio)) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            rb.transferTo(baos);
+            assertArrayEquals(new byte[]{1, 2, 3}, baos.toByteArray());
+        }
+    }
+
+    @Test
     public void createEmpty() {
         try (ReadBuffer rb = factory.createEmpty()) {
             assertEquals(0, rb.readable());

--- a/core/src/main/java/io/micronaut/core/io/buffer/NioReadBuffer.java
+++ b/core/src/main/java/io/micronaut/core/io/buffer/NioReadBuffer.java
@@ -17,12 +17,12 @@ package io.micronaut.core.io.buffer;
 
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.function.Function;
 
 /**
  * {@link ReadBuffer} implementation based on NIO {@link ByteBuffer}.
@@ -108,13 +108,13 @@ final class NioReadBuffer extends ReadBuffer {
     }
 
     @Override
-    public void transferTo(@NonNull OutputStream stream) throws IOException {
+    public <R> @Nullable R useFastHeapBuffer(@NonNull Function<ByteBuffer, @NonNull R> function) {
         checkOpen();
         if (buffer.hasArray()) {
             closed = true;
-            stream.write(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+            return function.apply(buffer);
         } else {
-            super.transferTo(stream);
+            return super.useFastHeapBuffer(function);
         }
     }
 

--- a/jackson-core/src/main/java/io/micronaut/jackson/core/parser/JacksonCoreParserFactory.java
+++ b/jackson-core/src/main/java/io/micronaut/jackson/core/parser/JacksonCoreParserFactory.java
@@ -39,7 +39,7 @@ import java.util.function.Function;
  * @deprecated Implement {@link io.micronaut.json.JsonMapper#readValue(ReadBuffer, Argument)} instead. The implementation can use {@link ReadBuffer#useFastHeapBuffer(Function)}.
  */
 @Internal
-@Deprecated
+@Deprecated(since = "5.0.0")
 public final class JacksonCoreParserFactory {
 
     private static final boolean HAS_NETTY_BUFFER;
@@ -67,7 +67,7 @@ public final class JacksonCoreParserFactory {
      * @throws IOException On failure of jackson createParser methods
      * @deprecated Use method with {@link ObjectReadContext} instead
      */
-    @Deprecated
+    @Deprecated(since = "5.0.0")
     public static JsonParser createJsonParser(JsonFactory factory, ByteBuffer<?> buffer) throws IOException {
         if (!HAS_NETTY_BUFFER || !(buffer.asNativeBuffer() instanceof ByteBuf byteBuf)) {
             return factory.createParser(buffer.toByteArray());

--- a/jackson-core/src/main/java/io/micronaut/jackson/core/parser/JacksonCoreParserFactory.java
+++ b/jackson-core/src/main/java/io/micronaut/jackson/core/parser/JacksonCoreParserFactory.java
@@ -15,16 +15,19 @@
  */
 package io.micronaut.jackson.core.parser;
 
-import tools.jackson.core.json.JsonFactory;
-import tools.jackson.core.JsonParser;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.io.buffer.ByteBuffer;
+import io.micronaut.core.io.buffer.ReadBuffer;
 import io.micronaut.core.type.Argument;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.json.JsonFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.function.Function;
 
 /**
  * Helper class for implementing
@@ -33,8 +36,10 @@ import java.io.InputStream;
  *
  * @author Jonas Konrad
  * @since 4.0.0
+ * @deprecated Implement {@link io.micronaut.json.JsonMapper#readValue(ReadBuffer, Argument)} instead. The implementation can use {@link ReadBuffer#useFastHeapBuffer(Function)}.
  */
 @Internal
+@Deprecated
 public final class JacksonCoreParserFactory {
 
     private static final boolean HAS_NETTY_BUFFER;
@@ -60,7 +65,9 @@ public final class JacksonCoreParserFactory {
      * @param buffer The input data
      * @return The created parser
      * @throws IOException On failure of jackson createParser methods
+     * @deprecated Use method with {@link ObjectReadContext} instead
      */
+    @Deprecated
     public static JsonParser createJsonParser(JsonFactory factory, ByteBuffer<?> buffer) throws IOException {
         if (!HAS_NETTY_BUFFER || !(buffer.asNativeBuffer() instanceof ByteBuf byteBuf)) {
             return factory.createParser(buffer.toByteArray());
@@ -70,6 +77,27 @@ public final class JacksonCoreParserFactory {
             return factory.createParser(byteBuf.array(), byteBuf.readerIndex() + byteBuf.arrayOffset(), byteBuf.readableBytes());
         } else {
             return factory.createParser((InputStream) new ByteBufInputStream(byteBuf));
+        }
+    }
+
+    /**
+     * Create a jackson {@link JsonParser} for the given input bytes.
+     *
+     * @param factory     The jackson {@link JsonFactory} for parse features
+     * @param readContext The jackson read context
+     * @param buffer      The input data
+     * @return The created parser
+     * @throws IOException On failure of jackson createParser methods
+     */
+    public static JsonParser createJsonParser(JsonFactory factory, ObjectReadContext readContext, ByteBuffer<?> buffer) throws IOException {
+        if (!HAS_NETTY_BUFFER || !(buffer.asNativeBuffer() instanceof ByteBuf byteBuf)) {
+            return factory.createParser(readContext, buffer.toByteArray());
+        }
+
+        if (byteBuf.hasArray()) {
+            return factory.createParser(readContext, byteBuf.array(), byteBuf.readerIndex() + byteBuf.arrayOffset(), byteBuf.readableBytes());
+        } else {
+            return factory.createParser(readContext, (InputStream) new ByteBufInputStream(byteBuf));
         }
     }
 }

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -17,12 +17,13 @@ package io.micronaut.json;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Experimental;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import io.micronaut.core.io.buffer.ByteBuffer;
+import io.micronaut.core.io.buffer.ReadBuffer;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.type.Argument;
 import io.micronaut.json.tree.JsonNode;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Processor;
 
 import java.io.IOException;
@@ -125,9 +126,25 @@ public interface JsonMapper {
      * @param <T> Type variable of the return type.
      * @return The deserialized object.
      * @throws IOException IOException
+     * @deprecated Prefer {@link #readValue(ReadBuffer, Argument)}
      */
+    @Deprecated
     default <T> T readValue(@NonNull ByteBuffer<?> byteBuffer, @NonNull Argument<T> type) throws IOException {
         return readValue(byteBuffer.toByteArray(), type);
+    }
+
+    /**
+     * Parse and map json from the given read buffer.
+     *
+     * @param readBuffer The input data.
+     * @param type       The type to deserialize to.
+     * @param <T>        Type variable of the return type.
+     * @return The deserialized object.
+     * @throws IOException IOException
+     * @since 5.0.0
+     */
+    default <T> T readValue(@NonNull ReadBuffer readBuffer, @NonNull Argument<T> type) throws IOException {
+        return readValue(readBuffer.toArray(), type);
     }
 
     /**

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -128,7 +128,7 @@ public interface JsonMapper {
      * @throws IOException IOException
      * @deprecated Prefer {@link #readValue(ReadBuffer, Argument)}
      */
-    @Deprecated
+    @Deprecated(since = "5.0.0")
     default <T> T readValue(@NonNull ByteBuffer<?> byteBuffer, @NonNull Argument<T> type) throws IOException {
         return readValue(byteBuffer.toByteArray(), type);
     }


### PR DESCRIPTION
- Introduce a new ReadBuffer.useFastHeapBuffer method to directly access a buffer's backing array, used for fast deserialization.
- Migrate ReadBuffer.transferTo to useFastHeapBuffer
- Add a readValue(ReadBuffer) method to replace the ByteBuffer one
- Implement this method using useFastHeapBuffer
- Add a method to JacksonCoreParserFactory that takes an ObjectReadContext (Jackson 3)

In the short term, micronaut-serialization can use the new JacksonCoreParserFactory method. In the long term, callers should migrate to the new ReadBuffer readValue which makes JacksonCoreParserFactory obsolete.