### PR TITLE
fix body argument spreading for JSON requests (#10263)

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/JsonBodyArgumentSpreadingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/JsonBodyArgumentSpreadingSpec.groovy
@@ -1,0 +1,62 @@
+package io.micronaut.http.server.netty.binding
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import spock.lang.Issue
+import spock.lang.Specification
+
+@MicronautTest
+@Issue('https://github.com/micronaut-projects/micronaut-core/issues/10263')
+class JsonBodyArgumentSpreadingSpec extends Specification implements TestPropertyProvider {
+
+    @Override
+    Map<String, String> getProperties() {
+        ['spec.name': 'JsonBodyArgumentSpreadingSpec']
+    }
+
+    @jakarta.inject.Inject
+    @Client('/')
+    HttpClient client
+
+    void 'json body argument spreading binds nullable parameter to null'() {
+        when:
+        String rsp = client.toBlocking().retrieve(HttpRequest.POST('/spread', [:]).contentType(MediaType.APPLICATION_JSON))
+
+        then:
+        rsp == '{}'
+    }
+
+    void 'json body argument spreading with explicit body component binds missing field to null'() {
+        when:
+        String rsp = client.toBlocking().retrieve(HttpRequest.POST('/spread-annotated', [:]).contentType(MediaType.APPLICATION_JSON))
+
+        then:
+        rsp == 'null'
+    }
+
+    @Controller
+    @Requires(property = 'spec.name', value = 'JsonBodyArgumentSpreadingSpec')
+    static class Ctrl {
+        @Post('/spread')
+        @Consumes(MediaType.APPLICATION_JSON)
+        String spread(@Body @jakarta.annotation.Nullable String q) {
+            // if binding fails, request will error out before reaching controller
+            return String.valueOf(q)
+        }
+
+        @Post('/spread-annotated')
+        @Consumes(MediaType.APPLICATION_JSON)
+        String spreadAnnotated(@Body('q') @jakarta.annotation.Nullable String q) {
+            return String.valueOf(q)
+        }
+    }
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyArgumentTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyArgumentTest.java
@@ -20,11 +20,13 @@ import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
+import jakarta.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -52,6 +54,18 @@ public class BodyArgumentTest {
                 .build()));
     }
 
+    @Test
+    void testNullableExplicitBodyComponentWithMissingJsonField() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.POST("/body-arguments-test/getNullableMessage", "{}")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.OK)
+                .body("null")
+                .build()));
+    }
+
     @Controller("/body-arguments-test")
     @Requires(property = "spec.name", value = SPEC_NAME)
     static class BodyController {
@@ -60,6 +74,12 @@ public class BodyArgumentTest {
         @Produces(MediaType.TEXT_PLAIN)
         String getA(String a) {
             return a;
+        }
+
+        @Post(uri = "/getNullableMessage")
+        @Produces(MediaType.TEXT_PLAIN)
+        String getNullableMessage(@Body("message") @Nullable String message) {
+            return String.valueOf(message);
         }
     }
 }

--- a/http/src/main/java/io/micronaut/http/bind/binders/DefaultBodyAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/DefaultBodyAnnotationBinder.java
@@ -94,7 +94,7 @@ public class DefaultBodyAnnotationBinder<T> extends AbstractArgumentBinder<T> im
         if (body.isPresent()) {
             return () -> (Optional) conversionService.convert(body.get(), ConvertibleValues.class);
         }
-        return () -> Optional.empty();
+        return Optional::empty;
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/bind/binders/DefaultBodyAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/DefaultBodyAnnotationBinder.java
@@ -90,8 +90,11 @@ public class DefaultBodyAnnotationBinder<T> extends AbstractArgumentBinder<T> im
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     protected BindingResult<ConvertibleValues<?>> bindFullBodyConvertibleValues(HttpRequest<?> source) {
-        Optional<ConvertibleValues> convertibleValuesBody = source.getBody(ConvertibleValues.class);
-        return () -> (Optional) convertibleValuesBody;
+        Optional<?> body = source.getBody();
+        if (body.isPresent()) {
+            return () -> (Optional) conversionService.convert(body.get(), ConvertibleValues.class);
+        }
+        return () -> Optional.empty();
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix `DefaultBodyAnnotationBinder` to convert the already-parsed request body through `ConversionService` when binding spread body arguments, instead of requesting direct deserialization into abstract `ConvertibleValues`
- this allows JSON map bodies to bind spread `@Body` arguments without failing with `Cannot construct instance of ConvertibleValues`
- add `JsonBodyArgumentSpreadingSpec` regression coverage with `@Issue` for https://github.com/micronaut-projects/micronaut-core/issues/10263

## Verification
- `./gradlew :micronaut-http-server-netty:test --tests '*JsonBodyArgumentSpreadingSpec*' -q`

Resolves #10263