### PR TITLE
test: add regression coverage for optional query value multipart streaming

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ConcurrentFormTransferSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ConcurrentFormTransferSpec.groovy
@@ -1,9 +1,13 @@
 package io.micronaut.http.server.netty.binding
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.multipart.MultipartBody
 import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Post
@@ -17,6 +21,8 @@ import spock.lang.Specification
 import spock.lang.Timeout
 
 import java.time.Duration
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.LongAdder
 import java.util.function.Supplier
 
 // java.net.http.HttpClient
@@ -91,6 +97,50 @@ Content-Type: ${contentType}\r
         ctx.stop()
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/10851')
+    @Timeout(15)
+    def 'optional query value does not force streaming upload materialization'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name': 'ConcurrentFormTransferSpec'
+        ])
+        def embeddedServer = ctx.getBean(EmbeddedServer)
+        embeddedServer.start()
+        def client = ctx.createBean(HttpClient, embeddedServer.URI).toBlocking()
+        byte[] data = new byte[1024 * 1024]
+        new Random(1).nextBytes(data)
+
+        when:
+        Map<String, Number> noQueryResponse = client.exchange(
+                HttpRequest.POST('/test-api/streaming-query', multipartBody(data))
+                        .contentType(MediaType.MULTIPART_FORM_DATA_TYPE),
+                Map
+        ).body()
+
+        Map<String, Number> withQueryResponse = client.exchange(
+                HttpRequest.POST('/test-api/streaming-query?md5=present', multipartBody(data))
+                        .contentType(MediaType.MULTIPART_FORM_DATA_TYPE),
+                Map
+        ).body()
+
+        then:
+        noQueryResponse.totalBytes.longValue() == data.length
+        withQueryResponse.totalBytes.longValue() == data.length
+        noQueryResponse.chunkCount.longValue() > 2
+        withQueryResponse.chunkCount.longValue() > 2
+        noQueryResponse.maxChunkSize.longValue() < data.length
+        withQueryResponse.maxChunkSize.longValue() < data.length
+
+        cleanup:
+        ctx.stop()
+    }
+
+    private static MultipartBody multipartBody(byte[] data) {
+        MultipartBody.builder()
+                .addPart('datasetFile', 'file.bin', MediaType.APPLICATION_OCTET_STREAM_TYPE, data)
+                .build()
+    }
+
     @Controller("/test-api")
     @io.micronaut.context.annotation.Requires(property = 'spec.name', value = 'ConcurrentFormTransferSpec')
     static class TransferController {
@@ -106,6 +156,35 @@ Content-Type: ${contentType}\r
             return Flux.from(dataFile)
                     .flatMap { it.transferTo(os) }
                     .then(Mono.just(HttpResponse.<String> ok('uploaded')))
+        }
+
+        @SuppressWarnings(['GrMethodMayBeStatic', 'unused'])
+        @Post('/streaming-query{?md5}')
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        Mono<Map<String, Number>> streamingQuery(@io.micronaut.http.annotation.QueryValue @Nullable String md5, StreamingFileUpload datasetFile) {
+            def chunkCount = new LongAdder()
+            def totalBytes = new LongAdder()
+            def maxChunkSize = new AtomicLong()
+            def body = datasetFile.streamingBody()
+            return Flux.from(body.toReadBufferPublisher())
+                    .map { readBuffer ->
+                        try {
+                            int size = readBuffer.readable()
+                            chunkCount.increment()
+                            totalBytes.add(size)
+                            maxChunkSize.accumulateAndGet(size as long, Math::max)
+                        } finally {
+                            readBuffer.close()
+                        }
+                    }
+                    .doFinally { body.close() }
+                    .then(Mono.fromSupplier {
+                        [
+                                chunkCount  : chunkCount.longValue(),
+                                maxChunkSize: maxChunkSize.get(),
+                                totalBytes  : totalBytes.longValue()
+                        ]
+                    })
         }
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ConcurrentFormTransferSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ConcurrentFormTransferSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.http.server.netty.binding
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
@@ -19,6 +18,8 @@ import reactor.core.publisher.Mono
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Timeout
+
+import jakarta.annotation.Nullable
 
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicLong
@@ -106,7 +107,8 @@ Content-Type: ${contentType}\r
         ])
         def embeddedServer = ctx.getBean(EmbeddedServer)
         embeddedServer.start()
-        def client = ctx.createBean(HttpClient, embeddedServer.URI).toBlocking()
+        HttpClient httpClient = ctx.createBean(HttpClient, embeddedServer.URI)
+        def client = httpClient.toBlocking()
         byte[] data = new byte[1024 * 1024]
         new Random(1).nextBytes(data)
 
@@ -126,18 +128,19 @@ Content-Type: ${contentType}\r
         then:
         noQueryResponse.totalBytes.longValue() == data.length
         withQueryResponse.totalBytes.longValue() == data.length
-        noQueryResponse.chunkCount.longValue() > 2
-        withQueryResponse.chunkCount.longValue() > 2
+        noQueryResponse.chunkCount.longValue() >= 1
+        withQueryResponse.chunkCount.longValue() >= 1
         noQueryResponse.maxChunkSize.longValue() < data.length
         withQueryResponse.maxChunkSize.longValue() < data.length
 
         cleanup:
+        httpClient.close()
         ctx.stop()
     }
 
     private static MultipartBody multipartBody(byte[] data) {
         MultipartBody.builder()
-                .addPart('datasetFile', 'file.bin', MediaType.APPLICATION_OCTET_STREAM_TYPE, data)
+                .addPart('datasetFile', 'file.bin', MediaType.APPLICATION_OCTET_STREAM_TYPE, new ByteArrayInputStream(data), data.length)
                 .build()
     }
 
@@ -167,7 +170,7 @@ Content-Type: ${contentType}\r
             def maxChunkSize = new AtomicLong()
             def body = datasetFile.streamingBody()
             return Flux.from(body.toReadBufferPublisher())
-                    .map { readBuffer ->
+                    .doOnNext { readBuffer ->
                         try {
                             int size = readBuffer.readable()
                             chunkCount.increment()


### PR DESCRIPTION
## Summary
- add a regression test for issue #10851 in `ConcurrentFormTransferSpec`
- cover multipart streaming behavior for `StreamingFileUpload` with optional `@QueryValue` both missing and present
- assert that uploads stay chunked (instead of materializing into one large chunk) in both request variants on 5.0.x

## Testing
- `./gradlew :micronaut-http-server-netty:test --tests "io.micronaut.http.server.netty.binding.ConcurrentFormTransferSpec"`