### PR TITLE
fix: preserve SSL configuration when refreshing netty HTTP client

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -533,6 +533,17 @@ public class DefaultHttpClient implements
         return this;
     }
 
+    @Override
+    public HttpClient refresh() {
+        if (isRunning()) {
+            connectionManager.refresh();
+        } else {
+            start();
+            connectionManager.refresh();
+        }
+        return this;
+    }
+
     /**
      * @return The {@link MediaTypeCodecRegistry} used by this client
      * @deprecated Use body handlers instead

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
@@ -416,6 +416,30 @@ class ConnectionManagerSpec extends Specification {
         ctx.close()
     }
 
+    def 'http1 tls works after client refresh'() {
+        def ctx = ApplicationContext.run([
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
+                'spec.name': ConnectionManagerSpec.simpleName,
+        ])
+        def client = ctx.getBean(DefaultHttpClient)
+
+        def conn1 = new EmbeddedTestConnectionHttp1()
+        conn1.setupHttp1Tls()
+        def conn2 = new EmbeddedTestConnectionHttp1()
+        conn2.setupHttp1Tls()
+        patch(client, conn1, conn2)
+
+        conn1.testExchangeResponse(conn1.testExchangeRequest(client))
+        client.refresh()
+        conn2.testExchangeResponse(conn2.testExchangeRequest(client))
+
+        assertPoolConnections(client, 1)
+
+        cleanup:
+        client.close()
+        ctx.close()
+    }
+
     def 'http1 plain text customization'() {
         given:
         def ctx = ApplicationContext.run(['spec.name': ConnectionManagerSpec.simpleName])


### PR DESCRIPTION
## Summary
- override `DefaultHttpClient.refresh()` to refresh the underlying `ConnectionManager` directly instead of using `stop()/start()` semantics that clear SSL context state
- keep behavior safe for non-running clients by calling `start()` before `connectionManager.refresh()` when needed
- add a regression test in `ConnectionManagerSpec` proving TLS requests still succeed after `client.refresh()`

## Verification
- `./gradlew -p http-client test --tests 'io.micronaut.http.client.netty.ConnectionManagerSpec.http1 tls works after client refresh' --no-daemon -q`
- `./gradlew -p http-client test --tests 'io.micronaut.http.client.netty.ConnectionManagerSpec.*refresh*' --no-daemon -q`
- `./gradlew -p http-client check --no-daemon -q` *(fails in existing `ProxyBackpressureTest` with awaitility timeouts unrelated to this change)*

## Reproduction context
Calling `HttpClient.refresh()` on a TLS-configured client could lead to subsequent HTTPS calls failing with:
`Cannot send HTTPS request. SSL is disabled`.
This change preserves SSL context reload on refresh.