### PR TITLE
Correct "post construct" generation in bean definition writer

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -1260,32 +1260,29 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
 
         if (buildMethodDefinition.postConstruct != null) {
             //  for "super bean definition" we only add code to trigger "initialize"
-            if (!superBeanDefinition) {
-                classDefBuilder.addSuperinterface(TypeDef.of(InitializingBeanDefinition.class));
+            classDefBuilder.addSuperinterface(TypeDef.of(InitializingBeanDefinition.class));
+            if (buildMethodDefinition.postConstruct.intercepted) {
+                // Create a new method that will be invoked by the intercepted chain
+                MethodDef targetInitializeMethod = buildInitializeMethod(buildMethodDefinition.postConstruct, MethodDef.builder("initialize$intercepted")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addParameters(BeanResolutionContext.class, BeanContext.class, Object.class)
+                    .returns(Object.class));
 
-                if (buildMethodDefinition.postConstruct.intercepted) {
-                    // Create a new method that will be invoked by the intercepted chain
-                    MethodDef targetInitializeMethod = buildInitializeMethod(buildMethodDefinition.postConstruct, MethodDef.builder("initialize$intercepted")
-                        .addModifiers(Modifier.PUBLIC)
-                        .addParameters(BeanResolutionContext.class, BeanContext.class, Object.class)
-                        .returns(Object.class));
+                classDefBuilder.addMethod(
+                    targetInitializeMethod
+                );
 
-                    classDefBuilder.addMethod(
-                        targetInitializeMethod
-                    );
-
-                    // Original initialize method is invoking the interceptor chain
-                    classDefBuilder.addMethod(
-                        MethodDef.override(METHOD_INITIALIZE).build((aThis, methodParameters) -> {
-                            ClassTypeDef executableMethodInterceptor = createExecutableMethodInterceptor(targetInitializeMethod, "InitializeInterceptor");
-                            return interceptAndReturn(aThis, methodParameters, executableMethodInterceptor, INITIALIZE_INTERCEPTOR_METHOD);
-                        })
-                    );
-                } else {
-                    classDefBuilder.addMethod(
-                        buildInitializeMethod(buildMethodDefinition.postConstruct, MethodDef.override(METHOD_INITIALIZE))
-                    );
-                }
+                // Original initialize method is invoking the interceptor chain
+                classDefBuilder.addMethod(
+                    MethodDef.override(METHOD_INITIALIZE).build((aThis, methodParameters) -> {
+                        ClassTypeDef executableMethodInterceptor = createExecutableMethodInterceptor(targetInitializeMethod, "InitializeInterceptor");
+                        return interceptAndReturn(aThis, methodParameters, executableMethodInterceptor, INITIALIZE_INTERCEPTOR_METHOD);
+                    })
+                );
+            } else {
+                classDefBuilder.addMethod(
+                    buildInitializeMethod(buildMethodDefinition.postConstruct, MethodDef.override(METHOD_INITIALIZE))
+                );
             }
         }
 

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -1279,7 +1279,8 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
                         return interceptAndReturn(aThis, methodParameters, executableMethodInterceptor, INITIALIZE_INTERCEPTOR_METHOD);
                     })
                 );
-            } else {
+            } else if (!superBeanDefinition) {
+                //  for "super bean definition" we only add code to trigger "initialize"
                 classDefBuilder.addMethod(
                     buildInitializeMethod(buildMethodDefinition.postConstruct, MethodDef.override(METHOD_INITIALIZE))
                 );

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -1260,26 +1260,32 @@ public final class BeanDefinitionWriter implements ClassOutputWriter, BeanDefini
 
         if (buildMethodDefinition.postConstruct != null) {
             //  for "super bean definition" we only add code to trigger "initialize"
-            if (!superBeanDefinition || buildMethodDefinition.postConstruct.intercepted) {
+            if (!superBeanDefinition) {
                 classDefBuilder.addSuperinterface(TypeDef.of(InitializingBeanDefinition.class));
 
-                // Create a new method that will be invoked by the intercepted chain
-                MethodDef targetInitializeMethod = buildInitializeMethod(buildMethodDefinition.postConstruct, MethodDef.builder("initialize$intercepted")
-                    .addModifiers(Modifier.PUBLIC)
-                    .addParameters(BeanResolutionContext.class, BeanContext.class, Object.class)
-                    .returns(Object.class));
+                if (buildMethodDefinition.postConstruct.intercepted) {
+                    // Create a new method that will be invoked by the intercepted chain
+                    MethodDef targetInitializeMethod = buildInitializeMethod(buildMethodDefinition.postConstruct, MethodDef.builder("initialize$intercepted")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addParameters(BeanResolutionContext.class, BeanContext.class, Object.class)
+                        .returns(Object.class));
 
-                classDefBuilder.addMethod(
-                    targetInitializeMethod
-                );
+                    classDefBuilder.addMethod(
+                        targetInitializeMethod
+                    );
 
-                // Original initialize method is invoking the interceptor chain
-                classDefBuilder.addMethod(
-                    MethodDef.override(METHOD_INITIALIZE).build((aThis, methodParameters) -> {
-                        ClassTypeDef executableMethodInterceptor = createExecutableMethodInterceptor(targetInitializeMethod, "InitializeInterceptor");
-                        return interceptAndReturn(aThis, methodParameters, executableMethodInterceptor, INITIALIZE_INTERCEPTOR_METHOD);
-                    })
-                );
+                    // Original initialize method is invoking the interceptor chain
+                    classDefBuilder.addMethod(
+                        MethodDef.override(METHOD_INITIALIZE).build((aThis, methodParameters) -> {
+                            ClassTypeDef executableMethodInterceptor = createExecutableMethodInterceptor(targetInitializeMethod, "InitializeInterceptor");
+                            return interceptAndReturn(aThis, methodParameters, executableMethodInterceptor, INITIALIZE_INTERCEPTOR_METHOD);
+                        })
+                    );
+                } else {
+                    classDefBuilder.addMethod(
+                        buildInitializeMethod(buildMethodDefinition.postConstruct, MethodDef.override(METHOD_INITIALIZE))
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Right now it always generates an interceptor