### PR TITLE
Jackson2 annotation support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ zacsweers-kotlin-compile-testing = "0.12.1"
 errorprone-gradle-plugin = "4.3.0"
 nullaway = "0.12.15"
 error_prone_core = "2.45.0"
+jackson2 = "2.21.1"
 
 #
 # Versions which start with managed- are managed by Micronaut in the sense
@@ -246,6 +247,8 @@ junit4 = { module = "junit:junit", version.ref = "junit4" }
 
 jazzer-junit = { module = "com.code-intelligence:jazzer-junit", version.ref = "jazzer" }
 jazzer-api = { module = "com.code-intelligence:jazzer-api", version.ref = "jazzer" }
+
+jackson2-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson2" }
 
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 

--- a/jackson-databind/build.gradle.kts
+++ b/jackson-databind/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     api(projects.micronautJacksonCore)
 
     compileOnly(libs.graal)
+    compileOnly(libs.jackson2.databind)
     compileOnly(platform(libs.test.boms.micronaut.validation))
     compileOnly(libs.micronaut.validation) {
         exclude(group = "io.micronaut")
@@ -28,6 +29,7 @@ dependencies {
     testImplementation(projects.micronautInjectGroovy)
     testImplementation(libs.managed.jackson.dataformat.xml)
     testImplementation(libs.managed.snakeyaml)
+    testImplementation(libs.jackson2.databind)
     testImplementation(libs.micronaut.test.junit5) {
         exclude(group = "io.micronaut")
     }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/Jackson2AnnotationSupport.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/Jackson2AnnotationSupport.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.jackson;
 
-import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Experimental;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.core.Version;
 import tools.jackson.databind.AnnotationIntrospector;
@@ -39,13 +39,13 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * Support for Jackson 2.x databind annotations.
+ * Support for Jackson 2.x databind annotations. Used by micronaut-oracle-cloud.
  *
  * @since 5.0.0
  * @author Jonas Konrad
  */
-@Internal
-final class Jackson2AnnotationSupport {
+@Experimental
+public final class Jackson2AnnotationSupport {
     private static final boolean JACKSON2_AVAILABLE;
 
     static {
@@ -59,7 +59,12 @@ final class Jackson2AnnotationSupport {
         JACKSON2_AVAILABLE = available;
     }
 
-    static void installJackson2Introspector(MapperBuilder<?, ?> builder) {
+    /**
+     * Adapt an object mapper builder to support some jackson-databind 2.x annotations.
+     *
+     * @param builder The builder
+     */
+    public static void installJackson2Introspector(MapperBuilder<?, ?> builder) {
         if (!JACKSON2_AVAILABLE) {
             return;
         }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/Jackson2AnnotationSupport.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/Jackson2AnnotationSupport.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.core.Version;
+import tools.jackson.databind.AnnotationIntrospector;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.introspect.Annotated;
+import tools.jackson.databind.introspect.AnnotatedClass;
+import tools.jackson.databind.introspect.AnnotationIntrospectorPair;
+import tools.jackson.databind.util.ClassUtil;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Support for Jackson 2.x databind annotations.
+ *
+ * @since 5.0.0
+ * @author Jonas Konrad
+ */
+@Internal
+final class Jackson2AnnotationSupport {
+    private static final boolean JACKSON2_AVAILABLE;
+
+    static {
+        boolean available;
+        try {
+            Class.forName(com.fasterxml.jackson.databind.annotation.JsonDeserialize.class.getName());
+            available = true;
+        } catch (LinkageError | ClassNotFoundException e) {
+            available = false;
+        }
+        JACKSON2_AVAILABLE = available;
+    }
+
+    static void installJackson2Introspector(MapperBuilder<?, ?> builder) {
+        if (!JACKSON2_AVAILABLE) {
+            return;
+        }
+        AnnotationIntrospector prev = builder.annotationIntrospector();
+        builder.annotationIntrospector(new AnnotationIntrospectorPair(
+            prev,
+            new Jackson2CompatibleAnnotationIntrospector(prev)
+        ));
+    }
+
+    private static class Jackson2CompatibleAnnotationIntrospector extends AnnotationIntrospector {
+        final AnnotationIntrospector delegate;
+
+        Jackson2CompatibleAnnotationIntrospector(AnnotationIntrospector delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public JavaType refineSerializationType(MapperConfig<?> config, Annotated a, JavaType baseType) {
+            return delegate.refineSerializationType(config, mapAnnotations(a), baseType);
+        }
+
+        // add nullable annotation
+        @Override
+        @Nullable
+        protected <A extends Annotation> A _findAnnotation(Annotated ann, Class<A> annoClass) {
+            return super._findAnnotation(ann, annoClass);
+        }
+
+        @Override
+        @Nullable
+        public Class<?> findPOJOBuilder(MapperConfig<?> config, AnnotatedClass ac) {
+            com.fasterxml.jackson.databind.annotation.JsonDeserialize ann = _findAnnotation(ac, com.fasterxml.jackson.databind.annotation.JsonDeserialize.class);
+            return (ann == null) ? null : classIfExplicit(ann.builder());
+        }
+
+        @Override
+        public JsonPOJOBuilder.@Nullable Value findPOJOBuilderConfig(MapperConfig<?> config, AnnotatedClass ac) {
+            com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder ann = _findAnnotation(ac, com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder.class);
+            return (ann == null) ? null : new JsonPOJOBuilder.Value((JsonPOJOBuilder) map(com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder.class, JsonPOJOBuilder.class, ann));
+        }
+
+        @Nullable
+        private Class<?> classIfExplicit(@Nullable Class<?> cls) {
+            if (cls == null || ClassUtil.isBogusClass(cls)) {
+                return null;
+            }
+            return cls;
+        }
+
+        @Override
+        public JsonSerialize.Typing findSerializationTyping(MapperConfig<?> config, Annotated a) {
+            return delegate.findSerializationTyping(config, mapAnnotations(a));
+        }
+
+        @Override
+        public JavaType refineDeserializationType(MapperConfig<?> config, Annotated a, JavaType baseType) {
+            return delegate.refineDeserializationType(config, mapAnnotations(a), baseType);
+        }
+
+        @Override
+        public Version version() {
+            return Version.unknownVersion();
+        }
+
+        private Annotated mapAnnotations(Annotated ann) {
+            ann = mapIfPresent(ann, com.fasterxml.jackson.databind.annotation.JsonDeserialize.class, tools.jackson.databind.annotation.JsonDeserialize.class);
+            ann = mapIfPresent(ann, com.fasterxml.jackson.databind.annotation.JsonSerialize.class, tools.jackson.databind.annotation.JsonSerialize.class);
+            ann = mapIfPresent(ann, com.fasterxml.jackson.databind.annotation.JsonAppend.class, tools.jackson.databind.annotation.JsonAppend.class);
+            ann = mapIfPresent(ann, com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder.class, tools.jackson.databind.annotation.JsonPOJOBuilder.class);
+            return ann;
+        }
+
+        private static <F extends Annotation, T extends Annotation> Annotated mapIfPresent(Annotated original, Class<F> from, Class<T> to) {
+            F ann = original.<@Nullable F>getAnnotation(from);
+            if (ann == null) {
+                return original;
+            }
+            T mapped = to.cast(map(from, to, ann));
+            return new AmendedAnnotated<>(original, to, mapped);
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Object map(Class<? extends Annotation> from, Class<? extends Annotation> to, Object annotation) {
+            return Proxy.newProxyInstance(Jackson2AnnotationSupport.class.getClassLoader(), new Class[]{to}, (proxy, method, args) -> {
+                Method fromMethod = from.getMethod(method.getName());
+                Object fromValue = fromMethod.invoke(annotation);
+                if (Objects.equals(fromMethod.getDefaultValue(), fromValue)) {
+                    return method.getDefaultValue();
+                }
+                Class<?> fromMemberType = fromMethod.getReturnType();
+                Class<?> toMemberType = method.getReturnType();
+                if (fromMemberType == toMemberType) {
+                    return fromValue;
+                } else if (fromMemberType.isEnum() && toMemberType.isEnum()) {
+                    return ((Optional<Object>) Stream.of(toMemberType.getEnumConstants())
+                        .filter(c -> ((Enum<?>) c).name().equals(((Enum<?>) fromValue).name()))
+                        .findAny()).orElse(method.getDefaultValue());
+                } else if (fromMemberType.isAnnotation() && toMemberType.isAnnotation()) {
+                    return map(fromMemberType.asSubclass(Annotation.class), toMemberType.asSubclass(Annotation.class), fromValue);
+                }
+                return method.getDefaultValue();
+            });
+        }
+    }
+
+    private static final class AmendedAnnotated<A extends Annotation> extends DelegateAnnotated {
+        private final Class<A> type;
+        private final A annotation;
+
+        private AmendedAnnotated(Annotated delegate, Class<A> type, A annotation) {
+            super(delegate);
+            this.type = type;
+            this.annotation = annotation;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <B extends Annotation> B getAnnotation(Class<B> acls) {
+            if (acls == this.type) {
+                return (B) annotation;
+            }
+            return super.getAnnotation(acls);
+        }
+
+        @Override
+        public Stream<Annotation> annotations() {
+            return Stream.concat(super.annotations().filter(a -> !type.isInstance(a)), Stream.of(annotation));
+        }
+
+        @Override
+        public boolean hasAnnotation(Class<? extends Annotation> acls) {
+            return super.hasAnnotation(acls) || acls == type;
+        }
+
+        @Override
+        public boolean hasOneOf(Class<? extends Annotation>[] annoClasses) {
+            return super.hasOneOf(annoClasses) || Arrays.asList(annoClasses).contains(type);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int hashCode() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String toString() {
+            return "Amended[" + delegate + " + " + annotation + "]";
+        }
+    }
+
+    private abstract static class DelegateAnnotated extends Annotated {
+        final Annotated delegate;
+
+        private DelegateAnnotated(Annotated delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public <A extends Annotation> A getAnnotation(Class<A> acls) {
+            return delegate.getAnnotation(acls);
+        }
+
+        @Override
+        public Stream<Annotation> annotations() {
+            return delegate.annotations();
+        }
+
+        @Override
+        public boolean hasAnnotation(Class<? extends Annotation> acls) {
+            return delegate.hasAnnotation(acls);
+        }
+
+        @Override
+        public boolean hasOneOf(Class<? extends Annotation>[] annoClasses) {
+            return delegate.hasOneOf(annoClasses);
+        }
+
+        @Override
+        public AnnotatedElement getAnnotated() {
+            return delegate.getAnnotated();
+        }
+
+        @Override
+        protected int getModifiers() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isPublic() {
+            return delegate.isPublic();
+        }
+
+        @Override
+        public boolean isStatic() {
+            return delegate.isStatic();
+        }
+
+        @Override
+        public String getName() {
+            return delegate.getName();
+        }
+
+        @Override
+        public JavaType getType() {
+            return delegate.getType();
+        }
+
+        @Override
+        public Class<?> getRawType() {
+            return delegate.getRawType();
+        }
+    }
+}

--- a/jackson-databind/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
@@ -101,6 +101,7 @@ public class JacksonConfiguration implements JsonConfiguration {
     private PropertyNamingStrategy propertyNamingStrategy = null;
     private boolean alwaysSerializeErrorsAsList = true;
     private boolean trimStrings = false;
+    private boolean jackson2DatabindAnnotationSupport = true;
 
     /**
      * Whether Jackson modules should be scanned for.
@@ -483,6 +484,28 @@ public class JacksonConfiguration implements JsonConfiguration {
      */
     public void setTrimStrings(boolean trimStrings) {
         this.trimStrings = trimStrings;
+    }
+
+    /**
+     * Enable support for some jackson-databind 2.x annotations (in the
+     * com.fasterxml.jackson.databind.annotation package). Only works if the annotations are on the
+     * classpath at runtime.
+     *
+     * @return Whether to enable jackson-databind 2.x annotation support
+     */
+    public boolean isJackson2DatabindAnnotationSupport() {
+        return jackson2DatabindAnnotationSupport;
+    }
+
+    /**
+     * Enable support for some jackson-databind 2.x annotations (in the
+     * com.fasterxml.jackson.databind.annotation package). Only works if the annotations are on the
+     * classpath at runtime.
+     *
+     * @param jackson2DatabindAnnotationSupport Whether to enable jackson-databind 2.x annotation support
+     */
+    public void setJackson2DatabindAnnotationSupport(boolean jackson2DatabindAnnotationSupport) {
+        this.jackson2DatabindAnnotationSupport = jackson2DatabindAnnotationSupport;
     }
 
     /**

--- a/jackson-databind/src/main/java/io/micronaut/jackson/JacksonDatabindFeature.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/JacksonDatabindFeature.java
@@ -15,10 +15,15 @@
  */
 package io.micronaut.jackson;
 
-import tools.jackson.databind.PropertyNamingStrategies;
 import io.micronaut.core.annotation.Internal;
 import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeProxyCreation;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonAppend;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 import java.util.stream.Stream;
 
@@ -42,5 +47,23 @@ final class JacksonDatabindFeature implements Feature {
             PropertyNamingStrategies.KebabCaseStrategy.class,
             PropertyNamingStrategies.LowerDotCaseStrategy.class
         ).forEach(RuntimeReflection::registerForReflectiveInstantiation);
+
+        try {
+            RuntimeReflection.register(com.fasterxml.jackson.databind.annotation.JsonDeserialize.class);
+            RuntimeReflection.register(com.fasterxml.jackson.databind.annotation.JsonSerialize.class);
+            RuntimeReflection.register(com.fasterxml.jackson.databind.annotation.JsonSerialize.Typing.class);
+            RuntimeReflection.register(com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.class);
+            RuntimeReflection.register(com.fasterxml.jackson.databind.annotation.JsonAppend.class);
+            RuntimeReflection.register(com.fasterxml.jackson.databind.annotation.JsonAppend.Attr.class);
+            RuntimeReflection.register(com.fasterxml.jackson.databind.annotation.JsonAppend.Prop.class);
+            RuntimeReflection.register(com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder.class);
+            RuntimeProxyCreation.register(JsonDeserialize.class);
+            RuntimeProxyCreation.register(JsonSerialize.class);
+            RuntimeProxyCreation.register(JsonAppend.class);
+            RuntimeProxyCreation.register(JsonAppend.Attr.class);
+            RuntimeProxyCreation.register(JsonAppend.Prop.class);
+            RuntimeProxyCreation.register(JsonPOJOBuilder.class);
+        } catch (LinkageError ignored) {
+        }
     }
 }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
@@ -272,6 +272,10 @@ public class ObjectMapperFactory {
             jacksonConfiguration.getSerializationFeatures().forEach(builder::configure);
         }
 
+        if (jacksonConfiguration == null || jacksonConfiguration.isJackson2DatabindAnnotationSupport()) {
+            Jackson2AnnotationSupport.installJackson2Introspector(builder);
+        }
+
         return builder;
     }
 }

--- a/jackson-databind/src/test/java/io/micronaut/jackson/databind/Jackson2AnnotationTest.java
+++ b/jackson-databind/src/test/java/io/micronaut/jackson/databind/Jackson2AnnotationTest.java
@@ -1,0 +1,46 @@
+package io.micronaut.jackson.databind;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.json.JsonMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Jackson2AnnotationTest {
+
+    @Test
+    public void test() throws IOException {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            JsonMapper mapper = ctx.getBean(JsonMapper.class);
+            assertEquals("fizz", Objects.requireNonNull(mapper.readValue("{\"bar\":\"fizz\"}", MyClass.class)).foo);
+        }
+    }
+
+    @JsonDeserialize(builder = MyClass.Builder.class)
+    static final class MyClass {
+        final String foo;
+
+        private MyClass(String foo) {
+            this.foo = foo;
+        }
+
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            String foo;
+
+            public Builder bar(String bar) {
+                this.foo = bar;
+                return this;
+            }
+
+            public MyClass build() {
+                return new MyClass(foo);
+            }
+        }
+    }
+}


### PR DESCRIPTION
oci-java-sdk modules still use jackson 2 databind annotations. This change translates those annotations to their jackson 3 equivalents in micronaut-jackson-databind.