### PR TITLE
In CORS Filter add GET as available method for static resources

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsStaticResourceTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsStaticResourceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.tests.cors;
+
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.uri.UriBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class CorsStaticResourceTest {
+    public static final String SPEC_NAME = "CorsStaticResourceTest";
+
+    @Test
+    public void staticResource() throws IOException {
+        asserts(SPEC_NAME,
+            Map.of(
+                "micronaut.server.cors.enabled", StringUtils.TRUE,
+                "micronaut.server.cors.configurations.default.allowed-origins", "http://some.domain.com",
+                "micronaut.server.cors.configurations.default.allowed-methods[0]", "GET",
+                "micronaut.router.static-resources.assets.mapping", "/assets/**",
+                "micronaut.router.static-resources.assets.paths", "classpath:assets"),
+            HttpRequest.GET(UriBuilder.of("/assets").path("hello.txt").build())
+                .accept(MediaType.TEXT_PLAIN)
+                .header(HttpHeaders.ORIGIN, "http://some.domain.com")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name()),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpStatus.OK,
+                "Hello World",
+                Collections.singletonMap(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN)));
+    }
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsStaticResourceTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsStaticResourceTest.java
@@ -22,11 +22,11 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.HttpResponseAssertion;
 import io.micronaut.http.uri.UriBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 
 import static io.micronaut.http.tck.TestScenario.asserts;
@@ -38,23 +38,33 @@ import static io.micronaut.http.tck.TestScenario.asserts;
 })
 public class CorsStaticResourceTest {
     public static final String SPEC_NAME = "CorsStaticResourceTest";
+    public static final String ORIGIN = "http://some.domain.com";
 
     @Test
     public void staticResource() throws IOException {
-        asserts(SPEC_NAME,
-            Map.of(
-                "micronaut.server.cors.enabled", StringUtils.TRUE,
-                "micronaut.server.cors.configurations.default.allowed-origins", "http://some.domain.com",
-                "micronaut.server.cors.configurations.default.allowed-methods[0]", "GET",
-                "micronaut.router.static-resources.assets.mapping", "/assets/**",
-                "micronaut.router.static-resources.assets.paths", "classpath:assets"),
-            HttpRequest.GET(UriBuilder.of("/assets").path("hello.txt").build())
-                .accept(MediaType.TEXT_PLAIN)
-                .header(HttpHeaders.ORIGIN, "http://some.domain.com")
-                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name()),
-            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
-                HttpStatus.OK,
-                "Hello World",
-                Collections.singletonMap(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN)));
+        Map<String, Object> config = Map.of(
+            "micronaut.server.cors.enabled", StringUtils.TRUE,
+            "micronaut.server.cors.configurations.default.allowed-origins", ORIGIN,
+            "micronaut.server.cors.configurations.default.allowed-methods[0]", "GET",
+            "micronaut.router.static-resources.assets.mapping", "/assets/**",
+            "micronaut.router.static-resources.assets.paths", "classpath:assets");
+        HttpRequest<?> request = HttpRequest.OPTIONS(UriBuilder.of("/assets").path("hello.txt").build())
+            .accept(MediaType.TEXT_PLAIN)
+            .header(HttpHeaders.ORIGIN, ORIGIN)
+            .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name());
+        Map<String, String> expectedHeaders = Map.of(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, HttpMethod.GET.name(),
+            HttpHeaders.ACCESS_CONTROL_MAX_AGE, "1800",
+            HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, ORIGIN,
+            HttpHeaders.VARY, "Origin");
+        asserts(SPEC_NAME, config, request,
+            (server, req) ->
+                AssertionUtils.assertDoesNotThrow(server, req, HttpStatus.OK, null, expectedHeaders));
+        request = HttpRequest.OPTIONS(UriBuilder.of("/assets").path("nonexisiting.txt").build())
+            .accept(MediaType.TEXT_PLAIN)
+            .header(HttpHeaders.ORIGIN, ORIGIN)
+            .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name());
+        asserts(SPEC_NAME, config, request,
+            (server, req) ->
+                AssertionUtils.assertThrowsStatus(HttpStatus.FORBIDDEN));
     }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -23,6 +23,7 @@ import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ImmutableArgumentConversionContext;
 import io.micronaut.core.io.socket.SocketUtils;
 import io.micronaut.core.order.Ordered;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpMethod;
@@ -40,11 +41,14 @@ import io.micronaut.http.server.annotation.PreMatching;
 import io.micronaut.http.server.util.HttpHostResolver;
 import io.micronaut.web.router.Router;
 import io.micronaut.web.router.UriRouteMatch;
