### PR TITLE
don’t cache failures until the context is running

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,3 +1,0 @@
-#
-#Mon Jan 12 10:59:53 CET 2026
-micronaut-build-version=8.0.0-M14

--- a/function/build.gradle.kts
+++ b/function/build.gradle.kts
@@ -10,4 +10,7 @@ dependencies {
 
     testAnnotationProcessor(projects.micronautInjectJava)
     testImplementation(projects.micronautJacksonDatabind)
+    testImplementation(libs.micronaut.test.junit5) {
+        exclude(group = "io.micronaut")
+    }
 }

--- a/function/src/test/java/io/micronaut/function/executor/FunctionInitializerTest.java
+++ b/function/src/test/java/io/micronaut/function/executor/FunctionInitializerTest.java
@@ -1,0 +1,42 @@
+package io.micronaut.function.executor;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class FunctionInitializerTest {
+
+    @Test
+    void fnInitializerWithProperties() {
+        try (ApplicationContext ctx = ApplicationContext.builder()
+            .properties(Map.of("spec.name" , "FunctionInitializerTest"))
+            .build()) {
+
+            try (FunctionInitializer fn = new FooFunctionInitializer(ctx)) {
+                assertDoesNotThrow(() -> fn.getApplicationContext().getBean(Foo.class));
+                assertDoesNotThrow(() -> fn.getApplicationContext().getBean(Bar.class));
+            }
+        }
+    }
+
+    static class FooFunctionInitializer extends FunctionInitializer {
+        public FooFunctionInitializer(ApplicationContext ctx) {
+            super(ctx);
+            startThis(applicationContext);
+        }
+    }
+
+    @Singleton
+    static class Foo {
+    }
+
+    @Requires(property = "spec.name" , value = "FunctionInitializerTest")
+    @Singleton
+    static class Bar {
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
@@ -656,7 +656,13 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
             if (isReferenceEnabled(ref, context, resolutionContext)) {
                 return ref;
             } else {
-                this.reference = null;
+                // Only permanently disable if the context is running.
+                // Before startup, property sources may not yet be processed
+                // into the environment resolver, so condition evaluation
+                // results are unreliable and should not be cached.
+                if (context.isRunning()) {
+                    this.reference = null;
+                }
                 return null;
             }
         }
@@ -686,8 +692,10 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
             }
             BeanDefinitionReference<T> ref = getReferenceIfEnabled(context, resolutionContext);
             if (ref == null) {
-                // shortcut for future calls
-                this.definition = DEFINITION_DISABLED_SENTINEL;
+                if (context.isRunning()) {
+                    // shortcut for future calls
+                    this.definition = DEFINITION_DISABLED_SENTINEL;
+                }
                 return null;
             }
             if (beanType != null && !(beanType.getType().equals(Object.class) || ref.isCandidateBean(beanType))) {


### PR DESCRIPTION
[The Test in this PR passed in MN 4](https://github.com/micronaut-projects/micronaut-core/pull/12396). This regression breaks Micronaut AWS Lambda support and other Serverless Functions.

Fixed with the help of AI

>  Two changes in DefaultBeanDefinitionService.java BeanDefinitionProducer:
> 1. `getReferenceIfEnabled (line 659)`: Only permanently null out `this.reference` when `context.isRunning()`. Before startup, the reference is preserved so conditions can be re-evaluated later.
>  2. `getDefinitionIfEnabled (line 690)`: Only set `this.definition = DEFINITION_DISABLED_SENTINEL` when `context.isRunning()`. Same rationale.
> Why this works: Before start(), the environment hasn't processed property sources into the resolver catalog, so property-based `@Require` conditions fail incorrectly. By not caching these failures permanently, the conditions are re-evaluated after `start()` when properties are available. The performance impact is negligible — the checkEnabledBeans ForkJoinTask and normal bean lookups after startup will still permanently cache results as before.
