### PR TITLE
Don't dispose request body on HTTP/2 RST

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
@@ -95,7 +95,8 @@ abstract class MultiplexedServerHandler {
         private Object attachment;
 
         private boolean requestAccepted;
-        private boolean responseDone;
+        private boolean finished;
+        private boolean reset;
         private Compressor.Session compressionSession;
 
         MultiplexedStream(int streamId) {
@@ -228,17 +229,14 @@ abstract class MultiplexedServerHandler {
          * @param e The exception that should be forwarded to the stream consumer
          */
         final void onRstStreamRead(Exception e) {
+            reset = true;
             if (streamer != null) {
                 streamer.error(e);
             }
-            finish();
+            disposeWriteSide();
         }
 
-        private boolean finish() {
-            if (responseDone) {
-                return false;
-            }
-            responseDone = true;
+        private void disposeWriteSide() {
             if (writerUpstream != null) {
                 writerUpstream.allowDiscard();
                 writerUpstream.disregardBackpressure();
@@ -246,6 +244,14 @@ abstract class MultiplexedServerHandler {
             if (compressionSession != null) {
                 compressionSession.discard();
             }
+        }
+
+        private boolean finish() {
+            if (finished) {
+                return false;
+            }
+            finished = true;
+            disposeWriteSide();
             requestHandler.responseWritten(attachment);
             return true;
         }
@@ -253,7 +259,7 @@ abstract class MultiplexedServerHandler {
         @Override
         public void write(@NonNull HttpResponse response, @NonNull ByteBody body) {
             body.touch();
-            if (responseDone) {
+            if (finished) {
                 body.touch();
                 // stream reset
                 return;
@@ -310,10 +316,14 @@ abstract class MultiplexedServerHandler {
                     }
 
                     private void complete0() {
-                        if (!responseDone) {
-                            writeData(Unpooled.EMPTY_BUFFER, true, endPromise(response));
+                        if (!finished) {
+                            if (!reset) {
+                                writeData(Unpooled.EMPTY_BUFFER, true, endPromise(response));
+                            }
                             if (finish()) {
-                                flush();
+                                if (!reset) {
+                                    flush();
+                                }
                             }
                         }
                     }
@@ -344,10 +354,15 @@ abstract class MultiplexedServerHandler {
                 return;
             }
 
-            if (responseDone) {
+            if (finished) {
+                upstream.allowDiscard();
+                upstream.disregardBackpressure();
+                return;
+            } else if (reset) {
                 // connection closed?
-                writerUpstream.allowDiscard();
-                writerUpstream.disregardBackpressure();
+                upstream.allowDiscard();
+                upstream.disregardBackpressure();
+                finish();
                 return;
             }
 
@@ -366,9 +381,13 @@ abstract class MultiplexedServerHandler {
         }
 
         private void writeFull(@NonNull HttpResponse response, @NonNull ByteBuf content) {
-            if (responseDone) {
+            if (finished) {
+                content.release();
+                return;
+            } else if (reset) {
                 // stream closed
                 content.release();
+                finish();
                 return;
             }
             if (!ctx.executor().inEventLoop()) {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
@@ -1,6 +1,5 @@
 package io.micronaut.http.server.netty.handler
 
-
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.http.body.CloseableByteBody
 import io.micronaut.http.body.InternalByteBody
@@ -37,7 +36,6 @@ import io.netty.handler.codec.http2.Http2Frame
 import io.netty.handler.codec.http2.Http2FrameCodec
 import io.netty.handler.codec.http2.Http2FrameCodecBuilder
 import io.netty.handler.codec.http2.Http2HeadersFrame
-import io.netty.handler.codec.http2.Http2PingFrame
 import io.netty.handler.codec.http2.Http2ResetFrame
 import io.netty.handler.codec.http2.Http2SettingsAckFrame
 import io.netty.handler.codec.http2.Http2SettingsFrame
@@ -413,9 +411,12 @@ class Http2ServerHandlerSpec extends Specification {
         Throwable err = null
         CompositeByteBuf received = ByteBufAllocator.DEFAULT.compositeBuffer()
         boolean complete = false
+        boolean responseWritten = false
+        OutboundAccess outboundAccessR = null
         def (server, client, duplexHandler) = configure(new RequestHandler() {
             @Override
             void accept(ChannelHandlerContext ctx, HttpRequest request, CloseableByteBody body, OutboundAccess outboundAccess) {
+                outboundAccessR = outboundAccess
                 NettyByteBodyFactory.toByteBufs(body).subscribe(new Subscriber<ByteBuf>() {
                     @Override
                     void onSubscribe(Subscription s) {
@@ -437,6 +438,11 @@ class Http2ServerHandlerSpec extends Specification {
                         complete = true
                     }
                 })
+            }
+
+            @Override
+            void responseWritten(Object attachment) {
+                responseWritten = true
             }
 
             @Override
@@ -471,6 +477,12 @@ class Http2ServerHandlerSpec extends Specification {
         EmbeddedTestUtil.advance(server, client)
         then:
         err instanceof ClosedChannelException
+        !responseWritten
+
+        when:
+        outboundAccessR.write(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK), NettyByteBodyFactory.empty())
+        then:
+        responseWritten
 
         cleanup:
         received.release()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
@@ -36,6 +36,7 @@ import io.netty.handler.codec.http2.Http2Frame
 import io.netty.handler.codec.http2.Http2FrameCodec
 import io.netty.handler.codec.http2.Http2FrameCodecBuilder
 import io.netty.handler.codec.http2.Http2HeadersFrame
+import io.netty.handler.codec.http2.Http2PingFrame
 import io.netty.handler.codec.http2.Http2ResetFrame
 import io.netty.handler.codec.http2.Http2SettingsAckFrame
 import io.netty.handler.codec.http2.Http2SettingsFrame


### PR DESCRIPTION
When a RST frame is received, the handler would call responseWritten, discarding the request body. When filter processing is in progress, this could lead to a "can't claim body" error.

This change delays the responseWritten call until the response is actually passed to the OutboundAccess. This matches HTTP/1 behavior.