### PR TITLE
feat: Add ExternalPropertyResolver API for external property system integration

### DIFF
--- a/core/src/main/java/io/micronaut/core/value/ExternalPropertyResolver.java
+++ b/core/src/main/java/io/micronaut/core/value/ExternalPropertyResolver.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.value;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Optional;
+
+/**
+ * An interface for resolving properties from an external source.
+ *
+ * <p>This interface allows external property systems (such as Spring's Environment)
+ * to be integrated with Micronaut's property resolution mechanism without requiring
+ * subclassing of internal classes.</p>
+ *
+ * <p>When configured via {@link io.micronaut.context.ApplicationContextBuilder#externalPropertyResolver},
+ * the external resolver becomes the <b>exclusive</b> source for property resolution.
+ * Micronaut's internal property catalog is bypassed entirely, making the external system
+ * the sole authority for all property lookups.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * ApplicationContext.builder()
+ *     .externalPropertyResolver(new ExternalPropertyResolver() {
+ *         public <T> Optional<T> resolve(String name, ArgumentConversionContext<T> context) {
+ *             return Optional.ofNullable(externalSource.getProperty(name, context.getArgument().getType()));
+ *         }
+ *
+ *         public boolean contains(String name) {
+ *             return externalSource.containsProperty(name);
+ *         }
+ *     })
+ *     .build();
+ * }</pre>
+ *
+ * @author Micronaut Team
+ * @since 5.0
+ * @see io.micronaut.context.ApplicationContextBuilder#externalPropertyResolver
+ */
+@NullMarked
+@Experimental
+public interface ExternalPropertyResolver {
+
+    /**
+     * Resolve a property value from the external source.
+     *
+     * @param name The property name
+     * @param conversionContext The conversion context containing type information
+     * @param <T> The expected property type
+     * @return An optional containing the property value if found, empty otherwise
+     */
+    @NonNull
+    <T> Optional<T> resolve(@NonNull String name, @NonNull ArgumentConversionContext<T> conversionContext);
+
+    /**
+     * Check if a property exists in the external source.
+     *
+     * <p>The default implementation calls {@link #resolve} and checks if the result is present.</p>
+     *
+     * @param name The property name
+     * @return true if the property exists in the external source, false otherwise
+     */
+    default boolean contains(@NonNull String name) {
+        return resolve(name, ConversionContext.STRING).isPresent();
+    }
+
+    /**
+     * Check if nested properties exist under the given prefix in the external source.
+     *
+     * <p>The default implementation delegates to {@link #contains}.</p>
+     *
+     * @param name The property prefix
+     * @return true if any properties exist under this prefix, false otherwise
+     */
+    default boolean containsProperties(@NonNull String name) {
+        return contains(name);
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -18,6 +18,7 @@ package io.micronaut.context;
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.env.PropertySourcesLocator;
+import io.micronaut.core.value.ExternalPropertyResolver;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
@@ -398,6 +399,25 @@ public interface ApplicationContextBuilder {
      * @since 5.0
      */
     ApplicationContextBuilder propertySourcesLocator(PropertySourcesLocator propertySourcesLocator);
+
+    /**
+     * Sets an external property resolver that is consulted before Micronaut's internal property catalog.
+     *
+     * <p>This allows external property systems (such as Spring's Environment) to be the source of truth
+     * for property resolution, enabling full integration without subclassing internal classes.</p>
+     *
+     * <p>When set, the resolver's {@link ExternalPropertyResolver#contains} method is called for
+     * {@code containsProperty()} checks, and {@link ExternalPropertyResolver#resolve} is called
+     * for property value resolution, both before consulting the internal catalog.</p>
+     *
+     * @param resolver the external property resolver, or null to clear
+     * @return This builder
+     * @since 5.0
+     * @see ExternalPropertyResolver
+     */
+    default ApplicationContextBuilder externalPropertyResolver(@Nullable ExternalPropertyResolver resolver) {
+        return this;
+    }
 
     /**
      * Starts the {@link ApplicationContext}.

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.context;
 import io.micronaut.context.env.EnvironmentNamesDeducer;
 import io.micronaut.context.env.EnvironmentPackagesDeducer;
 import io.micronaut.context.env.PropertySourcesLocator;
+import io.micronaut.core.value.ExternalPropertyResolver;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.convert.MutableConversionService;
@@ -205,6 +206,18 @@ public interface ApplicationContextConfiguration extends BeanContextConfiguratio
      */
     default Collection<PropertySourcesLocator> getPropertySourcesLocators() {
         return Collections.emptyList();
+    }
+
+    /**
+     * Returns the external property resolver that should be consulted before the internal property catalog.
+     *
+     * @return The external property resolver, or null if not set
+     * @since 5.0
+     * @see ExternalPropertyResolver
+     */
+    @Nullable
+    default ExternalPropertyResolver getExternalPropertyResolver() {
+        return null;
     }
 
 }

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfigurationDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfigurationDelegate.java
@@ -19,6 +19,7 @@ import io.micronaut.context.env.EnvironmentNamesDeducer;
 import io.micronaut.context.env.EnvironmentPackagesDeducer;
 import io.micronaut.context.env.PropertySourcesLocator;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.value.ExternalPropertyResolver;
 import io.micronaut.inject.BeanConfiguration;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -139,6 +140,11 @@ class ApplicationContextConfigurationDelegate implements ApplicationContextConfi
     @Override
     public Collection<PropertySourcesLocator> getPropertySourcesLocators() {
         return delegate.getPropertySourcesLocators();
+    }
+
+    @Override
+    public @Nullable ExternalPropertyResolver getExternalPropertyResolver() {
+        return delegate.getExternalPropertyResolver();
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -20,6 +20,7 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.env.PropertySourcesLocator;
 import io.micronaut.context.env.SystemPropertiesPropertySource;
+import io.micronaut.core.value.ExternalPropertyResolver;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.cli.CommandLine;
@@ -88,6 +89,8 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     private Predicate<QualifiedBeanType<?>> beansPredicate;
     @Nullable
     private Predicate<BeanConfiguration> beanConfigurationsPredicate;
+    @Nullable
+    private ExternalPropertyResolver externalPropertyResolver;
 
     /**
      * Default constructor.
@@ -451,6 +454,18 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     @Override
     public List<PropertySourcesLocator> getPropertySourcesLocators() {
         return propertySourcesLocators;
+    }
+
+    @Override
+    public ApplicationContextBuilder externalPropertyResolver(@Nullable ExternalPropertyResolver resolver) {
+        this.externalPropertyResolver = resolver;
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public ExternalPropertyResolver getExternalPropertyResolver() {
+        return externalPropertyResolver;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -34,6 +34,10 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.value.ExternalPropertyResolver;
 import io.micronaut.core.value.PropertyCatalog;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.inject.BeanConfiguration;
@@ -100,6 +104,8 @@ final class DefaultEnvironment implements Environment, PropertyResolverDelegate 
     private final Collection<String> configLocations;
     private final PropertySourcePropertyResolver propertyPlaceholderResolver;
     private final PropertyResolver propertyResolver;
+    @Nullable
+    private final ExternalPropertyResolver externalPropertyResolver;
 
     private final List<PropertySource> refreshablePropertySources = new ArrayList<>(10);
     private final Map<String, PropertySource> propertySources = Collections.synchronizedMap(CollectionUtils.newLinkedHashMap(10));
@@ -125,6 +131,7 @@ final class DefaultEnvironment implements Environment, PropertyResolverDelegate 
             throw new ConfigurationException("Application name cannot be blank");
         }
         this.propertyResolver = propertyPlaceholderResolver;
+        this.externalPropertyResolver = configuration.getExternalPropertyResolver();
         this.mutableConversionService = conversionService;
         this.configuration = configuration;
         this.resourceLoader = configuration.getResourceLoader();
@@ -155,6 +162,60 @@ final class DefaultEnvironment implements Environment, PropertyResolverDelegate 
     @Override
     public PropertyResolver delegate() {
         return propertyResolver;
+    }
+
+    @Override
+    public boolean containsProperty(@NonNull String name) {
+        // When external resolver is configured, it is the exclusive source
+        if (externalPropertyResolver != null) {
+            return externalPropertyResolver.contains(name);
+        }
+        return PropertyResolverDelegate.super.containsProperty(name);
+    }
+
+    @Override
+    public boolean containsProperties(@NonNull String name) {
+        // When external resolver is configured, it is the exclusive source
+        if (externalPropertyResolver != null) {
+            return externalPropertyResolver.containsProperties(name);
+        }
+        return PropertyResolverDelegate.super.containsProperties(name);
+    }
+
+    @Override
+    public @NonNull <T> Optional<T> getProperty(@NonNull String name, @NonNull ArgumentConversionContext<T> conversionContext) {
+        // When external resolver is configured, it is the exclusive source
+        if (externalPropertyResolver != null) {
+            return externalPropertyResolver.resolve(name, conversionContext);
+        }
+        return PropertyResolverDelegate.super.getProperty(name, conversionContext);
+    }
+
+    @Override
+    public @NonNull <T> Optional<T> getProperty(@NonNull String name, @NonNull Class<T> requiredType) {
+        // When external resolver is configured, route to our overridden method
+        if (externalPropertyResolver != null) {
+            return getProperty(name, ConversionContext.of(requiredType));
+        }
+        return PropertyResolverDelegate.super.getProperty(name, requiredType);
+    }
+
+    @Override
+    public @NonNull <T> Optional<T> getProperty(@NonNull String name, @NonNull Argument<T> argument) {
+        // When external resolver is configured, route to our overridden method
+        if (externalPropertyResolver != null) {
+            return getProperty(name, ConversionContext.of(argument));
+        }
+        return PropertyResolverDelegate.super.getProperty(name, argument);
+    }
+
+    @Override
+    public @NonNull <T> Optional<T> getProperty(@NonNull String name, @NonNull Class<T> requiredType, @NonNull ConversionContext context) {
+        // When external resolver is configured, route to our overridden method
+        if (externalPropertyResolver != null) {
+            return getProperty(name, context.with(Argument.of(requiredType)));
+        }
+        return PropertyResolverDelegate.super.getProperty(name, requiredType, context);
     }
 
     @Override


### PR DESCRIPTION
This PR adds a new `ExternalPropertyResolver` interface that allows external property systems (like Spring's Environment) to be the exclusive source for property resolution in Micronaut.

#### Motivation
When embedding Micronaut beans inside a Spring application via `micronaut-spring`'s `MicronautBeanProcessor`, Micronaut beans need access to Spring's properties. The existing `PropertySourcesLocator` API is insufficient because `containsProperty()` checks Micronaut's internal catalog rather than delegating to the external source.

This became a blocking issue for the `micronaut-spring` upgrade to Micronaut 5, since the previous workaround (subclassing `DefaultEnvironment`) is no longer possible.

#### Changes

**New Interface:**
- `io.micronaut.core.value.ExternalPropertyResolver` - Interface for external property resolution with three methods:
  - `resolve()` - Get property value
  - `contains()` - Check property existence
  - `containsProperties()` - Check nested properties existence

**Builder API:**
- `ApplicationContextBuilder.externalPropertyResolver(ExternalPropertyResolver)` - Configure external resolver
- `ApplicationContextConfiguration.getExternalPropertyResolver()` - Retrieve configured resolver

**DefaultEnvironment:**
- Added field to store external resolver
- Override `containsProperty()`, `containsProperties()`, and multiple `getProperty()` overloads to use external resolver exclusively when configured

#### Behavior
When `ExternalPropertyResolver` is configured:
- All property resolution methods delegate exclusively to the external resolver
- Micronaut's internal property catalog is bypassed
- This matches the behavior that was possible in Micronaut 4 by subclassing `DefaultEnvironment`

When `ExternalPropertyResolver` is NOT configured:
- No change in behavior - existing functionality preserved

#### Testing
in progress

#### Breaking Changes
None as this is an additive change.

Closes #12351 