### PR TITLE
add null check for environment

### DIFF
--- a/inject/src/main/java/io/micronaut/context/ConsoleBeanResolutionTracer.java
+++ b/inject/src/main/java/io/micronaut/context/ConsoleBeanResolutionTracer.java
@@ -55,6 +55,10 @@ abstract sealed class ConsoleBeanResolutionTracer
 
     @Override
     public void traceInitialConfiguration(Environment environment, Collection<BeanDefinitionReference<?>> beanReferences, Collection<DisabledBean<?>> disabledBeans) {
+        if (environment == null) {
+            return;
+        }
+
         Collection<PropertySource> propertySources = environment.getPropertySources();
         Set<String> activeNames = environment.getActiveNames();
         StringWriter sw = new StringWriter();

--- a/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
@@ -8,6 +8,20 @@ import spock.lang.Specification
 
 class ApplicationContextBuilderSpec extends Specification {
 
+    void "test start tracing"() {
+        when:
+        ApplicationContextBuilder builder = ApplicationContext.builder()
+        builder.bootstrapEnvironment(true)
+        builder.beanResolutionTrace(BeanResolutionTraceMode.LOG)
+        def context = builder.start()
+
+        then:
+        context != null
+
+        cleanup:
+        context.close()
+    }
+
     void "test configure() context"() {
         when:"a context is built"
         ApplicationContextBuilder builder = ApplicationContext.builder()


### PR DESCRIPTION
Fixes:

```
java.lang.NullPointerException: Cannot invoke "io.micronaut.context.env.Environment.getPropertySources()" because "environment" is null
at io.micronaut.context.ConsoleBeanResolutionTracer.traceInitialConfiguration(ConsoleBeanResolutionTracer.java:58)
at io.micronaut.context.DefaultApplicationContext.lambda$configureContextInternal$1(DefaultApplicationContext.java:148)
at java.base/java.util.Optional.ifPresent(Optional.java:178)
```