### PR TITLE
create JsonMapper.Builder as prototype bean

### DIFF
--- a/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
@@ -20,6 +20,7 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Type;
 import io.micronaut.core.convert.ConversionService;
@@ -29,6 +30,7 @@ import io.micronaut.jackson.serialize.MicronautDeserializers;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.json.JsonFactory;
@@ -130,18 +132,29 @@ public class ObjectMapperFactory {
     }
 
     /**
+     * Builds the core Jackson {@link JsonMapper} from a {@link JsonMapper.Builder}
+     *
+     * @param jsonMapperBuilder JsonMapper Builder
+     * @return The {@link JsonMapper}
+     */
+    @Singleton
+    @Primary
+    @Named("json")
+    @BootstrapContextCompatible
+    public JsonMapper jsonMapper(JsonMapper.@NonNull Builder jsonMapperBuilder) {
+        return jsonMapperBuilder.build();
+    }
+
+    /**
      * Builds the core Jackson {@link ObjectMapper} from the optional configuration and {@link JsonFactory}.
      *
      * @param jacksonConfiguration The configuration
      * @param jsonFactory The JSON factory
      * @return The {@link ObjectMapper}
      */
-    @Singleton
-    @Primary
-    @Named("json")
-    @BootstrapContextCompatible
-    public JsonMapper objectMapper(@Nullable JacksonConfiguration jacksonConfiguration,
-                                     @Nullable JsonFactory jsonFactory) {
+    @Prototype
+    public JsonMapper.Builder jsonMapperBuilder(@Nullable JacksonConfiguration jacksonConfiguration,
+                                   @Nullable JsonFactory jsonFactory) {
         JsonMapper.Builder builder = jsonFactory != null ? JsonMapper.builder(jsonFactory) : JsonMapper.builder();
 
         final boolean hasConfiguration = jacksonConfiguration != null;
@@ -261,6 +274,6 @@ public class ObjectMapperFactory {
             jacksonConfiguration.getSerializationFeatures().forEach(builder::configure);
         }
 
-        return builder.build();
+        return builder;
     }
 }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
@@ -40,7 +40,6 @@ import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JacksonModule;
 import tools.jackson.databind.KeyDeserializer;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.PropertyNamingStrategy;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.ValueSerializer;
@@ -132,7 +131,7 @@ public class ObjectMapperFactory {
     }
 
     /**
-     * Builds the core Jackson {@link JsonMapper} from a {@link JsonMapper.Builder}
+     * Builds the core Jackson {@link JsonMapper} from a {@link JsonMapper.Builder}.
      *
      * @param jsonMapperBuilder JsonMapper Builder
      * @return The {@link JsonMapper}

--- a/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
@@ -151,6 +151,7 @@ public class ObjectMapperFactory {
      * @param jsonFactory The JSON factory
      * @return The {@link JsonMapper.Builder}
      */
+    @BootstrapContextCompatible
     @Prototype
     public JsonMapper.Builder jsonMapperBuilder(@Nullable JacksonConfiguration jacksonConfiguration,
                                    @Nullable JsonFactory jsonFactory) {

--- a/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
@@ -146,11 +146,11 @@ public class ObjectMapperFactory {
     }
 
     /**
-     * Builds the core Jackson {@link ObjectMapper} from the optional configuration and {@link JsonFactory}.
+     * Builds the core Jackson {@link JsonMapper.Builder} from the optional configuration and {@link JsonFactory}.
      *
      * @param jacksonConfiguration The configuration
      * @param jsonFactory The JSON factory
-     * @return The {@link ObjectMapper}
+     * @return The {@link JsonMapper.Builder}
      */
     @Prototype
     public JsonMapper.Builder jsonMapperBuilder(@Nullable JacksonConfiguration jacksonConfiguration,

--- a/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
@@ -132,7 +132,7 @@ public final class JacksonDatabindMapper implements JsonMapper {
         var objectMapperFactory = new ObjectMapperFactory();
         objectMapperFactory.setDeserializers(new JsonNodeDeserializer());
         objectMapperFactory.setSerializers(new JsonNodeSerializer());
-        return objectMapperFactory.objectMapper(null, null);
+        return objectMapperFactory.jsonMapperBuilder(null, null).build();
     }
 
     @Internal

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/serialize/JacksonObjectSerializerSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/serialize/JacksonObjectSerializerSpec.groovy
@@ -9,7 +9,7 @@ class JacksonObjectSerializerSpec extends Specification {
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/2282")
     void "test empty optional is returned"() {
-        ObjectMapper objectMapper = new ObjectMapperFactory().objectMapper(null, null)
+        ObjectMapper objectMapper = new ObjectMapperFactory().jsonMapperBuilder(null, null).build()
 
         when:
         Optional<Object> optional = new JacksonObjectSerializer(objectMapper).deserialize("null".bytes)

--- a/jackson-databind/src/test/groovy/io/micronaut/json/JsonObjectSerializerSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/json/JsonObjectSerializerSpec.groovy
@@ -10,7 +10,7 @@ class JsonObjectSerializerSpec extends Specification {
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/2282")
     void "test empty optional is returned"() {
-        ObjectMapper objectMapper = new ObjectMapperFactory().objectMapper(null, null)
+        ObjectMapper objectMapper = new ObjectMapperFactory().jsonMapperBuilder(null, null).build()
 
         when:
         Optional<Object> optional = new JsonObjectSerializer(new JacksonDatabindMapper(objectMapper)).deserialize("null".bytes)


### PR DESCRIPTION
This could allow to register for example filter providers in Jackson 3:

```java
package io.micronaut.serde.tck.jackson.databind;

import io.micronaut.context.event.BeanCreatedEvent;
import io.micronaut.context.event.BeanCreatedEventListener;
import org.jspecify.annotations.NonNull;
import jakarta.inject.Singleton;
import tools.jackson.databind.json.JsonMapper;
import tools.jackson.databind.ser.std.SimpleFilterProvider;

@Singleton
public class JsonsMapperBeanCreatedEventListener implements BeanCreatedEventListener<JsonMapper.Builder> {

    private final DatabindPredicateFilter predicateFilter;

    public JsonsMapperBeanCreatedEventListener(DatabindPredicateFilter predicateFilter) {
        this.predicateFilter = predicateFilter;
    }

    @Override
    public JsonMapper.Builder onCreated(@NonNull BeanCreatedEvent<JsonMapper.Builder> event) {
        JsonMapper.Builder builder = event.getBean();
        SimpleFilterProvider filterProvider = new SimpleFilterProvider();
        filterProvider.addFilter("ignore-value", predicateFilter);
        builder.filterProvider(filterProvider);
        return builder;
    }
}
```