### PR TITLE
Generation of JSON schema from Micronaut Configuration Properties

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
@@ -15,14 +15,13 @@
  */
 package io.micronaut.inject.configuration;
 
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.inject.ast.ClassElement;
-
-import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.PropertyElement;
-import io.micronaut.inject.ast.PropertyElementQuery;
+import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.ClassWriterOutputVisitor;
 import io.micronaut.inject.writer.GeneratedFile;
@@ -30,6 +29,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -37,6 +37,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 
 /**
@@ -54,7 +56,12 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             return;
         }
         // We need VisitorContext for richer type info where available.
-        final VisitorContext vc = (outputVisitor instanceof VisitorContext visitorContext) ? visitorContext : null;
+        final VisitorContext vc;
+        if (outputVisitor instanceof VisitorContext) {
+            vc = (VisitorContext) outputVisitor;
+        } else {
+            vc = null;
+        }
 
         // Build quick index of properties by path for efficient filtering
         final List<PropertyMetadata> props = metadataBuilder.getProperties();
@@ -140,7 +147,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             comma(out);
             emitAdditionalPropertiesRef(out);
             // defs entry schema
-            emitEntryDefs(cm, basePrefix, allProps, vc, out, true);
+            emitEntryDefs(cm, basePrefix, allProps, vc, out, true, vc != null ? vc.getClassElement(cm.getType()).orElse(null) : null);
         } else if (isEachList) {
             // type: array; minItems:1; items: $ref $defs.Entry
             attr(out, "type");
@@ -151,7 +158,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             comma(out);
             attr(out, "items");
             refEntry(out);
-            emitEntryDefs(cm, basePrefix, allProps, vc, out, false);
+            emitEntryDefs(cm, basePrefix, allProps, vc, out, false, vc != null ? vc.getClassElement(cm.getType()).orElse(null) : null);
         } else {
             // Plain configuration object
             attr(out, "type");
@@ -159,7 +166,21 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             comma(out);
             // properties: object
             attr(out, "properties");
-            writePropertiesObject(out, cm, basePrefix, allProps, vc, /*containerMode*/ null);
+            ClassElement classElement = vc != null ? vc.getClassElement(cm.getType()).orElse(null) : null;
+            Set<String> required = writePropertiesObject(out, cm, basePrefix, allProps, vc, /*containerMode*/ null, classElement);
+            if (!required.isEmpty()) {
+                comma(out);
+                attr(out, "required");
+                out.write('[');
+                Iterator<String> r = required.iterator();
+                while (r.hasNext()) {
+                    str(out, r.next());
+                    if (r.hasNext()) {
+                        out.write(',');
+                    }
+                }
+                out.write(']');
+            }
             // keep additionalProperties default (omitted) or explicitly true
         }
         out.write('}');
@@ -170,7 +191,8 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                                List<PropertyMetadata> allProps,
                                @org.jspecify.annotations.Nullable VisitorContext vc,
                                Writer out,
-                               boolean mapMode) throws IOException {
+                               boolean mapMode,
+                               @org.jspecify.annotations.Nullable ClassElement classElement) throws IOException {
         comma(out);
         attr(out, "$defs");
         out.write('{');
@@ -180,7 +202,20 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         str(out, "object");
         comma(out);
         attr(out, "properties");
-        writePropertiesObject(out, cm, basePrefix, allProps, vc, mapMode ? ContainerMode.MAP : ContainerMode.LIST);
+        Set<String> required = writePropertiesObject(out, cm, basePrefix, allProps, vc, mapMode ? ContainerMode.MAP : ContainerMode.LIST, classElement);
+        if (!required.isEmpty()) {
+            comma(out);
+            attr(out, "required");
+            out.write('[');
+            Iterator<String> r = required.iterator();
+            while (r.hasNext()) {
+                str(out, r.next());
+                if (r.hasNext()) {
+                    out.write(',');
+                }
+            }
+            out.write(']');
+        }
         out.write('}');
         out.write('}');
     }
@@ -190,15 +225,16 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         LIST
     }
 
-    private void writePropertiesObject(Writer out,
-                                       ConfigurationMetadata cm,
-                                       String basePrefix,
-                                       List<PropertyMetadata> allProps,
-                                       @org.jspecify.annotations.Nullable VisitorContext vc,
-                                       @org.jspecify.annotations.Nullable ContainerMode containerMode) throws IOException {
-        ClassElement classElement = vc != null ? vc.getClassElement(cm.type).orElse(null) : null;
+    private Set<String> writePropertiesObject(Writer out,
+                                              ConfigurationMetadata cm,
+                                              String basePrefix,
+                                              List<PropertyMetadata> allProps,
+                                              @org.jspecify.annotations.Nullable VisitorContext vc,
+                                              @org.jspecify.annotations.Nullable ContainerMode containerMode,
+                                              @org.jspecify.annotations.Nullable ClassElement classElement) throws IOException {
         // Build nested property tree from matching properties
         Map<String, Object> tree = new LinkedHashMap<>();
+        Set<String> required = new java.util.LinkedHashSet<>();
         for (PropertyMetadata pm : allProps) {
             String path = pm.getPath();
             String matchPrefix = basePrefix + ".";
@@ -235,22 +271,31 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 }
             }
         }
+        if (tree.isEmpty()) {
+            for (PropertyMetadata pm : allProps) {
+                if (pm.getDeclaringType().equals(cm.getType())) {
+                    tree.put(pm.getName(), pm);
+                }
+            }
+        }
         // Serialize properties from the tree
         out.write('{');
         Iterator<Map.Entry<String, Object>> it = tree.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<String, Object> e = it.next();
-            attr(out, e.getKey());
-            writeSchemaNode(out, e.getValue(), cm, vc, classElement);
+            String key = e.getKey();
+            attr(out, key);
+            writeSchemaNode(out, e.getValue(), cm, vc, classElement, key, required);
             if (it.hasNext()) {
                 out.write(',');
             }
         }
         out.write('}');
+        return required;
     }
 
     @SuppressWarnings("unchecked")
