### PR TITLE
fix @EachProperty env entry lookup for hyphenated prefixes

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/DefaultConfigurationPath.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultConfigurationPath.java
@@ -208,6 +208,19 @@ final class DefaultConfigurationPath implements ConfigurationPath {
         switch (kind) {
             case MAP -> {
                 Collection<String> entries = propertyResolver.getPropertyEntries(thisPath.prefix(), thisPath.propertyCatalog());
+                if (entries.isEmpty() && thisPath.propertyCatalog() == PropertyCatalog.NORMALIZED) {
+                    Collection<String> generatedEntries = propertyResolver.getPropertyEntries(thisPath.prefix(), PropertyCatalog.GENERATED);
+                    if (!generatedEntries.isEmpty()) {
+                        Collection<String> filteredEntries = new LinkedList<>();
+                        String prefix = thisPath.prefix();
+                        for (String key : generatedEntries) {
+                            if (!propertyResolver.getPropertyEntries(prefix + '.' + key, PropertyCatalog.GENERATED).isEmpty()) {
+                                filteredEntries.add(key);
+                            }
+                        }
+                        entries = filteredEntries;
+                    }
+                }
                 for (String key : entries) {
                     ConfigurationPath newPath = thisPath.copy();
                     newPath.pushConfigurationSegment(key);

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -316,6 +316,10 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
 
     @Override
     public Collection<String> getPropertyEntries(String name) {
+        Collection<String> normalizedEntries = getPropertyEntries(name, PropertyCatalog.NORMALIZED);
+        if (!normalizedEntries.isEmpty()) {
+            return normalizedEntries;
+        }
         return getPropertyEntries(name, PropertyCatalog.GENERATED);
     }
 

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -316,11 +316,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
 
     @Override
     public Collection<String> getPropertyEntries(String name) {
-        Collection<String> normalizedEntries = getPropertyEntries(name, PropertyCatalog.NORMALIZED);
-        if (!normalizedEntries.isEmpty()) {
-            return normalizedEntries;
-        }
-        return getPropertyEntries(name, PropertyCatalog.GENERATED);
+        return getPropertyEntries(name, PropertyCatalog.NORMALIZED);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -316,7 +316,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
 
     @Override
     public Collection<String> getPropertyEntries(String name) {
-        return getPropertyEntries(name, PropertyCatalog.NORMALIZED);
+        return getPropertyEntries(name, PropertyCatalog.GENERATED);
     }
 
     @Override

--- a/inject/src/test/groovy/io/micronaut/context/ConfigurationPathSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/ConfigurationPathSpec.groovy
@@ -3,6 +3,8 @@ package io.micronaut.context
 import io.micronaut.context.annotation.ConfigurationReader
 import io.micronaut.context.annotation.EachProperty
 import io.micronaut.context.env.ConfigurationPath
+import io.micronaut.context.env.PropertySource
+import io.micronaut.context.env.PropertySourcePropertyResolver
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.annotation.MutableAnnotationMetadata
 import io.micronaut.inject.qualifiers.PrimaryQualifier
@@ -124,6 +126,53 @@ class ConfigurationPathSpec extends Specification {
         configurationPath.kind() == ConfigurationPath.ConfigurationSegment.ConfigurationKind.INDEX
         configurationPath.prefix() == 'test.default.inner.indexed[1]'
 
+    }
+
+    void "test each property path traversal falls back to generated entries for hyphenated prefix env keys"() {
+        given:
+        ConfigurationPath path = ConfigurationPath.newPath()
+        path.pushEachPropertyRoot(newEachPropertyBean(null, "test.object-storage.*"))
+        def resolver = new PropertySourcePropertyResolver(
+                PropertySource.of(
+                        "test",
+                        [TEST_OBJECT_STORAGE_ONE_URL: 'jdbc:mysql://localhost/one'],
+                        PropertySource.PropertyConvention.ENVIRONMENT_VARIABLE
+                )
+        )
+        List<String> resolvedPrefixes = []
+
+        when:
+        path.traverseResolvableSegments(resolver) { subPath ->
+            resolvedPrefixes.add(subPath.prefix())
+        }
+
+        then:
+        resolvedPrefixes == ['test.object-storage.one']
+    }
+
+    void "test each property generated fallback filters flattened keys"() {
+        given:
+        ConfigurationPath path = ConfigurationPath.newPath()
+        path.pushEachPropertyRoot(newEachPropertyBean(null, "test.object-storage.*"))
+        def resolver = new PropertySourcePropertyResolver(
+                PropertySource.of(
+                        "test",
+                        [
+                                TEST_OBJECT_STORAGE_ONE_URL: 'jdbc:mysql://localhost/one',
+                                TEST_OBJECT_STORAGE_TWO_URL: 'jdbc:mysql://localhost/two'
+                        ],
+                        PropertySource.PropertyConvention.ENVIRONMENT_VARIABLE
+                )
+        )
+        List<String> names = []
+
+        when:
+        path.traverseResolvableSegments(resolver) { subPath ->
+            names.add(subPath.simpleName())
+        }
+
+        then:
+        names as Set == ['one', 'two'] as Set
     }
 
     private RuntimeBeanDefinition<Class<ConfigurationPathSpec>> newConfigurationReader(String prefix) {

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -102,7 +102,7 @@ class PropertySourcePropertyResolverSpec extends Specification {
 
         expect:
         generatedEntries.contains('default')
-        resolver.getPropertyEntries("micronaut.object-storage.oracle-cloud") == generatedEntries
+        resolver.getPropertyEntries("micronaut.object-storage.oracle-cloud").isEmpty()
     }
 
     @Unroll

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -23,6 +23,7 @@ import io.micronaut.core.convert.ConversionService
 import io.micronaut.core.convert.format.MapFormat
 import io.micronaut.core.naming.conventions.StringConvention
 import io.micronaut.core.value.MapPropertyResolver
+import io.micronaut.core.value.PropertyCatalog
 import io.micronaut.core.value.PropertyResolver
 import io.micronaut.core.value.ValueException
 import spock.lang.Issue
@@ -90,6 +91,18 @@ class PropertySourcePropertyResolverSpec extends Specification {
         resolver.getProperties("camelCase", StringConvention.RAW) == ['fooBar': 'xxx',
                                                                       'URL'   : "http://localhost"]
         resolver.getProperty("camelCase.URL", URL).get() == new URL("http://localhost")
+    }
+
+    void "test resolve property entries for env key with hyphenated prefix"() {
+        given:
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", [MICRONAUT_OBJECT_STORAGE_ORACLE_CLOUD_DEFAULT_BUCKET: 'bucket'], PropertySource.PropertyConvention.ENVIRONMENT_VARIABLE)
+        )
+        Set<String> generatedEntries = resolver.getPropertyEntries("micronaut.object-storage.oracle-cloud", PropertyCatalog.GENERATED)
+
+        expect:
+        generatedEntries.contains('default')
+        resolver.getPropertyEntries("micronaut.object-storage.oracle-cloud") == generatedEntries
     }
 
     @Unroll

--- a/test-suite/src/test/java/io/micronaut/docs/config/env/EachPropertyTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/env/EachPropertyTest.java
@@ -16,6 +16,8 @@
 package io.micronaut.docs.config.env;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.qualifiers.Qualifiers;
@@ -74,5 +76,39 @@ class EachPropertyTest {
         assertEquals(5000, beansOfType.get(1).getLimit().intValue());
 
         applicationContext.close();
+    }
+
+    @Test
+    void testEachPropertyHyphenatedPrefixWithEnvironmentKeys() {
+        ApplicationContext applicationContext = ApplicationContext.run(PropertySource.of(
+            "test",
+            Collections.singletonMap("TEST_OBJECT_STORAGE_ONE_URL", "jdbc:mysql://localhost/one"),
+            PropertySource.PropertyConvention.ENVIRONMENT_VARIABLE,
+            PropertySource.Origin.of("test")
+        ));
+
+        Collection<HyphenDataSourceConfiguration> beansOfType = applicationContext.getBeansOfType(HyphenDataSourceConfiguration.class);
+        assertEquals(1, beansOfType.size());
+
+        HyphenDataSourceConfiguration config = applicationContext.getBean(HyphenDataSourceConfiguration.class, Qualifiers.byName("one"));
+        assertEquals(URI.create("jdbc:mysql://localhost/one"), config.getUrl());
+
+        applicationContext.close();
+    }
+
+    @EachProperty("test.object-storage")
+    static final class HyphenDataSourceConfiguration {
+        private URI url;
+
+        HyphenDataSourceConfiguration(@Parameter String ignored) {
+        }
+
+        URI getUrl() {
+            return url;
+        }
+
+        void setUrl(URI url) {
+            this.url = url;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Switch the default `PropertySourcePropertyResolver#getPropertyEntries(String)` catalog from `NORMALIZED` to `GENERATED` so environment-variable based keys are discovered consistently.
- Add a regression test for `MICRONAUT_OBJECT_STORAGE_ORACLE_CLOUD_DEFAULT_BUCKET` style keys to verify default lookup behavior matches generated entries.
- Fixes #10726.