### PR TITLE
Fix: Relative redirects not resolved against request URI

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1274,12 +1274,12 @@ public class DefaultHttpClient implements
             if (parentRequest == null || parentRequest.getUri().getHost() == null) {
                 return resolveURI(request, false);
             } else {
-                URI parentURI = parentRequest.getUri();
-                UriBuilder uriBuilder = UriBuilder.of(requestURI)
-                        .scheme(parentURI.getScheme())
-                        .userInfo(parentURI.getUserInfo())
-                        .host(parentURI.getHost())
-                        .port(parentURI.getPort());
+                URI redirectedURI = parentRequest.getUri().resolve(requestURI).normalize();
+                UriBuilder uriBuilder = UriBuilder.of(redirectedURI)
+                        .scheme(redirectedURI.getScheme())
+                        .userInfo(redirectedURI.getUserInfo())
+                        .host(redirectedURI.getHost())
+                        .port(redirectedURI.getPort());
                 return ExecutionFlow.just(uriBuilder.build());
             }
         }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1275,12 +1275,7 @@ public class DefaultHttpClient implements
                 return resolveURI(request, false);
             } else {
                 URI redirectedURI = parentRequest.getUri().resolve(requestURI).normalize();
-                UriBuilder uriBuilder = UriBuilder.of(redirectedURI)
-                        .scheme(redirectedURI.getScheme())
-                        .userInfo(redirectedURI.getUserInfo())
-                        .host(redirectedURI.getHost())
-                        .port(redirectedURI.getPort());
-                return ExecutionFlow.just(uriBuilder.build());
+                return ExecutionFlow.just(redirectedURI);
             }
         }
     }

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientRedirectSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientRedirectSpec.groovy
@@ -1,6 +1,5 @@
 package io.micronaut.http.client
 
-import groovy.test.NotYetImplemented
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Nullable
@@ -50,7 +49,6 @@ class ClientRedirectSpec extends Specification {
         response.body() == "It works!"
     }
 
-    @NotYetImplemented
     void "test - client: full uri, redirect: relative"() {
         when:
         HttpResponse<String> response = client.toBlocking().exchange('/test/redirect-relative', String)

--- a/http-client/src/test/groovy/io/micronaut/http/client/RelativeRedirectSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/RelativeRedirectSpec.groovy
@@ -1,0 +1,144 @@
+package io.micronaut.http.client
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+@Property(name = "spec.name", value = "RelativeRedirectSpec")
+class RelativeRedirectSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient
+
+    void "redirect with relative path './target' is resolved correctly"() {
+        when:
+        String result = httpClient.toBlocking().retrieve("/redirect/relative-dot")
+
+        then:
+        result == "OK from /redirect/target"
+    }
+
+    void "redirect with relative path '../result' is resolved correctly"() {
+        when:
+        String result = httpClient.toBlocking().retrieve("/a/b/redirect-up")
+
+        then:
+        result == "OK from /a/result"
+    }
+
+    void "redirect with root-relative path '/other' is resolved correctly"() {
+        when:
+        String result = httpClient.toBlocking().retrieve("/redirect/to-root-relative")
+
+        then:
+        result == "OK from /other"
+    }
+
+    void "redirect with absolute Location URL still works"() {
+        when:
+        String result = httpClient.toBlocking().retrieve("/redirect/to-absolute")
+
+        then:
+        result == "OK from /target/absolute"
+    }
+
+    void "multi-hop redirect (relative then root-relative) works"() {
+        when:
+        String result = httpClient.toBlocking().retrieve("/redirect/chain")
+
+        then:
+        result == "OK from /target/final"
+    }
+
+    @Controller
+    @Requires(property = "spec.name", value = "RelativeRedirectSpec")
+    static class RedirectController {
+
+        /** Redirects to ./target (same-directory relative) */
+        @Get("/redirect/relative-dot")
+        HttpResponse<?> redirectRelativeDot() {
+            HttpResponse.temporaryRedirect(URI.create("./target"))
+        }
+
+        /** Target endpoint of the ./target redirect */
+        @Get("/redirect/target")
+        @Produces(MediaType.TEXT_PLAIN)
+        String redirectTarget() {
+            "OK from /redirect/target"
+        }
+
+        /** Redirects to ../result (parent-directory relative) */
+        @Get("/a/b/redirect-up")
+        HttpResponse<?> redirectUp() {
+            HttpResponse.temporaryRedirect(URI.create("../result"))
+        }
+
+        /** Target endpoint of ../result redirect */
+        @Get("/a/result")
+        @Produces(MediaType.TEXT_PLAIN)
+        String aResult() {
+            "OK from /a/result"
+        }
+
+        /** Redirects to /other (root-relative path) */
+        @Get("/redirect/to-root-relative")
+        HttpResponse<?> redirectRootRelative() {
+            HttpResponse.temporaryRedirect(URI.create("/other"))
+        }
+
+        @Get("/other")
+        @Produces(MediaType.TEXT_PLAIN)
+        String other() {
+            "OK from /other"
+        }
+
+        /**
+         * Redirects to an absolute URL.
+         * Reconstructs the full URL from the incoming request so the
+         * embedded test server can handle the redirect internally.
+         */
+        @Get("/redirect/to-absolute")
+        HttpResponse<?> redirectToAbsolute(HttpRequest<?> request) {
+            URI target = UriBuilder.of(request.getUri())
+                    .replacePath("/target/absolute")
+                    .build()
+            HttpResponse.temporaryRedirect(target)
+        }
+
+        @Get("/target/absolute")
+        @Produces(MediaType.TEXT_PLAIN)
+        String targetAbsolute() {
+            "OK from /target/absolute"
+        }
+
+        /** Hop 1: redirects to ./step2 (relative) */
+        @Get("/redirect/chain")
+        HttpResponse<?> redirectChain() {
+            HttpResponse.temporaryRedirect(URI.create("./step2"))
+        }
+
+        /** Hop 2: redirects to /target/final (root-relative) */
+        @Get("/redirect/step2")
+        HttpResponse<?> redirectStep2() {
+            HttpResponse.temporaryRedirect(URI.create("/target/final"))
+        }
+
+        @Get("/target/final")
+        @Produces(MediaType.TEXT_PLAIN)
+        String targetFinal() {
+            "OK from /target/final"
+        }
+    }
+}


### PR DESCRIPTION
Problem
When DefaultHttpClient receives a redirect response (301/302/307/308) with a relative Location header, it should resolve it against the original request URI per [RFC 7231 §7.1.2](https://tools.ietf.org/html/rfc7231#section-7.1.2):

The field value consists of a single URI-reference. When it has the form of a relative reference, the final value is computed by resolving it against the effective request URI.

Root Cause
In DefaultHttpClient.java, the method that processes the redirect Location header calls URI.create(location) directly — which for a relative URI like ./target creates a URI with no scheme/host. When this is then used to construct the next request, the path ./target is sent as-is without normalization.
The fix from 2.x (#4757) was lost during the large Netty HTTP client refactoring that happened between 2.x and 4.x.

java.net.URI.resolve() implements RFC 3986 §5.2 reference resolution exactly, so all edge cases are handled.

Tests
Added RelativeRedirectSpec.groovy in:
http-client/src/test/groovy/io/micronaut/http/client/RelativeRedirectSpec.groovy
Covers:

./target — same-directory relative redirect
../sibling — parent-directory relative redirect
/root-relative — root-relative redirect (was already working, regression guard)
Absolute URL redirect — must still work
Multi-hop chain with mixed relative + absolute redirects