### PR TITLE
Docs: Add note about YAML reserved words in ConfigurationProperties

### DIFF
--- a/src/main/docs/guide/config/configurationProperties.adoc
+++ b/src/main/docs/guide/config/configurationProperties.adoc
@@ -32,6 +32,40 @@ Note for more complex configurations you can structure ann:context.annotation.Co
 
 For example creating a subclass of `EngineConfig` with `@ConfigurationProperties('bar')` will resolve all properties under the path `my.engine.bar`.
 
+[NOTE]
+====
+YAML Reserved Words
+~~~~~~~~~~~~~~~~~~~~
+
+When using YAML configuration files, certain words are reserved by the YAML specification and will be automatically converted to boolean values. This includes:
+
+* `yes` / `no`
+* `true` / `false`
+* `on` / `off`
+
+If you use these words as unquoted property keys in YAML, they will be parsed as booleans instead of strings:
+
+[source,yaml]
+----
+foo:
+  bar:
+    yes: "1"     # yes is parsed as true (boolean)
+    no: "2"      # no is parsed as false (boolean)
+----
+
+To use these words as property names, you must quote the keys:
+
+[source,yaml]
+----
+foo:
+  bar:
+    "yes": "1"   # forces YAML to treat as string
+    "no": "2"    # forces YAML to treat as string
+----
+
+This is a limitation of YAML/SnakeYAML parsing and not specific to Micronaut. For more information, see the link:https://yaml.org/spec/1.2/spec.html#id2765879[YAML 1.2 Specification].
+====
+
 == Includes / Excludes
 
 For the cases where the configuration properties class inherits properties from a parent class, it may be desirable to exclude properties from the parent class. The `includes` and `excludes` members of the ann:io.micronaut.context.annotation.ConfigurationProperties[] annotation allow for that functionality. The list applies to both local properties and inherited properties.

--- a/src/main/docs/guide/config/configurationProperties.adoc
+++ b/src/main/docs/guide/config/configurationProperties.adoc
@@ -37,7 +37,7 @@ For example creating a subclass of `EngineConfig` with `@ConfigurationProperties
 YAML Reserved Words
 ~~~~~~~~~~~~~~~~~~~~
 
-When using YAML configuration files, certain words are reserved by the YAML specification and will be automatically converted to boolean values. This includes:
+When using YAML configuration files, certain words are reserved by the YAML specification and will be automatically converted to boolean values. These include:
 
 * `yes` / `no`
 * `true` / `false`


### PR DESCRIPTION
## Summary

Added documentation explaining YAML reserved boolean words (yes/no, true/false, on/off) and how they are automatically converted to boolean values when used as unquoted keys in YAML configuration.

## Problem

When property names like yes or no are used in YAML configuration without quotes, SnakeYAML parses them as boolean values (true/false) instead of strings. This causes the property binding to fail.

## Solution

Added a comprehensive note in the configurationProperties.adoc documentation that:

1. Lists all YAML reserved boolean words
2. Explains the parsing behavior
3. Shows the incorrect and correct YAML syntax
4. Provides a workaround using quoted keys
5. References the YAML 1.2 specification

## Changes

Modified:
- src/main/docs/guide/config/configurationProperties.adoc

## Test Plan

- Documentation built successfully
- Checked for correct AsciiDoc syntax
- Verified code examples are clear

Fixes #12409