### PR TITLE
Add explicit `@Target` to `@Internal` annotation for Groovy 5 compatibility and JLS compliance.

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/Internal.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Internal.java
@@ -16,9 +16,11 @@
 package io.micronaut.core.annotation;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Annotates a class or method regarded as internal and not for public consumption.</p>
@@ -30,6 +32,18 @@ import java.lang.annotation.RetentionPolicy;
  * @author Graeme Rocher
  * @since 1.0
  */
+@Target({
+    ElementType.TYPE,
+    ElementType.FIELD,
+    ElementType.METHOD,
+    ElementType.PARAMETER,
+    ElementType.CONSTRUCTOR,
+    ElementType.LOCAL_VARIABLE,
+    ElementType.ANNOTATION_TYPE,
+    ElementType.PACKAGE,
+    ElementType.MODULE,
+    ElementType.RECORD_COMPONENT
+})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited


### PR DESCRIPTION
  ## Problem

  Groovy 5 has a bug (GROOVY-11831) where it incorrectly treats annotations without explicit `@Target` as if they include `TYPE_USE`. This violates JLS 9.6.4.1:

  > *"If an annotation of type java.lang.annotation.Target is not present on the declaration of an annotation interface A, then A is applicable in all declaration contexts and in no type contexts."*

  This causes a compiler crash when AST transformations add `@Internal` to void methods:

  BUG! exception in phase 'class generation' in source unit '...'
  Adding type annotation @Internal to non-redirect node: void

  ## Solution

  Add explicit `@Target` to `@Internal` with all declaration contexts (per JLS default), excluding `TYPE_USE` and `TYPE_PARAMETER`.

  This is backwards compatible and matches the JLS-defined default behavior.

  ## Related

  - Fixes #12313
  - Groovy bug: https://issues.apache.org/jira/browse/GROOVY-11831
  - Unblocks: micronaut-groovy upgrade to Micronaut 5