+import io.micronaut.web.router.resource.StaticResourceResolver;
 import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -86,31 +90,48 @@ public class CorsFilter implements Ordered, ConditionalFilter {
 
     private final Router router;
 
+    @Nullable
+    private final StaticResourceResolver staticResourceResolver;
+
     /**
      * @param corsConfiguration The {@link CorsOriginConfiguration} instance
      * @param httpHostResolver  HTTP Host resolver
-     * @deprecated use {@link CorsFilter(HttpServerConfiguration.CorsConfiguration, HttpHostResolver, Router)} instead.
+     * @deprecated Use {@link CorsFilter(HttpServerConfiguration, StaticResourceResolver, Router, HttpHostResolver)} instead.
      */
     @Deprecated(since = "4.7", forRemoval = true)
     public CorsFilter(HttpServerConfiguration.CorsConfiguration corsConfiguration,
                       @Nullable HttpHostResolver httpHostResolver) {
-        this.corsConfiguration = corsConfiguration;
-        this.httpHostResolver = httpHostResolver;
-        this.router = null;
+        this(corsConfiguration, httpHostResolver, null);
     }
 
     /**
      * @param corsConfiguration The {@link CorsOriginConfiguration} instance
      * @param httpHostResolver  HTTP Host resolver
      * @param router  Router
+     * @deprecated Use {@link CorsFilter(HttpServerConfiguration, StaticResourceResolver, Router, HttpHostResolver)} instead.
      */
-    @Inject
+    @Deprecated(forRemoval = true, since = "4.10.12")
     public CorsFilter(HttpServerConfiguration.CorsConfiguration corsConfiguration,
                       @Nullable HttpHostResolver httpHostResolver,
                       Router router) {
+        this(corsConfiguration, null,  router, httpHostResolver);
+    }
+
+    /**
+     * @param corsConfiguration The {@link CorsOriginConfiguration} instance
+     * @param staticResourceResolver Static Resource Resolver
+     * @param router  Router
+     * @param httpHostResolver  HTTP Host resolver
+     */
+    @Inject
+    public CorsFilter(HttpServerConfiguration.CorsConfiguration corsConfiguration,
+                      StaticResourceResolver staticResourceResolver,
+                      Router router,
+                      @Nullable HttpHostResolver httpHostResolver) {
         this.corsConfiguration = corsConfiguration;
         this.httpHostResolver = httpHostResolver;
         this.router = router;
+        this.staticResourceResolver = staticResourceResolver;
     }
 
     @Override
@@ -391,10 +412,12 @@ public class CorsFilter implements Ordered, ConditionalFilter {
         if (requestOrigin == null) {
             return Optional.empty();
         }
-        for (UriRouteMatch<Object, Object> routeMatch : router.findAny(request)) {
-            Optional<CorsOriginConfiguration> corsOriginConfiguration = CrossOriginUtil.getCorsOriginConfiguration(routeMatch);
-            if (corsOriginConfiguration.isPresent() && matchesOrigin(corsOriginConfiguration.get(), requestOrigin)) {
-                return corsOriginConfiguration;
+        if (router != null) {
+            for (UriRouteMatch<Object, Object> routeMatch : router.findAny(request)) {
+                Optional<CorsOriginConfiguration> corsOriginConfiguration = CrossOriginUtil.getCorsOriginConfiguration(routeMatch);
+                if (corsOriginConfiguration.isPresent() && matchesOrigin(corsOriginConfiguration.get(), requestOrigin)) {
+                    return corsOriginConfiguration;
+                }
             }
         }
         if (!corsConfiguration.isEnabled()) {
@@ -505,7 +528,7 @@ public class CorsFilter implements Ordered, ConditionalFilter {
         if (!CorsUtil.isPreflightRequest(request)) {
             return false;
         }
-        List<HttpMethod> availableHttpMethods = router.findAny(request).stream().map(UriRouteMatch::getHttpMethod).toList();
+        List<HttpMethod> availableHttpMethods = availableHttpMethods(request);
         if (availableHttpMethods.stream().noneMatch(method -> method.equals(methodToMatch))) {
             return false;
         }
@@ -521,5 +544,18 @@ public class CorsFilter implements Ordered, ConditionalFilter {
             }
         }
         return true;
+    }
+
+    private List<HttpMethod> availableHttpMethods(@NonNull HttpRequest<?> request) {
+        List<HttpMethod> methods = new ArrayList<>(router != null
+            ? router.findAny(request).stream().map(UriRouteMatch::getHttpMethod).toList()
+            : Collections.emptyList()
+        );
+        if (CollectionUtils.isEmpty(methods) &&
+            staticResourceResolver != null &&
+            staticResourceResolver.resolve(request.getUri().getPath()).isPresent()) {
+            methods.add(HttpMethod.GET);
+        }
+        return methods;
     }
 }

--- a/http-tck/src/main/java/io/micronaut/http/tck/BodyAssertion.java
+++ b/http-tck/src/main/java/io/micronaut/http/tck/BodyAssertion.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -232,7 +233,7 @@ public final class BodyAssertion<T, E> {
         @Override
         public boolean test(String expected, String received) {
             return switch (type) {
-                case EQUAL -> (received == null && expected == null) || received.equals(expected);
+                case EQUAL -> Objects.equals(received, expected);
                 case CONTAIN -> (received == null && expected == null) || received.contains(expected);
                 case DOESNT_CONTAIN -> !received.contains(expected);
             };

--- a/http-tck/src/main/java/io/micronaut/http/tck/BodyAssertion.java
+++ b/http-tck/src/main/java/io/micronaut/http/tck/BodyAssertion.java
@@ -233,7 +233,7 @@ public final class BodyAssertion<T, E> {
         public boolean test(String expected, String received) {
             return switch (type) {
                 case EQUAL -> received.equals(expected);
-                case CONTAIN -> received.contains(expected);
+                case CONTAIN -> (received == null && expected == null) || received.contains(expected);
                 case DOESNT_CONTAIN -> !received.contains(expected);
             };
         }

--- a/http-tck/src/main/java/io/micronaut/http/tck/BodyAssertion.java
+++ b/http-tck/src/main/java/io/micronaut/http/tck/BodyAssertion.java
@@ -232,7 +232,7 @@ public final class BodyAssertion<T, E> {
         @Override
         public boolean test(String expected, String received) {
             return switch (type) {
-                case EQUAL -> received.equals(expected);
+                case EQUAL -> (received == null && expected == null) || received.equals(expected);
                 case CONTAIN -> (received == null && expected == null) || received.contains(expected);
                 case DOESNT_CONTAIN -> !received.contains(expected);
             };


### PR DESCRIPTION
Close: #12260 

This Pull-request modifies the CORS filter to add GET as an available HTTP Methods for Static resources. 

@driverpt says they detected a regression about this in 4.10.0 