-    private void writeSchemaNode(Writer out, Object node, ConfigurationMetadata cm, @Nullable VisitorContext vc, @Nullable ClassElement classElement) throws IOException {
+    private void writeSchemaNode(Writer out, Object node, ConfigurationMetadata cm, @org.jspecify.annotations.Nullable VisitorContext vc, @org.jspecify.annotations.Nullable ClassElement classElement, @org.jspecify.annotations.Nullable String currentKey, Set<String> requiredOut) throws IOException {
         if (node instanceof PropertyMetadata pm) {
             // Leaf property schema
             out.write('{');
@@ -287,42 +332,44 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             out.write(',');
             attr(out, "x-micronaut-path");
             str(out, pm.getPath());
-            // deprecated (if resolvable)
-            if (classElement != null) {
-                List<PropertyElement> beanProperties =
-                    classElement.getBeanProperties(PropertyElementQuery.of(classElement).includes(Set.of(pm.getName())));
-                if (!beanProperties.isEmpty()) {
-                    PropertyElement pe = beanProperties.getFirst();
-                    if (!wroteDefault) {
-                        String defaultValue = pe.stringValue(Bindable.class, "defaultValue").orElse(null);
-                        if (defaultValue != null) {
-                            Object aDefault = coerceDefault(defaultValue, pm.getType());
-                            if (aDefault != null) {
-                                out.write(',');
-                                attr(out, "default");
-                                writeJsonValue(out, aDefault);
-                            }
-                        } else {
-                            String constantName = "DEFAULT_" + NameUtils.environmentName(pm.getName());
-                            FieldElement constantField = classElement.getEnclosedElement(ElementQuery.ALL_FIELDS.named(constantName).onlyStatic())
-                                .orElse(null);
-                            if (constantField != null) {
-                                Object constantValue = constantField.getConstantValue();
-                                if (constantValue != null) {
+            if (vc != null) {
+                ClassElement ceLocal = vc.getClassElement(pm.getDeclaringType()).orElse(null);
+                if (ceLocal != null) {
+                    PropertyElement pe = ceLocal.getBeanProperties().stream()
+                        .filter(p -> p.getName().equals(pm.getName()) || (currentKey != null && p.getName().equals(currentKey)))
+                        .findFirst().orElse(null);
+                    if (pe != null) {
+                        applyValidationConstraints(out, pe, pm, currentKey, requiredOut, vc);
+                        if (!wroteDefault) {
+                            String defaultValue = pe.stringValue(Bindable.class, "defaultValue").orElse(null);
+                            if (defaultValue != null) {
+                                Object aDefault = coerceDefault(defaultValue, pm.getType());
+                                if (aDefault != null) {
                                     out.write(',');
                                     attr(out, "default");
-                                    writeJsonValue(out, constantValue);
+                                    writeJsonValue(out, aDefault);
+                                }
+                            } else {
+                                String constantName = "DEFAULT_" + NameUtils.environmentName(pm.getName());
+                                FieldElement constantField = ceLocal.getEnclosedElement(ElementQuery.ALL_FIELDS.named(constantName).onlyStatic()).orElse(null);
+                                if (constantField != null) {
+                                    Object constantValue = constantField.getConstantValue();
+                                    if (constantValue != null) {
+                                        out.write(',');
+                                        attr(out, "default");
+                                        writeJsonValue(out, constantValue);
+                                    }
                                 }
                             }
                         }
-                    }
-                    if (pe.hasStereotype(Deprecated.class)) {
-                        try {
-                            out.write(',');
-                            attr(out, "deprecated");
-                            out.write("true");
-                        } catch (IOException ignored) {
-                            // ignore
+                        if (pe.hasStereotype(Deprecated.class)) {
+                            try {
+                                out.write(',');
+                                attr(out, "deprecated");
+                                out.write("true");
+                            } catch (IOException ignored) {
+                                // ignored
+                            }
                         }
                     }
                 }
@@ -339,8 +386,9 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             Iterator<Map.Entry<String, Object>> it = m.entrySet().iterator();
             while (it.hasNext()) {
                 Map.Entry<String, Object> e = it.next();
-                attr(out, e.getKey());
-                writeSchemaNode(out, e.getValue(), cm, vc, classElement);
+                String key = e.getKey();
+                attr(out, key);
+                writeSchemaNode(out, e.getValue(), cm, vc, classElement, key, requiredOut);
                 if (it.hasNext()) {
                     out.write(',');
                 }
@@ -552,6 +600,232 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         attr(out, "$ref");
         str(out, "#/$defs/Entry");
         out.write('}');
+    }
+
+    private void applyValidationConstraints(Writer out,
+                                            PropertyElement pe,
+                                            PropertyMetadata pm,
+                                            @org.jspecify.annotations.Nullable String currentKey,
+                                            Set<String> requiredOut,
+                                            VisitorContext context) throws IOException {
+        java.util.function.Function<String, Boolean> has = ann -> {
+            List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
+            return !values.isEmpty();
+        };
+        java.util.function.BiFunction<String, String, @Nullable String> sval = (ann, member) ->
+            pe.stringValue(ann, member).orElseGet(() -> {
+                List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
+                if (!values.isEmpty()) {
+                    return values.getFirst().stringValue(member).orElse(null);
+                }
+                return null;
+            }
+        );
+
+        java.util.function.BiFunction<String, String, @Nullable Integer> ival = (ann, member) -> {
+            OptionalInt opt = pe.intValue(ann, member);
+            if (opt.isPresent()) {
+                return opt.getAsInt();
+            } else {
+                List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
+                if (!values.isEmpty()) {
+                    OptionalInt optionalInt = values.getFirst().intValue(member);
+                    if (optionalInt.isPresent()) {
+                        return optionalInt.getAsInt();
+                    }
+                }
+                return null;
+            }
+        };
+
+        java.util.function.BiFunction<String, String, @Nullable Long> lval = (ann, member) -> {
+            OptionalLong opt = pe.longValue(ann, member);
+            if (opt.isPresent()) {
+                return opt.getAsLong();
+            } else {
+                List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
+                if (!values.isEmpty()) {
+                    OptionalLong optionalInt = values.getFirst().longValue(member);
+                    if (optionalInt.isPresent()) {
+                        return optionalInt.getAsLong();
+                    }
+                }
+                return null;
+            }
+        };
+
+        java.util.function.BiFunction<String, String, @Nullable Boolean> bval = (ann, member) ->
+            pe.booleanValue(ann, member).orElseGet(() -> {
+                    List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
+                    if (!values.isEmpty()) {
+                        return values.getFirst().booleanValue(member).orElse(null);
+                    }
+                    return null;
+                }
+            );
+
+        // Collect NotNull -> required
+        if ((has.apply("jakarta.validation.constraints.NotNull") || has.apply("jakarta.validation.constraints.NotBlank")) && currentKey != null) {
+            requiredOut.add(currentKey);
+        }
+        // Null -> const null? skip (rare); users should use @Nullable to allow nulls
+        // AssertTrue/False -> const
+        if (has.apply("jakarta.validation.constraints.AssertTrue")) {
+            comma(out);
+            attr(out, "const");
+            out.write("true");
+        }
+        if (has.apply("jakarta.validation.constraints.AssertFalse")) {
+            comma(out);
+            attr(out, "const");
+            out.write("false");
+        }
+        // Email
+        if (has.apply("jakarta.validation.constraints.Email")) {
+            comma(out);
+            attr(out, "format");
+            str(out, "email");
+        }
+        // Pattern
+        String pattern = sval.apply("jakarta.validation.constraints.Pattern", "regexp");
+        if (pattern != null && !pattern.isEmpty()) {
+            comma(out);
+            attr(out, "pattern");
+            str(out, pattern);
+        }
+        // Size
+        Integer sizeMinBox = ival.apply("jakarta.validation.constraints.Size", "min");
+        Integer sizeMaxBox = ival.apply("jakarta.validation.constraints.Size", "max");
+        int sizeMin = sizeMinBox == null ? -1 : sizeMinBox;
+        int sizeMax = sizeMaxBox == null ? -1 : sizeMaxBox;
+        ClassElement t = pe.getType();
+        boolean isString = "java.lang.String".equals(t.getName());
+        boolean isArray = t.isArray() || t.isIterable();
+        boolean isMap = t.isAssignable(java.util.Map.class);
+        if (isString) {
+            if (has.apply("jakarta.validation.constraints.NotBlank") || has.apply("jakarta.validation.constraints.NotEmpty")) {
+                sizeMin = Math.max(sizeMin, 1);
+            }
+            if (sizeMin >= 0) {
+                comma(out);
+                attr(out, "minLength");
+                out.write(Integer.toString(sizeMin));
+            }
+            if (sizeMax >= 0) {
+                comma(out);
+                attr(out, "maxLength");
+                out.write(Integer.toString(sizeMax));
+            }
+        } else if (isArray) {
+            if (has.apply("jakarta.validation.constraints.NotEmpty")) {
+                sizeMin = Math.max(sizeMin, 1);
+            }
+            if (sizeMin >= 0) {
+                comma(out);
+                attr(out, "minItems");
+                out.write(Integer.toString(sizeMin));
+            }
+            if (sizeMax >= 0) {
+                comma(out);
+                attr(out, "maxItems");
+                out.write(Integer.toString(sizeMax));
+            }
+        } else if (isMap) {
+            if (has.apply("jakarta.validation.constraints.NotEmpty")) {
+                sizeMin = Math.max(sizeMin, 1);
+            }
+            if (sizeMin >= 0) {
+                comma(out);
+                attr(out, "minProperties");
+                out.write(Integer.toString(sizeMin));
+            }
+            if (sizeMax >= 0) {
+                comma(out);
+                attr(out, "maxProperties");
+                out.write(Integer.toString(sizeMax));
+            }
+        }
+        // Min/Max
+        Long min = lval.apply("jakarta.validation.constraints.Min", "value");
+        Long max = lval.apply("jakarta.validation.constraints.Max", "value");
+        if (min != null) {
+            comma(out);
+            attr(out, "minimum");
+            out.write(Long.toString(min));
+        }
+        if (max != null) {
+            comma(out);
+            attr(out, "maximum");
+            out.write(Long.toString(max));
+        }
+        // DecimalMin/DecimalMax
+        String dmin = sval.apply("jakarta.validation.constraints.DecimalMin", "value");
+        Boolean dminInc = bval.apply("jakarta.validation.constraints.DecimalMin", "inclusive");
+        if (dmin != null) {
+            if (dminInc == null || dminInc) {
+                comma(out);
+                attr(out, "minimum");
+                out.write(dmin);
+            } else {
+                comma(out);
+                attr(out, "exclusiveMinimum");
+                out.write(dmin);
+            }
+        }
+        String dmax = sval.apply("jakarta.validation.constraints.DecimalMax", "value");
+        Boolean dmaxInc = bval.apply("jakarta.validation.constraints.DecimalMax", "inclusive");
+        if (dmax != null) {
+            if (dmaxInc == null || dmaxInc) {
+                comma(out);
+                attr(out, "maximum");
+                out.write(dmax);
+            } else {
+                comma(out);
+                attr(out, "exclusiveMaximum");
+                out.write(dmax);
+            }
+        }
+        // Positive / Negative variants
+        if (has.apply("jakarta.validation.constraints.Positive")) {
+            comma(out);
+            attr(out, "exclusiveMinimum");
+            out.write("0");
+        }
+        if (has.apply("jakarta.validation.constraints.PositiveOrZero")) {
+            comma(out);
+            attr(out, "minimum");
+            out.write("0");
+        }
+        if (has.apply("jakarta.validation.constraints.Negative")) {
+            comma(out);
+            attr(out, "exclusiveMaximum");
+            out.write("0");
+        }
+        if (has.apply("jakarta.validation.constraints.NegativeOrZero")) {
+            comma(out);
+            attr(out, "maximum");
+            out.write("0");
+        }
+        // Digits -> regex
+        Integer intDigits = ival.apply("jakarta.validation.constraints.Digits", "integer");
+        Integer fracDigits = ival.apply("jakarta.validation.constraints.Digits", "fraction");
+        if (intDigits != null || fracDigits != null) {
+            StringBuilder re = new StringBuilder("^");
+            int id = intDigits != null ? intDigits : 0;
+            int fd = fracDigits != null ? fracDigits : 0;
+            if (id > 0) {
+                re.append("\\d{1,").append(id).append("}");
+            } else {
+                re.append("\\d+");
+            }
+            if (fd > 0) {
+                re.append("(\\.\\d{1,").append(fd).append("})?");
+            }
+            re.append("$");
+            comma(out);
+            attr(out, "pattern");
+            str(out, re.toString());
+        }
     }
 
     // JSON writing helpers

--- a/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
@@ -171,22 +171,26 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             attr(out, "properties");
             ClassElement classElement = vc != null ? vc.getClassElement(cm.getType()).orElse(null) : null;
             Set<String> required = writePropertiesObject(out, cm, basePrefix, allProps, vc, /*containerMode*/ null, classElement);
-            if (!required.isEmpty()) {
-                comma(out);
-                attr(out, "required");
-                out.write('[');
-                Iterator<String> r = required.iterator();
-                while (r.hasNext()) {
-                    str(out, r.next());
-                    if (r.hasNext()) {
-                        out.write(',');
-                    }
-                }
-                out.write(']');
-            }
+            emitRequired(out, required);
             // keep additionalProperties default (omitted) or explicitly true
         }
         out.write('}');
+    }
+
+    private void emitRequired(Writer out, Set<String> required) throws IOException {
+        if (!required.isEmpty()) {
+            comma(out);
+            attr(out, "required");
+            out.write('[');
+            Iterator<String> r = required.iterator();
+            while (r.hasNext()) {
+                str(out, r.next());
+                if (r.hasNext()) {
+                    out.write(',');
+                }
+            }
+            out.write(']');
+        }
     }
 
     private void emitEntryDefs(ConfigurationMetadata cm,
@@ -206,19 +210,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         comma(out);
         attr(out, "properties");
         Set<String> required = writePropertiesObject(out, cm, basePrefix, allProps, vc, mapMode ? ContainerMode.MAP : ContainerMode.LIST, classElement);
-        if (!required.isEmpty()) {
-            comma(out);
-            attr(out, "required");
-            out.write('[');
-            Iterator<String> r = required.iterator();
-            while (r.hasNext()) {
-                str(out, r.next());
-                if (r.hasNext()) {
-                    out.write(',');
-                }
-            }
-            out.write(']');
-        }
+        emitRequired(out, required);
         out.write('}');
         out.write('}');
     }
@@ -282,6 +274,11 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             }
         }
         // Serialize properties from the tree
+        emitProperties(out, vc, classElement, tree, required);
+        return required;
+    }
+
+    private void emitProperties(Writer out, @Nullable VisitorContext vc, @Nullable ClassElement classElement, Map<String, Object> tree, Set<String> required) throws IOException {
         out.write('{');
         Iterator<Map.Entry<String, Object>> it = tree.entrySet().iterator();
         while (it.hasNext()) {
@@ -294,7 +291,6 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             }
         }
         out.write('}');
-        return required;
     }
 
     @SuppressWarnings("unchecked")
@@ -339,7 +335,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 if (classElement != null) {
                     PropertyElement pe = findProperty(classElement, currentKey, pm);
                     if (pe != null) {
-                        applyValidationConstraints(out, pe, pm, currentKey, requiredOut, vc);
+                        applyValidationConstraints(out, pe, currentKey, requiredOut);
                         if (!wroteDefault) {
                             String defaultValue = pe.stringValue(Bindable.class, "defaultValue").orElse(null);
                             if (defaultValue != null) {
@@ -382,18 +378,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             str(out, "object");
             out.write(',');
             attr(out, "properties");
-            out.write('{');
-            Iterator<Map.Entry<String, Object>> it = m.entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry<String, Object> e = it.next();
-                String key = e.getKey();
-                attr(out, key);
-                writeSchemaNode(out, e.getValue(), vc, classElement, key, requiredOut);
-                if (it.hasNext()) {
-                    out.write(',');
-                }
-            }
-            out.write('}');
+            emitProperties(out, vc, classElement, m, requiredOut);
             out.write('}');
         } else {
             // Should not happen; write permissive schema
@@ -440,7 +425,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 } else {
                     ClassElement item = t.getFirstTypeArgument().orElse(null);
                     if (item != null) {
-                        writeChildTypeSchema(out, item, vc);
+                        writeChildTypeSchema(out, item);
                     } else {
                         writeChildTypeName(out, "java.lang.String");
                     }
@@ -460,20 +445,20 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 if (v == null) {
                     v = t;
                 }
-                writeChildTypeSchema(out, v, vc);
+                writeChildTypeSchema(out, v);
                 return;
             }
             // Plain type
-            writeSimpleTypeSchema(out, t, vc);
+            writeSimpleTypeSchema(out, t);
             return;
         }
         // Fallback: map simple by name
         writeSimpleTypeName(out, fqcn);
     }
 
-    private void writeChildTypeSchema(Writer out, ClassElement t, @Nullable VisitorContext vc) throws IOException {
+    private void writeChildTypeSchema(Writer out, ClassElement t) throws IOException {
         out.write('{');
-        writeSimpleTypeSchema(out, t, vc);
+        writeSimpleTypeSchema(out, t);
         out.write('}');
     }
 
@@ -483,7 +468,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         out.write('}');
     }
 
-    private void writeSimpleTypeSchema(Writer out, ClassElement t, @Nullable VisitorContext vc) throws IOException {
+    private void writeSimpleTypeSchema(Writer out, ClassElement t) throws IOException {
         // Enum
         if (t.isEnum()) {
             attr(out, "type");
@@ -568,7 +553,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 return;
             }
             case Number number -> {
-                out.write(v.toString());
+                out.write(number.toString());
                 return;
             }
             default -> {
@@ -611,10 +596,8 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
 
     private void applyValidationConstraints(Writer out,
                                             PropertyElement pe,
-                                            PropertyMetadata pm,
                                             @Nullable String currentKey,
-                                            Set<String> requiredOut,
-                                            VisitorContext context) throws IOException {
+                                            Set<String> requiredOut) throws IOException {
         Function<String, Boolean> has = ann -> {
             List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
             return !values.isEmpty();
@@ -769,28 +752,24 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         String dmin = sval.apply("jakarta.validation.constraints.DecimalMin", "value");
         Boolean dminInc = bval.apply("jakarta.validation.constraints.DecimalMin", "inclusive");
         if (dmin != null) {
+            comma(out);
             if (dminInc == null || dminInc) {
-                comma(out);
                 attr(out, "minimum");
-                out.write(dmin);
             } else {
-                comma(out);
                 attr(out, "exclusiveMinimum");
-                out.write(dmin);
             }
+            out.write(dmin);
         }
         String dmax = sval.apply("jakarta.validation.constraints.DecimalMax", "value");
         Boolean dmaxInc = bval.apply("jakarta.validation.constraints.DecimalMax", "inclusive");
         if (dmax != null) {
+            comma(out);
             if (dmaxInc == null || dmaxInc) {
-                comma(out);
                 attr(out, "maximum");
-                out.write(dmax);
             } else {
-                comma(out);
                 attr(out, "exclusiveMaximum");
-                out.write(dmax);
             }
+            out.write(dmax);
         }
         // Positive / Negative variants
         if (has.apply("jakarta.validation.constraints.Positive")) {

--- a/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
@@ -30,6 +30,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -40,6 +41,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * A {@link ConfigurationMetadataWriter} that writes per-class JSON Schema (Draft 2020-12)
@@ -86,7 +89,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
 
     private void writeSchemaFor(ConfigurationMetadata cm,
                                 List<PropertyMetadata> allProps,
-                                @org.jspecify.annotations.Nullable VisitorContext vc,
+                                @Nullable VisitorContext vc,
                                 Writer out) throws IOException {
         // Determine prefix and whether this is EachProperty
         String fullPrefix = cm.getName(); // may contain .* or [*]
@@ -189,10 +192,10 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
     private void emitEntryDefs(ConfigurationMetadata cm,
                                String basePrefix,
                                List<PropertyMetadata> allProps,
-                               @org.jspecify.annotations.Nullable VisitorContext vc,
+                               @Nullable VisitorContext vc,
                                Writer out,
                                boolean mapMode,
-                               @org.jspecify.annotations.Nullable ClassElement classElement) throws IOException {
+                               @Nullable ClassElement classElement) throws IOException {
         comma(out);
         attr(out, "$defs");
         out.write('{');
@@ -229,9 +232,9 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                                               ConfigurationMetadata cm,
                                               String basePrefix,
                                               List<PropertyMetadata> allProps,
-                                              @org.jspecify.annotations.Nullable VisitorContext vc,
-                                              @org.jspecify.annotations.Nullable ContainerMode containerMode,
-                                              @org.jspecify.annotations.Nullable ClassElement classElement) throws IOException {
+                                              @Nullable VisitorContext vc,
+                                              @Nullable ContainerMode containerMode,
+                                              @Nullable ClassElement classElement) throws IOException {
         // Build nested property tree from matching properties
         Map<String, Object> tree = new LinkedHashMap<>();
         Set<String> required = new java.util.LinkedHashSet<>();
@@ -285,7 +288,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             Map.Entry<String, Object> e = it.next();
             String key = e.getKey();
             attr(out, key);
-            writeSchemaNode(out, e.getValue(), cm, vc, classElement, key, required);
+            writeSchemaNode(out, e.getValue(), vc, classElement, key, required);
             if (it.hasNext()) {
                 out.write(',');
             }
@@ -295,7 +298,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
     }
 
     @SuppressWarnings("unchecked")
-    private void writeSchemaNode(Writer out, Object node, ConfigurationMetadata cm, @org.jspecify.annotations.Nullable VisitorContext vc, @org.jspecify.annotations.Nullable ClassElement classElement, @org.jspecify.annotations.Nullable String currentKey, Set<String> requiredOut) throws IOException {
+    private void writeSchemaNode(Writer out, Object node, @Nullable VisitorContext vc, @Nullable ClassElement classElement, @Nullable String currentKey, Set<String> requiredOut) throws IOException {
         if (node instanceof PropertyMetadata pm) {
             // Leaf property schema
             out.write('{');
@@ -333,11 +336,8 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             attr(out, "x-micronaut-path");
             str(out, pm.getPath());
             if (vc != null) {
-                ClassElement ceLocal = vc.getClassElement(pm.getDeclaringType()).orElse(null);
-                if (ceLocal != null) {
-                    PropertyElement pe = ceLocal.getBeanProperties().stream()
-                        .filter(p -> p.getName().equals(pm.getName()) || (currentKey != null && p.getName().equals(currentKey)))
-                        .findFirst().orElse(null);
+                if (classElement != null) {
+                    PropertyElement pe = findProperty(classElement, currentKey, pm);
                     if (pe != null) {
                         applyValidationConstraints(out, pe, pm, currentKey, requiredOut, vc);
                         if (!wroteDefault) {
@@ -351,7 +351,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                                 }
                             } else {
                                 String constantName = "DEFAULT_" + NameUtils.environmentName(pm.getName());
-                                FieldElement constantField = ceLocal.getEnclosedElement(ElementQuery.ALL_FIELDS.named(constantName).onlyStatic()).orElse(null);
+                                FieldElement constantField = classElement.getEnclosedElement(ElementQuery.ALL_FIELDS.named(constantName).onlyStatic()).orElse(null);
                                 if (constantField != null) {
                                     Object constantValue = constantField.getConstantValue();
                                     if (constantValue != null) {
@@ -388,7 +388,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 Map.Entry<String, Object> e = it.next();
                 String key = e.getKey();
                 attr(out, key);
-                writeSchemaNode(out, e.getValue(), cm, vc, classElement, key, requiredOut);
+                writeSchemaNode(out, e.getValue(), vc, classElement, key, requiredOut);
                 if (it.hasNext()) {
                     out.write(',');
                 }
@@ -401,13 +401,20 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         }
     }
 
-    private void writeTypeForProperty(Writer out, PropertyMetadata pm, @org.jspecify.annotations.Nullable VisitorContext vc) throws IOException {
+    @Nullable
+    private static PropertyElement findProperty(ClassElement classElement, @Nullable String currentKey, PropertyMetadata pm) {
+        return classElement.getBeanProperties()
+            .stream().filter(p -> p.getName().equals(currentKey) || p.getName().equals(pm.getName()))
+            .findFirst().orElse(null);
+    }
+
+    private void writeTypeForProperty(Writer out, PropertyMetadata pm, @Nullable VisitorContext vc) throws IOException {
         String fqcn = pm.getType();
         // Try to refine via VisitorContext (generics, enums)
         ClassElement ce = (vc != null) ? vc.getClassElement(pm.getDeclaringType()).orElse(null) : null;
         PropertyElement pe = null;
         if (ce != null) {
-            pe = ce.getBeanProperties().stream().filter(p -> p.getName().equals(pm.getName())).findFirst().orElse(null);
+            pe = findProperty(ce, null, pm);
         }
         if (pe != null) {
             // Optional
@@ -464,7 +471,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         writeSimpleTypeName(out, fqcn);
     }
 
-    private void writeChildTypeSchema(Writer out, ClassElement t, @org.jspecify.annotations.Nullable VisitorContext vc) throws IOException {
+    private void writeChildTypeSchema(Writer out, ClassElement t, @Nullable VisitorContext vc) throws IOException {
         out.write('{');
         writeSimpleTypeSchema(out, t, vc);
         out.write('}');
@@ -476,7 +483,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         out.write('}');
     }
 
-    private void writeSimpleTypeSchema(Writer out, ClassElement t, @org.jspecify.annotations.Nullable VisitorContext vc) throws IOException {
+    private void writeSimpleTypeSchema(Writer out, ClassElement t, @Nullable VisitorContext vc) throws IOException {
         // Enum
         if (t.isEnum()) {
             attr(out, "type");
@@ -534,7 +541,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         str(out, type);
     }
 
-    private @org.jspecify.annotations.Nullable Object coerceDefault(String value, String typeName) {
+    private @Nullable Object coerceDefault(String value, String typeName) {
         try {
             return switch (typeName) {
                 case "boolean", "java.lang.Boolean" -> Boolean.parseBoolean(value);
@@ -579,9 +586,9 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
 
     private static List<String> splitOnDot(String rel) {
         if (rel.indexOf('.') < 0) {
-            return java.util.List.of(rel);
+            return List.of(rel);
         }
-        java.util.List<String> parts = new java.util.ArrayList<>();
+        List<String> parts = new ArrayList<>();
         int start = 0;
         for (int i = 0; i < rel.length(); i++) {
             if (rel.charAt(i) == '.') {
@@ -605,14 +612,14 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
     private void applyValidationConstraints(Writer out,
                                             PropertyElement pe,
                                             PropertyMetadata pm,
-                                            @org.jspecify.annotations.Nullable String currentKey,
+                                            @Nullable String currentKey,
                                             Set<String> requiredOut,
                                             VisitorContext context) throws IOException {
-        java.util.function.Function<String, Boolean> has = ann -> {
+        Function<String, Boolean> has = ann -> {
             List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
             return !values.isEmpty();
         };
-        java.util.function.BiFunction<String, String, @Nullable String> sval = (ann, member) ->
+        BiFunction<String, String, @Nullable String> sval = (ann, member) ->
             pe.stringValue(ann, member).orElseGet(() -> {
                 List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
                 if (!values.isEmpty()) {
@@ -622,7 +629,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             }
         );
 
-        java.util.function.BiFunction<String, String, @Nullable Integer> ival = (ann, member) -> {
+        BiFunction<String, String, @Nullable Integer> ival = (ann, member) -> {
             OptionalInt opt = pe.intValue(ann, member);
             if (opt.isPresent()) {
                 return opt.getAsInt();

--- a/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
@@ -1,0 +1,572 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.configuration;
+
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.naming.NameUtils;
+import io.micronaut.inject.ast.ClassElement;
+
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.FieldElement;
+import io.micronaut.inject.ast.PropertyElement;
+import io.micronaut.inject.ast.PropertyElementQuery;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.inject.writer.ClassWriterOutputVisitor;
+import io.micronaut.inject.writer.GeneratedFile;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A {@link ConfigurationMetadataWriter} that writes per-class JSON Schema (Draft 2020-12)
+ * for each {@code @ConfigurationProperties} / {@code @EachProperty} annotated type.
+ */
+public final class JsonSchemaConfigurationMetadataWriter implements ConfigurationMetadataWriter {
+
+    private static final String SCHEMAS_DIR = "micronaut-configuration-schemas";
+
+    @Override
+    public void write(ConfigurationMetadataBuilder metadataBuilder, ClassWriterOutputVisitor outputVisitor) throws IOException {
+        final List<ConfigurationMetadata> configs = metadataBuilder.getConfigurations();
+        if (configs.isEmpty()) {
+            return;
+        }
+        // We need VisitorContext for richer type info where available.
+        final VisitorContext vc = (outputVisitor instanceof VisitorContext visitorContext) ? visitorContext : null;
+
+        // Build quick index of properties by path for efficient filtering
+        final List<PropertyMetadata> props = metadataBuilder.getProperties();
+
+        Set<String> seen = new HashSet<>();
+        for (ConfigurationMetadata cm : configs) {
+            final String fqcn = cm.getType();
+            if (!seen.add(fqcn)) {
+                continue;
+            }
+            final String fileName = SCHEMAS_DIR + "/" + fqcn + ".json";
+            Optional<GeneratedFile> fileOpt = outputVisitor.visitMetaInfFile(fileName, metadataBuilder.getOriginatingElements());
+            if (fileOpt.isEmpty()) {
+                continue;
+            }
+
+            try (Writer out = fileOpt.get().openWriter()) {
+                writeSchemaFor(cm, props, vc, out);
+            }
+        }
+    }
+
+    private void writeSchemaFor(ConfigurationMetadata cm,
+                                List<PropertyMetadata> allProps,
+                                @org.jspecify.annotations.Nullable VisitorContext vc,
+                                Writer out) throws IOException {
+        // Determine prefix and whether this is EachProperty
+        String fullPrefix = cm.getName(); // may contain .* or [*]
+        boolean isEachMap = fullPrefix.endsWith(".*");
+        boolean isEachList = fullPrefix.endsWith("[*]");
+        String basePrefix = fullPrefix;
+        if (isEachMap) {
+            basePrefix = fullPrefix.substring(0, fullPrefix.length() - 2);
+        }
+        if (isEachList) {
+            basePrefix = fullPrefix.substring(0, fullPrefix.length() - 3);
+        }
+
+        // JSON begin
+        out.write('{');
+        attr(out, "$schema");
+        str(out, "https://json-schema.org/draft/2020-12/schema");
+        comma(out);
+        attr(out, "$id");
+        str(out, "urn:micronaut:config:" + cm.getType());
+        comma(out);
+        attr(out, "title");
+        str(out, cm.getType());
+        comma(out);
+        if (cm.getDescription() != null) {
+            attr(out, "description");
+            str(out, cm.getDescription());
+            comma(out);
+        }
+        // Vendor extension at root
+        attr(out, "x-micronaut");
+        out.write('{');
+        attr(out, "prefix");
+        str(out, basePrefix);
+        comma(out);
+        attr(out, "type");
+        str(out, cm.getType());
+        comma(out);
+        boolean isEach = isEachMap || isEachList;
+        attr(out, "kind");
+        str(out, isEach ? "each-property" : "configuration-properties");
+        if (isEach) {
+            comma(out);
+            attr(out, "container");
+            str(out, isEachMap ? "map" : "list");
+        }
+        out.write('}');
+        comma(out);
+
+        // Root schema shape
+        if (isEachMap) {
+            // type: object; minProperties:1; additionalProperties: $ref $defs.Entry
+            attr(out, "type");
+            str(out, "object");
+            comma(out);
+            attr(out, "minProperties");
+            out.write("1");
+            comma(out);
+            emitAdditionalPropertiesRef(out);
+            // defs entry schema
+            emitEntryDefs(cm, basePrefix, allProps, vc, out, true);
+        } else if (isEachList) {
+            // type: array; minItems:1; items: $ref $defs.Entry
+            attr(out, "type");
+            str(out, "array");
+            comma(out);
+            attr(out, "minItems");
+            out.write("1");
+            comma(out);
+            attr(out, "items");
+            refEntry(out);
+            emitEntryDefs(cm, basePrefix, allProps, vc, out, false);
+        } else {
+            // Plain configuration object
+            attr(out, "type");
+            str(out, "object");
+            comma(out);
+            // properties: object
+            attr(out, "properties");
+            writePropertiesObject(out, cm, basePrefix, allProps, vc, /*containerMode*/ null);
+            // keep additionalProperties default (omitted) or explicitly true
+        }
+        out.write('}');
+    }
+
+    private void emitEntryDefs(ConfigurationMetadata cm,
+                               String basePrefix,
+                               List<PropertyMetadata> allProps,
+                               @org.jspecify.annotations.Nullable VisitorContext vc,
+                               Writer out,
+                               boolean mapMode) throws IOException {
+        comma(out);
+        attr(out, "$defs");
+        out.write('{');
+        attr(out, "Entry");
+        out.write('{');
+        attr(out, "type");
+        str(out, "object");
+        comma(out);
+        attr(out, "properties");
+        writePropertiesObject(out, cm, basePrefix, allProps, vc, mapMode ? ContainerMode.MAP : ContainerMode.LIST);
+        out.write('}');
+        out.write('}');
+    }
+
+    private enum ContainerMode {
+        MAP,
+        LIST
+    }
+
+    private void writePropertiesObject(Writer out,
+                                       ConfigurationMetadata cm,
+                                       String basePrefix,
+                                       List<PropertyMetadata> allProps,
+                                       @org.jspecify.annotations.Nullable VisitorContext vc,
+                                       @org.jspecify.annotations.Nullable ContainerMode containerMode) throws IOException {
+        ClassElement classElement = vc != null ? vc.getClassElement(cm.type).orElse(null) : null;
+        // Build nested property tree from matching properties
+        Map<String, Object> tree = new LinkedHashMap<>();
+        for (PropertyMetadata pm : allProps) {
+            String path = pm.getPath();
+            String matchPrefix = basePrefix + ".";
+            if (containerMode == ContainerMode.MAP) {
+                matchPrefix = basePrefix + ".*.";
+            }
+            if (containerMode == ContainerMode.LIST) {
+                matchPrefix = basePrefix + "[*].";
+            }
+            if (!path.startsWith(matchPrefix)) {
+                continue;
+            }
+            String rel = path.substring(matchPrefix.length());
+            if (rel.isEmpty()) {
+                continue;
+            }
+            // Split into segments
+            List<String> segs = splitOnDot(rel);
+            Map<String, Object> cursor = tree;
+            for (int i = 0; i < segs.size(); i++) {
+                String seg = segs.get(i);
+                boolean last = (i == segs.size() - 1);
+                if (last) {
+                    // Leaf: store PropertyMetadata
+                    cursor.put(seg, pm);
+                } else {
+                    Object n = cursor.get(seg);
+                    if (!(n instanceof Map)) {
+                        n = new LinkedHashMap<String, Object>();
+                        cursor.put(seg, n);
+                    }
+                    //noinspection unchecked
+                    cursor = (Map<String, Object>) n;
+                }
+            }
+        }
+        // Serialize properties from the tree
+        out.write('{');
+        Iterator<Map.Entry<String, Object>> it = tree.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Object> e = it.next();
+            attr(out, e.getKey());
+            writeSchemaNode(out, e.getValue(), cm, vc, classElement);
+            if (it.hasNext()) {
+                out.write(',');
+            }
+        }
+        out.write('}');
+    }
+
+    @SuppressWarnings("unchecked")
+    private void writeSchemaNode(Writer out, Object node, ConfigurationMetadata cm, @Nullable VisitorContext vc, @Nullable ClassElement classElement) throws IOException {
+        if (node instanceof PropertyMetadata pm) {
+            // Leaf property schema
+            out.write('{');
+            // type mapping (best effort)
+            writeTypeForProperty(out, pm, vc);
+            // description
+            if (pm.getDescription() != null) {
+                out.write(',');
+                attr(out, "description");
+                str(out, pm.getDescription());
+            }
+            // default
+            boolean wroteDefault;
+            if (pm.getDefaultValue() != null) {
+                Object coerced = coerceDefault(pm.getDefaultValue(), pm.getType());
+                if (coerced != null) {
+                    out.write(',');
+                    attr(out, "default");
+                    writeJsonValue(out, coerced);
+                    wroteDefault = true;
+                } else {
+                    wroteDefault = false;
+                }
+            } else {
+                wroteDefault = false;
+            }
+            // vendor ext per property
+            out.write(',');
+            attr(out, "x-micronaut-javaType");
+            str(out, pm.getType());
+            out.write(',');
+            attr(out, "x-micronaut-sourceType");
+            str(out, pm.getDeclaringType());
+            out.write(',');
+            attr(out, "x-micronaut-path");
+            str(out, pm.getPath());
+            // deprecated (if resolvable)
+            if (classElement != null) {
+                List<PropertyElement> beanProperties =
+                    classElement.getBeanProperties(PropertyElementQuery.of(classElement).includes(Set.of(pm.getName())));
+                if (!beanProperties.isEmpty()) {
+                    PropertyElement pe = beanProperties.getFirst();
+                    if (!wroteDefault) {
+                        String defaultValue = pe.stringValue(Bindable.class, "defaultValue").orElse(null);
+                        if (defaultValue != null) {
+                            Object aDefault = coerceDefault(defaultValue, pm.getType());
+                            if (aDefault != null) {
+                                out.write(',');
+                                attr(out, "default");
+                                writeJsonValue(out, aDefault);
+                            }
+                        } else {
+                            String constantName = "DEFAULT_" + NameUtils.environmentName(pm.getName());
+                            FieldElement constantField = classElement.getEnclosedElement(ElementQuery.ALL_FIELDS.named(constantName).onlyStatic())
+                                .orElse(null);
+                            if (constantField != null) {
+                                Object constantValue = constantField.getConstantValue();
+                                if (constantValue != null) {
+                                    out.write(',');
+                                    attr(out, "default");
+                                    writeJsonValue(out, constantValue);
+                                }
+                            }
+                        }
+                    }
+                    if (pe.hasStereotype(Deprecated.class)) {
+                        try {
+                            out.write(',');
+                            attr(out, "deprecated");
+                            out.write("true");
+                        } catch (IOException ignored) {
+                            // ignore
+                        }
+                    }
+                }
+            }
+            out.write('}');
+        } else if (node instanceof Map) {
+            Map<String, Object> m = (Map<String, Object>) node;
+            out.write('{');
+            attr(out, "type");
+            str(out, "object");
+            out.write(',');
+            attr(out, "properties");
+            out.write('{');
+            Iterator<Map.Entry<String, Object>> it = m.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<String, Object> e = it.next();
+                attr(out, e.getKey());
+                writeSchemaNode(out, e.getValue(), cm, vc, classElement);
+                if (it.hasNext()) {
+                    out.write(',');
+                }
+            }
+            out.write('}');
+            out.write('}');
+        } else {
+            // Should not happen; write permissive schema
+            out.write("{\"type\":\"object\"}");
+        }
+    }
+
+    private void writeTypeForProperty(Writer out, PropertyMetadata pm, @org.jspecify.annotations.Nullable VisitorContext vc) throws IOException {
+        String fqcn = pm.getType();
+        // Try to refine via VisitorContext (generics, enums)
+        ClassElement ce = (vc != null) ? vc.getClassElement(pm.getDeclaringType()).orElse(null) : null;
+        PropertyElement pe = null;
+        if (ce != null) {
+            pe = ce.getBeanProperties().stream().filter(p -> p.getName().equals(pm.getName())).findFirst().orElse(null);
+        }
+        if (pe != null) {
+            // Optional
+            ClassElement t = pe.getGenericType();
+            if (t.isOptional()) {
+                t = t.getOptionalValueType().orElse(t);
+            }
+            // Collection/Array
+            if (t.isArray() || t.isIterable()) {
+                out.write('"');
+                out.write("type");
+                out.write('"');
+                out.write(':');
+                str(out, "array");
+                out.write(',');
+                attr(out, "items");
+                if (t.isArray()) {
+                    String n = t.getName();
+                    while (n.endsWith("[]")) {
+                        n = n.substring(0, n.length() - 2);
+                    }
+                    writeChildTypeName(out, n);
+                } else {
+                    ClassElement item = t.getFirstTypeArgument().orElse(null);
+                    if (item != null) {
+                        writeChildTypeSchema(out, item, vc);
+                    } else {
+                        writeChildTypeName(out, "java.lang.String");
+                    }
+                }
+                return;
+            }
+            // Map
+            if (t.isAssignable(Map.class)) {
+                out.write('"');
+                out.write("type");
+                out.write('"');
+                out.write(':');
+                str(out, "object");
+                out.write(',');
+                attr(out, "additionalProperties");
+                ClassElement v = t.getTypeArguments().get("V");
+                if (v == null) {
+                    v = t;
+                }
+                writeChildTypeSchema(out, v, vc);
+                return;
+            }
+            // Plain type
+            writeSimpleTypeSchema(out, t, vc);
+            return;
+        }
+        // Fallback: map simple by name
+        writeSimpleTypeName(out, fqcn);
+    }
+
+    private void writeChildTypeSchema(Writer out, ClassElement t, @org.jspecify.annotations.Nullable VisitorContext vc) throws IOException {
+        out.write('{');
+        writeSimpleTypeSchema(out, t, vc);
+        out.write('}');
+    }
+
+    private void writeChildTypeName(Writer out, String fqcn) throws IOException {
+        out.write('{');
+        writeSimpleTypeName(out, fqcn);
+        out.write('}');
+    }
+
+    private void writeSimpleTypeSchema(Writer out, ClassElement t, @org.jspecify.annotations.Nullable VisitorContext vc) throws IOException {
+        // Enum
+        if (t.isEnum()) {
+            attr(out, "type");
+            str(out, "string");
+            out.write(',');
+            attr(out, "enum");
+            out.write('[');
+            List<String> values;
+            if (t instanceof io.micronaut.inject.ast.EnumElement ee) {
+                values = ee.values();
+            } else {
+                values = Collections.emptyList();
+            }
+            for (int i = 0; i < values.size(); i++) {
+                str(out, values.get(i));
+                if (i + 1 < values.size()) {
+                    out.write(',');
+                }
+            }
+            out.write(']');
+            return;
+        }
+        // URI/URL
+        String n = t.getName();
+        if ("java.net.URI".equals(n) || "java.net.URL".equals(n)) {
+            attr(out, "type");
+            str(out, "string");
+            out.write(',');
+            attr(out, "format");
+            str(out, "uri");
+            return;
+        }
+        if ("java.time.Duration".equals(n)) {
+            attr(out, "type");
+            str(out, "string");
+            out.write(',');
+            attr(out, "format");
+            str(out, "duration");
+            return;
+        }
+        // Basic primitives/wrappers/strings
+        writeSimpleTypeName(out, n);
+    }
+
+    private void writeSimpleTypeName(Writer out, String fqcn) throws IOException {
+        String type = switch (fqcn) {
+            case "boolean", "java.lang.Boolean" -> "boolean";
+            case "byte", "short", "int", "long", "java.lang.Byte", "java.lang.Short",
+                 "java.lang.Integer", "java.lang.Long", "java.math.BigInteger" -> "integer";
+            case "float", "double", "java.lang.Float", "java.lang.Double", "java.math.BigDecimal" ->
+                "number";
+            default -> "string";
+        };
+        attr(out, "type");
+        str(out, type);
+    }
+
+    private @org.jspecify.annotations.Nullable Object coerceDefault(String value, String typeName) {
+        try {
+            return switch (typeName) {
+                case "boolean", "java.lang.Boolean" -> Boolean.parseBoolean(value);
+                case "byte", "short", "int", "long", "java.lang.Byte", "java.lang.Short",
+                     "java.lang.Integer", "java.lang.Long", "java.math.BigInteger" ->
+                    Long.parseLong(value);
+                case "float", "double", "java.lang.Float", "java.lang.Double",
+                     "java.math.BigDecimal" -> Double.parseDouble(value);
+                default -> value; // string/enum/uri fall back to string
+            };
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void writeJsonValue(Writer out, Object v) throws IOException {
+        switch (v) {
+            case String s -> {
+                str(out, s);
+                return;
+            }
+            case Boolean b -> {
+                out.write(b ? "true" : "false");
+                return;
+            }
+            case Number number -> {
+                out.write(v.toString());
+                return;
+            }
+            default -> {
+                // no-oip
+            }
+        }
+        // fallback to string
+        str(out, String.valueOf(v));
+    }
+
+    private void emitAdditionalPropertiesRef(Writer out) throws IOException {
+        attr(out, "additionalProperties");
+        refEntry(out);
+    }
+
+    private static List<String> splitOnDot(String rel) {
+        if (rel.indexOf('.') < 0) {
+            return java.util.List.of(rel);
+        }
+        java.util.List<String> parts = new java.util.ArrayList<>();
+        int start = 0;
+        for (int i = 0; i < rel.length(); i++) {
+            if (rel.charAt(i) == '.') {
+                parts.add(rel.substring(start, i));
+                start = i + 1;
+            }
+        }
+        if (start <= rel.length()) {
+            parts.add(rel.substring(start));
+        }
+        return parts;
+    }
+
+    private void refEntry(Writer out) throws IOException {
+        out.write('{');
+        attr(out, "$ref");
+        str(out, "#/$defs/Entry");
+        out.write('}');
+    }
+
+    // JSON writing helpers
+    private void attr(Writer out, String name) throws IOException {
+        out.write('"');
+        out.write(name);
+        out.write('"');
+        out.write(':');
+    }
+
+    private void str(Writer out, String s) throws IOException {
+        out.write(ConfigurationMetadataBuilder.quote(s));
+    }
+
+    private void comma(Writer out) throws IOException {
+        out.write(',');
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
@@ -15,9 +15,11 @@
  */
 package io.micronaut.inject.configuration;
 
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.PropertyElement;
@@ -42,7 +44,6 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * A {@link ConfigurationMetadataWriter} that writes per-class JSON Schema (Draft 2020-12)
@@ -51,6 +52,41 @@ import java.util.function.Function;
 public final class JsonSchemaConfigurationMetadataWriter implements ConfigurationMetadataWriter {
 
     private static final String SCHEMAS_DIR = "micronaut-configuration-schemas";
+    private static final String ATTR_MIN = "minimum";
+    private static final String ATTR_MAX = "maximum";
+    private static final String ATTR_CONST = "const";
+    private static final String ATTR_FORMAT = "format";
+    private static final String ATTR_PATTERN = "pattern";
+    private static final String ATTR_TYPE = "type";
+    private static final String ATTR_ENUM = "enum";
+    private static final String ATTR_PROPERTIES = "properties";
+    private static final String JV_NOT_NULL = "jakarta.validation.constraints.NotNull";
+    private static final String JV_NOT_BLANK = "jakarta.validation.constraints.NotBlank";
+    private static final String JV_ASSERT_TRUE = "jakarta.validation.constraints.AssertTrue";
+    private static final String JV_ASSERT_FALSE = "jakarta.validation.constraints.AssertFalse";
+    private static final String JV_EMAIL = "jakarta.validation.constraints.Email";
+    private static final String JV_PATTERN = "jakarta.validation.constraints.Pattern";
+    private static final String JV_SIZE = "jakarta.validation.constraints.Size";
+    private static final String JV_NOT_EMPTY = "jakarta.validation.constraints.NotEmpty";
+    private static final String ATTR_MIN_PROPERTIES = "minProperties";
+    private static final String ATTR_MAX_PROPERTIES = "maxProperties";
+    private static final String JV_MIN = "jakarta.validation.constraints.Min";
+    private static final String JV_MAX = "jakarta.validation.constraints.Max";
+    private static final String JV_DIGITS = "jakarta.validation.constraints.Digits";
+    private static final String JV_NEGATIVE = "jakarta.validation.constraints.Negative";
+    private static final String JV_NEGATIVE_OR_ZERO = "jakarta.validation.constraints.NegativeOrZero";
+    private static final String ATTR_EXCLUSIVE_MINIMUM = "exclusiveMinimum";
+    private static final String ATTR_EXCLUSIVE_MAXIMUM = "exclusiveMaximum";
+    private static final String JV_POSITIVE = "jakarta.validation.constraints.Positive";
+    private static final String JV_POSITIVE_OR_ZERO = "jakarta.validation.constraints.PositiveOrZero";
+    private static final String OBJECT = "object";
+    private static final String DEFAULT = "default";
+    private static final String ARRAY = "array";
+    private static final String ATTR_MIN_ITEMS = "minItems";
+    private static final String URL_JSON_SCHEMA = "https://json-schema.org/draft/2020-12/schema";
+    private static final String STRING = "string";
+    private static final String DURATION = "duration";
+    private static final String ATTR_ADDITIONAL_PROPERTIES = "additionalProperties";
 
     @Override
     public void write(ConfigurationMetadataBuilder metadataBuilder, ClassWriterOutputVisitor outputVisitor) throws IOException {
@@ -106,7 +142,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         // JSON begin
         out.write('{');
         attr(out, "$schema");
-        str(out, "https://json-schema.org/draft/2020-12/schema");
+        str(out, URL_JSON_SCHEMA);
         comma(out);
         attr(out, "$id");
         str(out, "urn:micronaut:config:" + cm.getType());
@@ -125,7 +161,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         attr(out, "prefix");
         str(out, basePrefix);
         comma(out);
-        attr(out, "type");
+        attr(out, ATTR_TYPE);
         str(out, cm.getType());
         comma(out);
         boolean isEach = isEachMap || isEachList;
@@ -142,10 +178,10 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         // Root schema shape
         if (isEachMap) {
             // type: object; minProperties:1; additionalProperties: $ref $defs.Entry
-            attr(out, "type");
-            str(out, "object");
+            attr(out, ATTR_TYPE);
+            str(out, OBJECT);
             comma(out);
-            attr(out, "minProperties");
+            attr(out, ATTR_MIN_PROPERTIES);
             out.write("1");
             comma(out);
             emitAdditionalPropertiesRef(out);
@@ -153,10 +189,10 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             emitEntryDefs(cm, basePrefix, allProps, vc, out, true, vc != null ? vc.getClassElement(cm.getType()).orElse(null) : null);
         } else if (isEachList) {
             // type: array; minItems:1; items: $ref $defs.Entry
-            attr(out, "type");
-            str(out, "array");
+            attr(out, ATTR_TYPE);
+            str(out, ARRAY);
             comma(out);
-            attr(out, "minItems");
+            attr(out, ATTR_MIN_ITEMS);
             out.write("1");
             comma(out);
             attr(out, "items");
@@ -164,11 +200,11 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             emitEntryDefs(cm, basePrefix, allProps, vc, out, false, vc != null ? vc.getClassElement(cm.getType()).orElse(null) : null);
         } else {
             // Plain configuration object
-            attr(out, "type");
-            str(out, "object");
+            attr(out, ATTR_TYPE);
+            str(out, OBJECT);
             comma(out);
             // properties: object
-            attr(out, "properties");
+            attr(out, ATTR_PROPERTIES);
             ClassElement classElement = vc != null ? vc.getClassElement(cm.getType()).orElse(null) : null;
             Set<String> required = writePropertiesObject(out, cm, basePrefix, allProps, vc, /*containerMode*/ null, classElement);
             emitRequired(out, required);
@@ -205,10 +241,10 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         out.write('{');
         attr(out, "Entry");
         out.write('{');
-        attr(out, "type");
-        str(out, "object");
+        attr(out, ATTR_TYPE);
+        str(out, OBJECT);
         comma(out);
-        attr(out, "properties");
+        attr(out, ATTR_PROPERTIES);
         Set<String> required = writePropertiesObject(out, cm, basePrefix, allProps, vc, mapMode ? ContainerMode.MAP : ContainerMode.LIST, classElement);
         emitRequired(out, required);
         out.write('}');
@@ -312,7 +348,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 Object coerced = coerceDefault(pm.getDefaultValue(), pm.getType());
                 if (coerced != null) {
                     out.write(',');
-                    attr(out, "default");
+                    attr(out, DEFAULT);
                     writeJsonValue(out, coerced);
                     wroteDefault = true;
                 } else {
@@ -342,7 +378,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                                 Object aDefault = coerceDefault(defaultValue, pm.getType());
                                 if (aDefault != null) {
                                     out.write(',');
-                                    attr(out, "default");
+                                    attr(out, DEFAULT);
                                     writeJsonValue(out, aDefault);
                                 }
                             } else {
@@ -352,7 +388,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                                     Object constantValue = constantField.getConstantValue();
                                     if (constantValue != null) {
                                         out.write(',');
-                                        attr(out, "default");
+                                        attr(out, DEFAULT);
                                         writeJsonValue(out, constantValue);
                                     }
                                 }
@@ -374,10 +410,10 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         } else if (node instanceof Map) {
             Map<String, Object> m = (Map<String, Object>) node;
             out.write('{');
-            attr(out, "type");
-            str(out, "object");
+            attr(out, ATTR_TYPE);
+            str(out, OBJECT);
             out.write(',');
-            attr(out, "properties");
+            attr(out, ATTR_PROPERTIES);
             emitProperties(out, vc, classElement, m, requiredOut);
             out.write('}');
         } else {
@@ -410,10 +446,10 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             // Collection/Array
             if (t.isArray() || t.isIterable()) {
                 out.write('"');
-                out.write("type");
+                out.write(ATTR_TYPE);
                 out.write('"');
                 out.write(':');
-                str(out, "array");
+                str(out, ARRAY);
                 out.write(',');
                 attr(out, "items");
                 if (t.isArray()) {
@@ -435,12 +471,12 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             // Map
             if (t.isAssignable(Map.class)) {
                 out.write('"');
-                out.write("type");
+                out.write(ATTR_TYPE);
                 out.write('"');
                 out.write(':');
-                str(out, "object");
+                str(out, OBJECT);
                 out.write(',');
-                attr(out, "additionalProperties");
+                attr(out, ATTR_ADDITIONAL_PROPERTIES);
                 ClassElement v = t.getTypeArguments().get("V");
                 if (v == null) {
                     v = t;
@@ -471,10 +507,10 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
     private void writeSimpleTypeSchema(Writer out, ClassElement t) throws IOException {
         // Enum
         if (t.isEnum()) {
-            attr(out, "type");
-            str(out, "string");
+            attr(out, ATTR_TYPE);
+            str(out, STRING);
             out.write(',');
-            attr(out, "enum");
+            attr(out, ATTR_ENUM);
             out.write('[');
             List<String> values;
             if (t instanceof io.micronaut.inject.ast.EnumElement ee) {
@@ -494,19 +530,19 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
         // URI/URL
         String n = t.getName();
         if ("java.net.URI".equals(n) || "java.net.URL".equals(n)) {
-            attr(out, "type");
-            str(out, "string");
+            attr(out, ATTR_TYPE);
+            str(out, STRING);
             out.write(',');
-            attr(out, "format");
+            attr(out, ATTR_FORMAT);
             str(out, "uri");
             return;
         }
         if ("java.time.Duration".equals(n)) {
-            attr(out, "type");
-            str(out, "string");
+            attr(out, ATTR_TYPE);
+            str(out, STRING);
             out.write(',');
-            attr(out, "format");
-            str(out, "duration");
+            attr(out, ATTR_FORMAT);
+            str(out, DURATION);
             return;
         }
         // Basic primitives/wrappers/strings
@@ -520,9 +556,9 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                  "java.lang.Integer", "java.lang.Long", "java.math.BigInteger" -> "integer";
             case "float", "double", "java.lang.Float", "java.lang.Double", "java.math.BigDecimal" ->
                 "number";
-            default -> "string";
+            default -> STRING;
         };
-        attr(out, "type");
+        attr(out, ATTR_TYPE);
         str(out, type);
     }
 
@@ -549,7 +585,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 return;
             }
             case Boolean b -> {
-                out.write(b ? "true" : "false");
+                out.write(b ? StringUtils.TRUE : StringUtils.FALSE);
                 return;
             }
             case Number number -> {
@@ -565,7 +601,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
     }
 
     private void emitAdditionalPropertiesRef(Writer out) throws IOException {
-        attr(out, "additionalProperties");
+        attr(out, ATTR_ADDITIONAL_PROPERTIES);
         refEntry(out);
     }
 
@@ -598,10 +634,6 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                                             PropertyElement pe,
                                             @Nullable String currentKey,
                                             Set<String> requiredOut) throws IOException {
-        Function<String, Boolean> has = ann -> {
-            List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
-            return !values.isEmpty();
-        };
         BiFunction<String, String, @Nullable String> sval = (ann, member) ->
             pe.stringValue(ann, member).orElseGet(() -> {
                 List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
@@ -612,88 +644,46 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             }
         );
 
-        BiFunction<String, String, @Nullable Integer> ival = (ann, member) -> {
-            OptionalInt opt = pe.intValue(ann, member);
-            if (opt.isPresent()) {
-                return opt.getAsInt();
-            } else {
-                List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
-                if (!values.isEmpty()) {
-                    OptionalInt optionalInt = values.getFirst().intValue(member);
-                    if (optionalInt.isPresent()) {
-                        return optionalInt.getAsInt();
-                    }
-                }
-                return null;
-            }
-        };
-
-        java.util.function.BiFunction<String, String, @Nullable Long> lval = (ann, member) -> {
-            OptionalLong opt = pe.longValue(ann, member);
-            if (opt.isPresent()) {
-                return opt.getAsLong();
-            } else {
-                List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
-                if (!values.isEmpty()) {
-                    OptionalLong optionalInt = values.getFirst().longValue(member);
-                    if (optionalInt.isPresent()) {
-                        return optionalInt.getAsLong();
-                    }
-                }
-                return null;
-            }
-        };
-
-        java.util.function.BiFunction<String, String, @Nullable Boolean> bval = (ann, member) ->
-            pe.booleanValue(ann, member).orElseGet(() -> {
-                    List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
-                    if (!values.isEmpty()) {
-                        return values.getFirst().booleanValue(member).orElse(null);
-                    }
-                    return null;
-                }
-            );
-
         // Collect NotNull -> required
-        if ((has.apply("jakarta.validation.constraints.NotNull") || has.apply("jakarta.validation.constraints.NotBlank")) && currentKey != null) {
+        if ((hasValidationAnnotation(pe, JV_NOT_NULL) || hasValidationAnnotation(pe, JV_NOT_BLANK)) && currentKey != null) {
             requiredOut.add(currentKey);
         }
         // Null -> const null? skip (rare); users should use @Nullable to allow nulls
         // AssertTrue/False -> const
-        if (has.apply("jakarta.validation.constraints.AssertTrue")) {
+        if (hasValidationAnnotation(pe, JV_ASSERT_TRUE)) {
             comma(out);
-            attr(out, "const");
-            out.write("true");
+            attr(out, ATTR_CONST);
+            out.write(StringUtils.TRUE);
         }
-        if (has.apply("jakarta.validation.constraints.AssertFalse")) {
+        if (hasValidationAnnotation(pe, JV_ASSERT_FALSE)) {
             comma(out);
-            attr(out, "const");
-            out.write("false");
+            attr(out, ATTR_CONST);
+            out.write(StringUtils.FALSE);
         }
         // Email
-        if (has.apply("jakarta.validation.constraints.Email")) {
+        if (hasValidationAnnotation(pe, JV_EMAIL)) {
             comma(out);
-            attr(out, "format");
+            attr(out, ATTR_FORMAT);
             str(out, "email");
         }
         // Pattern
-        String pattern = sval.apply("jakarta.validation.constraints.Pattern", "regexp");
+        String pattern = sval.apply(JV_PATTERN, "regexp");
         if (pattern != null && !pattern.isEmpty()) {
             comma(out);
-            attr(out, "pattern");
+            attr(out, ATTR_PATTERN);
             str(out, pattern);
         }
         // Size
-        Integer sizeMinBox = ival.apply("jakarta.validation.constraints.Size", "min");
-        Integer sizeMaxBox = ival.apply("jakarta.validation.constraints.Size", "max");
+        Integer sizeMinBox = intValue(pe, JV_SIZE, "min");
+        Integer sizeMaxBox = intValue(pe, JV_SIZE, "max");
         int sizeMin = sizeMinBox == null ? -1 : sizeMinBox;
         int sizeMax = sizeMaxBox == null ? -1 : sizeMaxBox;
         ClassElement t = pe.getType();
-        boolean isString = "java.lang.String".equals(t.getName());
+        boolean isString = String.class.getName().equals(t.getName());
         boolean isArray = t.isArray() || t.isIterable();
         boolean isMap = t.isAssignable(java.util.Map.class);
         if (isString) {
-            if (has.apply("jakarta.validation.constraints.NotBlank") || has.apply("jakarta.validation.constraints.NotEmpty")) {
+            if (hasValidationAnnotation(pe, JV_NOT_BLANK) || hasValidationAnnotation(pe, JV_NOT_EMPTY)) {
                 sizeMin = Math.max(sizeMin, 1);
             }
             if (sizeMin >= 0) {
@@ -707,12 +697,12 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 out.write(Integer.toString(sizeMax));
             }
         } else if (isArray) {
-            if (has.apply("jakarta.validation.constraints.NotEmpty")) {
+            if (hasValidationAnnotation(pe, JV_NOT_EMPTY)) {
                 sizeMin = Math.max(sizeMin, 1);
             }
             if (sizeMin >= 0) {
                 comma(out);
-                attr(out, "minItems");
+                attr(out, ATTR_MIN_ITEMS);
                 out.write(Integer.toString(sizeMin));
             }
             if (sizeMax >= 0) {
@@ -721,80 +711,80 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
                 out.write(Integer.toString(sizeMax));
             }
         } else if (isMap) {
-            if (has.apply("jakarta.validation.constraints.NotEmpty")) {
+            if (hasValidationAnnotation(pe, JV_NOT_EMPTY)) {
                 sizeMin = Math.max(sizeMin, 1);
             }
             if (sizeMin >= 0) {
                 comma(out);
-                attr(out, "minProperties");
+                attr(out, ATTR_MIN_PROPERTIES);
                 out.write(Integer.toString(sizeMin));
             }
             if (sizeMax >= 0) {
                 comma(out);
-                attr(out, "maxProperties");
+                attr(out, ATTR_MAX_PROPERTIES);
                 out.write(Integer.toString(sizeMax));
             }
         }
         // Min/Max
-        Long min = lval.apply("jakarta.validation.constraints.Min", "value");
-        Long max = lval.apply("jakarta.validation.constraints.Max", "value");
+        Long min = longValue(pe, JV_MIN, AnnotationMetadata.VALUE_MEMBER);
+        Long max = longValue(pe, JV_MAX, AnnotationMetadata.VALUE_MEMBER);
         if (min != null) {
             comma(out);
-            attr(out, "minimum");
+            attr(out, ATTR_MIN);
             out.write(Long.toString(min));
         }
         if (max != null) {
             comma(out);
-            attr(out, "maximum");
+            attr(out, ATTR_MAX);
             out.write(Long.toString(max));
         }
         // DecimalMin/DecimalMax
-        String dmin = sval.apply("jakarta.validation.constraints.DecimalMin", "value");
-        Boolean dminInc = bval.apply("jakarta.validation.constraints.DecimalMin", "inclusive");
+        String dmin = sval.apply("jakarta.validation.constraints.DecimalMin", AnnotationMetadata.VALUE_MEMBER);
+        Boolean dminInc = booleanValue(pe, "jakarta.validation.constraints.DecimalMin", "inclusive");
         if (dmin != null) {
             comma(out);
             if (dminInc == null || dminInc) {
-                attr(out, "minimum");
+                attr(out, ATTR_MIN);
             } else {
-                attr(out, "exclusiveMinimum");
+                attr(out, ATTR_EXCLUSIVE_MINIMUM);
             }
             out.write(dmin);
         }
-        String dmax = sval.apply("jakarta.validation.constraints.DecimalMax", "value");
-        Boolean dmaxInc = bval.apply("jakarta.validation.constraints.DecimalMax", "inclusive");
+        String dmax = sval.apply("jakarta.validation.constraints.DecimalMax", AnnotationMetadata.VALUE_MEMBER);
+        Boolean dmaxInc = booleanValue(pe, "jakarta.validation.constraints.DecimalMax", "inclusive");
         if (dmax != null) {
             comma(out);
             if (dmaxInc == null || dmaxInc) {
-                attr(out, "maximum");
+                attr(out, ATTR_MAX);
             } else {
-                attr(out, "exclusiveMaximum");
+                attr(out, ATTR_EXCLUSIVE_MAXIMUM);
             }
             out.write(dmax);
         }
         // Positive / Negative variants
-        if (has.apply("jakarta.validation.constraints.Positive")) {
+        if (hasValidationAnnotation(pe, JV_POSITIVE)) {
             comma(out);
-            attr(out, "exclusiveMinimum");
+            attr(out, ATTR_EXCLUSIVE_MINIMUM);
             out.write("0");
         }
-        if (has.apply("jakarta.validation.constraints.PositiveOrZero")) {
+        if (hasValidationAnnotation(pe, JV_POSITIVE_OR_ZERO)) {
             comma(out);
-            attr(out, "minimum");
+            attr(out, ATTR_MIN);
             out.write("0");
         }
-        if (has.apply("jakarta.validation.constraints.Negative")) {
+        if (hasValidationAnnotation(pe, JV_NEGATIVE)) {
             comma(out);
-            attr(out, "exclusiveMaximum");
+            attr(out, ATTR_EXCLUSIVE_MAXIMUM);
             out.write("0");
         }
-        if (has.apply("jakarta.validation.constraints.NegativeOrZero")) {
+        if (hasValidationAnnotation(pe, JV_NEGATIVE_OR_ZERO)) {
             comma(out);
-            attr(out, "maximum");
+            attr(out, ATTR_MAX);
             out.write("0");
         }
         // Digits -> regex
-        Integer intDigits = ival.apply("jakarta.validation.constraints.Digits", "integer");
-        Integer fracDigits = ival.apply("jakarta.validation.constraints.Digits", "fraction");
+        Integer intDigits = intValue(pe, JV_DIGITS, "integer");
+        Integer fracDigits = intValue(pe, JV_DIGITS, "fraction");
         if (intDigits != null || fracDigits != null) {
             StringBuilder re = new StringBuilder("^");
             int id = intDigits != null ? intDigits : 0;
@@ -809,9 +799,60 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
             }
             re.append("$");
             comma(out);
-            attr(out, "pattern");
+            attr(out, ATTR_PATTERN);
             str(out, re.toString());
         }
+    }
+
+    @Nullable
+    private static Boolean booleanValue(PropertyElement pe, String ann, String member) {
+        return pe.booleanValue(ann, member).orElseGet(() -> {
+                List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
+                if (!values.isEmpty()) {
+                    return values.getFirst().booleanValue(member).orElse(null);
+                }
+                return null;
+            }
+        );
+    }
+
+    @Nullable
+    private static Long longValue(PropertyElement pe, String ann, String member) {
+        OptionalLong opt = pe.longValue(ann, member);
+        if (opt.isPresent()) {
+            return opt.getAsLong();
+        } else {
+            List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
+            if (!values.isEmpty()) {
+                OptionalLong optionalInt = values.getFirst().longValue(member);
+                if (optionalInt.isPresent()) {
+                    return optionalInt.getAsLong();
+                }
+            }
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Integer intValue(PropertyElement pe, String ann, String member) {
+        OptionalInt opt = pe.intValue(ann, member);
+        if (opt.isPresent()) {
+            return opt.getAsInt();
+        } else {
+            List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
+            if (!values.isEmpty()) {
+                OptionalInt optionalInt = values.getFirst().intValue(member);
+                if (optionalInt.isPresent()) {
+                    return optionalInt.getAsInt();
+                }
+            }
+            return null;
+        }
+    }
+
+    private static boolean hasValidationAnnotation(PropertyElement pe, String ann) {
+        List<AnnotationValue<Annotation>> values = pe.getDeclaredAnnotationValuesByName(ann);
+        return !values.isEmpty();
     }
 
     // JSON writing helpers

--- a/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/configuration/JsonSchemaConfigurationMetadataWriter.java
@@ -87,6 +87,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
     private static final String STRING = "string";
     private static final String DURATION = "duration";
     private static final String ATTR_ADDITIONAL_PROPERTIES = "additionalProperties";
+    private static final String BOOLEAN = "boolean";
 
     @Override
     public void write(ConfigurationMetadataBuilder metadataBuilder, ClassWriterOutputVisitor outputVisitor) throws IOException {
@@ -551,7 +552,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
 
     private void writeSimpleTypeName(Writer out, String fqcn) throws IOException {
         String type = switch (fqcn) {
-            case "boolean", "java.lang.Boolean" -> "boolean";
+            case BOOLEAN, "java.lang.Boolean" -> BOOLEAN;
             case "byte", "short", "int", "long", "java.lang.Byte", "java.lang.Short",
                  "java.lang.Integer", "java.lang.Long", "java.math.BigInteger" -> "integer";
             case "float", "double", "java.lang.Float", "java.lang.Double", "java.math.BigDecimal" ->
@@ -565,7 +566,7 @@ public final class JsonSchemaConfigurationMetadataWriter implements Configuratio
     private @Nullable Object coerceDefault(String value, String typeName) {
         try {
             return switch (typeName) {
-                case "boolean", "java.lang.Boolean" -> Boolean.parseBoolean(value);
+                case BOOLEAN, "java.lang.Boolean" -> Boolean.parseBoolean(value);
                 case "byte", "short", "int", "long", "java.lang.Byte", "java.lang.Short",
                      "java.lang.Integer", "java.lang.Long", "java.math.BigInteger" ->
                     Long.parseLong(value);

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.configuration.ConfigurationMetadataWriter
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.configuration.ConfigurationMetadataWriter
@@ -1,1 +1,2 @@
 io.micronaut.inject.configuration.JsonConfigurationMetadataWriter
+io.micronaut.inject.configuration.JsonSchemaConfigurationMetadataWriter

--- a/core/src/main/java/io/micronaut/core/bind/annotation/Bindable.java
+++ b/core/src/main/java/io/micronaut/core/bind/annotation/Bindable.java
@@ -27,7 +27,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.METHOD})
+@Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
 @Inherited
 public @interface Bindable {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationJsonSchemaDefaultsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationJsonSchemaDefaultsSpec.groovy
@@ -1,0 +1,114 @@
+package io.micronaut.inject.configuration
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.annotation.processing.test.JavaParser
+import org.intellij.lang.annotations.Language
+import groovy.json.JsonSlurper
+
+class ConfigurationJsonSchemaDefaultsSpec extends AbstractTypeElementSpec {
+
+    @Override
+    protected JavaParser newJavaParser() {
+        new JavaParser() {}
+    }
+
+    private static String readSchemaFile(AbstractTypeElementSpec self, String fqcn, @Language("java") String cls) {
+        String path = "META-INF/micronaut-configuration-schemas/${fqcn}.json"
+        return self.buildAndReadResourceAsString(path, cls)
+    }
+
+    private static Map parseJson(String json) { new JsonSlurper().parseText(json) as Map }
+
+    void "test field constants as defaults (int/string/boolean)"() {
+        when:
+        String schema = readSchemaFile(this, 'test.Consts', '''
+package test;
+import io.micronaut.context.annotation.*;
+
+@ConfigurationProperties("consts")
+class Consts {
+  public static final int DEFAULT_I = 42;
+  public static final String DEFAULT_STRING_VALUE = "hello";
+  public static final boolean DEFAULT_B = true;
+
+  private int i = DEFAULT_I;
+  private String stringValue = DEFAULT_STRING_VALUE;
+  private boolean b = DEFAULT_B;
+
+  public int getI() { return i; }
+  public void setI(int v) { this.i = v; }
+  public String getStringValue() { return stringValue; }
+  public void setStringValue(String v) { this.stringValue = v; }
+  public boolean isB() { return b; }
+  public void setB(boolean v) { this.b = v; }
+}
+''')
+        then:
+        def m = parseJson(schema)
+        Map props = (Map) m.get('properties')
+        ((Map) props.get('i')).get('default') == 42
+        ((Map) props.get('string-value')).get('default') == 'hello'
+        ((Map) props.get('b')).get('default') == true
+    }
+
+    void "test @Bindable default on setter parameter is used"() {
+        when:
+        String schema = readSchemaFile(this, 'test.BindableSetter', '''
+package test;
+import io.micronaut.context.annotation.*;
+import io.micronaut.core.bind.annotation.Bindable;
+
+@ConfigurationProperties("bindable.setter")
+class BindableSetter {
+  @Bindable(defaultValue = "64")
+  private int size;
+  public int getSize() { return size; }
+  public void setSize(int size) { this.size = size; }
+}
+''')
+        then:
+        def m = parseJson(schema)
+        Map props = (Map) m.get('properties')
+        ((Map) props.get('size')).get('default') == 64
+    }
+
+    void "test @Bindable default on property method (interface) is used"() {
+        when:
+        String schema = readSchemaFile(this, 'test.ItfProps', '''
+package test;
+import io.micronaut.context.annotation.*;
+import io.micronaut.core.bind.annotation.Bindable;
+
+@ConfigurationProperties("itf")
+interface ItfProps {
+  @Bindable(defaultValue = "http://default")
+  java.net.URI getEndpoint();
+}
+''')
+        then:
+        def m = parseJson(schema)
+        Map props = (Map) m.get('properties')
+        ((Map) props.get('endpoint')).get('default') == 'http://default'
+        ((Map) props.get('endpoint')).get('format') == 'uri'
+    }
+
+    void "test @Bindable default on property method record is used"() {
+        when:
+        String schema = readSchemaFile(this, 'test.ItfProps', '''
+package test;
+import io.micronaut.context.annotation.*;
+import io.micronaut.core.bind.annotation.Bindable;
+
+@ConfigurationProperties("itf")
+record ItfProps(
+  @Bindable(defaultValue = "http://default")
+  java.net.URI endpoint) {
+}
+''')
+        then:
+        def m = parseJson(schema)
+        Map props = (Map) m.get('properties')
+        ((Map) props.get('endpoint')).get('default') == 'http://default'
+        ((Map) props.get('endpoint')).get('format') == 'uri'
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationJsonSchemaSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationJsonSchemaSpec.groovy
@@ -1,0 +1,200 @@
+package io.micronaut.inject.configuration
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.annotation.processing.test.JavaParser
+import org.intellij.lang.annotations.Language
+import groovy.json.JsonSlurper
+
+class ConfigurationJsonSchemaSpec extends AbstractTypeElementSpec {
+
+    @Override
+    protected JavaParser newJavaParser() {
+        new JavaParser() {}
+    }
+
+    private static Map readSchema(String fqcn, String json) {
+        new JsonSlurper().parseText(json) as Map
+    }
+
+    private static String readSchemaFile(AbstractTypeElementSpec self, String fqcn, @Language("java") String cls) {
+        String path = "META-INF/micronaut-configuration-schemas/${fqcn}.json"
+        return self.buildAndReadResourceAsString(path, cls)
+    }
+
+    void "test simple configuration properties schema"() {
+        when:
+        String schema = readSchemaFile(this, 'test.MyProps', '''
+package test;
+
+import io.micronaut.context.annotation.*;
+
+/** My props */
+@ConfigurationProperties("foo.bar")
+class MyProps {
+    private String host;
+    private int port;
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public int getPort() { return port; }
+    public void setPort(int port) { this.port = port; }
+}
+''')
+
+        then:
+        def m = readSchema('test.MyProps', schema)
+        m.'$schema' == 'https://json-schema.org/draft/2020-12/schema'
+        m.'$id' == 'urn:micronaut:config:test.MyProps'
+        m.title == 'test.MyProps'
+        m.'x-micronaut'.prefix == 'foo.bar'
+        m.type == 'object'
+        Map props = (Map) m.get('properties')
+        ((Map) props.get('host')).get('type') == 'string'
+        ((Map) props.get('port')).get('type') == 'integer'
+    }
+
+    void "test each property map schema with requires"() {
+        when:
+        String schema = readSchemaFile(this, 'test.Ds', '''
+package test;
+import io.micronaut.context.annotation.*;
+
+@EachProperty("dataSources")
+class Ds {
+    private java.net.URI url;
+    public java.net.URI getUrl() { return url; }
+    public void setUrl(java.net.URI url) { this.url = url; }
+}
+''')
+
+        then:
+        def m = readSchema('test.Ds', schema)
+        m.'x-micronaut'.kind == 'each-property'
+        m.'x-micronaut'.container == 'map'
+        m.'x-micronaut'.prefix == 'data-sources'
+        m.type == 'object'
+        m.minProperties == 1
+        m.additionalProperties.'$ref' == '#/$defs/Entry'
+        m.'$defs'.Entry.type == 'object'
+        Map entryProps = (Map) ((Map) m.get('$defs')).get('Entry').get('properties')
+        ((Map) entryProps.get('url')).get('format') == 'uri'
+    }
+
+    void "test each property list schema with requires"() {
+        when:
+        String schema = readSchemaFile(this, 'test.Buckets', '''
+package test;
+import io.micronaut.context.annotation.*;
+
+@EachProperty(value = "buckets", list = true)
+class Buckets {
+    private String region;
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+}
+''')
+
+        then:
+        def m = readSchema('test.Buckets', schema)
+        m.'x-micronaut'.kind == 'each-property'
+        m.'x-micronaut'.container == 'list'
+        m.type == 'array'
+        m.minItems == 1
+        m.items.'$ref' == '#/$defs/Entry'
+        Map entryProps2 = (Map) ((Map) m.get('$defs')).get('Entry').get('properties')
+        ((Map) entryProps2.get('region')).get('type') == 'string'
+    }
+
+    void "test nested configuration properties produce separate schema files"() {
+        when:
+        String schemaOuter = readSchemaFile(this, 'test.Outer', '''
+package test;
+import io.micronaut.context.annotation.*;
+
+@ConfigurationProperties("outer")
+class Outer {
+  Inner inner = new Inner();
+  @ConfigurationProperties("inner")
+  public static class Inner {
+    private boolean enabled;
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+  }
+}
+''')
+        String schemaInner = readSchemaFile(this, 'test.Outer$Inner', '''
+package test;
+import io.micronaut.context.annotation.*;
+
+@ConfigurationProperties("outer")
+class Outer {
+  Inner inner = new Inner();
+  @ConfigurationProperties("inner")
+  public static class Inner {
+    private boolean enabled;
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+  }
+}
+''')
+        then:
+        def outer = readSchema('test.Outer', schemaOuter)
+        outer.'x-micronaut'.prefix == 'outer'
+        outer.type == 'object'
+        def inner = readSchema('test.Outer$Inner', schemaInner)
+        inner.'x-micronaut'.prefix == 'outer.inner'
+        inner.type == 'object'
+        Map iprops = (Map) inner.get('properties')
+        ((Map) iprops.get('enabled')).get('type') == 'boolean'
+    }
+
+    void "test common java types mapping"() {
+        when:
+        String schema = readSchemaFile(this, 'test.Types', '''
+package test;
+import io.micronaut.context.annotation.*;
+import java.net.URI;
+import java.time.Duration;
+import java.util.*;
+
+@ConfigurationProperties("types")
+class Types {
+  private String s; private int i; private long l; private double d; private boolean b;
+  private URI uri; private Duration dur; private Optional<Integer> opt;
+  private java.util.List<String> names; private java.util.Map<String,String> labels;
+  private Color color;
+  public String getS(){return s;} public void setS(String s){this.s=s;}
+  public int getI(){return i;} public void setI(int v){this.i=v;}
+  public long getL(){return l;} public void setL(long v){this.l=v;}
+  public double getD(){return d;} public void setD(double v){this.d=v;}
+  public boolean isB(){return b;} public void setB(boolean v){this.b=v;}
+  public URI getUri(){return uri;} public void setUri(URI u){this.uri=u;}
+  public Duration getDur(){return dur;} public void setDur(Duration u){this.dur=u;}
+  public Optional<Integer> getOpt(){return opt;} public void setOpt(Optional<Integer> o){this.opt=o;}
+  public java.util.List<String> getNames(){return names;} public void setNames(java.util.List<String> n){this.names=n;}
+  public java.util.Map<String,String> getLabels(){return labels;} public void setLabels(java.util.Map<String,String> m){this.labels=m;}
+  public Color getColor(){return color;} public void setColor(Color c){this.color=c;}
+  public static enum Color { RED, GREEN, BLUE }
+}
+''')
+        then:
+        def m = readSchema('test.Types', schema)
+        m.'x-micronaut'.prefix == 'types'
+
+        def properties = m.get('properties')
+        properties['s']['type'] == 'string'
+        properties['i']['type'] == 'integer'
+        properties['l']['type'] == 'integer'
+        properties['d']['type'] == 'number'
+        properties['b']['type'] == 'boolean'
+        properties['uri']['format'] == 'uri'
+        properties['dur']['format'] == 'duration'
+        properties['names']['type'] == 'array'
+        properties['names']['items']['type'] == 'string'
+        properties['labels']['type'] == 'object'
+        properties['labels']['additionalProperties']['type'] == 'string'
+        properties['color']['type'] == 'string'
+        properties['color']['enum'] == ['RED', 'GREEN', 'BLUE']
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationJsonSchemaValidationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationJsonSchemaValidationSpec.groovy
@@ -1,0 +1,256 @@
+package io.micronaut.inject.configuration
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.annotation.processing.test.JavaParser
+import org.intellij.lang.annotations.Language
+import groovy.json.JsonSlurper
+
+class ConfigurationJsonSchemaValidationSpec extends AbstractTypeElementSpec {
+
+    @Override
+    protected JavaParser newJavaParser() {
+        new JavaParser() {}
+    }
+
+    private static String readSchemaFile(AbstractTypeElementSpec self, String fqcn, @Language("java") String cls) {
+        String path = "META-INF/micronaut-configuration-schemas/${fqcn}.json"
+        return self.buildAndReadResourceAsString(path, cls)
+    }
+
+    private static Map parseJson(String json) { new JsonSlurper().parseText(json) as Map }
+
+    void "string constraints: NotBlank, Size, Pattern, Email"() {
+        when:
+        String schema = readSchemaFile(this, 'test.Props', '''
+package test;
+import io.micronaut.context.annotation.*;
+import jakarta.validation.constraints.*;
+
+@ConfigurationProperties("props")
+class Props {
+  @NotBlank
+  @Size(min=2, max=5)
+  @Pattern(regexp = "[a-z]+")
+  @Email
+  private String s;
+
+  public String getS() { return s; }
+  public void setS(String v) { this.s = v; }
+}
+''')
+        then:
+        def m = parseJson(schema)
+        def props = m.get("properties")
+        Map s = props['s']
+        assert m.required.contains('s')
+        s.minLength == 2
+        s.maxLength == 5
+        s.pattern == '[a-z]+'
+        s.format == 'email'
+    }
+
+    void "number constraints: Min/Max, DecimalMin/DecimalMax exclusive, Positive, NegativeOrZero"() {
+        when:
+        String schema = readSchemaFile(this, 'test.NumProps', '''
+package test;
+import io.micronaut.context.annotation.*;
+import jakarta.validation.constraints.*;
+
+@ConfigurationProperties("num")
+class NumProps {
+  @Min(10)
+  @Max(100)
+  private int a;
+
+  @DecimalMin(value="1.5", inclusive=false)
+  @DecimalMax(value="9.5", inclusive=false)
+  private double b;
+
+  @Positive
+  private long c;
+
+  @NegativeOrZero
+  private long d;
+
+  public int getA(){return a;} public void setA(int v){this.a=v;}
+  public double getB(){return b;} public void setB(double v){this.b=v;}
+  public long getC(){return c;} public void setC(long v){this.c=v;}
+  public long getD(){return d;} public void setD(long v){this.d=v;}
+}
+''')
+        then:
+        def m = parseJson(schema)
+        Map props = m.get("properties")
+        Map a = props['a']
+        Map b = props['b']
+        Map c = props['c']
+        Map d = props['d']
+        a.minimum == 10
+        a.maximum == 100
+        b.exclusiveMinimum == 1.5
+        b.exclusiveMaximum == 9.5
+        c.exclusiveMinimum == 0
+        d.maximum == 0
+    }
+
+    void "collection constraints: NotEmpty and Size on List and Map"() {
+        when:
+        String schema = readSchemaFile(this, 'test.CollProps', '''
+package test;
+import io.micronaut.context.annotation.*;
+import jakarta.validation.constraints.*;
+import java.util.*;
+
+@ConfigurationProperties("coll")
+class CollProps {
+  @NotEmpty
+  @Size(min=2, max=4)
+  private java.util.List<String> l;
+
+  @NotEmpty
+  @Size(min=1, max=3)
+  private java.util.Map<String,String> m;
+
+  public java.util.List<String> getL(){return l;} public void setL(java.util.List<String> v){this.l=v;}
+  public java.util.Map<String,String> getM(){return m;} public void setM(java.util.Map<String,String> v){this.m=v;}
+}
+''')
+        then:
+        def m = parseJson(schema)
+        Map props = m.get("properties")
+        Map l = props['l']
+        Map pmap = props['m']
+        l.minItems == 2
+        l.maxItems == 4
+        pmap.minProperties == 1
+        pmap.maxProperties == 3
+    }
+
+    void "required with NotNull and EachProperty entry constraints"() {
+        when:
+        String schema = readSchemaFile(this, 'test.Each', '''
+package test;
+import io.micronaut.context.annotation.*;
+import jakarta.validation.constraints.*;
+
+@EachProperty("things")
+class Each {
+  @NotNull
+  private String name;
+
+  public String getName(){return name;} public void setName(String v){this.name=v;}
+}
+''')
+        then:
+        def m = parseJson(schema)
+        m.type == 'object' || m.type == 'array'
+        def entry = m.'$defs'.Entry
+        assert entry.required != null && entry.required.contains('name')
+        (entry.get("properties")['name']).type == 'string'
+    }
+
+    void "assertTrue/assertFalse map to const"() {
+        when:
+        String schema = readSchemaFile(this, 'test.BoolProps', '''
+package test;
+import io.micronaut.context.annotation.*;
+import jakarta.validation.constraints.*;
+
+@ConfigurationProperties("bools")
+class BoolProps {
+  @AssertTrue
+  private boolean on;
+  @AssertFalse
+  private boolean off;
+  public boolean isOn(){return on;} public void setOn(boolean v){this.on=v;}
+  public boolean isOff(){return off;} public void setOff(boolean v){this.off=v;}
+}
+''')
+        then:
+        def m = parseJson(schema)
+        Map props = m.get("properties")
+        props.on.const == true
+        props.off.const == false
+    }
+
+    void "NotNull implies required for configuration properties"() {
+        when:
+        String schema = readSchemaFile(this, 'test.RequiredProps', '''
+package test;
+import io.micronaut.context.annotation.*;
+import jakarta.validation.constraints.*;
+
+@ConfigurationProperties("required")
+class RequiredProps {
+  @NotNull
+  private String must;
+  public String getMust(){return must;} public void setMust(String v){this.must=v;}
+}
+''')
+        then:
+        def m = parseJson(schema)
+        m.required.contains('must')
+    }
+
+    void "Digits maps to conservative pattern"() {
+        when:
+        String schema = readSchemaFile(this, 'test.DigitsProps', '''
+package test;
+import io.micronaut.context.annotation.*;
+import jakarta.validation.constraints.*;
+
+@ConfigurationProperties("digits")
+class DigitsProps {
+  @Digits(integer=3, fraction=2)
+  private java.math.BigDecimal amount;
+  public java.math.BigDecimal getAmount(){return amount;} public void setAmount(java.math.BigDecimal v){this.amount=v;}
+}
+''')
+        then:
+        def m = parseJson(schema)
+        Map props = m.get("properties")
+        String pat = props.amount.pattern
+        assert pat != null
+        assert pat.contains("\\d")
+    }
+
+    void "EachProperty entry NotEmpty list implies minItems"() {
+        when:
+        String schema = readSchemaFile(this, 'test.EachList', '''
+package test;
+import io.micronaut.context.annotation.*;
+import jakarta.validation.constraints.*;
+import java.util.*;
+
+@EachProperty("groups")
+class EachList {
+  @NotEmpty
+  private java.util.List<String> names;
+  public java.util.List<String> getNames(){return names;} public void setNames(java.util.List<String> v){this.names=v;}
+}
+''')
+        then:
+        def m = parseJson(schema)
+        def entry = m.'$defs'.Entry
+        (entry.get("properties").names).minItems == 1
+    }
+
+    void "Nullable properties are not required"() {
+        when:
+        String schema = readSchemaFile(this, 'test.NullableProps', '''
+package test;
+import io.micronaut.context.annotation.*;
+import org.jspecify.annotations.Nullable;
+
+@ConfigurationProperties("nullable")
+class NullableProps {
+  @Nullable
+  private String maybe;
+  public String getMaybe(){return maybe;} public void setMaybe(String v){this.maybe=v;}
+}
+''')
+        then:
+        def m = parseJson(schema)
+        assert m.required == null || !m.required.contains('maybe')
+    }
+}


### PR DESCRIPTION
This PR adds generation of JSON schema definitions for `@ConfigurationProperties` and `@EachPropery`. The idea here is to use these definitions in build tooling (coming in a separate PR) to validate user configuration. AI was used in the generation of the implementation.

Example JSON schema for `HttpServerConfiguration`.:

```json
{
  "$schema": "https:\/\/json-schema.org\/draft\/2020-12\/schema",
  "$id": "urn:micronaut:config:io.micronaut.http.server.HttpServerConfiguration",
  "title": "io.micronaut.http.server.HttpServerConfiguration",
  "description": "<p>A base {@link ConfigurationProperties} for servers.<\/p>",
  "x-micronaut": {
    "prefix": "micronaut.server",
    "type": "io.micronaut.http.server.HttpServerConfiguration",
    "kind": "configuration-properties"
  },
  "type": "object",
  "properties": {
    "http-version": {
      "type": "string",
      "enum": [
        "HTTP_1_0",
        "HTTP_1_1",
        "HTTP_2_0"
      ],
      "description": "Sets the HTTP version to use. Defaults to {@link HttpVersion#HTTP_1_1}.",
      "x-micronaut-javaType": "io.micronaut.http.HttpVersion",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.http-version"
    },
    "thread-selection": {
      "type": "string",
      "enum": [
        "AUTO",
        "MANUAL",
        "IO",
        "BLOCKING"
      ],
      "description": "Sets the {@link io.micronaut.scheduling.executor.ThreadSelection} model to use for the server. Default value MANUAL.",
      "x-micronaut-javaType": "io.micronaut.scheduling.executor.ThreadSelection",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.thread-selection"
    },
    "default-charset": {
      "type": "string",
      "description": "The default charset to use",
      "x-micronaut-javaType": "java.nio.charset.Charset",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.default-charset"
    },
    "port": {
      "type": "integer",
      "description": "Sets the port to bind to. Default value ({@value #DEFAULT_RANDOM_PORT})",
      "x-micronaut-javaType": "int",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.port",
      "default": 8080
    },
    "host": {
      "type": "string",
      "description": "Sets the host to bind to.",
      "x-micronaut-javaType": "java.lang.String",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.host"
    },
    "read-timeout": {
      "type": "integer",
      "description": "Sets the default read timeout.",
      "x-micronaut-javaType": "java.lang.Integer",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.read-timeout"
    },
    "max-request-size": {
      "type": "integer",
      "description": "Sets the maximum request size. Default value ({@value #DEFAULT_MAX_REQUEST_SIZE} =&gt; \/\/ 10MB)",
      "x-micronaut-javaType": "long",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.max-request-size",
      "default": 10485760
    },
    "max-request-buffer-size": {
      "type": "integer",
      "description": "Sets the maximum number of request bytes that will be buffered. Fully streamed requests can\n still exceed this value. Default value ({@value #DEFAULT_MAX_REQUEST_BUFFER_SIZE} =&gt; \/\/ 10MB).\n Currently limited to {@code 2^31}, if you need longer request bodies, stream them.<br>\n Note that there is always some internal buffering, so a very low value ({@code < ~64K}) will\n essentially act like a request size limit.",
      "x-micronaut-javaType": "long",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.max-request-buffer-size",
      "default": 10485760
    },
    "read-idle-timeout": {
      "type": "string",
      "format": "duration",
      "description": "Sets the amount of time a connection can remain idle without any reads occurring. Default value ({@value #DEFAULT_READ_IDLE_TIME_MINUTES} minutes).",
      "x-micronaut-javaType": "java.time.Duration",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.read-idle-timeout"
    },
    "write-idle-timeout": {
      "type": "string",
      "format": "duration",
      "description": "Sets the amount of time a connection can remain idle without any writes occurring. Default value ({@value #DEFAULT_WRITE_IDLE_TIME_MINUTES} minutes).",
      "x-micronaut-javaType": "java.time.Duration",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.write-idle-timeout"
    },
    "idle-timeout": {
      "type": "string",
      "format": "duration",
      "description": "Sets the idle time of connections for the server. Default value ({@value #DEFAULT_IDLE_TIME_MINUTES} minutes).",
      "x-micronaut-javaType": "java.time.Duration",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.idle-timeout"
    },
    "server-header": {
      "type": "string",
      "description": "Sets the name of the server header.",
      "x-micronaut-javaType": "java.lang.String",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.server-header"
    },
    "date-header": {
      "type": "boolean",
      "description": "Sets whether a date header should be sent back. Default value ({@value #DEFAULT_DATEHEADER}).",
      "x-micronaut-javaType": "boolean",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.date-header"
    },
    "log-handled-exceptions": {
      "type": "boolean",
      "description": "Sets whether exceptions handled by either an error route or exception handler\n should still be logged. Default value ({@value #DEFAULT_LOG_HANDLED_EXCEPTIONS }).",
      "x-micronaut-javaType": "boolean",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.log-handled-exceptions",
      "default": false
    },
    "client-address-header": {
      "type": "string",
      "description": "Which header stores the original client",
      "x-micronaut-javaType": "java.lang.String",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.client-address-header"
    },
    "context-path": {
      "type": "string",
      "description": "Sets the context path for the web server.",
      "x-micronaut-javaType": "java.lang.String",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.context-path"
    },
    "dual-protocol": {
      "type": "boolean",
      "description": "if dual protocol has been enabled or not",
      "x-micronaut-javaType": "boolean",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.dual-protocol",
      "default": false
    },
    "http-to-https-redirect": {
      "type": "boolean",
      "description": "if redirection from HTTP to HTTPS is enabled or not",
      "x-micronaut-javaType": "boolean",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.http-to-https-redirect",
      "default": false
    },
    "dispatch-options-requests": {
      "type": "boolean",
      "description": "Set to true to dispatch OPTIONS requests. Default value ({@value #DEFAULT_DISPATCH_OPTIONS_REQUESTS}.",
      "x-micronaut-javaType": "boolean",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.dispatch-options-requests",
      "default": false
    },
    "validate-url": {
      "type": "boolean",
      "description": "If the url should be validated by converting it to {@link java.net.URI}.",
      "x-micronaut-javaType": "boolean",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.validate-url"
    },
    "escape-html-url": {
      "type": "boolean",
      "description": "Browsers can send characters (such as {@code |}) which are not permitted under RFC 3986 as\n part of the request path. These characters are normally rejected by the server. If this\n setting is enabled, the server will escape these characters before parsing them using\n {@link java.net.URI} so that they are not rejected. Default off.",
      "x-micronaut-javaType": "boolean",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.escape-html-url"
    },
    "not-found-on-missing-body": {
      "type": "boolean",
      "description": "True if not-found should be returned on missing body. False to return an empty body.",
      "x-micronaut-javaType": "boolean",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.not-found-on-missing-body"
    },
    "semicolon-is-normal-char": {
      "type": "boolean",
      "description": "Sets whether the semicolon should be considered a normal character in the query.\n A \"normal\" semicolon is one that is not used as a parameter separator.",
      "x-micronaut-javaType": "boolean",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.semicolon-is-normal-char",
      "default": false
    },
    "max-params": {
      "type": "integer",
      "description": "the maximum parameter count.",
      "x-micronaut-javaType": "int",
      "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration",
      "x-micronaut-path": "micronaut.server.max-params",
      "default": 1024
    },
    "multipart": {
      "type": "object",
      "properties": {
        "location": {
          "type": "string",
          "description": "Sets the location to store files.",
          "x-micronaut-javaType": "java.io.File",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$MultipartConfiguration",
          "x-micronaut-path": "micronaut.server.multipart.location"
        },
        "max-file-size": {
          "type": "integer",
          "description": "Sets the max file size. Default value ({@value #DEFAULT_MAX_FILE_SIZE} =&gt; 1MB).",
          "x-micronaut-javaType": "long",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$MultipartConfiguration",
          "x-micronaut-path": "micronaut.server.multipart.max-file-size"
        },
        "enabled": {
          "type": "boolean",
          "description": "Sets whether multipart processing is enabled. Default value ({@value #DEFAULT_ENABLED}).",
          "x-micronaut-javaType": "boolean",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$MultipartConfiguration",
          "x-micronaut-path": "micronaut.server.multipart.enabled"
        },
        "disk": {
          "type": "boolean",
          "description": "Sets whether to buffer data to disk or not. Default value ({@value #DEFAULT_DISK}).",
          "x-micronaut-javaType": "boolean",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$MultipartConfiguration",
          "x-micronaut-path": "micronaut.server.multipart.disk"
        },
        "mixed": {
          "type": "boolean",
          "description": "Sets whether to buffer data to disk if the size is greater than the\n threshold. Default value ({@value #DEFAULT_MIXED}).",
          "x-micronaut-javaType": "boolean",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$MultipartConfiguration",
          "x-micronaut-path": "micronaut.server.multipart.mixed"
        },
        "threshold": {
          "type": "integer",
          "description": "Sets the amount of data that should be received that will trigger\n the data to be stored to disk. Default value ({@value #DEFAULT_THRESHOLD}).",
          "x-micronaut-javaType": "long",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$MultipartConfiguration",
          "x-micronaut-path": "micronaut.server.multipart.threshold"
        }
      }
    },
    "cors": {
      "type": "object",
      "properties": {
        "enabled": {
          "type": "boolean",
          "description": "Sets whether CORS is enabled. Default value ({@value #DEFAULT_ENABLED})",
          "x-micronaut-javaType": "boolean",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$CorsConfiguration",
          "x-micronaut-path": "micronaut.server.cors.enabled"
        },
        "localhost-pass-through": {
          "type": "boolean",
          "description": "Sets whether localhost pass-through is enabled. Default value {@value #DEFAULT_LOCALHOST_PASS_THROUGH}.\n Setting this to true will allow requests to be made to localhost from any origin.",
          "x-micronaut-javaType": "boolean",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$CorsConfiguration",
          "x-micronaut-path": "micronaut.server.cors.localhost-pass-through"
        },
        "configurations": {
          "type": "object",
          "additionalProperties": {
            "type": "string"
          },
          "description": "Sets the CORS configurations.",
          "x-micronaut-javaType": "java.util.Map",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$CorsConfiguration",
          "x-micronaut-path": "micronaut.server.cors.configurations"
        },
        "single-header": {
          "type": "boolean",
          "description": "Sets whether CORS header values should be joined into a single header. Default value ({@value #DEFAULT_SINGLE_HEADER}).",
          "x-micronaut-javaType": "boolean",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$CorsConfiguration",
          "x-micronaut-path": "micronaut.server.cors.single-header"
        }
      }
    },
    "host-resolution": {
      "type": "object",
      "properties": {
        "host-header": {
          "type": "string",
          "description": "The host header name",
          "x-micronaut-javaType": "java.lang.String",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HostResolutionConfiguration",
          "x-micronaut-path": "micronaut.server.host-resolution.host-header"
        },
        "protocol-header": {
          "type": "string",
          "description": "The protocol header name",
          "x-micronaut-javaType": "java.lang.String",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HostResolutionConfiguration",
          "x-micronaut-path": "micronaut.server.host-resolution.protocol-header"
        },
        "port-header": {
          "type": "string",
          "description": "The port header name",
          "x-micronaut-javaType": "java.lang.String",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HostResolutionConfiguration",
          "x-micronaut-path": "micronaut.server.host-resolution.port-header"
        },
        "port-in-host": {
          "type": "boolean",
          "description": "If the host header supports a port",
          "x-micronaut-javaType": "boolean",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HostResolutionConfiguration",
          "x-micronaut-path": "micronaut.server.host-resolution.port-in-host"
        },
        "allowed-hosts": {
          "type": "array",
          "items": {
            "type": "string"
          },
          "description": "The list of hosts to validate the resolved host against.",
          "x-micronaut-javaType": "java.util.List",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HostResolutionConfiguration",
          "x-micronaut-path": "micronaut.server.host-resolution.allowed-hosts"
        }
      }
    },
    "locale-resolution": {
      "type": "object",
      "properties": {
        "fixed": {
          "type": "string",
          "description": "Set the language tag for the locale. Supports BCP 47 language\n tags (e.g. \"en-US\") and ISO standard (e.g \"en_US\").",
          "x-micronaut-javaType": "java.util.Locale",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HttpLocaleResolutionConfigurationProperties",
          "x-micronaut-path": "micronaut.server.locale-resolution.fixed"
        },
        "session-attribute": {
          "type": "string",
          "description": "Sets the key in the session to look for the locale.",
          "x-micronaut-javaType": "java.lang.String",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HttpLocaleResolutionConfigurationProperties",
          "x-micronaut-path": "micronaut.server.locale-resolution.session-attribute"
        },
        "default-locale": {
          "type": "string",
          "description": "Sets the locale that will be used if the locale cannot be\n resolved through any means. Defaults to the system default.",
          "x-micronaut-javaType": "java.util.Locale",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HttpLocaleResolutionConfigurationProperties",
          "x-micronaut-path": "micronaut.server.locale-resolution.default-locale"
        },
        "cookie-name": {
          "type": "string",
          "description": "Sets the name of the cookie that is used to store the locale.",
          "x-micronaut-javaType": "java.lang.String",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HttpLocaleResolutionConfigurationProperties",
          "x-micronaut-path": "micronaut.server.locale-resolution.cookie-name"
        },
        "header": {
          "type": "boolean",
          "description": "Set to true if the locale should be resolved from the `Accept-Language` header.\n Default value ({@value #DEFAULT_HEADER_RESOLUTION}).",
          "x-micronaut-javaType": "boolean",
          "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$HttpLocaleResolutionConfigurationProperties",
          "x-micronaut-path": "micronaut.server.locale-resolution.header"
        }
      }
    },
    "responses": {
      "type": "object",
      "properties": {
        "file": {
          "type": "object",
          "properties": {
            "cache-seconds": {
              "type": "integer",
              "description": "Cache Seconds. Default value ({@value #DEFAULT_CACHESECONDS}).",
              "x-micronaut-javaType": "int",
              "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$FileTypeHandlerConfiguration",
              "x-micronaut-path": "micronaut.server.responses.file.cache-seconds"
            },
            "cache-control": {
              "type": "object",
              "properties": {
                "public": {
                  "type": "boolean",
                  "description": "Sets whether the cache control is public. Default value ({@value #DEFAULT_PUBLIC_CACHE})",
                  "x-micronaut-javaType": "boolean",
                  "x-micronaut-sourceType": "io.micronaut.http.server.HttpServerConfiguration$FileTypeHandlerConfiguration$CacheControlConfiguration",
                  "x-micronaut-path": "micronaut.server.responses.file.cache-control.public"
                }
              }
            }
          }
        }
      }
    }
  }
}
```