### PR TITLE
Preserving Body Related Headers When Following 307 or 308 Redirects

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -227,25 +227,25 @@ public class DefaultHttpClient implements
     private static final int DEFAULT_HTTPS_PORT = 443;
 
     /**
-     * Which headers <i>not</i> to copy from the first request when redirecting to a second request. There doesn't
-     * appear to be a spec for this. {@link HttpURLConnection} seems to drop all headers, but that would be a
-     * breaking change.
-     * <p>
-     * Stored as a {@link HttpHeaders} with empty values because presumably someone thought about optimizing those
-     * already.
+     * When following a 307 or 308 redirect, body related headers should be kept. Standard hop-by-hop
+     * and host-specific headers are still dropped.
      */
-    private static final HttpHeaders REDIRECT_HEADER_BLOCKLIST;
+    private static final HttpHeaders REDIRECT_HEADER_BLOCKLIST_PRESERVE_BODY = new DefaultHttpHeaders()
+        .add(HttpHeaderNames.HOST, "")
+        .add(HttpHeaderNames.TRANSFER_ENCODING, "")
+        .add(HttpHeaderNames.CONNECTION, "");
 
-    static {
-        REDIRECT_HEADER_BLOCKLIST = new DefaultHttpHeaders();
-        // The host should be recalculated based on the location
-        REDIRECT_HEADER_BLOCKLIST.add(HttpHeaderNames.HOST, "");
-        // post body headers
-        REDIRECT_HEADER_BLOCKLIST.add(HttpHeaderNames.CONTENT_TYPE, "");
-        REDIRECT_HEADER_BLOCKLIST.add(HttpHeaderNames.CONTENT_LENGTH, "");
-        REDIRECT_HEADER_BLOCKLIST.add(HttpHeaderNames.TRANSFER_ENCODING, "");
-        REDIRECT_HEADER_BLOCKLIST.add(HttpHeaderNames.CONNECTION, "");
-    }
+    /**
+     * When following 3xx responses (that are not 307 or 308) the request bodies are dropped and converted
+     * to GET requests. Therefore, headers related to the content and length of the request body must
+     * also be stripped along with standard hop-by-hop and host-specific headers.
+     */
+    private static final HttpHeaders REDIRECT_HEADER_BLOCKLIST = new DefaultHttpHeaders()
+        .add(HttpHeaderNames.HOST, "")
+        .add(HttpHeaderNames.TRANSFER_ENCODING, "")
+        .add(HttpHeaderNames.CONNECTION, "")
+        .add(HttpHeaderNames.CONTENT_TYPE, "")
+        .add(HttpHeaderNames.CONTENT_LENGTH, "");
 
     protected MediaTypeCodecRegistry mediaTypeCodecRegistry;
     protected final ByteBufferFactory<ByteBufAllocator, ByteBuf> byteBufferFactory = new NettyByteBufferFactory();
@@ -1645,11 +1645,12 @@ public class DefaultHttpClient implements
                     if (code == 307 || code == 308) {
                         redirectRequest = io.micronaut.http.HttpRequest.create(request.getMethod(), location);
                         request.getBody().ifPresent(redirectRequest::body);
+                        setRedirectHeaders(request, redirectRequest, REDIRECT_HEADER_BLOCKLIST_PRESERVE_BODY);
                     } else {
                         redirectRequest = io.micronaut.http.HttpRequest.GET(location);
+                        setRedirectHeaders(request, redirectRequest, REDIRECT_HEADER_BLOCKLIST);
                     }
 
-                    setRedirectHeaders(request, redirectRequest);
                     return resolveRedirectURI(request, redirectRequest)
                         .flatMap(uri -> sendRequestWithRedirects(propagatedContext, blockHint, redirectRequest.uri(uri), readResponse));
                 } else {
@@ -2065,10 +2066,12 @@ public class DefaultHttpClient implements
         return result;
     }
 
