### PR TITLE
[CVE-2025-67735] Update managed-netty version to 4.2.9.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,7 +79,7 @@ managed-jackson-annotations = "2.20"
 managed-kotlin = "2.2.21"
 managed-kotlin-coroutines = "1.10.2"
 managed-methvin-directory-watcher = "0.19.1"
-managed-netty = "4.2.7.Final"
+managed-netty = "4.2.9.Final"
 managed-netty-tcnative = "2.0.74.Final"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM


### PR DESCRIPTION
Reference:  https://ossindex.sonatype.org/vulnerability/CVE-2025-67735?component-type=maven&component-name=io.netty%2Fnetty-codec-http&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.2