### PR TITLE
fix: avoid Path @QueryValue StackOverflow in declarative clients

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -654,6 +654,11 @@ public class DefaultMutableConversionService implements MutableConversionService
                         return Optional.empty();
                     }
                 });
+        addInternalConverter(
+                Path.class,
+                CharSequence.class,
+                (object, targetType, context) -> Optional.of(object.toString())
+        );
 
         // String -> Integer
         addInternalConverter(CharSequence.class, Integer.class, (CharSequence object, Class<Integer> targetType, ConversionContext context) -> {

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpHeadSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpHeadSpec.groovy
@@ -247,6 +247,13 @@ class HttpHeadSpec extends Specification {
         ex.message == "Client '/head': Empty body"
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/7332')
+    void "@QueryValue supports java.nio.file.Path"() {
+        expect:
+        myGetClient.queryPath(java.nio.file.Paths.get('a/b')) == 'a/b'
+        myGetClient.queryPath(java.nio.file.Paths.get('a', 'b')) == 'a/b'
+    }
+
     void "test body availability"() {
         when:
         Flux<HttpResponse> flowable = client.exchange(
@@ -491,6 +498,11 @@ class HttpHeadSpec extends Specification {
             return foo + '-' + bar
         }
 
+        @Get("/queryPath")
+        String queryPath(@QueryValue java.nio.file.Path path) {
+            return path.toString()
+        }
+
         @Get("/empty")
         Optional<String> empty() {
             return Optional.empty()
@@ -591,6 +603,9 @@ class HttpHeadSpec extends Specification {
 
         @Head("/multipleQueryParam")
         String queryParam(@QueryValue String foo, @QueryValue String bar)
+
+        @Get("/queryPath")
+        String queryPath(@QueryValue java.nio.file.Path path)
 
         @Head("/date/{myDate}")
         String formatDate(@Format('yyyy-MM-dd') Date myDate)


### PR DESCRIPTION
## Summary
- fix `DefaultMutableConversionService` to convert `Path` directly to `CharSequence`, avoiding recursive `Iterable` conversion for query parameters
- add a regression test in `HttpHeadSpec` for declarative client `@QueryValue Path` handling
- closes #7332

## Verification
- `./gradlew :micronaut-http-client:test --tests io.micronaut.http.client.HttpHeadSpec -q`