### PR TITLE
Fix duplicate content-type header bug, add test

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -744,7 +744,7 @@ public final class RouteExecutor {
         ).contextWrite(cv -> ReactorPropagation.addPropagatedContext(cv, propagatedContext).put(ServerRequestContext.KEY, request));
 
         return Mono.<MutableHttpResponse<?>>just(response
-            .header(HttpHeaders.CONTENT_TYPE, mediaType)
+            .contentType(mediaType)
             .body(ReactivePropagation.propagate(propagatedContext, bodyPublisher)))
             .contextWrite(context -> ReactorPropagation.addPropagatedContext(context, propagatedContext).put(ServerRequestContext.KEY, request));
     }

--- a/http-server/src/test/groovy/io/micronaut/http/server/RouteExecutorSpec.groovy
+++ b/http-server/src/test/groovy/io/micronaut/http/server/RouteExecutorSpec.groovy
@@ -1,0 +1,60 @@
+package io.micronaut.http.server
+
+import io.micronaut.context.BeanContext
+import io.micronaut.core.propagation.PropagatedContext
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.server.exceptions.response.ErrorResponseProcessor
+import io.micronaut.scheduling.executor.ExecutorSelector
+import io.micronaut.web.router.RouteInfo
+import io.micronaut.web.router.Router
+import io.micronaut.http.server.binding.RequestArgumentSatisfier
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+
+class RouteExecutorSpec extends Specification {
+
+    void "test duplicate content type header in processPublisherBody"() {
+        given:
+        Router router = Mock(Router)
+        BeanContext beanContext = Mock(BeanContext)
+        RequestArgumentSatisfier requestArgumentSatisfier = Mock(RequestArgumentSatisfier)
+        HttpServerConfiguration serverConfiguration = new HttpServerConfiguration()
+        ErrorResponseProcessor errorResponseProcessor = Mock(ErrorResponseProcessor)
+        ExecutorSelector executorSelector = Mock(ExecutorSelector)
+
+        RouteExecutor routeExecutor = new RouteExecutor(
+                router,
+                beanContext,
+                requestArgumentSatisfier,
+                serverConfiguration,
+                errorResponseProcessor,
+                executorSelector
+        )
+
+        HttpRequest<?> request = Mock(HttpRequest)
+        MutableHttpResponse<?> response = HttpResponse.ok().contentType(MediaType.APPLICATION_JSON_TYPE)
+        RouteInfo<?> routeInfo = Mock(RouteInfo)
+        routeInfo.isReactive() >> true
+
+        // A publisher that is NOT a single publisher to trigger the bug
+        Flux<String> bodyPublisher = Flux.just("item1", "item2")
+
+        when:
+        // Use Groovy's private method access
+        MutableHttpResponse<?> result = routeExecutor.processPublisherBody(
+                PropagatedContext.getOrEmpty(),
+                request,
+                response,
+                false, // isSinglePublisher = false
+                bodyPublisher,
+                routeInfo
+        ).block()
+
+        then:
+        result.getHeaders().getAll(HttpHeaders.CONTENT_TYPE) == ["application/json"]
+    }
+}


### PR DESCRIPTION
This PR is similar to #12350, but targets the 4.10.x branch insead of 5.0.x.

Micronaut adds a second `Content-Type` header to an HttpResponse when the result of the controller function is a `HttpResponse<Flux<String>>` (or other nested data type), and the controller explicitly sets the content type on the `HttpResponse`. This can be demonstrated with the following simple controller:
```kotlin
@Controller
class VariableContentTypeController {
	@Get("/")
	fun index(): HttpResponse<Flux<String>> {
		return HttpResponse.ok(Flux.just("Hello World!")).contentType("text/plain")
	}
}
```
See https://github.com/wfhartford-wordly/micronaut-duplicate-content-type-headers for a full project demonstrating the bug.

Calling this function from curl shows that two content type headers are present in the response.
```
$ curl localhost:8080 -v
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: text/plain
< Content-Type: text/plain
< date: Thu, 15 Jan 2026 23:45:04 GMT
< transfer-encoding: chunked
< 
* Connection #0 to host localhost left intact
Hello World!
```

This PR fixes the bug by changing the `RouteExecutor` to call the `contentType` function which _sets_ the header rather than the `header` function which _adds_ it. I've also included a unit test which verifies the fix.

I first encountered this bug in Micronaut version 4.3.8 and have confirmed that it is present in version 4.10.7 and on the 5.0.x branch.