### PR TITLE
fix: avoid wildcard default content type for responses

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/NoBodyResponseTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/NoBodyResponseTest.java
@@ -269,6 +269,29 @@ public class NoBodyResponseTest {
                     .build()));
     }
 
+    @Test
+    void noContentByteArrayDoesNotSetContentType() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/response-no-body/no-content-byte-array"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.NO_CONTENT)
+                    .body(BodyAssertion.IS_MISSING)
+                    .assertResponse(response -> org.junit.jupiter.api.Assertions.assertFalse(response.getHeaders().contains(HttpHeaders.CONTENT_TYPE)))
+                    .build()));
+    }
+
+    @Test
+    void nonEmptyByteArrayDefaultsToApplicationJson() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/response-no-body/non-empty-byte-array"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .assertResponse(response -> org.junit.jupiter.api.Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getContentType().orElse(null)))
+                    .build()));
+    }
+
     @Controller("/response-no-body")
     @Requires(property = "spec.name", value = SPEC_NAME)
     static class BodyController {
@@ -332,6 +355,16 @@ public class NoBodyResponseTest {
         @Post(uri = "/post-returns-response-pojo")
         HttpResponse<Point> postBodyReturnsPojoResponse(@Body Point data) {
             return HttpResponse.ok();
+        }
+
+        @Get("/no-content-byte-array")
+        HttpResponse<byte[]> noContentByteArray() {
+            return HttpResponse.<byte[]>status(HttpStatus.NO_CONTENT).body(new byte[0]);
+        }
+
+        @Get("/non-empty-byte-array")
+        HttpResponse<byte[]> nonEmptyByteArray() {
+            return HttpResponse.ok(new byte[]{1});
         }
 
     }

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/NoBodyResponseTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/NoBodyResponseTest.java
@@ -282,9 +282,57 @@ public class NoBodyResponseTest {
     }
 
     @Test
+    void noContentByteArrayWithParameterizedWildcardAcceptDoesNotSetContentType() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/response-no-body/no-content-byte-array")
+                .header(HttpHeaders.ACCEPT, "*/*;q=0.8"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.NO_CONTENT)
+                    .body(BodyAssertion.IS_MISSING)
+                    .assertResponse(response -> org.junit.jupiter.api.Assertions.assertFalse(response.getHeaders().contains(HttpHeaders.CONTENT_TYPE)))
+                    .build()));
+    }
+
+    @Test
     void nonEmptyByteArrayDefaultsToApplicationJson() throws IOException {
         asserts(SPEC_NAME,
             HttpRequest.GET("/response-no-body/non-empty-byte-array"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .assertResponse(response -> org.junit.jupiter.api.Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getContentType().orElse(null)))
+                    .build()));
+    }
+
+    @Test
+    void nonEmptyByteArrayWithParameterizedWildcardAcceptDefaultsToApplicationJson() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/response-no-body/non-empty-byte-array")
+                .header(HttpHeaders.ACCEPT, "*/*;q=0.8"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .assertResponse(response -> org.junit.jupiter.api.Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getContentType().orElse(null)))
+                    .build()));
+    }
+
+    @Test
+    void noContentByteArrayWithParameterizedWildcardProducesDoesNotSetContentType() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/response-no-body/no-content-byte-array-wildcard-parameterized-produces"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.NO_CONTENT)
+                    .body(BodyAssertion.IS_MISSING)
+                    .assertResponse(response -> org.junit.jupiter.api.Assertions.assertFalse(response.getHeaders().contains(HttpHeaders.CONTENT_TYPE)))
+                    .build()));
+    }
+
+    @Test
+    void nonEmptyByteArrayWithParameterizedWildcardProducesDefaultsToApplicationJson() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/response-no-body/non-empty-byte-array-wildcard-parameterized-produces"),
             (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
                 HttpResponseAssertion.builder()
                     .status(HttpStatus.OK)
@@ -364,6 +412,16 @@ public class NoBodyResponseTest {
 
         @Get("/non-empty-byte-array")
         HttpResponse<byte[]> nonEmptyByteArray() {
+            return HttpResponse.ok(new byte[]{1});
+        }
+
+        @Get(uri = "/no-content-byte-array-wildcard-parameterized-produces", produces = "*/*;v=1")
+        HttpResponse<byte[]> noContentByteArrayWildcardParameterizedProduces() {
+            return HttpResponse.<byte[]>status(HttpStatus.NO_CONTENT).body(new byte[0]);
+        }
+
+        @Get(uri = "/non-empty-byte-array-wildcard-parameterized-produces", produces = "*/*;v=1")
+        HttpResponse<byte[]> nonEmptyByteArrayWildcardParameterizedProduces() {
             return HttpResponse.ok(new byte[]{1});
         }
 

--- a/http-server/src/main/java/io/micronaut/http/server/ResponseLifecycle.java
+++ b/http-server/src/main/java/io/micronaut/http/server/ResponseLifecycle.java
@@ -147,7 +147,8 @@ public abstract class ResponseLifecycle {
             } else {
                 responseBodyType = Argument.of((Class<Object>) body.getClass());
             }
-            if (responseMediaType == null) {
+            boolean emptyBody = isImplicitlyEmptyBody(body);
+            if (responseMediaType == null && !emptyBody) {
                 // perf: check for common body types
                 //noinspection ConditionCoveredByFurtherCondition
                 if (!(body instanceof String) && !(body instanceof byte[]) && body instanceof MediaTypeProvider mediaTypeProvider) {
@@ -158,7 +159,6 @@ public abstract class ResponseLifecycle {
                     responseMediaType = MediaType.APPLICATION_JSON_TYPE;
                 }
             }
-
             if (messageBodyWriter == null) {
                 // lookup write to use, any logic that hits this path should consider setting
                 // a body writer on the response before writing
@@ -312,8 +312,8 @@ public abstract class ResponseLifecycle {
     }
 
     private <T> ExecutionFlow<ByteBodyHttpResponse<?>> buildFinalResponse(HttpRequest<?> nettyRequest,
-                                                                          MutableHttpResponse<T> response,
-                                                                          Argument<T> responseBodyType,
+                                                                           MutableHttpResponse<T> response,
+                                                                           Argument<T> responseBodyType,
                                                                           MediaType mediaType,
                                                                           T body,
                                                                           MessageBodyWriter<T> messageBodyWriter,
@@ -339,6 +339,10 @@ public abstract class ResponseLifecycle {
                     .write(byteBodyFactory, nettyRequest, errorResponse, type, errorContentType, errorBody));
             }
         }
+    }
+
+    private static boolean isImplicitlyEmptyBody(Object body) {
+        return body instanceof byte[] bytes && bytes.length == 0;
     }
 
 }

--- a/http-server/src/main/java/io/micronaut/http/server/ResponseLifecycle.java
+++ b/http-server/src/main/java/io/micronaut/http/server/ResponseLifecycle.java
@@ -132,6 +132,11 @@ public abstract class ResponseLifecycle {
             // usually this is a UriRouteInfo, avoid scalability issues here
             @SuppressWarnings("unchecked") final RouteInfo<Object> routeInfo = (RouteInfo<Object>) (routeInfoO instanceof DefaultUrlRouteInfo<?, ?> uri ? uri : (RouteInfo<?>) routeInfoO);
 
+            if (isImplicitlyEmptyBody(body)) {
+                response.body(null);
+                return encodeNoBody(response);
+            }
+
             if (Publishers.isConvertibleToPublisher(body)) {
                 response.body(null);
                 return mapToHttpContent(nettyRequest, response, body, routeInfo);
@@ -147,8 +152,7 @@ public abstract class ResponseLifecycle {
             } else {
                 responseBodyType = Argument.of((Class<Object>) body.getClass());
             }
-            boolean emptyBody = isImplicitlyEmptyBody(body);
-            if (responseMediaType == null && !emptyBody) {
+            if (responseMediaType == null) {
                 // perf: check for common body types
                 //noinspection ConditionCoveredByFurtherCondition
                 if (!(body instanceof String) && !(body instanceof byte[]) && body instanceof MediaTypeProvider mediaTypeProvider) {

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -236,7 +236,7 @@ public final class RouteExecutor {
             if (i.hasNext()) {
                 final MediaType mt = i.next();
                 if (producesList.contains(mt)) {
-                    return mt;
+                    return MediaType.ALL_TYPE.equals(mt) ? MediaType.APPLICATION_JSON_TYPE : mt;
                 }
             }
         }
@@ -248,7 +248,7 @@ public final class RouteExecutor {
         } else {
             defaultResponseMediaType = MediaType.APPLICATION_JSON_TYPE;
         }
-        return defaultResponseMediaType;
+        return MediaType.ALL_TYPE.equals(defaultResponseMediaType) ? MediaType.APPLICATION_JSON_TYPE : defaultResponseMediaType;
     }
 
     private MutableHttpResponse<?> notFoundErrorResponse(HttpRequest<?> request) {


### PR DESCRIPTION
## Summary
- normalize default response media type resolution so wildcard `*/*` is never emitted as the response `Content-Type`; use `application/json` as the concrete default instead
- treat empty `byte[]` response bodies as no body in `ResponseLifecycle`, so no implicit content type is added for empty bodies unless explicitly set
- add TCK coverage in `NoBodyResponseTest` for both `204` empty-byte-array (no `Content-Type`) and non-empty byte array defaulting to `application/json`

## Verification
- `:micronaut-http-server:spotlessCheck`
- `:micronaut-http-server-tck:spotlessCheck`
- `:test-suite-http-server-tck-netty:test`
- `:micronaut-http-server-netty:test --tests 'io.micronaut.http.server.netty.ContentNegotiationSpec' --tests 'io.micronaut.http.server.netty.handler.Http1RequestEventTest' --tests 'io.micronaut.http.server.netty.handler.Http2RequestEventTest'`