### PR TITLE
Check that basic Java types aren't being registered for introspection.

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -24,6 +24,7 @@ import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
@@ -112,6 +113,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         final String targetPackage = introspected.stringValue("targetPackage").orElse(element.getPackageName());
 
         if (!classes.isEmpty()) {
+            classes.forEach(className -> validateIntrospectedType(className, element));
             AtomicInteger index = new AtomicInteger(0);
             classes.stream().flatMap(className -> context.getClassElement(className).stream()).forEach(ce -> {
                 if (isIntrospected(context, ce)) {
@@ -145,6 +147,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     ClassElement[] elements = context.getClassElements(aPackage, includedAnnotations.toArray(EMPTY_STRING_ARRAY));
                     int j = 0;
                     for (ClassElement classElement : elements) {
+                        validateIntrospectedType(classElement.getName(), element);
                         if (classElement.isAbstract() || !classElement.isPublic() || isIntrospected(context, classElement)) {
                             continue;
                         }
@@ -171,6 +174,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             }
         } else {
             processBuilderDefinition(element, context, introspected, 0, targetPackage);
+            validateIntrospectedType(element.getName(), element);
             final BeanIntrospectionWriter writer;
             if (element.hasAnnotation(ImportedClass.class)) {
                 ClassElement originatingElement = context.getClassElement(element.stringValue(ImportedClass.class, "originatingElement").orElseThrow()).orElseThrow();
@@ -193,6 +197,12 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 );
             }
             processElement(metadata, indexedAnnotations, element, writer, ignoreSettersWithDifferingType);
+        }
+    }
+
+    private static void validateIntrospectedType(String className, ClassElement originatingElement) {
+        if (ClassUtils.isJavaBasicType(className)) {
+            throw new ProcessingException(originatingElement, ClassUtils.basicJavaTypeRegistrationMessage(className));
         }
     }
 

--- a/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
+++ b/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
@@ -119,7 +119,11 @@ class DefaultBeanIntrospector implements BeanIntrospector {
                             BeanIntrospectionReference::isPresent
                     );
                     for (BeanIntrospectionReference<Object> reference : beanIntrospectionReferences) {
-                        resolvedIntrospectionMap.put(reference.getName(), reference);
+                        String typeName = reference.getName();
+                        if (ClassUtils.isJavaBasicType(typeName)) {
+                            throw new IllegalArgumentException(ClassUtils.basicJavaTypeRegistrationMessage(typeName));
+                        }
+                        resolvedIntrospectionMap.put(typeName, reference);
                     }
                     this.introspectionMap = resolvedIntrospectionMap;
                 }

--- a/core/src/main/java/io/micronaut/core/reflect/ClassUtils.java
+++ b/core/src/main/java/io/micronaut/core/reflect/ClassUtils.java
@@ -272,6 +272,19 @@ public class ClassUtils {
     }
 
     /**
+     * Format the error message used when a basic JDK value type is registered in bean/introspection infrastructure.
+     *
+     * @param name The basic type name
+     * @return The formatted error message
+     * @since 4.10.17
+     */
+    @NonNull
+    public static String basicJavaTypeRegistrationMessage(@NonNull String name) {
+        return ("Basic JDK value type [%s] cannot be registered as introspectable or serializable. " +
+            "Register a dedicated wrapper/holder type instead.").formatted(name);
+    }
+
+    /**
      * The primitive type for the given type name. For example the value "byte" returns {@link Byte#TYPE}.
      *
      * @param primitiveType The type name

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -51,10 +51,15 @@ import javax.persistence.Id
 import javax.persistence.Version
 import java.lang.annotation.Annotation
 import java.lang.reflect.Field
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.stream.Collectors
 import java.util.stream.IntStream
 
 class BeanIntrospectionSpec extends AbstractTypeElementSpec {
+
+    private static final String BASIC_JDK_VALUE_TYPE_REGISTRATION_MESSAGE =
+        "Basic JDK value type [java.lang.String] cannot be registered as introspectable or serializable"
 
     void "test record with multiple constructors"() {
         when:
@@ -112,6 +117,26 @@ class Test {
         introspection != null
         introspection.getBeanProperties().size() == 2
         introspection.getProperty("content").get().get(new MuxedEvent1("abc", "xyz")) == "xyz"
+    }
+
+    void "test @Introspected(classes/classNames) rejects basic jdk value type"() {
+        when:
+        buildBeanIntrospection('test.Test', """
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected($memberDeclaration)
+class Test {
+}
+""")
+
+        then:
+        RuntimeException e = thrown()
+        e.message.contains(BASIC_JDK_VALUE_TYPE_REGISTRATION_MESSAGE)
+
+        where:
+        memberDeclaration << ['classes = String.class', 'classNames = "java.lang.String"']
     }
 
     @NextMajorVersion("This test should fail and require ReflectiveAccess on fields/class or there should be an option on the introspected to use reflective access by default by annotating the introspected type")
@@ -3086,6 +3111,67 @@ class Book {
         context?.close()
     }
 
+    // This generates the BeanIntrospectionReference class by hand because the runtime checks are designed to catch
+    // existing incrementally compiled codebases where the metadata already exists. The annotation processor won't
+    // allow such reference classes to be created anymore, but we still want to help users who have them in their
+    // codebases already. This test was added in March 2026. Eventually it can be removed, after we think users have
+    // all cleared their old build trees, or if the Micronaut compiler is adjusted to always delete obsolete generated
+    // files.
+    void "test BeanIntrospector rejects basic jdk value type reference registration"() {
+        given:
+        ClassLoader generatedClassLoader = buildClassLoader('test.StringIntrospectionReference', '''
+package test;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanIntrospectionReference;
+
+public class StringIntrospectionReference implements BeanIntrospectionReference<String> {
+    @Override
+    public boolean isPresent() {
+        return true;
+    }
+
+    @Override
+    public Class<String> getBeanType() {
+        return String.class;
+    }
+
+    @Override
+    public BeanIntrospection<String> load() {
+        throw new UnsupportedOperationException("Not needed for this test");
+    }
+
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        return AnnotationMetadata.EMPTY_METADATA;
+    }
+
+    @Override
+    public String getName() {
+        return String.class.getName();
+    }
+}
+''')
+        Path tempDir = Files.createTempDirectory("bean-introspector-basic-type-")
+        Path servicesDir = tempDir.resolve("META-INF/services")
+        Files.createDirectories(servicesDir)
+        Path serviceFile = servicesDir.resolve("io.micronaut.core.beans.BeanIntrospectionReference")
+        Files.writeString(serviceFile, "test.StringIntrospectionReference\n")
+        URLClassLoader classLoader = new URLClassLoader([tempDir.toUri().toURL()] as URL[], generatedClassLoader)
+        BeanIntrospector classLoaderIntrospector = BeanIntrospector.forClassLoader(classLoader)
+
+        when:
+        classLoaderIntrospector.findIntrospection(String.class)
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message.contains(BASIC_JDK_VALUE_TYPE_REGISTRATION_MESSAGE)
+
+        cleanup:
+        classLoader?.close()
+    }
+
     void "test multiple constructors with @JsonCreator"() {
         given:
         ApplicationContext context = buildContext('test.Test', '''
@@ -6023,4 +6109,3 @@ class AbcPerson {
         }
     }
 }
-


### PR DESCRIPTION
This is a programming error that can cause bugs elsewhere in Micronaut, such as in the HTTP server where missing query params may get mapped to default values accidentally.