### PR TITLE
fix: MediaType can decode quoted charset

### DIFF
--- a/benchmarks/src/jmh/java/io/micronaut/http/MediaTypeParameterParserBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/MediaTypeParameterParserBenchmark.java
@@ -1,0 +1,235 @@
+package io.micronaut.http;
+
+import io.micronaut.core.util.StringUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@State(Scope.Benchmark)
+public class MediaTypeParameterParserBenchmark {
+    private static final String NO_PARAMETERS = "application/json";
+    private static final String SIMPLE_PARAMETERS = "text/plain; charset=utf-8";
+    private static final String QUOTED_PARAMETERS = "text/plain; charset=\"utf-8\"";
+    private static final String QUOTED_SEMICOLON_PARAMETERS = "text/plain; foo=\"a;b\"; charset=\"utf-8\"";
+
+    @Benchmark
+    public void oldUpstreamNoParameters(Blackhole blackhole) {
+        blackhole.consume(parseWithOldUpstream(NO_PARAMETERS));
+    }
+
+    @Benchmark
+    public void newImplementationNoParameters(Blackhole blackhole) {
+        blackhole.consume(parseWithNewImplementation(NO_PARAMETERS));
+    }
+
+    @Benchmark
+    public void oldUpstreamSimpleParameters(Blackhole blackhole) {
+        blackhole.consume(parseWithOldUpstream(SIMPLE_PARAMETERS));
+    }
+
+    @Benchmark
+    public void newImplementationSimpleParameters(Blackhole blackhole) {
+        blackhole.consume(parseWithNewImplementation(SIMPLE_PARAMETERS));
+    }
+
+    @Benchmark
+    public void oldUpstreamQuotedParameters(Blackhole blackhole) {
+        blackhole.consume(parseWithOldUpstream(QUOTED_PARAMETERS));
+    }
+
+    @Benchmark
+    public void newImplementationQuotedParameters(Blackhole blackhole) {
+        blackhole.consume(parseWithNewImplementation(QUOTED_PARAMETERS));
+    }
+
+    @Benchmark
+    public void oldUpstreamQuotedSemicolonParameters(Blackhole blackhole) {
+        blackhole.consume(parseWithOldUpstream(QUOTED_SEMICOLON_PARAMETERS));
+    }
+
+    @Benchmark
+    public void newImplementationQuotedSemicolonParameters(Blackhole blackhole) {
+        blackhole.consume(parseWithNewImplementation(QUOTED_SEMICOLON_PARAMETERS));
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .include(".*" + MediaTypeParameterParserBenchmark.class.getSimpleName() + ".*")
+            .warmupIterations(3)
+            .measurementIterations(5)
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    private static ParsedMediaType parseWithOldUpstream(String name) {
+        name = name.trim();
+        String withoutArgs;
+        Iterator<String> splitIt = StringUtils.splitOmitEmptyStringsIterator(name, ';');
+        Map<CharSequence, String> parameters = Collections.emptyMap();
+        if (splitIt.hasNext()) {
+            withoutArgs = splitIt.next();
+            if (splitIt.hasNext()) {
+                Map<CharSequence, String> parsedParameters = null;
+                while (splitIt.hasNext()) {
+                    String paramExpression = splitIt.next();
+                    int i = paramExpression.indexOf('=');
+                    if (i > -1) {
+                        String paramName = paramExpression.substring(0, i).trim();
+                        String paramValue = paramExpression.substring(i + 1).trim();
+                        if (parsedParameters == null) {
+                            parsedParameters = new LinkedHashMap<>();
+                        }
+                        parsedParameters.put(paramName, paramValue);
+                    }
+                }
+                parameters = parsedParameters == null ? Collections.emptyMap() : parsedParameters;
+            }
+        } else {
+            withoutArgs = name;
+        }
+        return new ParsedMediaType(withoutArgs, parameters);
+    }
+
+    private static ParsedMediaType parseWithNewImplementation(String name) {
+        name = name.trim();
+        String[] parsedType = new String[1];
+        Map<CharSequence, String> parsedParameters = new LinkedHashMap<>();
+        new ParameterParser() {
+            @Override
+            void visitType(String type) {
+                parsedType[0] = type.trim();
+            }
+
+            @Override
+            boolean visitAttribute(String attribute) {
+                return !attribute.trim().isEmpty();
+            }
+
+            @Override
+            void visitAttributeValue(String attribute, String value) {
+                String normalizedAttribute = attribute.trim();
+                String normalizedValue = value.trim();
+                if ("q".equals(normalizedAttribute)) {
+                    new BigDecimal(unquoteParameterValue(normalizedValue));
+                }
+                parsedParameters.put(normalizedAttribute, normalizedValue);
+            }
+        }.run(name);
+        return new ParsedMediaType(
+            parsedType[0],
+            parsedParameters.isEmpty() ? Collections.emptyMap() : parsedParameters
+        );
+    }
+
+    private abstract static class ParameterParser {
+        abstract void visitType(String type);
+
+        abstract boolean visitAttribute(String attribute);
+
+        abstract void visitAttributeValue(String attribute, String value);
+
+        final void run(String headerValue) {
+            int typeEnd = headerValue.indexOf(';');
+            String type;
+            if (typeEnd == -1) {
+                type = headerValue;
+                typeEnd = headerValue.length();
+            } else {
+                type = headerValue.substring(0, typeEnd);
+            }
+            visitType(type);
+            for (int parameterStart = typeEnd + 1; parameterStart < headerValue.length(); ) {
+                int attributeEnd = headerValue.indexOf('=', parameterStart);
+                if (attributeEnd == -1) {
+                    break;
+                }
+                while (parameterStart < headerValue.length() && Character.isWhitespace(headerValue.charAt(parameterStart))) {
+                    parameterStart++;
+                }
+                String attribute = headerValue.substring(parameterStart, attributeEnd);
+                boolean needParameterValue = visitAttribute(attribute);
+
+                String parameterValue = null;
+                int parameterValueEnd = attributeEnd + 1;
+                if (parameterValueEnd < headerValue.length() && headerValue.charAt(parameterValueEnd) == '"') {
+                    StringBuilder valueBuilder = needParameterValue ? new StringBuilder() : null;
+                    boolean quoted = false;
+                    while (parameterValueEnd < headerValue.length()) {
+                        char c = headerValue.charAt(parameterValueEnd++);
+                        if (c == '"') {
+                            quoted = !quoted;
+                        } else {
+                            if (!quoted && c == ';') {
+                                parameterValueEnd--;
+                                break;
+                            } else if (quoted && c == '\\' && parameterValueEnd < headerValue.length()) {
+                                if (needParameterValue) {
+                                    valueBuilder.append(headerValue.charAt(parameterValueEnd));
+                                }
+                                parameterValueEnd++;
+                            } else {
+                                if (needParameterValue) {
+                                    valueBuilder.append(c);
+                                }
+                            }
+                        }
+                    }
+                    if (needParameterValue) {
+                        parameterValue = valueBuilder.toString();
+                    }
+                } else {
+                    parameterValueEnd = headerValue.indexOf(';', parameterValueEnd);
+                    if (parameterValueEnd == -1) {
+                        parameterValueEnd = headerValue.length();
+                    }
+                    if (needParameterValue) {
+                        parameterValue = headerValue.substring(attributeEnd + 1, parameterValueEnd);
+                    }
+                }
+                if (parameterValue != null) {
+                    visitAttributeValue(attribute, parameterValue);
+                }
+                parameterStart = parameterValueEnd + 1;
+            }
+        }
+    }
+
+    private static String unquoteParameterValue(String value) {
+        if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+            StringBuilder unescaped = new StringBuilder(value.length() - 2);
+            boolean escaped = false;
+            for (int i = 1; i < value.length() - 1; i++) {
+                char c = value.charAt(i);
+                if (escaped) {
+                    unescaped.append(c);
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else {
+                    unescaped.append(c);
+                }
+            }
+            if (escaped) {
+                unescaped.append('\\');
+            }
+            return unescaped.toString();
+        }
+        return value;
+    }
+
+    private record ParsedMediaType(String type, Map<CharSequence, String> parameters) {
+    }
+}

--- a/benchmarks/src/jmh/java/io/micronaut/http/MediaTypeParameterParserBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/MediaTypeParameterParserBenchmark.java
@@ -105,6 +105,10 @@ public class MediaTypeParameterParserBenchmark {
 
     private static ParsedMediaType parseWithNewImplementation(String name) {
         name = name.trim();
+        if (name.indexOf(';') == -1) {
+            return new ParsedMediaType(name, Collections.emptyMap());
+        }
+
         String[] parsedType = new String[1];
         Map<CharSequence, String> parsedParameters = new LinkedHashMap<>();
         new ParameterParser() {
@@ -143,14 +147,11 @@ public class MediaTypeParameterParserBenchmark {
 
         final void run(String headerValue) {
             int typeEnd = headerValue.indexOf(';');
-            String type;
             if (typeEnd == -1) {
-                type = headerValue;
-                typeEnd = headerValue.length();
-            } else {
-                type = headerValue.substring(0, typeEnd);
+                visitType(headerValue);
+                return;
             }
-            visitType(type);
+            visitType(headerValue.substring(0, typeEnd));
             for (int parameterStart = typeEnd + 1; parameterStart < headerValue.length(); ) {
                 int attributeEnd = headerValue.indexOf('=', parameterStart);
                 if (attributeEnd == -1) {

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/EncodingTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/EncodingTest.java
@@ -61,6 +61,20 @@ class EncodingTest {
                 .build()));
     }
 
+    @Test
+    void quotedCharsetDecodedCorrectly() throws IOException {
+        asserts(SPEC_NAME,
+                Map.of(),
+                HttpRequest.GET("/encoding/quotedCharset"),
+                (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                        .status(HttpStatus.OK)
+                        .assertResponse(response -> {
+                            assertEquals("foo", response.getBody(String.class).get());
+                        })
+                        .build()));
+    }
+
+
     @Requires(property = "spec.name", value = SPEC_NAME)
     @Controller("/encoding")
     static class EncodingTestController {
@@ -74,6 +88,12 @@ class EncodingTest {
         @Get("/string")
         @Produces("text/plain; charset=utf-16")
         String string() {
+            return "foo";
+        }
+
+        @Get("/quotedCharset")
+        @Produces("text/plain; charset=\"utf-16\"")
+        String quotedCharset() {
             return "foo";
         }
     }

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -1118,7 +1118,10 @@ public class MediaType implements CharSequence {
         if (charset == null) {
             return Optional.empty();
         }
-        return Optional.of(Charset.forName(charset));
+
+        String charsetWithoutQuotationMarks = charset.replace("\"", "");
+
+        return Optional.of(Charset.forName(charsetWithoutQuotationMarks));
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -846,43 +846,38 @@ public class MediaType implements CharSequence {
             throw new IllegalArgumentException("Argument [name] cannot be null");
         }
         name = name.trim();
-        String withoutArgs;
-        Iterator<String> splitIt = StringUtils.splitOmitEmptyStringsIterator(name, SEMICOLON);
-        if (splitIt.hasNext()) {
-            withoutArgs = splitIt.next();
-            if (splitIt.hasNext()) {
-                Map<CharSequence, String> parameters = null;
-                while (splitIt.hasNext()) {
-                    String paramExpression = splitIt.next();
-                    int i = paramExpression.indexOf('=');
-                    if (i > -1) {
-                        String paramName = paramExpression.substring(0, i).trim();
-                        String paramValue = paramExpression.substring(i + 1).trim();
-                        if ("q".equals(paramName)) {
-                            qualityNumberField = new BigDecimal(paramValue);
-                        }
-                        if (parameters == null) {
-                            parameters = new LinkedHashMap<>();
-                        }
-                        parameters.put(paramName, paramValue);
-                    }
-                }
-                if (parameters == null) {
-                    parameters = Collections.emptyMap();
-                }
-                this.parameters = parameters;
-            } else if (params == null) {
-                this.parameters = Collections.emptyMap();
-            } else {
-                this.parameters = (Map) params;
+        String[] parsedType = new String[1];
+        Map<CharSequence, String> parsedParameters = new LinkedHashMap<>();
+        new ParameterParser() {
+            @Override
+            void visitType(String type) {
+                parsedType[0] = type.trim();
             }
-        } else {
+
+            @Override
+            boolean visitAttribute(String attribute) {
+                return !attribute.trim().isEmpty();
+            }
+
+            @Override
+            void visitAttributeValue(String attribute, String value) {
+                String normalizedAttribute = attribute.trim();
+                String normalizedValue = value.trim();
+                if ("q".equals(normalizedAttribute)) {
+                    qualityNumberField = new BigDecimal(unquoteParameterValue(normalizedValue));
+                }
+                parsedParameters.put(normalizedAttribute, normalizedValue);
+            }
+        }.run(name);
+        String withoutArgs = parsedType[0];
+        if (parsedParameters.isEmpty()) {
             if (params == null) {
                 this.parameters = Collections.emptyMap();
             } else {
                 this.parameters = (Map) params;
             }
-            withoutArgs = name;
+        } else {
+            this.parameters = parsedParameters;
         }
         this.name = withoutArgs;
         this.lowerName = withoutArgs.toLowerCase(Locale.ROOT);
@@ -1119,9 +1114,107 @@ public class MediaType implements CharSequence {
             return Optional.empty();
         }
 
-        String charsetWithoutQuotationMarks = charset.replace("\"", "");
+        return Optional.of(Charset.forName(unquoteParameterValue(charset)));
+    }
 
-        return Optional.of(Charset.forName(charsetWithoutQuotationMarks));
+    /**
+     * Adapted from Netty's {@code ParmParser}:
+     * https://github.com/netty-contrib/codec-multipart/blob/1.0/multipart-core/src/main/java/io/netty/contrib/multipart/ParmParser.java
+     */
+    private abstract static class ParameterParser {
+        abstract void visitType(String type);
+
+        abstract boolean visitAttribute(String attribute);
+
+        abstract void visitAttributeValue(String attribute, String value);
+
+        final void run(String headerValue) {
+            int typeEnd = headerValue.indexOf(';');
+            String type;
+            if (typeEnd == -1) {
+                type = headerValue;
+                typeEnd = headerValue.length();
+            } else {
+                type = headerValue.substring(0, typeEnd);
+            }
+            visitType(type);
+            for (int parameterStart = typeEnd + 1; parameterStart < headerValue.length(); ) {
+                int attributeEnd = headerValue.indexOf('=', parameterStart);
+                if (attributeEnd == -1) {
+                    break;
+                }
+                while (parameterStart < headerValue.length() && Character.isWhitespace(headerValue.charAt(parameterStart))) {
+                    parameterStart++;
+                }
+                String attribute = headerValue.substring(parameterStart, attributeEnd);
+                boolean needParameterValue = visitAttribute(attribute);
+
+                String parameterValue = null;
+                int parameterValueEnd = attributeEnd + 1;
+                if (parameterValueEnd < headerValue.length() && headerValue.charAt(parameterValueEnd) == '"') {
+                    StringBuilder valueBuilder = needParameterValue ? new StringBuilder() : null;
+                    boolean quoted = false;
+                    while (parameterValueEnd < headerValue.length()) {
+                        char c = headerValue.charAt(parameterValueEnd++);
+                        if (c == '"') {
+                            quoted = !quoted;
+                        } else {
+                            if (!quoted && c == ';') {
+                                parameterValueEnd--;
+                                break;
+                            } else if (quoted && c == '\\' && parameterValueEnd < headerValue.length()) {
+                                if (needParameterValue) {
+                                    valueBuilder.append(headerValue.charAt(parameterValueEnd));
+                                }
+                                parameterValueEnd++;
+                            } else {
+                                if (needParameterValue) {
+                                    valueBuilder.append(c);
+                                }
+                            }
+                        }
+                    }
+                    if (needParameterValue) {
+                        parameterValue = valueBuilder.toString();
+                    }
+                } else {
+                    parameterValueEnd = headerValue.indexOf(';', parameterValueEnd);
+                    if (parameterValueEnd == -1) {
+                        parameterValueEnd = headerValue.length();
+                    }
+                    if (needParameterValue) {
+                        parameterValue = headerValue.substring(attributeEnd + 1, parameterValueEnd);
+                    }
+                }
+                if (parameterValue != null) {
+                    visitAttributeValue(attribute, parameterValue);
+                }
+                parameterStart = parameterValueEnd + 1;
+            }
+        }
+    }
+
+    private static String unquoteParameterValue(String value) {
+        if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+            StringBuilder unescaped = new StringBuilder(value.length() - 2);
+            boolean escaped = false;
+            for (int i = 1; i < value.length() - 1; i++) {
+                char c = value.charAt(i);
+                if (escaped) {
+                    unescaped.append(c);
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else {
+                    unescaped.append(c);
+                }
+            }
+            if (escaped) {
+                unescaped.append('\\');
+            }
+            return unescaped.toString();
+        }
+        return value;
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -40,7 +40,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -1127,80 +1126,6 @@ public class MediaType implements CharSequence {
         return Optional.of(Charset.forName(unquoteParameterValue(charset)));
     }
 
-    /**
-     * Adapted from Netty's {@code ParmParser}:
-     * https://github.com/netty-contrib/codec-multipart/blob/1.0/multipart-core/src/main/java/io/netty/contrib/multipart/ParmParser.java
-     */
-    private abstract static class ParameterParser {
-        abstract void visitType(String type);
-
-        abstract boolean visitAttribute(String attribute);
-
-        abstract void visitAttributeValue(String attribute, String value);
-
-        final void run(String headerValue) {
-            int typeEnd = headerValue.indexOf(';');
-            if (typeEnd == -1) {
-                visitType(headerValue);
-                return;
-            }
-            visitType(headerValue.substring(0, typeEnd));
-            for (int parameterStart = typeEnd + 1; parameterStart < headerValue.length(); ) {
-                int attributeEnd = headerValue.indexOf('=', parameterStart);
-                if (attributeEnd == -1) {
-                    break;
-                }
-                while (parameterStart < headerValue.length() && Character.isWhitespace(headerValue.charAt(parameterStart))) {
-                    parameterStart++;
-                }
-                String attribute = headerValue.substring(parameterStart, attributeEnd);
-                boolean needParameterValue = visitAttribute(attribute);
-
-                String parameterValue = null;
-                int parameterValueEnd = attributeEnd + 1;
-                if (parameterValueEnd < headerValue.length() && headerValue.charAt(parameterValueEnd) == '"') {
-                    StringBuilder valueBuilder = needParameterValue ? new StringBuilder() : null;
-                    boolean quoted = false;
-                    while (parameterValueEnd < headerValue.length()) {
-                        char c = headerValue.charAt(parameterValueEnd++);
-                        if (c == '"') {
-                            quoted = !quoted;
-                        } else {
-                            if (!quoted && c == ';') {
-                                parameterValueEnd--;
-                                break;
-                            } else if (quoted && c == '\\' && parameterValueEnd < headerValue.length()) {
-                                if (needParameterValue) {
-                                    valueBuilder.append(headerValue.charAt(parameterValueEnd));
-                                }
-                                parameterValueEnd++;
-                            } else {
-                                if (needParameterValue) {
-                                    valueBuilder.append(c);
-                                }
-                            }
-                        }
-                    }
-                    if (needParameterValue) {
-                        parameterValue = valueBuilder.toString();
-                    }
-                } else {
-                    parameterValueEnd = headerValue.indexOf(';', parameterValueEnd);
-                    if (parameterValueEnd == -1) {
-                        parameterValueEnd = headerValue.length();
-                    }
-                    if (needParameterValue) {
-                        parameterValue = headerValue.substring(attributeEnd + 1, parameterValueEnd);
-                    }
-                }
-                if (parameterValue != null) {
-                    visitAttributeValue(attribute, parameterValue);
-                }
-                parameterStart = parameterValueEnd + 1;
-            }
-        }
-    }
-
     private static String unquoteParameterValue(String value) {
         if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
             StringBuilder unescaped = new StringBuilder(value.length() - 2);
@@ -1518,5 +1443,78 @@ public class MediaType implements CharSequence {
         }
 
         return Collections.emptyMap();
+    }
+
+    /**
+     * Adapted from Netty's {@code ParmParser}.
+     *
+     * Source: https://github.com/netty-contrib/codec-multipart/blob/1.0/multipart-core/src/main/java/io/netty/contrib/multipart/ParmParser.java
+     */
+    private abstract static class ParameterParser {
+        abstract void visitType(String type);
+
+        abstract boolean visitAttribute(String attribute);
+
+        abstract void visitAttributeValue(String attribute, String value);
+
+        final void run(String headerValue) {
+            int typeEnd = headerValue.indexOf(';');
+            if (typeEnd == -1) {
+                visitType(headerValue);
+                return;
+            }
+            visitType(headerValue.substring(0, typeEnd));
+            for (int parameterStart = typeEnd + 1; parameterStart < headerValue.length(); ) {
+                int attributeEnd = headerValue.indexOf('=', parameterStart);
+                if (attributeEnd == -1) {
+                    break;
+                }
+                while (parameterStart < headerValue.length() && Character.isWhitespace(headerValue.charAt(parameterStart))) {
+                    parameterStart++;
+                }
+                String attribute = headerValue.substring(parameterStart, attributeEnd);
+                boolean needParameterValue = visitAttribute(attribute);
+
+                String parameterValue = null;
+                int parameterValueEnd = attributeEnd + 1;
+                if (parameterValueEnd < headerValue.length() && headerValue.charAt(parameterValueEnd) == '"') {
+                    StringBuilder valueBuilder = needParameterValue ? new StringBuilder() : null;
+                    boolean quoted = false;
+                    while (parameterValueEnd < headerValue.length()) {
+                        char c = headerValue.charAt(parameterValueEnd++);
+                        if (c == '"') {
+                            quoted = !quoted;
+                        } else {
+                            if (!quoted && c == ';') {
+                                parameterValueEnd--;
+                                break;
+                            } else if (quoted && c == '\\' && parameterValueEnd < headerValue.length()) {
+                                if (needParameterValue) {
+                                    valueBuilder.append(headerValue.charAt(parameterValueEnd));
+                                }
+                                parameterValueEnd++;
+                            } else if (needParameterValue) {
+                                valueBuilder.append(c);
+                            }
+                        }
+                    }
+                    if (needParameterValue) {
+                        parameterValue = valueBuilder.toString();
+                    }
+                } else {
+                    parameterValueEnd = headerValue.indexOf(';', parameterValueEnd);
+                    if (parameterValueEnd == -1) {
+                        parameterValueEnd = headerValue.length();
+                    }
+                    if (needParameterValue) {
+                        parameterValue = headerValue.substring(attributeEnd + 1, parameterValueEnd);
+                    }
+                }
+                if (parameterValue != null) {
+                    visitAttributeValue(attribute, parameterValue);
+                }
+                parameterStart = parameterValueEnd + 1;
+            }
+        }
     }
 }

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -846,38 +846,48 @@ public class MediaType implements CharSequence {
             throw new IllegalArgumentException("Argument [name] cannot be null");
         }
         name = name.trim();
-        String[] parsedType = new String[1];
-        Map<CharSequence, String> parsedParameters = new LinkedHashMap<>();
-        new ParameterParser() {
-            @Override
-            void visitType(String type) {
-                parsedType[0] = type.trim();
-            }
-
-            @Override
-            boolean visitAttribute(String attribute) {
-                return !attribute.trim().isEmpty();
-            }
-
-            @Override
-            void visitAttributeValue(String attribute, String value) {
-                String normalizedAttribute = attribute.trim();
-                String normalizedValue = value.trim();
-                if ("q".equals(normalizedAttribute)) {
-                    qualityNumberField = new BigDecimal(unquoteParameterValue(normalizedValue));
-                }
-                parsedParameters.put(normalizedAttribute, normalizedValue);
-            }
-        }.run(name);
-        String withoutArgs = parsedType[0];
-        if (parsedParameters.isEmpty()) {
+        String withoutArgs;
+        if (name.indexOf(SEMICOLON) == -1) {
+            withoutArgs = name;
             if (params == null) {
                 this.parameters = Collections.emptyMap();
             } else {
                 this.parameters = (Map) params;
             }
         } else {
-            this.parameters = parsedParameters;
+            String[] parsedType = new String[1];
+            Map<CharSequence, String> parsedParameters = new LinkedHashMap<>();
+            new ParameterParser() {
+                @Override
+                void visitType(String type) {
+                    parsedType[0] = type.trim();
+                }
+
+                @Override
+                boolean visitAttribute(String attribute) {
+                    return !attribute.trim().isEmpty();
+                }
+
+                @Override
+                void visitAttributeValue(String attribute, String value) {
+                    String normalizedAttribute = attribute.trim();
+                    String normalizedValue = value.trim();
+                    if ("q".equals(normalizedAttribute)) {
+                        qualityNumberField = new BigDecimal(unquoteParameterValue(normalizedValue));
+                    }
+                    parsedParameters.put(normalizedAttribute, normalizedValue);
+                }
+            }.run(name);
+            withoutArgs = parsedType[0];
+            if (parsedParameters.isEmpty()) {
+                if (params == null) {
+                    this.parameters = Collections.emptyMap();
+                } else {
+                    this.parameters = (Map) params;
+                }
+            } else {
+                this.parameters = parsedParameters;
+            }
         }
         this.name = withoutArgs;
         this.lowerName = withoutArgs.toLowerCase(Locale.ROOT);
@@ -1130,14 +1140,11 @@ public class MediaType implements CharSequence {
 
         final void run(String headerValue) {
             int typeEnd = headerValue.indexOf(';');
-            String type;
             if (typeEnd == -1) {
-                type = headerValue;
-                typeEnd = headerValue.length();
-            } else {
-                type = headerValue.substring(0, typeEnd);
+                visitType(headerValue);
+                return;
             }
-            visitType(type);
+            visitType(headerValue.substring(0, typeEnd));
             for (int parameterStart = typeEnd + 1; parameterStart < headerValue.length(); ) {
                 int attributeEnd = headerValue.indexOf('=', parameterStart);
                 if (attributeEnd == -1) {

--- a/http/src/test/java/io/micronaut/http/MediaTypeTest.java
+++ b/http/src/test/java/io/micronaut/http/MediaTypeTest.java
@@ -3,7 +3,9 @@ package io.micronaut.http;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.nio.charset.Charset;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static io.micronaut.http.MediaType.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -90,4 +92,68 @@ class MediaTypeTest {
             IMAGE_WEBP_TYPE,
             IMAGE_WMF_TYPE);
     }
+    @ParameterizedTest
+    @MethodSource
+    void parsesCharsetFromStandardizedContentTypeFormats(String contentType, String expectedCharsetName) {
+        MediaType mediaType = MediaType.of(contentType);
+
+        assertEquals(Charset.forName(expectedCharsetName), mediaType.getCharset().orElseThrow());
+    }
+
+    private static Stream<org.junit.jupiter.params.provider.Arguments> parsesCharsetFromStandardizedContentTypeFormats() {
+        return Stream.of(
+            org.junit.jupiter.params.provider.Arguments.of("text/plain;charset=utf-8", "utf-8"),
+            org.junit.jupiter.params.provider.Arguments.of("text/plain; charset=utf-8", "utf-8"),
+            org.junit.jupiter.params.provider.Arguments.of("text/plain; foo=bar; charset=utf-8", "utf-8"),
+            org.junit.jupiter.params.provider.Arguments.of("text/plain; charset=\"utf-8\"", "utf-8"),
+            org.junit.jupiter.params.provider.Arguments.of("text/plain; foo=bar ; charset=\"utf-8\"", "utf-8"),
+            org.junit.jupiter.params.provider.Arguments.of("text/plain; charset=\"UTF-8\"", "UTF-8"),
+            org.junit.jupiter.params.provider.Arguments.of("text/plain; charset=\"utf\\-8\"", "utf-8")
+        );
+    }
+
+
+    @ParameterizedTest
+    @MethodSource
+    void rejectsQuotedCharsetValuesThatAreNotValidCharsets(String contentType) {
+        MediaType mediaType = MediaType.of(contentType);
+
+        assertThrows(IllegalArgumentException.class, mediaType::getCharset);
+    }
+
+    private static Stream<String> rejectsQuotedCharsetValuesThatAreNotValidCharsets() {
+        return Stream.of(
+            "text/plain; charset=\"utf-8;version=2\""
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parsesQuotedCharsetParameterValues(String contentType, String expectedParameterValue) {
+        MediaType mediaType = MediaType.of(contentType);
+
+        assertEquals(expectedParameterValue, mediaType.getParametersMap().get(MediaType.CHARSET_PARAMETER));
+    }
+
+    private static Stream<org.junit.jupiter.params.provider.Arguments> parsesQuotedCharsetParameterValues() {
+        return Stream.of(
+            org.junit.jupiter.params.provider.Arguments.of("text/plain; charset=\"utf-8\"", "utf-8"),
+            org.junit.jupiter.params.provider.Arguments.of("text/plain; charset=\"utf-8;version=2\"", "utf-8;version=2")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parsesQuotedNonCharsetParameterValues(String contentType, String parameterName, String expectedParameterValue) {
+        MediaType mediaType = MediaType.of(contentType);
+
+        assertEquals(expectedParameterValue, mediaType.getParametersMap().get(parameterName));
+    }
+
+    private static Stream<org.junit.jupiter.params.provider.Arguments> parsesQuotedNonCharsetParameterValues() {
+        return Stream.of(
+            org.junit.jupiter.params.provider.Arguments.of("text/plain; foo=\"a;b\"; charset=utf-8", "foo", "a;b")
+        );
+    }
+
 }

--- a/http/src/test/java/io/micronaut/http/MediaTypeTest.java
+++ b/http/src/test/java/io/micronaut/http/MediaTypeTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.Charset;
+import java.util.Map;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -11,6 +12,75 @@ import static io.micronaut.http.MediaType.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MediaTypeTest {
+    @ParameterizedTest
+    @MethodSource
+    void noParameterFastPathMatchesSlowPathForValidMediaTypes(String contentType) {
+        SlowPathExpectation expected = slowPathExpectation(contentType);
+
+        MediaType mediaType = new MediaType(contentType);
+
+        assertEquals(expected.name(), mediaType.getName());
+        assertEquals(expected.type(), mediaType.getType());
+        assertEquals(expected.subtype(), mediaType.getSubtype());
+        assertEquals(expected.extension(), mediaType.getExtension());
+        assertEquals(expected.stringRepresentation(), mediaType.toString());
+        assertEquals(Map.of(), mediaType.getParametersMap());
+        assertEquals(0, mediaType.getQualityAsNumber().compareTo(expected.quality()));
+        assertTrue(mediaType.getCharset().isEmpty());
+    }
+
+    private static Stream<String> noParameterFastPathMatchesSlowPathForValidMediaTypes() {
+        return Stream.of(
+            "application/json",
+            " text/plain ",
+            "application/hal+json",
+            "APPLICATION/JSON",
+            "application/vnd.example+yaml"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void noParameterFastPathMatchesSlowPathForInvalidMediaTypes(String contentType) {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new MediaType(contentType));
+
+        assertEquals(slowPathFailureMessage(contentType), exception.getMessage());
+    }
+
+    private static Stream<String> noParameterFastPathMatchesSlowPathForInvalidMediaTypes() {
+        return Stream.of(
+            "applicationjson",
+            "",
+            "   ",
+            "textplain"
+        );
+    }
+
+    private static SlowPathExpectation slowPathExpectation(String contentType) {
+        String normalized = contentType.trim();
+        int slashIndex = normalized.indexOf('/');
+        if (slashIndex < 0) {
+            throw new IllegalArgumentException("Invalid mime type: " + normalized);
+        }
+        String type = normalized.substring(0, slashIndex);
+        String subtype = normalized.substring(slashIndex + 1);
+        int plusIndex = subtype.indexOf('+');
+        String extension = plusIndex > -1 ? subtype.substring(plusIndex + 1) : subtype;
+        return new SlowPathExpectation(normalized, type, subtype, extension, normalized, java.math.BigDecimal.ONE);
+    }
+
+    private static String slowPathFailureMessage(String contentType) {
+        return "Invalid mime type: " + contentType.trim();
+    }
+
+    private record SlowPathExpectation(String name,
+                                       String type,
+                                       String subtype,
+                                       String extension,
+                                       String stringRepresentation,
+                                       java.math.BigDecimal quality) {
+    }
+
     @ParameterizedTest
     @MethodSource
     void isJsonTrue(MediaType mediaType) {


### PR DESCRIPTION
This PR fixes #12247.

Opted for a simple removal of the quotes in the MediaType::getCharset() method as it looked cleared than doing it on the constructor.
Let me know what you think.