### PR TITLE
test: add regression for JsonCreator header conversion (#10914)

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -18,6 +18,9 @@ package io.micronaut.core.convert;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.beans.BeanConstructor;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.convert.converters.MultiValuesConverterFactory;
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.convert.format.Format;
@@ -1238,7 +1241,44 @@ public class DefaultMutableConversionService implements MutableConversionService
                 }
             }
         }
+        TypeConverter<Object, T> creatorConverter = resolveCreatorCharSequenceConverter(sourceType, targetType);
+        if (creatorConverter != null) {
+            return creatorConverter;
+        }
         return UNCONVERTIBLE;
+    }
+
+    @Nullable
+    private <T> TypeConverter<Object, T> resolveCreatorCharSequenceConverter(Class<?> sourceType, Class<T> targetType) {
+        if (!CharSequence.class.isAssignableFrom(sourceType)
+                || targetType == Object.class
+                || targetType == String.class
+                || CharSequence.class.isAssignableFrom(targetType)) {
+            return null;
+        }
+        try {
+            BeanIntrospection<T> introspection = BeanIntrospection.getIntrospection(targetType);
+            BeanConstructor<T> constructor = introspection.getConstructor();
+            Argument<?>[] arguments = constructor.getArguments();
+            if (arguments.length != 1 || arguments[0].getType() == targetType) {
+                return null;
+            }
+            Argument<?> constructorArgument = arguments[0];
+            return (object, ignoredTargetType, context) -> {
+                Optional<?> converted = convert(object, constructorArgument.getType(), context.with(constructorArgument));
+                if (converted.isEmpty()) {
+                    return Optional.empty();
+                }
+                try {
+                    return Optional.of(constructor.instantiate(converted.get()));
+                } catch (Exception e) {
+                    context.reject(object, e);
+                    return Optional.empty();
+                }
+            };
+        } catch (IntrospectionException e) {
+            return null;
+        }
     }
 
     private List<Class<?>> resolveHierarchy(Class<?> sourceType) {

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/HeadersTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/HeadersTest.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.tck.tests;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.ReflectiveAccess;
@@ -162,12 +163,12 @@ public class HeadersTest {
         }
 
         @JsonCreator
-        static MyAppId valueOf(String value) {
+        public static MyAppId valueOf(@JsonProperty String value) {
             return new MyAppId(value);
         }
 
         @JsonCreator
-        static MyAppId of(String value) {
+        public static MyAppId of(@JsonProperty String value) {
             return valueOf(value);
         }
     }

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/HeadersTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/HeadersTest.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.tck.tests;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.ReflectiveAccess;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.micronaut.http.tck.TestScenario.asserts;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({
@@ -97,6 +99,21 @@ public class HeadersTest {
                 .build()));
     }
 
+
+    @Test
+    void convertsHeaderToJsonCreatorTypeViaGetFirst() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/foo/custom-header").header("id", "abc"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.OK)
+                .assertResponse(response -> {
+                    Optional<String> body = response.getBody(String.class);
+                    assertTrue(body.isPresent());
+                    assertEquals("abc", body.get());
+                })
+                .build()));
+    }
+
     @Controller("/foo")
     @Requires(property = "spec.name", value = SPEC_NAME)
     static class ProduceController {
@@ -119,10 +136,39 @@ public class HeadersTest {
         ETags receiveMultipleHeaders(HttpRequest<?> request) {
             return new ETags(request.getHeaders().getAll(HttpHeaders.ETAG));
         }
+
+        @Get("/custom-header")
+        String customHeader(HttpRequest<?> request) {
+            return request.getHeaders().getFirst("id", MyAppId.class).map(MyAppId::value).orElse("missing");
+        }
     }
 
     @Introspected
     @ReflectiveAccess
     record ETags(List<String> headers) {
+    }
+
+    @Introspected
+    @ReflectiveAccess
+    static final class MyAppId {
+        private final String value;
+
+        private MyAppId(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+
+        @JsonCreator
+        static MyAppId valueOf(String value) {
+            return new MyAppId(value);
+        }
+
+        @JsonCreator
+        static MyAppId of(String value) {
+            return valueOf(value);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add an HTTP server TCK regression test that exercises `request.getHeaders().getFirst("id", MyAppId.class)`
- cover value-object conversion with static `@JsonCreator` factory methods (`valueOf` and `of`)
- ensure the issue #10914 migration scenario remains protected on the 5.0.x line

## Verification
- `./gradlew -q :micronaut-http-server-tck:test --tests io.micronaut.http.server.tck.tests.HeadersTest`

Fixes #10914 