### PR TITLE
Add FunctionInitilizerTest

### DIFF
--- a/function/build.gradle.kts
+++ b/function/build.gradle.kts
@@ -10,4 +10,7 @@ dependencies {
 
     testAnnotationProcessor(projects.micronautInjectJava)
     testImplementation(projects.micronautJacksonDatabind)
+    testImplementation(libs.micronaut.test.junit5) {
+        exclude(group = "io.micronaut")
+    }
 }

--- a/function/src/test/java/io/micronaut/function/executor/FunctionInitializerTest.java
+++ b/function/src/test/java/io/micronaut/function/executor/FunctionInitializerTest.java
@@ -1,0 +1,42 @@
+package io.micronaut.function.executor;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class FunctionInitializerTest {
+
+    @Test
+    void fnInitializerWithProperties() {
+        try (ApplicationContext ctx = ApplicationContext.builder()
+            .properties(Map.of("spec.name" , "FunctionInitializerTest"))
+            .build()) {
+
+            try (FunctionInitializer fn = new FooFunctionInitializer(ctx)) {
+                assertDoesNotThrow(() -> fn.getApplicationContext().getBean(Foo.class));
+                assertDoesNotThrow(() -> fn.getApplicationContext().getBean(Bar.class));
+            }
+        }
+    }
+
+    static class FooFunctionInitializer extends FunctionInitializer {
+        public FooFunctionInitializer(ApplicationContext ctx) {
+            super(ctx);
+            startThis(applicationContext);
+        }
+    }
+
+    @Singleton
+    static class Foo {
+    }
+
+    @Requires(property = "spec.name" , value = "FunctionInitializerTest")
+    @Singleton
+    static class Bar {
+    }
+}


### PR DESCRIPTION
this test passes in 4.10.x but [it fails in 5.0.x](https://github.com/micronaut-projects/micronaut-core/pull/12397) it tests the behaviour used in Micronaut AWS Lambda support. 