### PR TITLE
Correct nullability of ConversionService#convertRequired

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/ConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionService.java
@@ -15,10 +15,9 @@
  */
 package io.micronaut.core.convert;
 
-import org.jspecify.annotations.Nullable;
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.type.Argument;
-import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -138,13 +137,8 @@ public interface ConversionService {
      * @throws ConversionErrorException if the value cannot be converted
      * @since 1.1.4
      */
-    @Contract("null, _ -> null")
-    default @Nullable <T> T convertRequired(@Nullable Object value, Class<T> type) {
-        if (value == null) {
-            return null;
-        }
-        Argument<T> arg = Argument.of(type);
-        return convertRequired(value, arg);
+    default <T> T convertRequired(@Nullable Object value, Class<T> type) {
+        return convertRequired(value, Argument.of(type));
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -199,7 +199,6 @@ public class DefaultMutableConversionService implements MutableConversionService
         }
 
         @Override
-        @Nullable
         public <T> T convertRequired(@Nullable Object value, Class<T> type) {
             return DefaultMutableConversionService.this.convertRequired(value, type);
         }


### PR DESCRIPTION
The variation of `convertRequired` with an argument didn't have nullable but the one with Class did. 
`Optional convert` should be used if null is a possibility