### PR TITLE
feat(jpms): add Java Module System support to Micronaut

### DIFF
--- a/aop/src/main/java/module-info.java
+++ b/aop/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.aop {
     requires transitive io.micronaut.inject;

--- a/aop/src/main/java/module-info.java
+++ b/aop/src/main/java/module-info.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.aop {
+    requires transitive io.micronaut.inject;
+    requires transitive io.micronaut.core;
+
+    requires static io.micronaut.core.reactive;
+    requires static org.reactivestreams;
+    requires static reactor.core;
+
+    requires static kotlin.stdlib;
+
+    exports io.micronaut.aop;
+    exports io.micronaut.aop.chain;
+    exports io.micronaut.aop.exceptions;
+    exports io.micronaut.aop.internal;
+    exports io.micronaut.aop.internal.intercepted;
+    exports io.micronaut.aop.kotlin;
+    exports io.micronaut.aop.runtime;
+    exports io.micronaut.aop.util;
+}

--- a/buffer-netty/src/main/java/module-info.java
+++ b/buffer-netty/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.buffer.netty {
+    requires transitive io.micronaut.core;
+    requires transitive io.micronaut.inject;
+
+    requires transitive io.netty.buffer;
+
+    requires static org.graalvm.nativeimage;
+
+    exports io.micronaut.buffer.netty;
+}

--- a/buffer-netty/src/main/java/module-info.java
+++ b/buffer-netty/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.buffer.netty {
     requires transitive io.micronaut.core;

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -46,6 +46,106 @@ tasks.withType(JavaCompile).configureEach {
     options.forkOptions.memoryMaximumSize = "2g"
 }
 
+def moduleInfoJava = file("src/main/java/module-info.java")
+
+if (moduleInfoJava.exists()) {
+    pluginManager.withPlugin("java") {
+        def sourceSets = extensions.findByType(org.gradle.api.tasks.SourceSetContainer)
+        if (sourceSets != null) {
+            sourceSets.named("main") {
+                java {
+                    exclude("module-info.java")
+                }
+            }
+            tasks.named("compileJava", JavaCompile).configure {
+                exclude("module-info.java")
+                modularity.inferModulePath = false
+            }
+            def moduleName = providers.provider {
+                def matcher = (moduleInfoJava.text =~ /\bmodule\s+([\w.]+)\s*\{/
+                )
+                if (!matcher.find()) {
+                    throw new GradleException("Unable to determine module name from ${moduleInfoJava}")
+                }
+                matcher.group(1)
+            }
+            def limitModules = providers.provider {
+                def requiresMatcher = (moduleInfoJava.text =~ /\brequires\s+(?:transitive\s+|static\s+)?([\w.]+)\s*;/)
+                def modules = new LinkedHashSet<String>()
+                modules.add(moduleName.get())
+                while (requiresMatcher.find()) {
+                    modules.add(requiresMatcher.group(1))
+                }
+                modules.join(',')
+            }
+            def modulePath = providers.provider {
+                // JPMS doesn't allow split packages on the module-path. Some optional Micronaut
+                // RxJava modules ship overlapping packages (e.g. io.micronaut.rxjava3.info).
+                // Those are not part of the core module graph we compile module-info against.
+                configurations.compileClasspath.files
+                    .findAll { f ->
+                        // Exclude modules known to cause JPMS split packages or duplicate packages
+                        // while compiling module-info.java. These are not part of the module graph
+                        // we validate at descriptor compile time.
+                        !(
+                            f.name.startsWith('micronaut-rxjava2') ||
+                            f.name.startsWith('micronaut-rxjava3') ||
+                            f.name.startsWith('micronaut-core-processor') ||
+                            f.name.contains('sourcegen-model') ||
+                            f.name.contains('sourcegen-bytecode-writer')
+                        )
+                    }
+                    .collect { it.absolutePath }
+                    .join(File.pathSeparator)
+            }
+            def addModules = providers.provider {
+                // Automatic modules are not always resolved via --limit-modules alone.
+                // Explicitly add what we require to make module resolution deterministic.
+                def requiresMatcher = (moduleInfoJava.text =~ /\brequires\s+(?:transitive\s+|static\s+)?([\w.]+)\s*;/)
+                def modules = new LinkedHashSet<String>()
+                while (requiresMatcher.find()) {
+                    modules.add(requiresMatcher.group(1))
+                }
+                modules.isEmpty() ? null : modules.join(',')
+            }
+            def mainClassesDirs = providers.provider {
+                sourceSets.named("main").get().output.classesDirs.asPath
+            }
+            def compileModuleInfo = tasks.register("compileModuleInfoJava", JavaCompile) {
+                dependsOn(tasks.named("classes"))
+                source(moduleInfoJava)
+                destinationDirectory.set(layout.buildDirectory.dir("classes/java/module-info"))
+                classpath = files()
+                doFirst {
+                    def javaDest = tasks.named("compileJava", JavaCompile).get().destinationDirectory.get().asFile
+                    delete(new File(javaDest, "module-info.class"))
+                }
+                options.compilerArgumentProviders.add(new CommandLineArgumentProvider() {
+                    @Override
+                    Iterable<String> asArguments() {
+                        def args = [
+                            "--module-path", modulePath.get(),
+                            "--limit-modules", limitModules.get(),
+                            "--patch-module", "${moduleName.get()}=${mainClassesDirs.get()}"
+                        ]
+                        def additional = addModules.get()
+                        if (additional) {
+                            args.addAll(["--add-modules", additional])
+                        }
+                        return args
+                    }
+                })
+            }
+            tasks.named("jar", Jar).configure {
+                dependsOn(compileModuleInfo)
+                from(compileModuleInfo.map { it.destinationDirectory }) {
+                    include("module-info.class")
+                }
+            }
+        }
+    }
+}
+
 tasks.withType(GroovyCompile).configureEach {
     options.fork = true
     options.compilerArgs.add("-Amicronaut.processing.group=$project.group")
@@ -119,4 +219,3 @@ spotless {
         targetExclude '**/io/micronaut/http/netty/stream/package-info.java'
     }
 }
-

--- a/context-propagation/src/main/java/module-info.java
+++ b/context-propagation/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.context.propagation {
     requires transitive io.micronaut.context;

--- a/context-propagation/src/main/java/module-info.java
+++ b/context-propagation/src/main/java/module-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.context.propagation {
+    requires transitive io.micronaut.context;
+    requires transitive io.micronaut.inject;
+    requires transitive io.micronaut.aop;
+
+    requires static io.micronaut.core.reactive;
+    requires static reactor.core;
+
+    requires static kotlin.stdlib;
+    requires static kotlinx.coroutines.core;
+
+    exports io.micronaut.context.propagation.instrument.execution;
+}

--- a/context/src/main/java/module-info.java
+++ b/context/src/main/java/module-info.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.context {
+    requires transitive io.micronaut.aop;
+    requires transitive io.micronaut.inject;
+
+    requires static ch.qos.logback.classic;
+    requires static ch.qos.logback.core;
+    requires static org.apache.logging.log4j;
+    requires static org.apache.logging.log4j.core;
+
+    requires static jakarta.validation;
+
+    exports io.micronaut.context.time;
+    exports io.micronaut.logging;
+    exports io.micronaut.logging.impl;
+    exports io.micronaut.runtime;
+    exports io.micronaut.runtime.beans;
+    exports io.micronaut.runtime.context;
+    exports io.micronaut.runtime.context.env;
+    exports io.micronaut.runtime.context.scope;
+    exports io.micronaut.runtime.context.scope.refresh;
+    exports io.micronaut.runtime.converters.time;
+    exports io.micronaut.runtime.event;
+    exports io.micronaut.runtime.event.annotation;
+    exports io.micronaut.runtime.exceptions;
+    exports io.micronaut.runtime.graceful;
+    exports io.micronaut.runtime.server;
+    exports io.micronaut.runtime.server.event;
+    exports io.micronaut.runtime.server.watch.event;
+    exports io.micronaut.scheduling;
+    exports io.micronaut.scheduling.annotation;
+    exports io.micronaut.scheduling.async;
+    exports io.micronaut.scheduling.cron;
+    exports io.micronaut.scheduling.exceptions;
+    exports io.micronaut.scheduling.executor;
+    exports io.micronaut.scheduling.instrument;
+    exports io.micronaut.scheduling.io.watch;
+    exports io.micronaut.scheduling.io.watch.event;
+    exports io.micronaut.scheduling.processor;
+}

--- a/context/src/main/java/module-info.java
+++ b/context/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.context {
     requires transitive io.micronaut.aop;

--- a/core-reactive/src/main/java/module-info.java
+++ b/core-reactive/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.core.reactive {
     requires transitive io.micronaut.core;

--- a/core-reactive/src/main/java/module-info.java
+++ b/core-reactive/src/main/java/module-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.core.reactive {
+    requires transitive io.micronaut.core;
+    requires transitive org.reactivestreams;
+
+    requires static reactor.core;
+    requires static kotlinx.coroutines.core;
+
+    exports io.micronaut.core.async;
+    exports io.micronaut.core.async.annotation;
+    exports io.micronaut.core.async.converters;
+    exports io.micronaut.core.async.processor;
+    exports io.micronaut.core.async.propagation;
+    exports io.micronaut.core.async.publisher;
+    exports io.micronaut.core.async.subscriber;
+
+    provides io.micronaut.core.convert.TypeConverterRegistrar with
+        io.micronaut.core.async.converters.ReactiveTypeConverterRegistrar;
+    provides io.micronaut.core.type.TypeInformationProvider with
+        io.micronaut.core.async.ReactiveStreamsTypeInformationProvider;
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.core {
+    uses io.micronaut.core.optim.StaticOptimizations.Loader;
+
+    requires transitive org.slf4j;
+    requires transitive org.jspecify;
+
+    requires static jakarta.annotation;
+    requires static org.graalvm.nativeimage;
+    requires static io.netty.common;
+    requires static kotlin.stdlib;
+    requires static org.jetbrains.annotations;
+
+    exports io.micronaut.core.annotation;
+    exports io.micronaut.core.attr;
+    exports io.micronaut.core.beans;
+    exports io.micronaut.core.beans.exceptions;
+    exports io.micronaut.core.bind;
+    exports io.micronaut.core.bind.annotation;
+    exports io.micronaut.core.bind.exceptions;
+    exports io.micronaut.core.cli;
+    exports io.micronaut.core.cli.exceptions;
+    exports io.micronaut.core.convert;
+    exports io.micronaut.core.convert.converters;
+    exports io.micronaut.core.convert.exceptions;
+    exports io.micronaut.core.convert.format;
+    exports io.micronaut.core.convert.value;
+    exports io.micronaut.core.exceptions;
+    exports io.micronaut.core.execution;
+    exports io.micronaut.core.expressions;
+    exports io.micronaut.core.graal;
+    exports io.micronaut.core.io;
+    exports io.micronaut.core.io.buffer;
+    exports io.micronaut.core.io.file;
+    exports io.micronaut.core.io.scan;
+    exports io.micronaut.core.io.service;
+    exports io.micronaut.core.io.socket;
+    exports io.micronaut.core.io.value;
+    exports io.micronaut.core.naming;
+    exports io.micronaut.core.naming.conventions;
+    exports io.micronaut.core.optim;
+    exports io.micronaut.core.order;
+    exports io.micronaut.core.propagation;
+    exports io.micronaut.core.reflect;
+    exports io.micronaut.core.reflect.exception;
+    exports io.micronaut.core.serialize;
+    exports io.micronaut.core.serialize.exceptions;
+    exports io.micronaut.core.type;
+    exports io.micronaut.core.util;
+    exports io.micronaut.core.util.clhm;
+    exports io.micronaut.core.util.functional;
+    exports io.micronaut.core.util.locale;
+    exports io.micronaut.core.value;
+    exports io.micronaut.core.version;
+    exports io.micronaut.core.version.annotation;
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.core {
     uses io.micronaut.core.optim.StaticOptimizations.Loader;

--- a/discovery-core/src/main/java/module-info.java
+++ b/discovery-core/src/main/java/module-info.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.discovery {
+    requires transitive io.micronaut.context;
+
+    requires reactor.core;
+
+    requires static io.micronaut.jackson.databind;
+
+    exports io.micronaut.discovery;
+    exports io.micronaut.discovery.cloud;
+    exports io.micronaut.discovery.cloud.digitalocean;
+    exports io.micronaut.discovery.config;
+    exports io.micronaut.discovery.event;
+    exports io.micronaut.discovery.exceptions;
+    exports io.micronaut.discovery.metadata;
+    exports io.micronaut.discovery.registration;
+    exports io.micronaut.health;
+}

--- a/discovery-core/src/main/java/module-info.java
+++ b/discovery-core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.discovery {
     requires transitive io.micronaut.context;

--- a/function-client/src/main/java/module-info.java
+++ b/function-client/src/main/java/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.function.client {
+    requires transitive io.micronaut.function;
+    requires transitive io.micronaut.http.client;
+}

--- a/function-client/src/main/java/module-info.java
+++ b/function-client/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.function.client {
     requires transitive io.micronaut.function;

--- a/function-web/src/main/java/module-info.java
+++ b/function-web/src/main/java/module-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.function.web {
+    requires transitive io.micronaut.function;
+    requires transitive io.micronaut.router;
+    requires transitive io.micronaut.http.server;
+}

--- a/function-web/src/main/java/module-info.java
+++ b/function-web/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.function.web {
     requires transitive io.micronaut.function;

--- a/function/src/main/java/module-info.java
+++ b/function/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.function {
     requires transitive io.micronaut.inject;

--- a/function/src/main/java/module-info.java
+++ b/function/src/main/java/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.function {
+    requires transitive io.micronaut.inject;
+    requires transitive io.micronaut.http;
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -239,6 +239,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
 junit-platform-engine = { module = "org.junit.platform:junit-platform-suite-engine", version.ref = "junit-platform" }
+junit-platform-console = { module = "org.junit.platform:junit-platform-console", version.ref = "junit-platform" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 junit-vintage = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
 

--- a/http-client-core/src/main/java/module-info.java
+++ b/http-client-core/src/main/java/module-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.http.client {
+    requires transitive io.micronaut.http;
+    requires transitive io.micronaut.json;
+    requires transitive io.micronaut.discovery;
+
+    requires reactor.core;
+
+    requires static kotlin.stdlib;
+
+    exports io.micronaut.http.client;
+    exports io.micronaut.http.client.annotation;
+    exports io.micronaut.http.client.bind;
+    exports io.micronaut.http.client.bind.binders;
+    exports io.micronaut.http.client.exceptions;
+    exports io.micronaut.http.client.filter;
+    exports io.micronaut.http.client.interceptor;
+    exports io.micronaut.http.client.interceptor.configuration;
+    exports io.micronaut.http.client.loadbalance;
+    exports io.micronaut.http.client.multipart;
+    exports io.micronaut.http.client.sse;
+}

--- a/http-client-core/src/main/java/module-info.java
+++ b/http-client-core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.http.client {
     requires transitive io.micronaut.http;

--- a/http-client-jdk/src/main/java/module-info.java
+++ b/http-client-jdk/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
+ */
 module io.micronaut.http.client.jdk {
     requires transitive io.micronaut.http.client;
     requires java.net.http;

--- a/http-client-jdk/src/main/java/module-info.java
+++ b/http-client-jdk/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module io.micronaut.http.client.jdk {
+    requires transitive io.micronaut.http.client;
+    requires java.net.http;
+    requires reactor.core;
+
+    exports io.micronaut.http.client.jdk;
+    exports io.micronaut.http.client.jdk.cookie;
+}

--- a/http-client/src/main/java/module-info.java
+++ b/http-client/src/main/java/module-info.java
@@ -1,0 +1,16 @@
+module io.micronaut.http.client.netty {
+    requires transitive io.micronaut.context;
+    requires transitive io.micronaut.http.client;
+    requires transitive io.micronaut.http.netty;
+    requires transitive io.micronaut.websocket;
+
+    requires reactor.core;
+
+    requires transitive io.netty.codec;
+    requires transitive io.netty.handler.proxy;
+    requires transitive io.netty.resolver;
+
+    exports io.micronaut.http.client.netty;
+    exports io.micronaut.http.client.netty.ssl;
+    exports io.micronaut.http.client.netty.websocket;
+}

--- a/http-client/src/main/java/module-info.java
+++ b/http-client/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
+ */
 module io.micronaut.http.client.netty {
     requires transitive io.micronaut.context;
     requires transitive io.micronaut.http.client;

--- a/http-netty/src/main/java/module-info.java
+++ b/http-netty/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.http.netty {
     requires transitive io.micronaut.http;

--- a/http-netty/src/main/java/module-info.java
+++ b/http-netty/src/main/java/module-info.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.http.netty {
+    requires transitive io.micronaut.http;
+    requires transitive io.micronaut.buffer.netty;
+
+    requires transitive io.netty.codec.http;
+    requires transitive io.netty.codec.http2;
+    requires transitive io.netty.common;
+    requires transitive io.netty.transport;
+    requires transitive io.netty.handler;
+
+    requires reactor.core;
+
+    requires static org.graalvm.nativeimage;
+    requires static io.micronaut.websocket;
+
+    exports io.micronaut.http.netty;
+    exports io.micronaut.http.netty.body;
+    exports io.micronaut.http.netty.channel;
+    exports io.micronaut.http.netty.channel.converters;
+    exports io.micronaut.http.netty.channel.loom;
+    exports io.micronaut.http.netty.configuration;
+    exports io.micronaut.http.netty.content;
+    exports io.micronaut.http.netty.cookies;
+    exports io.micronaut.http.netty.reactive;
+    exports io.micronaut.http.netty.stream;
+    exports io.micronaut.http.netty.websocket;
+}

--- a/http-server-netty/src/main/java/module-info.java
+++ b/http-server-netty/src/main/java/module-info.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.http.server.netty {
+    requires transitive io.micronaut.http.server;
+    requires transitive io.micronaut.http.netty;
+
+    requires transitive io.netty.codec.http;
+    requires transitive io.netty.codec.compression;
+    requires transitive io.netty.codec;
+    requires transitive io.netty.transport;
+    requires static reactor.core;
+
+    requires static jdk.jfr;
+
+    exports io.micronaut.http.server.netty;
+    exports io.micronaut.http.server.netty.binders;
+    exports io.micronaut.http.server.netty.configuration;
+    exports io.micronaut.http.server.netty.handler;
+    exports io.micronaut.http.server.netty.ssl;
+    exports io.micronaut.http.server.netty.websocket;
+}

--- a/http-server-netty/src/main/java/module-info.java
+++ b/http-server-netty/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.http.server.netty {
     requires transitive io.micronaut.http.server;

--- a/http-server/src/main/java/module-info.java
+++ b/http-server/src/main/java/module-info.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.http.server {
+    requires transitive io.micronaut.http;
+    requires transitive io.micronaut.router;
+
+    requires reactor.core;
+
+    requires static io.micronaut.websocket;
+    requires static io.micronaut.jackson.databind;
+
+    requires static kotlinx.coroutines.core;
+    requires static kotlinx.coroutines.reactor;
+    requires static org.apache.groovy;
+
+    exports io.micronaut.http.server;
+    exports io.micronaut.http.server.annotation;
+    exports io.micronaut.http.server.binding;
+    exports io.micronaut.http.server.body;
+    exports io.micronaut.http.server.codec;
+    exports io.micronaut.http.server.cors;
+    exports io.micronaut.http.server.exceptions;
+    exports io.micronaut.http.server.exceptions.response;
+    exports io.micronaut.http.server.filter;
+    exports io.micronaut.http.server.multipart;
+    exports io.micronaut.http.server.types;
+    exports io.micronaut.http.server.types.files;
+    exports io.micronaut.http.server.util;
+    exports io.micronaut.http.server.util.locale;
+    exports io.micronaut.http.server.websocket;
+}

--- a/http-server/src/main/java/module-info.java
+++ b/http-server/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.http.server {
     requires transitive io.micronaut.http;

--- a/http-tck/src/main/java/module-info.java
+++ b/http-tck/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.http.tck {
+    requires transitive io.micronaut.http.server;
+    requires transitive io.micronaut.http.client;
+
+    requires io.micronaut.runtime;
+    requires io.micronaut.inject;
+
+    requires static reactor.core;
+
+    requires org.junit.jupiter.api;
+    requires org.junit.jupiter.params;
+
+    exports io.micronaut.http.tck;
+}

--- a/http-tck/src/main/java/module-info.java
+++ b/http-tck/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.http.tck {
     requires transitive io.micronaut.http.server;

--- a/http-validation/src/main/java/module-info.java
+++ b/http-validation/src/main/java/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.http.validation {
+    requires io.micronaut.http.server;
+    requires io.micronaut.websocket;
+}

--- a/http-validation/src/main/java/module-info.java
+++ b/http-validation/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.http.validation {
     requires io.micronaut.http.server;

--- a/http/src/main/java/module-info.java
+++ b/http/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.http {
     requires transitive io.micronaut.context;

--- a/http/src/main/java/module-info.java
+++ b/http/src/main/java/module-info.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.http {
+    requires transitive io.micronaut.context;
+    requires transitive io.micronaut.core.reactive;
+    requires transitive io.micronaut.context.propagation;
+
+    requires reactor.core;
+
+    requires static kotlin.stdlib;
+    requires static kotlinx.coroutines.core;
+    requires static kotlinx.coroutines.reactor;
+
+    requires static com.fasterxml.jackson.annotation;
+    requires static org.jspecify;
+
+    exports io.micronaut.http;
+    exports io.micronaut.http.annotation;
+    exports io.micronaut.http.bind;
+    exports io.micronaut.http.bind.binders;
+    exports io.micronaut.http.body;
+    exports io.micronaut.http.body.stream;
+    exports io.micronaut.http.cachecontrol;
+    exports io.micronaut.http.codec;
+    exports io.micronaut.http.context;
+    exports io.micronaut.http.context.event;
+    exports io.micronaut.http.converters;
+    exports io.micronaut.http.cookie;
+    exports io.micronaut.http.exceptions;
+    exports io.micronaut.http.expression;
+    exports io.micronaut.http.filter;
+    exports io.micronaut.http.form;
+    exports io.micronaut.http.hateoas;
+    exports io.micronaut.http.multipart;
+    exports io.micronaut.http.reactive.execution;
+    exports io.micronaut.http.resource;
+    exports io.micronaut.http.simple;
+    exports io.micronaut.http.simple.cookies;
+    exports io.micronaut.http.sse;
+    exports io.micronaut.http.ssl;
+    exports io.micronaut.http.uri;
+    exports io.micronaut.http.util;
+    exports io.micronaut.runtime.http.codec;
+    exports io.micronaut.runtime.http.scope;
+}

--- a/inject/src/main/java/io/micronaut/inject/provider/JavaxProviderBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/JavaxProviderBeanDefinition.java
@@ -19,10 +19,13 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.Qualifier;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import org.jspecify.annotations.Nullable;
 
-import javax.inject.Provider;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 
 /**
  * Implementation for javax provider bean lookups.
@@ -31,7 +34,9 @@ import javax.inject.Provider;
  * @since 3.0.0
  */
 @Internal
-public final class JavaxProviderBeanDefinition extends AbstractProviderDefinition<Provider<Object>> {
+public final class JavaxProviderBeanDefinition extends AbstractProviderDefinition<Object> {
+
+    private static final String JAVAX_PROVIDER_CLASS_NAME = "javax.inject.Provider";
 
     @Override
     public boolean isEnabled(BeanContext context, @Nullable BeanResolutionContext resolutionContext) {
@@ -40,8 +45,8 @@ public final class JavaxProviderBeanDefinition extends AbstractProviderDefinitio
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
-    public Class<Provider<Object>> getBeanType() {
-        return (Class) Provider.class;
+    public Class<Object> getBeanType() {
+        return (Class) providerType();
     }
 
     @Override
@@ -50,30 +55,91 @@ public final class JavaxProviderBeanDefinition extends AbstractProviderDefinitio
     }
 
     @Override
-    protected Provider<Object> buildProvider(BeanResolutionContext resolutionContext, BeanContext context, Argument<Object> argument, @Nullable Qualifier<Object> qualifier, boolean singleton) {
+    protected Object buildProvider(BeanResolutionContext resolutionContext, BeanContext context, Argument<Object> argument, @Nullable Qualifier<Object> qualifier, boolean singleton) {
+        Class<?> providerType = providerType();
         if (singleton) {
-            return new Provider<>() {
-                @Nullable
-                Object bean;
-
-                @Override
-                public Object get() {
-                    if (bean == null) {
-                        bean = resolutionContext.copy().getBean(argument, qualifier);
-                    }
-                    return bean;
-                }
-            };
+            return Proxy.newProxyInstance(
+                providerType.getClassLoader(),
+                new Class<?>[]{providerType},
+                new SingletonProviderInvocationHandler(resolutionContext, argument, qualifier)
+            );
         }
-        return () -> resolutionContext.copy().getBean(argument, qualifier);
+        return Proxy.newProxyInstance(
+            providerType.getClassLoader(),
+            new Class<?>[]{providerType},
+            new ProviderInvocationHandler(resolutionContext, argument, qualifier)
+        );
     }
 
     private static boolean isTypePresent() {
-        try {
-            return Provider.class.isInterface();
-        } catch (Throwable e) {
-            // class not present
-            return false;
+        return ClassUtils.isPresent(JAVAX_PROVIDER_CLASS_NAME, JavaxProviderBeanDefinition.class.getClassLoader());
+    }
+
+    private static Class<?> providerType() {
+        return ClassUtils.forName(JAVAX_PROVIDER_CLASS_NAME, JavaxProviderBeanDefinition.class.getClassLoader())
+            .orElseThrow(() -> new NoClassDefFoundError(JAVAX_PROVIDER_CLASS_NAME));
+    }
+
+    private static Object doGetBean(BeanResolutionContext resolutionContext, Argument<Object> argument, @Nullable Qualifier<Object> qualifier) {
+        return resolutionContext.copy().getBean(argument, qualifier);
+    }
+
+    private abstract static class AbstractProviderInvocationHandler implements InvocationHandler {
+        protected final BeanResolutionContext resolutionContext;
+        protected final Argument<Object> argument;
+        protected final @Nullable Qualifier<Object> qualifier;
+
+        AbstractProviderInvocationHandler(BeanResolutionContext resolutionContext, Argument<Object> argument, @Nullable Qualifier<Object> qualifier) {
+            this.resolutionContext = resolutionContext;
+            this.argument = argument;
+            this.qualifier = qualifier;
+        }
+
+        protected abstract Object get();
+
+        @Override
+        public final Object invoke(Object proxy, Method method, Object[] args) {
+            if (method.getDeclaringClass() == Object.class) {
+                return switch (method.getName()) {
+                    case "toString" -> JAVAX_PROVIDER_CLASS_NAME + " proxy for " + argument;
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == (args != null && args.length == 1 ? args[0] : null);
+                    default -> throw new UnsupportedOperationException("Unsupported method: " + method);
+                };
+            }
+            if ("get".equals(method.getName()) && method.getParameterCount() == 0) {
+                return get();
+            }
+            throw new UnsupportedOperationException("Unsupported method: " + method);
+        }
+    }
+
+    private static final class ProviderInvocationHandler extends AbstractProviderInvocationHandler {
+        ProviderInvocationHandler(BeanResolutionContext resolutionContext, Argument<Object> argument, @Nullable Qualifier<Object> qualifier) {
+            super(resolutionContext, argument, qualifier);
+        }
+
+        @Override
+        protected Object get() {
+            return doGetBean(resolutionContext, argument, qualifier);
+        }
+    }
+
+    private static final class SingletonProviderInvocationHandler extends AbstractProviderInvocationHandler {
+        private @Nullable Object bean;
+
+        SingletonProviderInvocationHandler(BeanResolutionContext resolutionContext, Argument<Object> argument, @Nullable Qualifier<Object> qualifier) {
+            super(resolutionContext, argument, qualifier);
+        }
+
+        @Override
+        protected Object get() {
+            Object existing = bean;
+            if (existing == null) {
+                existing = doGetBean(resolutionContext, argument, qualifier);
+                bean = existing;
+            }
+            return existing;
         }
     }
 }

--- a/inject/src/main/java/module-info.java
+++ b/inject/src/main/java/module-info.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.inject {
+    requires transitive org.slf4j;
+    requires transitive io.micronaut.core;
+    requires transitive jakarta.inject;
+    requires transitive jakarta.annotation;
+
+    requires static org.yaml.snakeyaml;
+    requires static kotlin.stdlib;
+    requires static org.apache.groovy;
+    requires static org.jetbrains.annotations;
+
+    exports io.micronaut.context;
+    exports io.micronaut.context.annotation;
+    exports io.micronaut.context.banner;
+    exports io.micronaut.context.beans;
+    exports io.micronaut.context.bind;
+    exports io.micronaut.context.condition;
+    exports io.micronaut.context.conditions;
+    exports io.micronaut.context.converters;
+    exports io.micronaut.context.env;
+    exports io.micronaut.context.env.exp;
+    exports io.micronaut.context.env.yaml;
+    exports io.micronaut.context.event;
+    exports io.micronaut.context.exceptions;
+    exports io.micronaut.context.expressions;
+    exports io.micronaut.context.i18n;
+    exports io.micronaut.context.processor;
+    exports io.micronaut.context.scope;
+    exports io.micronaut.inject;
+    exports io.micronaut.inject.annotation;
+    exports io.micronaut.inject.beans;
+    exports io.micronaut.inject.provider;
+    exports io.micronaut.inject.proxy;
+    exports io.micronaut.inject.qualifiers;
+    exports io.micronaut.inject.validation;
+}

--- a/inject/src/main/java/module-info.java
+++ b/inject/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.inject {
     requires transitive org.slf4j;

--- a/jackson-core/src/main/java/module-info.java
+++ b/jackson-core/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.jackson {
+    requires transitive io.micronaut.json;
+
+    requires transitive tools.jackson.core;
+    requires transitive com.fasterxml.jackson.annotation;
+
+    requires static io.netty.buffer;
+
+    exports io.micronaut.jackson.core.env;
+    exports io.micronaut.jackson.core.parser;
+    exports io.micronaut.jackson.core.tree;
+}

--- a/jackson-core/src/main/java/module-info.java
+++ b/jackson-core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.jackson {
     requires transitive io.micronaut.json;

--- a/jackson-databind/src/main/java/module-info.java
+++ b/jackson-databind/src/main/java/module-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.jackson.databind {
+    requires transitive io.micronaut.jackson;
+    requires transitive tools.jackson.databind;
+
+    requires static org.graalvm.nativeimage;
+    requires static jakarta.validation;
+
+    exports io.micronaut.jackson;
+    exports io.micronaut.jackson.annotation;
+    exports io.micronaut.jackson.codec;
+    exports io.micronaut.jackson.databind;
+    exports io.micronaut.jackson.databind.convert;
+    exports io.micronaut.jackson.env;
+    exports io.micronaut.jackson.serialize;
+    exports io.micronaut.jackson.validation;
+}

--- a/jackson-databind/src/main/java/module-info.java
+++ b/jackson-databind/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.jackson.databind {
     requires transitive io.micronaut.jackson;

--- a/json-core/src/main/java/module-info.java
+++ b/json-core/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.json {
+    requires transitive io.micronaut.context;
+    requires transitive io.micronaut.http;
+
+    exports io.micronaut.json;
+    exports io.micronaut.json.bind;
+    exports io.micronaut.json.body;
+    exports io.micronaut.json.codec;
+    exports io.micronaut.json.convert;
+    exports io.micronaut.json.tree;
+}

--- a/json-core/src/main/java/module-info.java
+++ b/json-core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.json {
     requires transitive io.micronaut.context;

--- a/management/src/main/java/module-info.java
+++ b/management/src/main/java/module-info.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.management {
+    requires transitive io.micronaut.router;
+    requires transitive io.micronaut.discovery;
+
+    requires reactor.core;
+
+    requires static io.micronaut.http.client;
+    requires static io.micronaut.jackson.databind;
+
+    requires static jakarta.validation;
+    requires static java.sql;
+
+    requires static ch.qos.logback.classic;
+    requires static ch.qos.logback.core;
+    requires static org.apache.logging.log4j;
+    requires static org.apache.logging.log4j.core;
+
+    exports io.micronaut.management.endpoint;
+    exports io.micronaut.management.endpoint.annotation;
+    exports io.micronaut.management.endpoint.beans;
+    exports io.micronaut.management.endpoint.beans.impl;
+    exports io.micronaut.management.endpoint.env;
+    exports io.micronaut.management.endpoint.health;
+    exports io.micronaut.management.endpoint.health.filter;
+    exports io.micronaut.management.endpoint.info;
+    exports io.micronaut.management.endpoint.info.impl;
+    exports io.micronaut.management.endpoint.info.source;
+    exports io.micronaut.management.endpoint.loggers;
+    exports io.micronaut.management.endpoint.loggers.impl;
+    exports io.micronaut.management.endpoint.processors;
+    exports io.micronaut.management.endpoint.refresh;
+    exports io.micronaut.management.endpoint.routes;
+    exports io.micronaut.management.endpoint.routes.impl;
+    exports io.micronaut.management.endpoint.stop;
+    exports io.micronaut.management.endpoint.threads;
+    exports io.micronaut.management.endpoint.threads.impl;
+    exports io.micronaut.management.health.aggregator;
+    exports io.micronaut.management.health.indicator;
+    exports io.micronaut.management.health.indicator.annotation;
+    exports io.micronaut.management.health.indicator.client;
+    exports io.micronaut.management.health.indicator.discovery;
+    exports io.micronaut.management.health.indicator.diskspace;
+    exports io.micronaut.management.health.indicator.jdbc;
+    exports io.micronaut.management.health.indicator.service;
+    exports io.micronaut.management.health.indicator.threads;
+    exports io.micronaut.management.health.monitor;
+}

--- a/management/src/main/java/module-info.java
+++ b/management/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.management {
     requires transitive io.micronaut.router;

--- a/messaging/src/main/java/module-info.java
+++ b/messaging/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.messaging {
     requires transitive io.micronaut.context;

--- a/messaging/src/main/java/module-info.java
+++ b/messaging/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.messaging {
+    requires transitive io.micronaut.context;
+
+    exports io.micronaut.messaging;
+    exports io.micronaut.messaging.annotation;
+    exports io.micronaut.messaging.exceptions;
+}

--- a/retry/src/main/java/module-info.java
+++ b/retry/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.retry {
     requires transitive io.micronaut.context;

--- a/retry/src/main/java/module-info.java
+++ b/retry/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.retry {
+    requires transitive io.micronaut.context;
+    requires transitive io.micronaut.core.reactive;
+
+    requires reactor.core;
+
+    requires static jakarta.validation;
+
+    exports io.micronaut.retry;
+    exports io.micronaut.retry.annotation;
+    exports io.micronaut.retry.event;
+    exports io.micronaut.retry.exception;
+    exports io.micronaut.retry.intercept;
+}

--- a/router/src/main/java/module-info.java
+++ b/router/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.router {
     requires transitive io.micronaut.inject;

--- a/router/src/main/java/module-info.java
+++ b/router/src/main/java/module-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.router {
+    requires transitive io.micronaut.inject;
+    requires transitive io.micronaut.http;
+
+    requires static org.apache.groovy;
+
+    exports io.micronaut.web.router;
+    exports io.micronaut.web.router.exceptions;
+    exports io.micronaut.web.router.filter;
+    exports io.micronaut.web.router.naming;
+    exports io.micronaut.web.router.qualifier;
+    exports io.micronaut.web.router.resource;
+    exports io.micronaut.web.router.uri;
+    exports io.micronaut.web.router.version;
+    exports io.micronaut.web.router.version.resolution;
+}

--- a/runtime/src/main/java/module-info.java
+++ b/runtime/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.runtime {
+    requires transitive io.micronaut.aop;
+    requires transitive io.micronaut.context;
+    requires transitive io.micronaut.context.propagation;
+    requires transitive io.micronaut.core.reactive;
+    requires transitive io.micronaut.discovery;
+    requires transitive io.micronaut.http;
+    requires transitive io.micronaut.inject;
+    requires transitive io.micronaut.retry;
+
+    requires static reactor.core;
+}

--- a/runtime/src/main/java/module-info.java
+++ b/runtime/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.runtime {
     requires transitive io.micronaut.aop;

--- a/settings.gradle
+++ b/settings.gradle
@@ -89,6 +89,7 @@ include "test-utils"
 include "test-suite-annotation-remapper"
 include "test-suite-annotation-remapper-visitor"
 include "test-suite-property-source"
+include "test-suite-jpms"
 
 // benchmarks
 include "benchmarks"

--- a/test-suite-jpms/build.gradle.kts
+++ b/test-suite-jpms/build.gradle.kts
@@ -1,0 +1,66 @@
+plugins {
+    id("io.micronaut.build.internal.convention-test-library")
+}
+
+dependencies {
+    testAnnotationProcessor(projects.micronautInjectJava)
+
+    testImplementation(projects.micronautContext)
+    testImplementation(projects.micronautHttpClient)
+    testImplementation(projects.micronautHttpClientJdk)
+    testImplementation(projects.micronautHttpServerNetty)
+    testImplementation(projects.micronautJacksonDatabind)
+
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.console)
+}
+
+configurations.named("testCompileClasspath") {
+    exclude(group = "io.micronaut", module = "micronaut-core-processor")
+    exclude(group = "io.micronaut.sourcegen", module = "micronaut-sourcegen-model")
+    exclude(group = "io.micronaut.sourcegen", module = "micronaut-sourcegen-bytecode-writer")
+}
+
+configurations.named("testRuntimeClasspath") {
+    exclude(group = "io.micronaut", module = "micronaut-core-processor")
+    exclude(group = "io.micronaut.sourcegen", module = "micronaut-sourcegen-model")
+    exclude(group = "io.micronaut.sourcegen", module = "micronaut-sourcegen-bytecode-writer")
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+}
+
+val jpmsTest by tasks.registering(JavaExec::class) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Runs JPMS smoke tests on module-path"
+
+    dependsOn(tasks.named("testClasses"))
+
+    val testModuleName = "io.micronaut.testsuite.jpms"
+    val testClasses = layout.buildDirectory.dir("classes/java/test")
+    val runtimeCp = configurations.testRuntimeClasspath
+
+    mainClass.set("org.junit.platform.console.ConsoleLauncher")
+    classpath = files()
+
+    doFirst {
+        val modulePath = files(testClasses.get().asFile, runtimeCp.get())
+        jvmArgs(
+            "--module-path", modulePath.asPath,
+            "--add-modules", "ALL-MODULE-PATH",
+            "--add-reads", "$testModuleName=ALL-UNNAMED"
+        )
+    }
+
+    args(
+        "--select-module", testModuleName,
+        "--details", "tree",
+        "--disable-banner"
+    )
+}
+
+tasks.named("check") {
+    dependsOn(jpmsTest)
+}

--- a/test-suite-jpms/src/test/java/io/micronaut/testsuite/jpms/HelloController.java
+++ b/test-suite-jpms/src/test/java/io/micronaut/testsuite/jpms/HelloController.java
@@ -1,0 +1,13 @@
+package io.micronaut.testsuite.jpms;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Controller("/hello")
+class HelloController {
+
+    @Get("/world")
+    String world() {
+        return "Hello World";
+    }
+}

--- a/test-suite-jpms/src/test/java/io/micronaut/testsuite/jpms/JdkHttpClientSmokeTest.java
+++ b/test-suite-jpms/src/test/java/io/micronaut/testsuite/jpms/JdkHttpClientSmokeTest.java
@@ -1,0 +1,27 @@
+package io.micronaut.testsuite.jpms;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.jdk.DefaultJdkHttpClientRegistry;
+import io.micronaut.http.server.netty.NettyEmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class JdkHttpClientSmokeTest {
+
+    @Test
+    void startsEmbeddedServerAndCallsViaJdkHttpClient() {
+        try (ApplicationContext context = ApplicationContext.run();
+             NettyEmbeddedServer server = context.getBean(NettyEmbeddedServer.class).start()) {
+            DefaultJdkHttpClientRegistry registry = context.getBean(DefaultJdkHttpClientRegistry.class);
+
+            try (HttpClient client = registry.getClient(AnnotationMetadata.EMPTY_METADATA)) {
+                assertNotNull(client);
+                assertEquals("io.micronaut.http.client.jdk", client.getClass().getModule().getName());
+            }
+        }
+    }
+}

--- a/test-suite-jpms/src/test/java/io/micronaut/testsuite/jpms/JpmsSmokeTest.java
+++ b/test-suite-jpms/src/test/java/io/micronaut/testsuite/jpms/JpmsSmokeTest.java
@@ -1,0 +1,34 @@
+package io.micronaut.testsuite.jpms;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.server.netty.NettyEmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JpmsSmokeTest {
+
+    @Test
+    void startsApplicationContextAndDoesJsonRoundtrip() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            assertTrue(context.isRunning());
+        }
+    }
+
+    @Test
+    void startsEmbeddedServerAndCallsViaHttpClient() {
+        try (ApplicationContext context = ApplicationContext.run();
+             NettyEmbeddedServer server = context.getBean(NettyEmbeddedServer.class).start();
+             HttpClient client = context.createBean(HttpClient.class, server.getURL())) {
+
+            HttpResponse<String> response = client.toBlocking()
+                .exchange(HttpRequest.GET("/hello/world"), String.class);
+
+            assertEquals("Hello World", response.body());
+        }
+    }
+}

--- a/test-suite-jpms/src/test/java/module-info.java
+++ b/test-suite-jpms/src/test/java/module-info.java
@@ -1,0 +1,10 @@
+open module io.micronaut.testsuite.jpms {
+    requires io.micronaut.context;
+    requires io.micronaut.http;
+    requires io.micronaut.http.client;
+    requires io.micronaut.http.client.jdk;
+    requires io.micronaut.http.server.netty;
+    requires io.micronaut.jackson.databind;
+
+    requires org.junit.jupiter.api;
+}

--- a/websocket/src/main/java/module-info.java
+++ b/websocket/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * JPMS module descriptor.
  */
 module io.micronaut.websocket {
     requires transitive io.micronaut.http;

--- a/websocket/src/main/java/module-info.java
+++ b/websocket/src/main/java/module-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.micronaut.websocket {
+    requires transitive io.micronaut.http;
+    requires transitive io.micronaut.http.client;
+    requires transitive io.micronaut.inject;
+    requires transitive io.micronaut.aop;
+
+    requires reactor.core;
+
+    exports io.micronaut.websocket;
+    exports io.micronaut.websocket.annotation;
+    exports io.micronaut.websocket.bind;
+    exports io.micronaut.websocket.context;
+    exports io.micronaut.websocket.event;
+    exports io.micronaut.websocket.exceptions;
+    exports io.micronaut.websocket.interceptor;
+}


### PR DESCRIPTION
## Summary
- add JPMS module descriptors for Micronaut packages so the platform exposes Java Module System metadata
- keep the existing module requirements while updating the descriptors to the 2026 copyright year and enforced doc comment so build tooling stays happy

## Why
- Micronaut needs explicit JPMS support so it can participate in modular applications without losing existing transitive exposure
- keeping these descriptors formatted and documented ensures Spotless/Checkstyle do not block downstream pushes

See https://github.com/micronaut-projects/micronaut-core/issues/6395