### PR TITLE
Fix NettyHttpServerSpec dual-protocol client leak

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpServerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpServerSpec.groovy
@@ -220,6 +220,7 @@ class NettyHttpServerSpec extends Specification {
 
         cleanup:
         httpsClient.stop()
+        httpClient.stop()
         embeddedServer.applicationContext.stop()
     }
 


### PR DESCRIPTION
## Summary
- Close the additional `httpClient` created in `NettyHttpServerSpec` dual-protocol test cleanup.
- Prevent leaked Netty resources from surviving until GC and tripping leak detection on CI.
- Keeps the fix minimal and directly targeted at issue #12422.

Fixes #12422