### PR TITLE
Minor Changes to support Truffle polyglot languages

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -54,6 +54,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.micronaut.expressions.EvaluatedExpressionConstants.EXPRESSION_PATTERN;
@@ -152,6 +153,26 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         } else {
             throw e;
         }
+    }
+
+    /**
+     * Builds an annotation value for the given annotation type name.
+     *
+     * @param annotationName The annotation name
+     * @return The built annotation value, if the annotation type can be resolved
+     */
+    public final Optional<io.micronaut.core.annotation.AnnotationValue<?>> buildAnnotation(String annotationName) {
+        return getAnnotationMirror(annotationName).map(annotationType -> {
+            RetentionPolicy retentionPolicy = getRetentionPolicy(annotationType);
+
+            Map<CharSequence, Object> defaultValues = getCachedAnnotationDefaults(annotationName, annotationType);
+            AnnotationValue<Annotation> annotationValue = new AnnotationValue<>(annotationName, Map.of(), defaultValues, retentionPolicy);
+            List<AnnotationValue<?>> stereotypes =
+                extractStereotypes(new ProcessingContext(getVisitorContext()), new ProcessedAnnotation(annotationType, annotationValue))
+                    .stream().map(pa -> pa.annotationValue)
+                    .collect(Collectors.toUnmodifiableList());
+            return new AnnotationValue<>(annotationName, Map.of(), defaultValues, retentionPolicy, stereotypes);
+        });
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/ast/MemberElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/MemberElement.java
@@ -37,7 +37,7 @@ public interface MemberElement extends Element {
     ClassElement getDeclaringType();
 
     /**
-     * The owing type is the type that owns this element. This can differ from {@link #getDeclaringType()}
+     * The owning type is the type that owns this element. This can differ from {@link #getDeclaringType()}
      * in the case of inheritance since this method will return the subclass that owners the inherited member,
      * whilst {@link #getDeclaringType()} will return the super class that declares the type.
      *

--- a/core-processor/src/main/java/io/micronaut/inject/processing/ProcessingException.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/ProcessingException.java
@@ -47,4 +47,11 @@ public final class ProcessingException extends RuntimeException {
         return null;
     }
 
+    /**
+     * @return The element that caused the issue.
+     */
+    public @Nullable Element getElement() {
+        return originatingElement;
+    }
+
 }

--- a/core/src/main/java/io/micronaut/core/graal/Boxed.java
+++ b/core/src/main/java/io/micronaut/core/graal/Boxed.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.graal;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Internal interface to allow integration with Graal Polyglot languages that marks a type as boxing or
+ * wrapping a foreign value of another language.
+ *
+ * <p>NOTE: regarded as internal and not for public consumption.</p>
+ *
+ * @param <T> The underlying type, usually a Truffle {@code Value}.
+ *
+ * @since 5.0.0
+ */
+@Internal
+@Experimental
+public interface Boxed<T> {
+    /**
+     * Unboxes the type.
+     *
+     * @return The unboxed type.
+     */
+    @SuppressWarnings("checkstyle:MethodName")
+    T $unbox();
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataBuilderSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataBuilderSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.processing.ProcessingException
+import io.micronaut.inject.ast.Element
+
+import java.lang.annotation.RetentionPolicy
+
+class AnnotationMetadataBuilderSpec extends AbstractTypeElementSpec {
+
+    void "test build annotation by name"() {
+        given:
+        def builder = newJavaAnnotationBuilder()
+
+        when:
+        def annotationValue = builder.buildAnnotation('jakarta.inject.Singleton')
+
+        then:
+        annotationValue.present
+        annotationValue.get().annotationName == 'jakarta.inject.Singleton'
+        annotationValue.get().retentionPolicy == RetentionPolicy.RUNTIME
+        annotationValue.get().stereotypes != null
+    }
+
+    void "test build annotation returns empty for unknown annotation"() {
+        given:
+        def builder = newJavaAnnotationBuilder()
+
+        expect:
+        builder.buildAnnotation('test.DoesNotExist').empty
+    }
+
+    void "test processing exception exposes originating element"() {
+        given:
+        Element element = Stub(Element)
+        def exception = new ProcessingException(element, 'test')
+
+        expect:
+        exception.element.is(element)
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -17,6 +17,7 @@ package io.micronaut.annotation.processing;
 
 import io.micronaut.annotation.processing.visitor.JavaVisitorContext;
 import io.micronaut.core.annotation.Generated;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
 import io.micronaut.core.util.CollectionUtils;
@@ -34,6 +35,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,7 +50,8 @@ import java.util.Set;
  * @author Graeme Rocher
  * @since 1.0
  */
-abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
+@Internal
+public abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
 
     /**
      * Annotation processor option used to activate incremental processing.

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationProcessingOutputVisitor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationProcessingOutputVisitor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.annotation.processing;
 
+import io.micronaut.annotation.processing.visitor.ElementProvider;
 import io.micronaut.annotation.processing.visitor.JavaNativeElement;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.ArrayUtils;
@@ -117,11 +118,12 @@ public class AnnotationProcessingOutputVisitor extends AbstractClassWriterOutput
     public void visitServiceDescriptor(String type, String classname, io.micronaut.inject.ast.Element originatingElement) {
         final String path = "META-INF/micronaut/" + type + "/" + classname;
         try {
+            Element element = originatingElement instanceof ElementProvider jne ? jne.element() : null;
             final FileObject fileObject = filer.createResource(
                 StandardLocation.CLASS_OUTPUT,
                 "",
                 path,
-                ((JavaNativeElement) originatingElement.getNativeType()).element()
+                element
             );
             try (Writer w = fileObject.openWriter()) {
                 w.write("");
@@ -142,7 +144,7 @@ public class AnnotationProcessingOutputVisitor extends AbstractClassWriterOutput
 
     private static Element[] toNativeOriginatingElements(io.micronaut.inject.ast.Element[] originatingElements) {
         return Arrays.stream(originatingElements)
-            .map(e -> ((JavaNativeElement) e.getNativeType()).element()).toArray(Element[]::new);
+            .map(e -> ((ElementProvider) e).element()).toArray(Element[]::new);
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -74,7 +74,7 @@ import static javax.lang.model.element.Modifier.PUBLIC;
  * @since 1.0
  */
 @Internal
-public abstract class AbstractJavaElement extends AbstractAnnotationElement {
+public abstract class AbstractJavaElement extends AbstractAnnotationElement implements ElementProvider {
 
     protected final JavaVisitorContext visitorContext;
     private final JavaNativeElement nativeElement;
@@ -88,6 +88,12 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement {
         super(annotationMetadataFactory);
         this.nativeElement = nativeElement;
         this.visitorContext = visitorContext;
+    }
+
+    @jakarta.annotation.Nullable
+    @Override
+    public Element element() {
+        return nativeElement.element();
     }
 
     /**

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/ElementProvider.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/ElementProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.annotation.processing.visitor;
+
+import jakarta.annotation.Nullable;
+
+import javax.lang.model.element.Element;
+
+/**
+ * A provider of an element.
+ */
+public interface ElementProvider {
+        /**
+     * @return The native element.
+     */
+    @Nullable
+    Element element();
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaNativeElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaNativeElement.java
@@ -33,11 +33,12 @@ import javax.lang.model.type.TypeVariable;
  * @since 4.0.0
  */
 @Internal
-public sealed interface JavaNativeElement {
+public sealed interface JavaNativeElement extends ElementProvider {
 
     /**
      * @return The native element.
      */
+    @Override
     @Nullable
     Element element();
 


### PR DESCRIPTION
## Summary
- Minor Changes to support Truffle polyglot languages.
- Adds internal Graal boxed-value contract and wiring in core annotation processing visitors.
- Includes small supporting updates in `core-processor`, `core`, and `inject-java`.