### PR TITLE
bugfix(test): fix SslRefreshSpec test by dynamically validating available ciphers

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
@@ -20,6 +20,7 @@ import io.netty.handler.ssl.util.SelfSignedCertificate
 import spock.lang.Shared
 import spock.lang.Specification
 
+import javax.net.ssl.SSLServerSocketFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyStore
@@ -52,6 +53,8 @@ class SslRefreshSpec extends Specification {
             println "Using OpenSSL provider. Supported ciphers: $ciphers"
         } else {
             // JDK will be used
+            def supportedCiphers = SSLServerSocketFactory.default.getSupportedCipherSuites() as List
+            ciphers = requiredCiphers.findAll { supportedCiphers.contains(it) }
             println "Using JDK provider. Supported ciphers: $ciphers"
         }
     }

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
@@ -14,23 +14,23 @@ import io.micronaut.http.server.netty.NettyHttpRequest
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent
 import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.handler.ssl.SslHandler
+import io.netty.handler.ssl.SslProvider
+import io.netty.handler.ssl.OpenSsl
 import io.netty.handler.ssl.util.SelfSignedCertificate
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
-import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Specification
 
+import javax.net.ssl.SSLContext
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyStore
 import java.security.cert.Certificate
 import java.security.cert.X509Certificate
 
