### PR TITLE
Create a fix for native image build with ContextConfigurer on GraalVM 22+

### DIFF
--- a/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
+++ b/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
@@ -18,6 +18,7 @@ Args=--enable-http \
        --initialize-at-build-time=io.micronaut.context.annotation \
        --initialize-at-build-time=io.micronaut.inject.annotation \
        --initialize-at-build-time=io.micronaut.runtime.converters.time \
+       --initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer$1 \
        --initialize-at-build-time=io.micronaut.context.conditions.MatchesAbsenceOfBeansCondition \
        --initialize-at-build-time=io.micronaut.context.conditions.MatchesAbsenceOfClassesCondition \
        --initialize-at-build-time=io.micronaut.context.conditions.MatchesAbsenceOfClassNamesCondition \


### PR DESCRIPTION
On GraalVM 22 and GraalVM 25 if an application has an implemented `ApplicationContextConfigurer`, native build fails with this error:

```java
Error: An object of type 'io.micronaut.context.ApplicationContextConfigurer$1' was found in the image heap. This type, however, is marked for initialization at image run time for the following reason: classes are initialized at run time by default.
This is not allowed for correctness reasons: All objects that are stored in the image heap must be initialized at build time.

You now have two options to resolve this:

1) If it is intended that objects of type 'io.micronaut.context.ApplicationContextConfigurer$1' are persisted in the image heap, add 

    '--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer$1'

to the native-image arguments. Note that initializing new types can store additional objects to the heap. It is advised to check the static fields of 'io.micronaut.context.ApplicationContextConfigurer$1' to see if they are safe for build-time initialization,  and that they do not contain any sensitive data that should not become part of the image.

2) If if it is not intended that objects of type 'io.micronaut.context.ApplicationContextConfigurer$1' are persisted in the image heap, examine the stack trace and use 

    '--initialize-at-run-time=io.micronaut.context.ApplicationContextConfigurer'

to prevent instantiation of the culprit object.
The culprit object has been instantiated by the 'io.micronaut.context.ApplicationContextConfigurer' class initializer with the following trace:
        at io.micronaut.context.ApplicationContextConfigurer$1.<init>(ApplicationContextConfigurer.java:43)
        at io.micronaut.context.ApplicationContextConfigurer.<clinit>(ApplicationContextConfigurer.java:43)
```

This resolves the issue by adding an `--initialize-at-build-time` flag.