### PR TITLE
Reproduce missing type annotation from compiled class

### DIFF
--- a/inject-java-helper/src/main/java/io/micronaut/inject/test/MyBean.java
+++ b/inject-java-helper/src/main/java/io/micronaut/inject/test/MyBean.java
@@ -1,0 +1,26 @@
+package io.micronaut.inject.test;
+
+import org.jspecify.annotations.Nullable;
+
+public class MyBean {
+
+    private String name;
+    @Nullable
+    private Integer age;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+}

--- a/inject-java-helper/src/main/java/io/micronaut/inject/test/MyBean.java
+++ b/inject-java-helper/src/main/java/io/micronaut/inject/test/MyBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.inject.test;
 
 import org.jspecify.annotations.Nullable;

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -40,7 +40,7 @@ import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Null
 import spock.lang.IgnoreIf
 import spock.lang.Issue
-import spock.lang.PendingFeature
+import spock.lang.Requires
 import spock.lang.Unroll
 import spock.util.environment.Jvm
 
@@ -50,7 +50,7 @@ import java.util.function.Supplier
 
 class ClassElementSpec extends AbstractTypeElementSpec {
 
-    @PendingFeature(reason = "Javac bug - missing type annotations in compiled class")
+    @Requires({Jvm.current.isJava22Compatible()})
     void "test external type annotation nullable property"() {
         expect:
         buildClassElement('''

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -38,14 +38,74 @@ import io.micronaut.inject.ast.WildcardElement
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Null
-import java.sql.SQLException
-import java.util.function.Supplier
 import spock.lang.IgnoreIf
 import spock.lang.Issue
+import spock.lang.PendingFeature
 import spock.lang.Unroll
 import spock.util.environment.Jvm
 
+import javax.lang.model.element.VariableElement
+import java.sql.SQLException
+import java.util.function.Supplier
+
 class ClassElementSpec extends AbstractTypeElementSpec {
+
+    @PendingFeature(reason = "Javac bug - missing type annotations in compiled class")
+    void "test external type annotation nullable property"() {
+        expect:
+        buildClassElement('''
+class MyClass {
+
+    io.micronaut.inject.test.MyBean myField;
+
+}
+''') { ClassElement classElement ->
+            def ageProperty =  classElement.getFields().iterator().next().getType().getBeanProperties().find { it.name == "age"}
+            def propertyField = ageProperty.getField().get()
+            VariableElement javaField = propertyField.getNativeType().element()
+            assert javaField.asType().getAnnotationMirrors().size() == 1
+            assert ageProperty.isNullable()
+            ageProperty
+        }
+    }
+
+    void "test type annotation nullable property"() {
+        expect:
+        buildClassElement('''
+import org.jspecify.annotations.Nullable;
+
+class MyBean {
+
+    private String name;
+    @Nullable
+    private Integer age;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+}
+
+''') { ClassElement classElement ->
+            def ageProperty =  classElement.getBeanProperties().find { it.name == "age"}
+            def propertyField = ageProperty.getField().get()
+            VariableElement javaField = propertyField.getNativeType().element()
+            assert javaField.asType().getAnnotationMirrors().size() == 1
+            assert ageProperty.isNullable()
+            ageProperty
+        }
+    }
 
     void "test duplicate methods"() {
         expect:


### PR DESCRIPTION
Reproducing a Javac bug that not able to read type annotations of a compiled class.
The bug is fixed in Java 22 https://bugs.openjdk.org/browse/JDK-8323093