-    private static void setRedirectHeaders(@Nullable io.micronaut.http.HttpRequest<?> request, MutableHttpRequest<Object> redirectRequest) {
+    private static void setRedirectHeaders(@Nullable io.micronaut.http.HttpRequest<?> request,
+                                           MutableHttpRequest<Object> redirectRequest,
+                                           HttpHeaders headersToBlock) {
         if (request != null) {
             for (Map.Entry<String, List<String>> originalHeader : request.getHeaders()) {
-                if (!REDIRECT_HEADER_BLOCKLIST.contains(originalHeader.getKey())) {
+                if (!headersToBlock.contains(originalHeader.getKey())) {
                     final List<String> originalHeaderValue = originalHeader.getValue();
                     if (originalHeaderValue != null && !originalHeaderValue.isEmpty()) {
                         for (String value : originalHeaderValue) {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -181,7 +181,6 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -232,7 +232,6 @@ public class DefaultHttpClient implements
      */
     private static final HttpHeaders REDIRECT_HEADER_BLOCKLIST_PRESERVE_BODY = new DefaultHttpHeaders()
         .add(HttpHeaderNames.HOST, "")
-        .add(HttpHeaderNames.TRANSFER_ENCODING, "")
         .add(HttpHeaderNames.CONNECTION, "");
 
     /**

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
@@ -593,7 +593,7 @@ class HttpPostSpec extends Specification {
 
         @Post(uri = "/permanentRedirect", consumes = MediaType.APPLICATION_FORM_URLENCODED)
         HttpResponse permanentRedirect() {
-            return HttpResponse.temporaryRedirect(URI.create("/post/permanentRedirectTarget"))
+            return HttpResponse.permanentRedirect(URI.create("/post/permanentRedirectTarget"))
         }
 
         @Post(uri = "/permanentRedirectTarget", consumes = MediaType.APPLICATION_FORM_URLENCODED)

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
@@ -415,6 +415,42 @@ class HttpPostSpec extends Specification {
         res.getBody(String).get() == 'foo'
     }
 
+    void "test 307 temporary redirect preserves body and relevant headers"() {
+        given:
+        def book = new Book(title: "The Stand", pages: 1000)
+
+        when:
+        def res = client.toBlocking().exchange(
+                HttpRequest.POST('/post/tempRedirect', book).contentType(MediaType.APPLICATION_FORM_URLENCODED),
+                Book
+        )
+        def receivedBook = res.body()
+
+        then:
+        res.status == HttpStatus.OK
+        receivedBook != null
+        receivedBook.title == book.title
+        receivedBook.pages == book.pages
+    }
+
+    void "test 308 permanent redirect preserves body and relevant headers"() {
+        given:
+        def book = new Book(title: "The Stand", pages: 1000)
+
+        when:
+        def res = client.toBlocking().exchange(
+                HttpRequest.POST('/post/permanentRedirect', book).contentType(MediaType.APPLICATION_FORM_URLENCODED),
+                Book
+        )
+        def receivedBook = res.body()
+
+        then:
+        res.status == HttpStatus.OK
+        receivedBook != null
+        receivedBook.title == book.title
+        receivedBook.pages == book.pages
+    }
+
     void 'test format dates in form body with @Format'() {
         given:
         def client = this.postClient
@@ -543,6 +579,26 @@ class HttpPostSpec extends Specification {
         @Post(uri = "/redirectTarget")
         String redirectTargetPost() {
             return 'bar'
+        }
+
+        @Post(uri = "/tempRedirect", consumes = MediaType.APPLICATION_FORM_URLENCODED)
+        HttpResponse tempRedirect() {
+            return HttpResponse.temporaryRedirect(URI.create("/post/tempRedirectTarget"))
+        }
+
+        @Post(uri = "/tempRedirectTarget", consumes = MediaType.APPLICATION_FORM_URLENCODED)
+        Book tempRedirectTarget(@Body Book book) {
+            return book
+        }
+
+        @Post(uri = "/permanentRedirect", consumes = MediaType.APPLICATION_FORM_URLENCODED)
+        HttpResponse permanentRedirect() {
+            return HttpResponse.temporaryRedirect(URI.create("/post/permanentRedirectTarget"))
+        }
+
+        @Post(uri = "/permanentRedirectTarget", consumes = MediaType.APPLICATION_FORM_URLENCODED)
+        Book permanentRedirectTarget(@Body Book book) {
+            return book
         }
 
         @Post(uri = "/form/date", consumes = MediaType.APPLICATION_FORM_URLENCODED)


### PR DESCRIPTION
### Summary

Fixes https://github.com/micronaut-projects/micronaut-core/issues/12265. 

This PR resolves an issue where when following a 307 or 308 redirect, request headers that related to the request body were dropped.

This stems from changes made in https://github.com/micronaut-projects/micronaut-core/issues/6417 dealing with other 3xx responses. When converting from POST -> GET we stripped `content-type` and `content-length` since we were also stripping the request body.

However in a situation where the http method & body are preserved, we can't strip these headers.

As discussed in https://github.com/micronaut-projects/micronaut-core/issues/12265, we tested curl & various browsers, and found this was the behavior.

---

### Local testing

Before:
<img width="604" height="753" alt="mock-server-request-bodies" src="https://github.com/user-attachments/assets/f663d0ae-6e3b-4efc-b0ab-f60faa724e24" />

After, I setup a mock server, and using the changes in this branch observed:
<img width="878" height="754" alt="end-to-end-working-now" src="https://github.com/user-attachments/assets/60e5afff-ca97-4572-9256-f988239bc7e8" />

---

First time opening a micronaut PR, let me know if I missed anything!