### PR TITLE
Match jackson feature names and add config for remaining features

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonFactorySetupSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonFactorySetupSpec.groovy
@@ -15,12 +15,13 @@
  */
 package io.micronaut.http.server.netty.jackson
 
-import tools.jackson.core.json.JsonFactory
-import tools.jackson.databind.ObjectMapper
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.MapPropertySource
 import io.micronaut.context.env.PropertySource
 import spock.lang.Specification
+import tools.jackson.core.json.JsonFactory
+import tools.jackson.databind.ObjectMapper
+
 /**
  * @author Vladislav Chernogorov
  * @since 1.0
@@ -43,7 +44,7 @@ class JsonFactorySetupSpec extends Specification {
         given:
         ApplicationContext applicationContext = ApplicationContext.builder("test").build()
         applicationContext.environment.addPropertySource((MapPropertySource) PropertySource.of(
-                'jackson.factory.fail-on-symbol-hash-overflow': false
+                'jackson.json-factory-features.fail-on-symbol-hash-overflow': false
         ))
         applicationContext.start()
 

--- a/jackson-databind/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
@@ -16,6 +16,16 @@
 package io.micronaut.jackson;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.TypeHint;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.json.JsonConfiguration;
+import org.jspecify.annotations.NonNull;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.core.StreamWriteFeature;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.json.JsonReadFeature;
 import tools.jackson.core.json.JsonWriteFeature;
@@ -26,15 +36,10 @@ import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.PropertyNamingStrategy;
 import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.cfg.EnumFeature;
+import tools.jackson.databind.cfg.JsonNodeFeature;
 import tools.jackson.databind.type.TypeFactory;
-import io.micronaut.context.annotation.ConfigurationProperties;
-import org.jspecify.annotations.NonNull;
-import io.micronaut.core.annotation.TypeHint;
-import io.micronaut.core.type.Argument;
-import io.micronaut.core.util.ArgumentUtils;
-import io.micronaut.core.util.ArrayUtils;
-import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.json.JsonConfiguration;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -75,12 +80,17 @@ public class JacksonConfiguration implements JsonConfiguration {
     private Locale locale;
     private TimeZone timeZone;
     private int arraySizeThreshold = DEFAULT_ARRAYSIZETHRESHOLD;
-    private Map<SerializationFeature, Boolean> serialization = Collections.emptyMap();
-    private Map<DeserializationFeature, Boolean> deserialization = Collections.emptyMap();
-    private Map<MapperFeature, Boolean> mapper = Collections.emptyMap();
-    private Map<JsonReadFeature, Boolean> parser = Collections.emptyMap();
-    private Map<JsonWriteFeature, Boolean> generator = Collections.emptyMap();
-    private Map<JsonFactory.Feature, Boolean> factory = Collections.emptyMap();
+    private Map<SerializationFeature, Boolean> serializationFeatures = Collections.emptyMap();
+    private Map<DeserializationFeature, Boolean> deserializationFeatures = Collections.emptyMap();
+    private Map<MapperFeature, Boolean> mapperFeatures = Collections.emptyMap();
+    private Map<JsonReadFeature, Boolean> jsonReadFeatures = Collections.emptyMap();
+    private Map<JsonWriteFeature, Boolean> jsonWriteFeatures = Collections.emptyMap();
+    private Map<JsonFactory.Feature, Boolean> jsonFactoryFeatures = Collections.emptyMap();
+    private Map<StreamReadFeature, Boolean> streamReadFeatures = Collections.emptyMap();
+    private Map<StreamWriteFeature, Boolean> streamWriteFeatures = Collections.emptyMap();
+    private Map<EnumFeature, Boolean> enumFeatures = Collections.emptyMap();
+    private Map<DateTimeFeature, Boolean> dateTimeFeatures = Collections.emptyMap();
+    private Map<JsonNodeFeature, Boolean> jsonNodeFeatures = Collections.emptyMap();
     private JsonInclude.Include serializationInclusion = JsonInclude.Include.NON_EMPTY;
     private DefaultTyping defaultTyping = null;
     private PropertyNamingStrategy propertyNamingStrategy = null;
@@ -138,48 +148,6 @@ public class JacksonConfiguration implements JsonConfiguration {
      */
     public String getDateFormat() {
         return dateFormat;
-    }
-
-    /**
-     * @return The serialization settings
-     */
-    public Map<SerializationFeature, Boolean> getSerializationSettings() {
-        return serialization;
-    }
-
-    /**
-     * @return The deserialization settings
-     */
-    public Map<DeserializationFeature, Boolean> getDeserializationSettings() {
-        return deserialization;
-    }
-
-    /**
-     * @return Settings for the object mapper
-     */
-    public Map<MapperFeature, Boolean> getMapperSettings() {
-        return mapper;
-    }
-
-    /**
-     * @return Settings for the parser
-     */
-    public Map<JsonReadFeature, Boolean> getParserSettings() {
-        return parser;
-    }
-
-    /**
-     * @return Settings for the generator
-     */
-    public Map<JsonWriteFeature, Boolean> getGeneratorSettings() {
-        return generator;
-    }
-
-    /**
-     * @return Settings for the factory
-     */
-    public Map<JsonFactory.Feature, Boolean> getFactorySettings() {
-        return factory;
     }
 
     /**
@@ -257,67 +225,205 @@ public class JacksonConfiguration implements JsonConfiguration {
     /**
      * Sets the serialization features to use.
      *
-     * @param serialization The serialization features.
+     * @param serializationFeatures The serialization features.
      */
