### PR TITLE
Fix GraalVM 25 loom-carrier native image initialization

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/LoomCarrierGroup.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/LoomCarrierGroup.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.NativeImageUtils;
 import io.micronaut.scheduling.LoomSupport;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.IoEventLoop;
@@ -452,7 +453,7 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
 
             // JFR
             ContinuationScheduled scheduled;
-            if (ContinuationScheduled.INSTANCE.isEnabled()) {
+            if (NativeImageUtils.JFR_AVAILABLE && ContinuationScheduled.INSTANCE.isEnabled()) {
                 scheduled = new ContinuationScheduled();
                 long hash = System.identityHashCode(command);
                 scheduled.hashCode = hash;
@@ -513,7 +514,7 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
         }
 
         private void tick(int type) {
-            if (LoopTick.INSTANCE.isEnabled()) {
+            if (NativeImageUtils.JFR_AVAILABLE && LoopTick.INSTANCE.isEnabled()) {
                 LoopTick tick = new LoopTick();
                 tick.loopIndex = id;
                 tick.type = type;

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/PrivateLoomSupport.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/PrivateLoomSupport.java
@@ -20,6 +20,7 @@ import io.micronaut.context.condition.ConditionContext;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.TypeHint;
 import io.netty.util.internal.PlatformDependent;
 
 import java.lang.invoke.MethodHandle;
@@ -38,6 +39,13 @@ import java.util.concurrent.ForkJoinPool;
  */
 @Internal
 @Experimental
+@TypeHint(
+    typeNames = {
+        "java.lang.VirtualThread",
+        "java.lang.ThreadBuilders$VirtualThreadBuilder"
+    },
+    accessType = TypeHint.AccessType.ALL_DECLARED_FIELDS
+)
 public final class PrivateLoomSupport {
     private static final MethodHandle DEFAULT_SCHEDULER;
     private static final MethodHandle BUILDER_SCHEDULER;


### PR DESCRIPTION
## Summary
- Add native-image reflection metadata for `java.lang.VirtualThread` and `java.lang.ThreadBuilders$VirtualThreadBuilder` in `PrivateLoomSupport` so GraalVM 25 does not fail with `MissingReflectionRegistrationError` during loom internals access.
- Guard experimental loom-carrier JFR event usage (`ContinuationScheduled` and `LoopTick`) behind `NativeImageUtils.JFR_AVAILABLE`, matching the existing native-image JFR handling pattern.
- Keeps behavior compatible with older baselines (including Java 17) by using `@TypeHint(typeNames = ...)` without hard class references.

## Issue
Fixes #11981