-@Ignore
 class SslRefreshSpec extends Specification {
 
-    @Shared List<String> ciphers = ['TLS_RSA_WITH_AES_128_CBC_SHA',
+    // List of required ciphers
+    @Shared List<String> requiredCiphers = ['TLS_RSA_WITH_AES_128_CBC_SHA',
                                     'TLS_RSA_WITH_AES_256_CBC_SHA',
                                     'TLS_RSA_WITH_AES_128_GCM_SHA256',
                                     'TLS_RSA_WITH_AES_256_GCM_SHA384',
@@ -38,6 +38,33 @@ class SslRefreshSpec extends Specification {
                                     'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
                                     'TLS_DHE_DSS_WITH_AES_128_GCM_SHA256',
                                     'TLS_DHE_DSS_WITH_AES_256_GCM_SHA384']
+
+    // Dynamically determine enabled ciphers
+    @Shared List<String> ciphers;
+    def setupSpec() {
+        if (SslProvider.isAlpnSupported(SslProvider.OPENSSL_REFCNT)) {
+            // OpenSSL will be used
+            ciphers = requiredCiphers.findAll { cipher ->
+                OpenSsl.isCipherSuiteAvailable(cipher)
+            }
+            println "Using OpenSSL provider. Supported ciphers: $ciphers"
+        } else {
+            // JDK will be used
+            def context = SSLContext.getInstance("TLS")
+            context.init(null, null, null)
+            def engine = context.createSSLEngine()
+            ciphers = requiredCiphers.findAll { cipher ->
+                try {
+                    engine.setEnabledCipherSuites([cipher] as String[])
+                    true
+                } catch (IllegalArgumentException ignored) {
+                    false
+                }
+            }
+            println "Using JDK provider. Supported ciphers: $ciphers"
+        }
+    }
+
     @Shared Path keyStorePath
     @Shared Path trustStorePath
     @Shared Map<String, Object> config = [
@@ -56,6 +83,12 @@ class SslRefreshSpec extends Specification {
     ]
 
     private void makeClientCert(SelfSignedCertificate certificate) {
+        // Skip test if no ciphers are supported
+        if (!ciphers || ciphers.isEmpty()) {
+            println "No required ciphers are supported by JVM. Skipping test."
+            return
+        }
+
         keyStorePath = Files.createTempFile("micronaut-test-key-store", "pkcs12")
         trustStorePath = Files.createTempFile("micronaut-test-trust-store", "pkcs12")
 
@@ -84,6 +117,17 @@ class SslRefreshSpec extends Specification {
     }
 
     void "test server ssl refresh"() {
+        // Skip test if no ciphers are supported
+        if (!ciphers || ciphers.isEmpty()) {
+            println "No required ciphers are supported by JVM. Skipping test."
+            return
+        }
+
+        if (ciphers.size() <= 1) {
+            println "Not enough ciphers to simulate a change. Skipping test."
+            return
+        }
+
         given:
         makeClientCert(new SelfSignedCertificate("client1"))
         config.put('micronaut.server.ssl.ciphers', ciphers)
@@ -107,7 +151,7 @@ class SslRefreshSpec extends Specification {
         config.putAll('micronaut.server.ssl.key-store.path': 'classpath:keystore.p12',
                         'micronaut.server.ssl.key-store.password': 'foobar',
                         'micronaut.server.ssl.key-store.type': 'PKCS12',
-                        'micronaut.server.ssl.ciphers': ciphers[0..4])
+                        'micronaut.server.ssl.ciphers': ciphers[0..-2])
         def diff = embeddedServer.applicationContext.environment.refreshAndDiff()
         embeddedServer.applicationContext
                 .getBean(Argument.of(ApplicationEventPublisher, RefreshEvent))
@@ -116,7 +160,7 @@ class SslRefreshSpec extends Specification {
 
         then:
         response.status() == HttpStatus.OK
-        response.body().ciphers == ciphers[0..4]
+        response.body().ciphers == ciphers[0..-2]
         response.body().subjectDN == 'CN=example.local, OU=IT Department, O=Global Security, L=London, ST=London, C=GB'
 
         cleanup:
@@ -127,6 +171,12 @@ class SslRefreshSpec extends Specification {
     }
 
     void "test client ssl refresh"() {
+        // Skip test if no ciphers are supported
+        if (!ciphers || ciphers.isEmpty()) {
+            println "No required ciphers are supported by JVM. Skipping test."
+            return
+        }
+
         given:
         makeClientCert(new SelfSignedCertificate("client1"))
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
@@ -20,7 +20,6 @@ import io.netty.handler.ssl.util.SelfSignedCertificate
 import spock.lang.Shared
 import spock.lang.Specification
 
-import javax.net.ssl.SSLContext
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyStore
@@ -30,7 +29,8 @@ import java.security.cert.X509Certificate
 class SslRefreshSpec extends Specification {
 
     // List of required ciphers
-    @Shared List<String> requiredCiphers = ['TLS_RSA_WITH_AES_128_CBC_SHA',
+    @Shared
+    List<String> requiredCiphers = ['TLS_RSA_WITH_AES_128_CBC_SHA',
                                     'TLS_RSA_WITH_AES_256_CBC_SHA',
                                     'TLS_RSA_WITH_AES_128_GCM_SHA256',
                                     'TLS_RSA_WITH_AES_256_GCM_SHA384',
@@ -40,7 +40,9 @@ class SslRefreshSpec extends Specification {
                                     'TLS_DHE_DSS_WITH_AES_256_GCM_SHA384']
 
     // Dynamically determine enabled ciphers
-    @Shared List<String> ciphers;
+    @Shared
+    List<String> ciphers
+
     def setupSpec() {
         if (SslProvider.isAlpnSupported(SslProvider.OPENSSL_REFCNT)) {
             // OpenSSL will be used
@@ -50,36 +52,28 @@ class SslRefreshSpec extends Specification {
             println "Using OpenSSL provider. Supported ciphers: $ciphers"
         } else {
             // JDK will be used
-            def context = SSLContext.getInstance("TLS")
-            context.init(null, null, null)
-            def engine = context.createSSLEngine()
-            ciphers = requiredCiphers.findAll { cipher ->
-                try {
-                    engine.setEnabledCipherSuites([cipher] as String[])
-                    true
-                } catch (IllegalArgumentException ignored) {
-                    false
-                }
-            }
             println "Using JDK provider. Supported ciphers: $ciphers"
         }
     }
 
-    @Shared Path keyStorePath
-    @Shared Path trustStorePath
-    @Shared Map<String, Object> config = [
-            'spec.name': 'SslRefreshSpec',
-            'micronaut.ssl.enabled': true,
-            'micronaut.server.ssl.port':-1,
-            'micronaut.server.ssl.client-authentication': 'NEED',
-            'micronaut.server.ssl.key-store.path': 'classpath:certs/server.p12',
-            'micronaut.server.ssl.key-store.password': 'secret',
-            'micronaut.server.ssl.ciphers': ciphers,
-            'micronaut.http.client.ssl.client-authentication': 'NEED',
+    @Shared
+    Path keyStorePath
+    @Shared
+    Path trustStorePath
+    @Shared
+    Map<String, Object> config = [
+            'spec.name'                                                : 'SslRefreshSpec',
+            'micronaut.ssl.enabled'                                    : true,
+            'micronaut.server.ssl.port'                                : -1,
+            'micronaut.server.ssl.client-authentication'               : 'NEED',
+            'micronaut.server.ssl.key-store.path'                      : 'classpath:certs/server.p12',
+            'micronaut.server.ssl.key-store.password'                  : 'secret',
+            'micronaut.server.ssl.ciphers'                             : ciphers,
+            'micronaut.http.client.ssl.client-authentication'          : 'NEED',
             'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
-            'micronaut.http.client.pool.enabled': false,
+            'micronaut.http.client.pool.enabled'                       : false,
             // need to force http1 because our ciphers are not supported by http2
-            'micronaut.http.client.http-version': '1.1',
+            'micronaut.http.client.http-version'                       : '1.1',
     ]
 
     private void makeClientCert(SelfSignedCertificate certificate) {
@@ -107,11 +101,11 @@ class SslRefreshSpec extends Specification {
         }
 
         config.putAll([
-                'micronaut.server.ssl.trust-store.path': 'file://' + trustStorePath.toString(),
-                'micronaut.server.ssl.trust-store.type': 'JKS',
-                'micronaut.server.ssl.trust-store.password': '123456',
-                'micronaut.http.client.ssl.key-store.path': 'file://' + keyStorePath.toString(),
-                'micronaut.http.client.ssl.key-store.type': 'PKCS12',
+                'micronaut.server.ssl.trust-store.path'       : 'file://' + trustStorePath.toString(),
+                'micronaut.server.ssl.trust-store.type'       : 'JKS',
+                'micronaut.server.ssl.trust-store.password'   : '123456',
+                'micronaut.http.client.ssl.key-store.path'    : 'file://' + keyStorePath.toString(),
+                'micronaut.http.client.ssl.key-store.type'    : 'PKCS12',
                 'micronaut.http.client.ssl.key-store.password': '',
         ])
     }
@@ -149,9 +143,9 @@ class SslRefreshSpec extends Specification {
 
         when:
         config.putAll('micronaut.server.ssl.key-store.path': 'classpath:keystore.p12',
-                        'micronaut.server.ssl.key-store.password': 'foobar',
-                        'micronaut.server.ssl.key-store.type': 'PKCS12',
-                        'micronaut.server.ssl.ciphers': ciphers[0..-2])
+                'micronaut.server.ssl.key-store.password': 'foobar',
+                'micronaut.server.ssl.key-store.type': 'PKCS12',
+                'micronaut.server.ssl.ciphers': ciphers[0..-2])
         def diff = embeddedServer.applicationContext.environment.refreshAndDiff()
         embeddedServer.applicationContext
                 .getBean(Argument.of(ApplicationEventPublisher, RefreshEvent))


### PR DESCRIPTION
This PR addresses test instability related to SSL refresh spec execution across different environments.

Root Cause: 
The test was requesting a predefined list of cipher suites, but on some environments (depending on OS and OpenSSL version), not all of those ciphers are actually available. As a result, the test fails even though the SSL configuration itself is valid.

What This PR Changes: 

- Adds logic to dynamically check whether the requested cipher suites are actually supported by the active SSL provider.
- Filters the requested cipher list against the provider’s available cipher suites.
- Skips the test if the resulting filtered cipher list is empty (i.e., none of the requested ciphers are supported in the current environment).