-    public void setSerialization(Map<SerializationFeature, Boolean> serialization) {
-        if (CollectionUtils.isNotEmpty(serialization)) {
-            this.serialization = serialization;
+    public void setSerializationFeatures(Map<SerializationFeature, Boolean> serializationFeatures) {
+        if (CollectionUtils.isNotEmpty(serializationFeatures)) {
+            this.serializationFeatures = serializationFeatures;
         }
     }
 
     /**
      * Sets the deserialization features to use.
      *
-     * @param deserialization The deserialiation features.
+     * @param deserializationFeatures The deserialiation features.
      */
-    public void setDeserialization(Map<DeserializationFeature, Boolean> deserialization) {
-        if (CollectionUtils.isNotEmpty(deserialization)) {
-            this.deserialization = deserialization;
+    public void setDeserializationFeatures(Map<DeserializationFeature, Boolean> deserializationFeatures) {
+        if (CollectionUtils.isNotEmpty(deserializationFeatures)) {
+            this.deserializationFeatures = deserializationFeatures;
         }
     }
 
     /**
      * Sets the object mapper features to use.
      *
-     * @param mapper The object mapper features
+     * @param mapperFeatures The object mapper features
      */
-    public void setMapper(Map<MapperFeature, Boolean> mapper) {
-        if (CollectionUtils.isNotEmpty(mapper)) {
-            this.mapper = mapper;
+    public void setMapperFeatures(Map<MapperFeature, Boolean> mapperFeatures) {
+        if (CollectionUtils.isNotEmpty(mapperFeatures)) {
+            this.mapperFeatures = mapperFeatures;
         }
     }
 
     /**
-     * Sets the parser features to use.
+     * Format-independent stream write features.
      *
-     * @param parser The parser features
+     * @return The stream write features
      */
-    public void setParser(Map<JsonReadFeature, Boolean> parser) {
-        if (CollectionUtils.isNotEmpty(parser)) {
-            this.parser = parser;
-        }
+    public Map<StreamWriteFeature, Boolean> getStreamWriteFeatures() {
+        return streamWriteFeatures;
     }
 
     /**
-     * Sets the generator features to use.
+     * Format-independent stream write features.
      *
-     * @param generator The generator features
+     * @param streamWriteFeatures The stream write features
      */
-    public void setGenerator(Map<JsonWriteFeature, Boolean> generator) {
-        if (CollectionUtils.isNotEmpty(generator)) {
-            this.generator = generator;
-        }
+    public void setStreamWriteFeatures(Map<StreamWriteFeature, Boolean> streamWriteFeatures) {
+        this.streamWriteFeatures = streamWriteFeatures;
     }
 
     /**
-     * Sets the factory features to use.
+     * Format-independent stream read features.
      *
-     * @param factory The generator features
+     * @return The stream read features
      */
-    public void setFactory(Map<JsonFactory.Feature, Boolean> factory) {
-        if (CollectionUtils.isNotEmpty(factory)) {
-            this.factory = factory;
-        }
+    public Map<StreamReadFeature, Boolean> getStreamReadFeatures() {
+        return streamReadFeatures;
+    }
+
+    /**
+     * Format-independent stream read features.
+     *
+     * @param streamReadFeatures The stream read features
+     */
+    public void setStreamReadFeatures(Map<StreamReadFeature, Boolean> streamReadFeatures) {
+        this.streamReadFeatures = streamReadFeatures;
+    }
+
+    /**
+     * JSON factory features.
+     *
+     * @return JSON factory features
+     */
+    public Map<JsonFactory.Feature, Boolean> getJsonFactoryFeatures() {
+        return jsonFactoryFeatures;
+    }
+
+    /**
+     * JSON factory features.
+     *
+     * @param jsonFactoryFeatures JSON factory features
+     */
+    public void setJsonFactoryFeatures(Map<JsonFactory.Feature, Boolean> jsonFactoryFeatures) {
+        this.jsonFactoryFeatures = jsonFactoryFeatures;
+    }
+
+    /**
+     * JSON stream write features.
+     *
+     * @return JSON stream write features
+     */
+    public Map<JsonWriteFeature, Boolean> getJsonWriteFeatures() {
+        return jsonWriteFeatures;
+    }
+
+    /**
+     * JSON stream write features.
+     *
+     * @param jsonWriteFeatures JSON stream write features
+     */
+    public void setJsonWriteFeatures(Map<JsonWriteFeature, Boolean> jsonWriteFeatures) {
+        this.jsonWriteFeatures = jsonWriteFeatures;
+    }
+
+    /**
+     * JSON stream read features.
+     *
+     * @return JSON stream read features
+     */
+    public Map<JsonReadFeature, Boolean> getJsonReadFeatures() {
+        return jsonReadFeatures;
+    }
+
+    /**
+     * JSON stream read features.
+     *
+     * @param jsonReadFeatures JSON stream read features
+     */
+    public void setJsonReadFeatures(Map<JsonReadFeature, Boolean> jsonReadFeatures) {
+        this.jsonReadFeatures = jsonReadFeatures;
+    }
+
+    /**
+     * General mapper features.
+     *
+     * @return General mapper features
+     */
+    public Map<MapperFeature, Boolean> getMapperFeatures() {
+        return mapperFeatures;
+    }
+
+    /**
+     * General deserialization features.
+     *
+     * @return General deserialization features
+     */
+    public Map<DeserializationFeature, Boolean> getDeserializationFeatures() {
+        return deserializationFeatures;
+    }
+
+    /**
+     * General serialization features.
+     *
+     * @return General serialization features
+     */
+    public Map<SerializationFeature, Boolean> getSerializationFeatures() {
+        return serializationFeatures;
+    }
+
+    /**
+     * Enum data binding features.
+     *
+     * @return Enum data binding features
+     */
+    public Map<EnumFeature, Boolean> getEnumFeatures() {
+        return enumFeatures;
+    }
+
+    /**
+     * Enum data binding features.
+     *
+     * @param enumFeatures Enum data binding features
+     */
+    public void setEnumFeatures(Map<EnumFeature, Boolean> enumFeatures) {
+        this.enumFeatures = enumFeatures;
+    }
+
+    /**
+     * Date/time data binding features.
+     *
+     * @return Date/time data binding features
+     */
+    public Map<DateTimeFeature, Boolean> getDateTimeFeatures() {
+        return dateTimeFeatures;
+    }
+
+    /**
+     * Date/time data binding features.
+     *
+     * @param dateTimeFeatures Date/time data binding features
+     */
+    public void setDateTimeFeatures(Map<DateTimeFeature, Boolean> dateTimeFeatures) {
+        this.dateTimeFeatures = dateTimeFeatures;
+    }
+
+    /**
+     * JsonNode data binding features.
+     *
+     * @return JsonNode data binding features
+     */
+    public Map<JsonNodeFeature, Boolean> getJsonNodeFeatures() {
+        return jsonNodeFeatures;
+    }
+
+    /**
+     * JsonNode data binding features.
+     *
+     * @param jsonNodeFeatures JsonNode data binding features
+     */
+    public void setJsonNodeFeatures(Map<JsonNodeFeature, Boolean> jsonNodeFeatures) {
+        this.jsonNodeFeatures = jsonNodeFeatures;
     }
 
     /**

--- a/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
@@ -22,7 +22,6 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Type;
-import org.jspecify.annotations.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.reflect.GenericTypeUtils;
 import io.micronaut.core.util.StringUtils;
@@ -30,6 +29,7 @@ import io.micronaut.jackson.serialize.MicronautDeserializers;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.json.JsonFactoryBuilder;
@@ -105,7 +105,7 @@ public class ObjectMapperFactory {
     @BootstrapContextCompatible
     public JsonFactory jsonFactory(JacksonConfiguration jacksonConfiguration) {
         final JsonFactoryBuilder jsonFactoryBuilder = JsonFactory.builder();
-        jacksonConfiguration.getFactorySettings().forEach(jsonFactoryBuilder::configure);
+        jacksonConfiguration.getJsonFactoryFeatures().forEach(jsonFactoryBuilder::configure);
         return jsonFactoryBuilder.build();
     }
 
@@ -249,11 +249,16 @@ public class ObjectMapperFactory {
                 builder.propertyNamingStrategy(propertyNamingStrategy);
             }
 
-            jacksonConfiguration.getSerializationSettings().forEach(builder::configure);
-            jacksonConfiguration.getDeserializationSettings().forEach(builder::configure);
-            jacksonConfiguration.getMapperSettings().forEach(builder::configure);
-            jacksonConfiguration.getParserSettings().forEach(builder::configure);
-            jacksonConfiguration.getGeneratorSettings().forEach(builder::configure);
+            jacksonConfiguration.getStreamReadFeatures().forEach(builder::configure);
+            jacksonConfiguration.getStreamWriteFeatures().forEach(builder::configure);
+            jacksonConfiguration.getMapperFeatures().forEach(builder::configure);
+            jacksonConfiguration.getJsonReadFeatures().forEach(builder::configure);
+            jacksonConfiguration.getJsonWriteFeatures().forEach(builder::configure);
+            jacksonConfiguration.getDateTimeFeatures().forEach(builder::configure);
+            jacksonConfiguration.getEnumFeatures().forEach(builder::configure);
+            jacksonConfiguration.getJsonNodeFeatures().forEach(builder::configure);
+            jacksonConfiguration.getDeserializationFeatures().forEach(builder::configure);
+            jacksonConfiguration.getSerializationFeatures().forEach(builder::configure);
         }
 
         return builder.build();

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/JacksonSetupSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/JacksonSetupSpec.groovy
@@ -15,15 +15,15 @@
  */
 package io.micronaut.jackson
 
-import tools.jackson.databind.ObjectMapper
-import tools.jackson.databind.DefaultTyping
-import tools.jackson.databind.PropertyNamingStrategies
-import tools.jackson.databind.SerializationFeature
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.MapPropertySource
 import io.micronaut.context.env.PropertySource
 import spock.lang.Specification
 import spock.lang.Unroll
+import tools.jackson.databind.DefaultTyping
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.PropertyNamingStrategies
+import tools.jackson.databind.SerializationFeature
 
 /**
  * Created by graemerocher on 31/08/2017.
@@ -64,7 +64,7 @@ class JacksonSetupSpec extends Specification {
         ApplicationContext applicationContext = ApplicationContext.builder("test").build()
         applicationContext.environment.addPropertySource((MapPropertySource) PropertySource.of(
                 'jackson.dateFormat': 'yyMMdd',
-                'jackson.serialization.indentOutput': true,
+                'jackson.serialization-features.indentOutput': true,
                 'jackson.json-view.enabled': true
         ))
         applicationContext.start()
@@ -75,7 +75,7 @@ class JacksonSetupSpec extends Specification {
 
         applicationContext.containsBean(JacksonConfiguration)
         applicationContext.getBean(JacksonConfiguration).dateFormat == 'yyMMdd'
-        applicationContext.getBean(JacksonConfiguration).serializationSettings.get(SerializationFeature.INDENT_OUTPUT)
+        applicationContext.getBean(JacksonConfiguration).serializationFeatures.get(SerializationFeature.INDENT_OUTPUT)
 
         cleanup:
         applicationContext?.close()

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -10,6 +10,8 @@ This section documents breaking changes between Micronaut versions
 Micronaut Jackson Databind uses https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0[Jackson 3].
 If you use Micronaut Jackson Databind, check the https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md[Jackson 3 Migration Guide].
 
+Micronaut configuration properties for various Jackson features have been renamed. Please check the https://docs.micronaut.io/latest/guide/configurationreference.html#io.micronaut.jackson.JacksonConfiguration[configuration reference]. Also note that Jackson has renamed a few features upstream, and that various defaults have changed.
+
 ==== Update to Apache Groovy 5
 
 Micronaut 5 uses http://groovy-lang.org/releasenotes/groovy-5.0.html[Apache Groovy 5].

--- a/src/main/docs/guide/httpServer/jsonBinding/jacksonConfiguration/jacksonConfigurationFeatures.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding/jacksonConfiguration/jacksonConfigurationFeatures.adoc
@@ -1,26 +1,17 @@
 :jackson-core: https://fasterxml.github.io/jackson-core/javadoc/2.9/
 :jackson-databind: https://fasterxml.github.io/jackson-databind/javadoc/2.9/
 
-If you use <<jsonBinding, `micronaut-jackson-databind`>>, all Jackson's features can be configured with their name as the key and a boolean to indicate enabled or disabled.
-
-|======
-|serialization | Map | link:{jackson-databind}com/fasterxml/jackson/databind/SerializationFeature.html[SerializationFeature]
-|deserialization | Map | link:{jackson-databind}com/fasterxml/jackson/databind/DeserializationFeature.html[DeserializationFeature]
-|mapper | Map | link:{jackson-databind}com/fasterxml/jackson/databind/MapperFeature.html[MapperFeature]
-|parser | Map | link:{jackson-core}com/fasterxml/jackson/core/JsonParser.Feature.html[JsonParser.Feature]
-|generator | Map | link:{jackson-core}com/fasterxml/jackson/core/JsonGenerator.Feature.html[JsonGenerator.Feature]
-|factory | Map | link:{jackson-core}com/fasterxml/jackson/core/JsonFactory.Feature.html[JsonFactory.Feature]
-|======
+If you use <<jsonBinding, `micronaut-jackson-databind`>>, all Jackson's features can be configured with their name as the key and a boolean to indicate enabled or disabled. Please check the configuration reference for the property names.
 
 Example:
 
 [configuration]
 ----
 jackson:
-  serialization:
+  serialization-features:
     indentOutput: true
     writeDatesAsTimestamps: false
-  deserialization:
+  deserialization-features:
     useBigIntegerForInts: true
     failOnUnknownProperties: false
 ----

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/JacksonNullableTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/jackson/JacksonNullableTest.kt
@@ -1,12 +1,12 @@
 package io.micronaut.jackson
 
 import io.micronaut.context.annotation.Property
-import tools.jackson.databind.ObjectMapper
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.ObjectMapper
 
-@Property(name = "jackson.deserialization.failOnNullForPrimitives", value = "false")
+@Property(name = "jackson.deserialization-features.failOnNullForPrimitives", value = "false")
 @MicronautTest
 class JacksonNullableTest {
 


### PR DESCRIPTION
Jackson 3 split up some feature classes, so now we need more config. Also change the existing config properties to match the jackson enum names properly.