### PR TITLE
Changes to support Micronaut processors as a Native Image

### DIFF
--- a/core-processor/src/main/java/io/micronaut/aop/writer/RuntimeProxyBeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/RuntimeProxyBeanDefinitionWriter.java
@@ -46,6 +46,8 @@ import java.lang.reflect.Method;
 @Internal
 public class RuntimeProxyBeanDefinitionWriter extends ProxyingBeanDefinitionWriter {
 
+    public static final String RUNTIME_PROXY_SUFFIX = "$RuntimeProxy";
+
     private static final Method GET_BEAN = ReflectionUtils.getRequiredInternalMethod(
         BeanResolutionContext.class,
         "getBean",
@@ -65,8 +67,6 @@ public class RuntimeProxyBeanDefinitionWriter extends ProxyingBeanDefinitionWrit
         DefaultRuntimeProxyDefinition.class,
         "introduction",
         BeanResolutionContext.class, BeanDefinition.class);
-
-    public static final String RUNTIME_PROXY_SUFFIX = "$RuntimeProxy";
 
     public RuntimeProxyBeanDefinitionWriter(ClassElement targetType, BeanDefinitionWriter parent, OptionalValues<Boolean> settings, VisitorContext visitorContext, AnnotationValue<?>... interceptorBinding) {
         super(RUNTIME_PROXY_SUFFIX, targetType, targetType, parent, settings, visitorContext, interceptorBinding);

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -68,6 +69,8 @@ import static io.micronaut.expressions.EvaluatedExpressionConstants.EXPRESSION_P
  */
 @Internal
 public abstract class AbstractAnnotationMetadataBuilder<T, A> {
+    private static final String USE_CONTEXT_CLASSLOADER_PROPERTY = "micronaut.processing.use.context.classloader";
+
 
     /**
      * Names of annotations that should produce deprecation warnings.
@@ -84,8 +87,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private static final Map<String, Map<CharSequence, Object>> ANNOTATION_DEFAULTS = new HashMap<>(20);
 
     static {
-        for (AnnotationMapper<?> mapper : SoftServiceLoader.load(AnnotationMapper.class, AbstractAnnotationMetadataBuilder.class.getClassLoader())
-                .disableFork().collectAll()) {
+        ClassLoader classLoader = resolveServiceClassLoader();
+
+        for (AnnotationMapper<?> mapper : loadServices(AnnotationMapper.class, classLoader)) {
             try {
                 String name = null;
                 if (mapper instanceof TypedAnnotationMapper<?> typedAnnotationMapper) {
@@ -101,8 +105,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             }
         }
 
-        for (AnnotationTransformer<?> transformer : SoftServiceLoader.load(AnnotationTransformer.class, AbstractAnnotationMetadataBuilder.class.getClassLoader())
-                .disableFork().collectAll()) {
+        for (AnnotationTransformer<?> transformer : loadServices(AnnotationTransformer.class, classLoader)) {
             try {
                 String name = null;
                 if (transformer instanceof TypedAnnotationTransformer<?> typedAnnotationTransformer) {
@@ -118,8 +121,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             }
         }
 
-        for (AnnotationRemapper mapper : SoftServiceLoader.load(AnnotationRemapper.class, AbstractAnnotationMetadataBuilder.class.getClassLoader())
-                .disableFork().collectAll()) {
+        for (AnnotationRemapper mapper : loadServices(AnnotationRemapper.class, classLoader)) {
             try {
                 String name = mapper.getPackageName();
                 if (name.equals(AnnotationRemapper.ALL_PACKAGES)) {
@@ -131,7 +133,45 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 // mapper, missing dependencies, continue
             }
         }
-        ELEMENT_VALIDATOR = SoftServiceLoader.load(AnnotatedElementValidator.class).firstAvailable().orElse(null);
+        ELEMENT_VALIDATOR = loadFirstService(AnnotatedElementValidator.class, classLoader).orElse(null);
+    }
+
+    private static ClassLoader resolveServiceClassLoader() {
+        if (Boolean.getBoolean(USE_CONTEXT_CLASSLOADER_PROPERTY)) {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            if (contextClassLoader != null) {
+                return contextClassLoader;
+            }
+        }
+        return AbstractAnnotationMetadataBuilder.class.getClassLoader();
+    }
+
+    private static <S> List<S> loadServices(Class<S> serviceType, ClassLoader classLoader) {
+        List<S> services = SoftServiceLoader.load(serviceType, classLoader)
+            .disableFork()
+            .collectAll();
+        if (!services.isEmpty()) {
+            return services;
+        }
+        services = new ArrayList<>();
+        ServiceLoader<S> serviceLoader = ServiceLoader.load(serviceType, classLoader);
+        for (ServiceLoader.Provider<S> provider : serviceLoader.stream().toList()) {
+            try {
+                services.add(provider.get());
+            } catch (Throwable e) {
+                if (e instanceof VirtualMachineError virtualMachineError) {
+                    throw virtualMachineError;
+                }
+            }
+        }
+        return services;
+    }
+
+    private static <S> Optional<S> loadFirstService(Class<S> serviceType, ClassLoader classLoader) {
+        for (S service : loadServices(serviceType, classLoader)) {
+            return Optional.of(service);
+        }
+        return Optional.empty();
     }
 
     private boolean validating = true;

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -164,10 +164,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             return services;
         }
         services = new ArrayList<>();
-        ServiceLoader<S> serviceLoader = ServiceLoader.load(serviceType, classLoader);
-        for (ServiceLoader.Provider<S> provider : serviceLoader.stream().toList()) {
+        Iterator<ServiceLoader.Provider<S>> it = ServiceLoader.load(serviceType, classLoader).stream().iterator();
+        while (it.hasNext()) {
             try {
-                services.add(provider.get());
+                services.add(it.next().get());
             } catch (Throwable e) {
                 if (e instanceof VirtualMachineError virtualMachineError) {
                     throw virtualMachineError;

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -136,6 +136,16 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         ELEMENT_VALIDATOR = loadFirstService(AnnotatedElementValidator.class, classLoader).orElse(null);
     }
 
+    private boolean validating = true;
+    private final Set<T> erroneousElements = new HashSet<>();
+
+    /**
+     * Default constructor.
+     */
+    protected AbstractAnnotationMetadataBuilder() {
+
+    }
+
     private static ClassLoader resolveServiceClassLoader() {
         if (Boolean.getBoolean(VisitorContext.MICRONAUT_PROCESSING_USE_CONTEXT_CLASSLOADER)) {
             ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -190,16 +200,6 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             }
         }
         return Optional.empty();
-    }
-
-    private boolean validating = true;
-    private final Set<T> erroneousElements = new HashSet<>();
-
-    /**
-     * Default constructor.
-     */
-    protected AbstractAnnotationMetadataBuilder() {
-
     }
 
     @SuppressWarnings("java:S1872")

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -31,6 +31,7 @@ import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.core.io.service.SoftServiceLoader;
+import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
@@ -69,7 +70,6 @@ import static io.micronaut.expressions.EvaluatedExpressionConstants.EXPRESSION_P
  */
 @Internal
 public abstract class AbstractAnnotationMetadataBuilder<T, A> {
-    private static final String USE_CONTEXT_CLASSLOADER_PROPERTY = "micronaut.processing.use.context.classloader";
 
 
     /**
@@ -137,7 +137,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     private static ClassLoader resolveServiceClassLoader() {
-        if (Boolean.getBoolean(USE_CONTEXT_CLASSLOADER_PROPERTY)) {
+        if (Boolean.getBoolean(VisitorContext.MICRONAUT_PROCESSING_USE_CONTEXT_CLASSLOADER)) {
             ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
             if (contextClassLoader != null) {
                 return contextClassLoader;
@@ -168,8 +168,26 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     private static <S> Optional<S> loadFirstService(Class<S> serviceType, ClassLoader classLoader) {
-        for (S service : loadServices(serviceType, classLoader)) {
-            return Optional.of(service);
+        for (ServiceDefinition<S> definition : SoftServiceLoader.load(serviceType, classLoader).disableFork()) {
+            try {
+                if (definition.isPresent()) {
+                    return Optional.of(definition.load());
+                }
+            } catch (Throwable e) {
+                if (e instanceof VirtualMachineError virtualMachineError) {
+                    throw virtualMachineError;
+                }
+            }
+        }
+        Iterator<ServiceLoader.Provider<S>> it = ServiceLoader.load(serviceType, classLoader).stream().iterator();
+        while (it.hasNext()) {
+            try {
+                return Optional.of(it.next().get());
+            } catch (Throwable e) {
+                if (e instanceof VirtualMachineError virtualMachineError) {
+                    throw virtualMachineError;
+                }
+            }
         }
         return Optional.empty();
     }

--- a/core-processor/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorLoader.java
+++ b/core-processor/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorLoader.java
@@ -16,7 +16,10 @@
 package io.micronaut.inject.visitor;
 
 import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ServiceLoader;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.order.OrderUtil;
 
@@ -27,14 +30,21 @@ import io.micronaut.core.order.OrderUtil;
  * @since 3.0.0
  */
 final class BeanElementVisitorLoader {
+    private static final String USE_CONTEXT_CLASSLOADER_PROPERTY = "micronaut.processing.use.context.classloader";
+
     /**
      * @return The loaded visitors
      */
     @SuppressWarnings("unchecked")
     static List<BeanElementVisitor<?>> load() {
-        List<? extends BeanElementVisitor<?>> visitors = (List) SoftServiceLoader.load(BeanElementVisitor.class)
-            .disableFork()
-            .collectAll(BeanElementVisitor::isEnabled);
+        ClassLoader classLoader = BeanElementVisitorLoader.class.getClassLoader();
+        if (Boolean.getBoolean(USE_CONTEXT_CLASSLOADER_PROPERTY)) {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            if (contextClassLoader != null) {
+                classLoader = contextClassLoader;
+            }
+        }
+        List<BeanElementVisitor<?>> visitors = loadServices(classLoader);
 
         if (visitors.isEmpty()) {
             return Collections.emptyList();
@@ -42,5 +52,29 @@ final class BeanElementVisitorLoader {
             OrderUtil.sort(visitors);
             return Collections.unmodifiableList(visitors);
         }
+    }
+
+    private static List<BeanElementVisitor<?>> loadServices(ClassLoader classLoader) {
+        List<BeanElementVisitor<?>> visitors = (List) SoftServiceLoader.load(BeanElementVisitor.class, classLoader)
+            .disableFork()
+            .collectAll(BeanElementVisitor::isEnabled);
+        if (!visitors.isEmpty()) {
+            return visitors;
+        }
+        visitors = new ArrayList<>();
+        Iterator<ServiceLoader.Provider<BeanElementVisitor>> iterator = ServiceLoader.load(BeanElementVisitor.class, classLoader).stream().iterator();
+        while (iterator.hasNext()) {
+            try {
+                BeanElementVisitor<?> visitor = iterator.next().get();
+                if (visitor.isEnabled()) {
+                    visitors.add(visitor);
+                }
+            } catch (Throwable e) {
+                if (e instanceof VirtualMachineError virtualMachineError) {
+                    throw virtualMachineError;
+                }
+            }
+        }
+        return visitors;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorLoader.java
+++ b/core-processor/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorLoader.java
@@ -30,7 +30,6 @@ import io.micronaut.core.order.OrderUtil;
  * @since 3.0.0
  */
 final class BeanElementVisitorLoader {
-    private static final String USE_CONTEXT_CLASSLOADER_PROPERTY = "micronaut.processing.use.context.classloader";
 
     /**
      * @return The loaded visitors
@@ -38,7 +37,7 @@ final class BeanElementVisitorLoader {
     @SuppressWarnings("unchecked")
     static List<BeanElementVisitor<?>> load() {
         ClassLoader classLoader = BeanElementVisitorLoader.class.getClassLoader();
-        if (Boolean.getBoolean(USE_CONTEXT_CLASSLOADER_PROPERTY)) {
+        if (Boolean.getBoolean(VisitorContext.MICRONAUT_PROCESSING_USE_CONTEXT_CLASSLOADER)) {
             ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
             if (contextClassLoader != null) {
                 classLoader = contextClassLoader;

--- a/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
+++ b/core-processor/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
@@ -51,6 +51,7 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
     String MICRONAUT_PROCESSING_PROJECT_DIR = "micronaut.processing.project.dir";
     String MICRONAUT_PROCESSING_GROUP = "micronaut.processing.group";
     String MICRONAUT_PROCESSING_MODULE = "micronaut.processing.module";
+    String MICRONAUT_PROCESSING_USE_CONTEXT_CLASSLOADER = "micronaut.processing.use.context.classloader";
 
     /**
      * @return The visitor context's language.

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -298,14 +298,21 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
             } catch (InaccessibleObjectException | SecurityException e) {
                 // Module system or security policy denies reflective access; treat as illegal access
                 // so dynamic service scanning can skip this class gracefully
-                throw new IllegalAccessException("Cannot access constructor of " + clazz.getName() + ": " + e.getMessage());
+                IllegalAccessException iae = new IllegalAccessException("Cannot access constructor of " + clazz.getName() + ": " + e.getMessage());
+                iae.initCause(e);
+                throw iae;
             }
         }
         return constructor.newInstance();
     }
 
     /**
-     * A {@link ServiceDefinition} implementation that uses a {@link MethodHandles.Lookup} object to find a public constructor.
+     * A {@link ServiceDefinition} implementation that creates instances using the same instantiation
+     * strategy as {@link SoftServiceLoader#instantiate(Class)}: it first attempts to invoke a no-argument
+     * constructor via a {@link MethodHandles.Lookup} method handle, and if that fails due to access
+     * restrictions or similar conditions, it falls back to reflective instantiation using
+     * {@link java.lang.Class#getDeclaredConstructor()}. Depending on module and security configuration,
+     * this may allow invoking non-public no-argument constructors.
      *
      * @param <S> The service type
      */

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -20,6 +20,7 @@ import io.micronaut.core.reflect.ClassUtils;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -181,8 +182,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
             try {
                 @SuppressWarnings("unchecked") final Class<S> loadedClass =
                         (Class<S>) Class.forName(className, false, classLoader);
-                // MethodHandler should more performant than the basic reflection
-                S result = (S) LOOKUP.findConstructor(loadedClass, VOID_TYPE).invoke();
+                S result = instantiate(loadedClass);
                 if (predicate != null && !predicate.test(result)) {
                     return null;
                 }
@@ -276,6 +276,27 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
         return new ServiceScanner<>(classLoader, serviceName, lineCondition, transformer).createCollector();
     }
 
+    private static <S> S instantiate(Class<S> clazz) throws Throwable {
+        try {
+            return instantiateUsingMethodHandle(clazz);
+        } catch (NoSuchMethodException | IllegalAccessException | IllegalAccessError e) {
+            return instantiateUsingReflection(clazz);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <S> S instantiateUsingMethodHandle(Class<S> clazz) throws Throwable {
+        return (S) LOOKUP.findConstructor(clazz, VOID_TYPE).invoke();
+    }
+
+    private static <S> S instantiateUsingReflection(Class<S> clazz) throws ReflectiveOperationException {
+        Constructor<S> constructor = clazz.getDeclaredConstructor();
+        if (!constructor.canAccess(null)) {
+            constructor.setAccessible(true);
+        }
+        return constructor.newInstance();
+    }
+
     /**
      * A {@link ServiceDefinition} implementation that uses a {@link MethodHandles.Lookup} object to find a public constructor.
      *
@@ -317,7 +338,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
         @SuppressWarnings({"unchecked"})
         private static <S> S doCreate(Class<S> clazz) {
             try {
-                return (S) LOOKUP.findConstructor(clazz, VOID_TYPE).invoke();
+                return instantiate(clazz);
             } catch (Throwable e) {
                 throw new ServiceLoadingException(e);
             }

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -21,6 +21,7 @@ import io.micronaut.core.reflect.ClassUtils;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InaccessibleObjectException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -292,7 +293,13 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
     private static <S> S instantiateUsingReflection(Class<S> clazz) throws ReflectiveOperationException {
         Constructor<S> constructor = clazz.getDeclaredConstructor();
         if (!constructor.canAccess(null)) {
-            constructor.setAccessible(true);
+            try {
+                constructor.setAccessible(true);
+            } catch (InaccessibleObjectException | SecurityException e) {
+                // Module system or security policy denies reflective access; treat as illegal access
+                // so dynamic service scanning can skip this class gracefully
+                throw new IllegalAccessException("Cannot access constructor of " + clazz.getName() + ": " + e.getMessage());
+            }
         }
         return constructor.newInstance();
     }

--- a/core/src/test/java/io/micronaut/core/io/service/SoftServiceLoaderTest.java
+++ b/core/src/test/java/io/micronaut/core/io/service/SoftServiceLoaderTest.java
@@ -16,6 +16,20 @@ import io.micronaut.core.io.service.SoftServiceLoader.ServiceCollector;
 
 public class SoftServiceLoaderTest {
 
+    interface TestService {
+        String value();
+    }
+
+    static final class PackagePrivateConstructorService implements TestService {
+        PackagePrivateConstructorService() {
+        }
+
+        @Override
+        public String value() {
+            return "fallback";
+        }
+    }
+
     @Test
     void findServicesUsingJrtScheme() {
         String modulename = "io.micronaut.core.test";
@@ -39,5 +53,13 @@ public class SoftServiceLoaderTest {
         finally {
             Thread.currentThread().setContextClassLoader(oldLoader);
         }
+    }
+
+    @Test
+    void staticDefinitionFallsBackToReflectionWhenMethodHandleCannotAccessConstructor() {
+        SoftServiceLoader.StaticDefinition<PackagePrivateConstructorService> serviceDefinition =
+            SoftServiceLoader.StaticDefinition.of(PackagePrivateConstructorService.class.getName(), PackagePrivateConstructorService.class);
+
+        assertEquals("fallback", serviceDefinition.load().value());
     }
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -59,6 +59,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -81,6 +82,8 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
     VisitorContext.MICRONAUT_PROCESSING_MODULE
 })
 public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcessor {
+    private static final String USE_CONTEXT_CLASSLOADER_PROPERTY = "micronaut.processing.use.context.classloader";
+
     private static final Set<String> VISITOR_WARNINGS;
     private static final Set<String> SUPPORTED_ANNOTATION_NAMES;
 
@@ -214,13 +217,21 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
             .flatMap(Collection::stream);
         Stream<String> visitorsAnnotationsOptions = typeElementVisitors
             .stream()
-            .filter(tev -> tev.getClass().isAnnotationPresent(SupportedOptions.class))
+            .filter(this::hasSupportedOptionsAnnotation)
             .map(TypeElementVisitor::getClass)
             .map(cls -> (SupportedOptions) cls.getAnnotation(SupportedOptions.class))
             .flatMap((SupportedOptions supportedOptions) -> Arrays.stream(supportedOptions.value()));
         return Stream.of(baseOption, visitorsAnnotationsOptions, visitorsOptions)
             .flatMap(Stream::sequential)
             .collect(Collectors.toSet());
+    }
+
+    private boolean hasSupportedOptionsAnnotation(TypeElementVisitor<?, ?> visitor) {
+        try {
+            return visitor.getClass().isAnnotationPresent(SupportedOptions.class);
+        } catch (UnsupportedOperationException e) {
+            return false;
+        }
     }
 
     @NextMajorVersion("`roundEnv.getRootElements()` should be removed in Micronaut 4. " +
@@ -435,14 +446,27 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
     }
 
     private static Collection<? extends TypeElementVisitor<?, ?>> findCoreTypeElementVisitors(@Nullable Set<String> warnings) {
-        return SoftServiceLoader.load(TypeElementVisitor.class, TypeElementVisitorProcessor.class.getClassLoader())
-            .disableFork()
-            .collectAll(visitor -> {
+        ClassLoader classLoader = TypeElementVisitorProcessor.class.getClassLoader();
+        if (Boolean.getBoolean(USE_CONTEXT_CLASSLOADER_PROPERTY)) {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            if (contextClassLoader != null) {
+                classLoader = contextClassLoader;
+            }
+        }
+        return loadTypeElementVisitors(classLoader)
+            .stream()
+            .filter(visitor -> {
                 if (!visitor.isEnabled()) {
                     return false;
                 }
 
-                final Requires requires = visitor.getClass().getAnnotation(Requires.class);
+                final Requires requires;
+                try {
+                    requires = visitor.getClass().getAnnotation(Requires.class);
+                } catch (UnsupportedOperationException e) {
+                    // Crema can throw UnsupportedOperationException for runtime annotation lookup; ignore @Requires checks in that case.
+                    return true;
+                }
                 if (requires != null) {
                     final Requires.Sdk sdk = requires.sdk();
                     if (sdk == Requires.Sdk.MICRONAUT) {
@@ -460,10 +484,29 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                     }
                 }
                 return true;
-            }).stream()
-            .filter(Objects::nonNull)
-            .<TypeElementVisitor<?, ?>>map(e -> e)
+            })
             // remove duplicate classes
             .collect(Collectors.toMap(Object::getClass, v -> v, (a, b) -> a)).values();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<TypeElementVisitor<?, ?>> loadTypeElementVisitors(ClassLoader classLoader) {
+        List<TypeElementVisitor<?, ?>> visitors = (List) SoftServiceLoader.load(TypeElementVisitor.class, classLoader)
+            .disableFork()
+            .collectAll();
+        if (!visitors.isEmpty()) {
+            return visitors;
+        }
+        visitors = new ArrayList<>();
+        for (ServiceLoader.Provider<TypeElementVisitor> provider : ServiceLoader.load(TypeElementVisitor.class, classLoader).stream().toList()) {
+            try {
+                visitors.add(provider.get());
+            } catch (Throwable e) {
+                if (e instanceof VirtualMachineError virtualMachineError) {
+                    throw virtualMachineError;
+                }
+            }
+        }
+        return visitors;
     }
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -438,12 +438,16 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
      */
     protected synchronized Collection<? extends TypeElementVisitor<?, ?>> findTypeElementVisitors() {
         if (typeElementVisitors == null) {
-            for (String visitorWarning : VISITOR_WARNINGS) {
-                warning(visitorWarning);
-            }
+            reportWarnings();
             typeElementVisitors = findCoreTypeElementVisitors(null);
         }
         return typeElementVisitors;
+    }
+
+    private void reportWarnings() {
+        for (String visitorWarning : VISITOR_WARNINGS) {
+            warning(visitorWarning);
+        }
     }
 
     private static Collection<? extends TypeElementVisitor<?, ?>> findCoreTypeElementVisitors(@Nullable Set<String> warnings) {
@@ -454,7 +458,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                 classLoader = contextClassLoader;
             }
         }
-        return loadTypeElementVisitors(classLoader)
+        return loadTypeElementVisitors(classLoader, warnings)
             .stream()
             .filter(visitor -> {
                 if (!visitor.isEnabled()) {
@@ -491,7 +495,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
     }
 
     @SuppressWarnings("unchecked")
-    private static List<TypeElementVisitor<?, ?>> loadTypeElementVisitors(ClassLoader classLoader) {
+    private static List<TypeElementVisitor<?, ?>> loadTypeElementVisitors(ClassLoader classLoader, @Nullable Set<String> warnings) {
         List<TypeElementVisitor<?, ?>> visitors = (List) SoftServiceLoader.load(TypeElementVisitor.class, classLoader)
             .disableFork()
             .collectAll();
@@ -501,11 +505,18 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
         visitors = new ArrayList<>();
         Iterator<ServiceLoader.Provider<TypeElementVisitor>> it = ServiceLoader.load(TypeElementVisitor.class, classLoader).stream().iterator();
         while (it.hasNext()) {
+            Class<? extends TypeElementVisitor> type = null;
             try {
-                visitors.add(it.next().get());
+                ServiceLoader.Provider<TypeElementVisitor> provider = it.next();
+                type = provider.type();
+                visitors.add(provider.get());
             } catch (Throwable e) {
                 if (e instanceof VirtualMachineError virtualMachineError) {
                     throw virtualMachineError;
+                } else {
+                    if (warnings != null) {
+                        warnings.add("Error loading TypeElementVisitor " + (type != null ? type.getSimpleName() : "") + ": " + e.getMessage());
+                    }
                 }
             }
         }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -56,6 +56,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -82,7 +83,6 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
     VisitorContext.MICRONAUT_PROCESSING_MODULE
 })
 public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcessor {
-    private static final String USE_CONTEXT_CLASSLOADER_PROPERTY = "micronaut.processing.use.context.classloader";
 
     private static final Set<String> VISITOR_WARNINGS;
     private static final Set<String> SUPPORTED_ANNOTATION_NAMES;
@@ -447,7 +447,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
 
     private static Collection<? extends TypeElementVisitor<?, ?>> findCoreTypeElementVisitors(@Nullable Set<String> warnings) {
         ClassLoader classLoader = TypeElementVisitorProcessor.class.getClassLoader();
-        if (Boolean.getBoolean(USE_CONTEXT_CLASSLOADER_PROPERTY)) {
+        if (Boolean.getBoolean(VisitorContext.MICRONAUT_PROCESSING_USE_CONTEXT_CLASSLOADER)) {
             ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
             if (contextClassLoader != null) {
                 classLoader = contextClassLoader;
@@ -485,8 +485,8 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                 }
                 return true;
             })
-            // remove duplicate classes
-            .collect(Collectors.toMap(Object::getClass, v -> v, (a, b) -> a)).values();
+            // remove duplicate classes, preserving encounter order via LinkedHashMap
+            .collect(Collectors.toMap(Object::getClass, v -> v, (a, b) -> a, LinkedHashMap::new)).values();
     }
 
     @SuppressWarnings("unchecked")

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -56,6 +56,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -498,9 +499,10 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
             return visitors;
         }
         visitors = new ArrayList<>();
-        for (ServiceLoader.Provider<TypeElementVisitor> provider : ServiceLoader.load(TypeElementVisitor.class, classLoader).stream().toList()) {
+        Iterator<ServiceLoader.Provider<TypeElementVisitor>> it = ServiceLoader.load(TypeElementVisitor.class, classLoader).stream().iterator();
+        while (it.hasNext()) {
             try {
-                visitors.add(provider.get());
+                visitors.add(it.next().get());
             } catch (Throwable e) {
                 if (e instanceof VirtualMachineError virtualMachineError) {
                     throw virtualMachineError;

--- a/inject-java/src/test/groovy/io/micronaut/annotation/processing/TypeElementVisitorProcessorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/processing/TypeElementVisitorProcessorSpec.groovy
@@ -3,7 +3,12 @@ package io.micronaut.annotation.processing
 import io.micronaut.annotation.processing.TypeElementVisitorProcessor
 import io.micronaut.aop.introduction.Stub
 import io.micronaut.http.annotation.Controller
+import io.micronaut.inject.visitor.TypeElementVisitor
 import spock.lang.Specification
+
+import java.net.URL
+import java.util.Collections
+import java.util.Enumeration
 
 class TypeElementVisitorProcessorSpec extends Specification {
 
@@ -18,5 +23,61 @@ class TypeElementVisitorProcessorSpec extends Specification {
         visitedAnnotationNames.contains(Stub.name)
         visitedAnnotationNames.contains(Controller.name)
         !visitedAnnotationNames.contains("*")
+    }
+
+    void "test core visitors are de-duplicated"() {
+        given:
+        def warnings = new LinkedHashSet<String>()
+        def method = TypeElementVisitorProcessor.getDeclaredMethod("findCoreTypeElementVisitors", Set)
+        method.accessible = true
+
+        when:
+        Collection<TypeElementVisitor<?, ?>> visitors = (Collection<TypeElementVisitor<?, ?>>) method.invoke(null, warnings)
+        List<Class<?>> classes = visitors.collect { it.class }
+
+        then:
+        !visitors.isEmpty()
+        classes.size() == classes.toSet().size()
+    }
+
+    void "test context classloader can control visitor discovery"() {
+        given:
+        def method = TypeElementVisitorProcessor.getDeclaredMethod("findCoreTypeElementVisitors", Set)
+        method.accessible = true
+        def previous = Thread.currentThread().contextClassLoader
+        def propertyName = "micronaut.processing.use.context.classloader"
+        def previousProperty = System.getProperty(propertyName)
+
+        when:
+        Thread.currentThread().contextClassLoader = new NoResourcesClassLoader(previous)
+        System.setProperty(propertyName, "true")
+        Collection<TypeElementVisitor<?, ?>> visitors = (Collection<TypeElementVisitor<?, ?>>) method.invoke(null, [null] as Object[])
+
+        then:
+        visitors.isEmpty()
+
+        cleanup:
+        Thread.currentThread().contextClassLoader = previous
+        if (previousProperty == null) {
+            System.clearProperty(propertyName)
+        } else {
+            System.setProperty(propertyName, previousProperty)
+        }
+    }
+
+    private static final class NoResourcesClassLoader extends ClassLoader {
+        NoResourcesClassLoader(ClassLoader parent) {
+            super(parent)
+        }
+
+        @Override
+        Enumeration<URL> getResources(String name) {
+            return Collections.emptyEnumeration()
+        }
+
+        @Override
+        URL getResource(String name) {
+            return null
+        }
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/visitor/BeanElementVisitorLoaderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/visitor/BeanElementVisitorLoaderSpec.groovy
@@ -1,0 +1,49 @@
+package io.micronaut.inject.visitor
+
+import spock.lang.Specification
+
+import java.net.URL
+import java.util.Collections
+import java.util.Enumeration
+
+class BeanElementVisitorLoaderSpec extends Specification {
+
+    void "test context classloader can disable bean visitor discovery"() {
+        given:
+        def previous = Thread.currentThread().contextClassLoader
+        def propertyName = VisitorContext.MICRONAUT_PROCESSING_USE_CONTEXT_CLASSLOADER
+        def previousProperty = System.getProperty(propertyName)
+
+        when:
+        Thread.currentThread().contextClassLoader = new NoResourcesClassLoader(previous)
+        System.setProperty(propertyName, "true")
+        def visitors = BeanElementVisitorLoader.load()
+
+        then:
+        visitors.isEmpty()
+
+        cleanup:
+        Thread.currentThread().contextClassLoader = previous
+        if (previousProperty == null) {
+            System.clearProperty(propertyName)
+        } else {
+            System.setProperty(propertyName, previousProperty)
+        }
+    }
+
+    private static final class NoResourcesClassLoader extends ClassLoader {
+        NoResourcesClassLoader(ClassLoader parent) {
+            super(parent)
+        }
+
+        @Override
+        Enumeration<URL> getResources(String name) {
+            return Collections.emptyEnumeration()
+        }
+
+        @Override
+        URL getResource(String name) {
+            return null
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Split out non-`micronautc` prerequisite changes from #12444 so they can be reviewed and merged independently
- Keep processor service-loading and visitor bootstrapping updates needed for native-image processor execution
- Preserve MethodHandle-first constructor loading in `SoftServiceLoader` with reflection fallback and coverage in `SoftServiceLoaderTest`

## Verification
- `./gradlew :micronaut-core:test --tests 'io.micronaut.core.io.service.SoftServiceLoaderTest' :micronaut-core-processor:compileJava :micronaut-inject-java:compileJava`