### PR TITLE
Add %q and %U access log elements for Netty

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParser.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParser.java
@@ -58,7 +58,7 @@ import java.util.stream.Collectors;
  * If the format starts with begin: (default) the time is taken at the beginning of the request processing. If it starts with end: it is the time when the log entry gets written, close to the end of the request processing.
  * The format should follow the DateTimeFormatter syntax.</li>
  * <li><b>%u</b> - Remote user that was authenticated. Not implemented. Prints '-'.</li>
- * <li><b>%U</b> - Requested URI</li>
+ * <li><b>%U</b> - Requested URL path (excluding query string)</li>
  * <li><b>%v</b> - Local server name</li>
  * <li><b>%D</b> - Time taken to process the request, in millis</li>
  * <li><b>%T</b> - Time taken to process the request, in seconds</li>

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/QueryStringElement.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/QueryStringElement.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.handler.accesslog.element;
+
+import io.micronaut.core.annotation.NonNull;
+import io.netty.handler.codec.http.HttpHeaders;
+
+import java.util.Set;
+
+/**
+ * QueryStringElement LogElement. The request query string.
+ *
+ * @author yawkat
+ * @since 5.0.0
+ */
+final class QueryStringElement implements LogElement {
+    /**
+     * The query string marker.
+     */
+    public static final String QUERY_STRING = "q";
+
+    /**
+     * The QueryStringElement instance.
+     */
+    static final QueryStringElement INSTANCE = new QueryStringElement();
+
+    private QueryStringElement() {
+    }
+
+    @Override
+    public LogElement copy() {
+        return this;
+    }
+
+    @Override
+    public String onRequestHeaders(@NonNull ConnectionMetadata metadata,
+                                   @NonNull String method,
+                                   @NonNull HttpHeaders headers,
+                                   @NonNull String uri,
+                                   @NonNull String protocol) {
+        int queryStart = uri.indexOf('?');
+        return queryStart >= 0 && queryStart < uri.length() - 1 ? uri.substring(queryStart + 1) : "";
+    }
+
+    @Override
+    public Set<Event> events() {
+        return Event.REQUEST_HEADERS_EVENTS;
+    }
+
+    @Override
+    public String toString() {
+        return '%' + QUERY_STRING;
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/RequestUriElementBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/RequestUriElementBuilder.java
@@ -31,6 +31,12 @@ public final class RequestUriElementBuilder implements LogElementBuilder {
         if (RequestUriElement.REQUEST_URI.equals(token)) {
             return RequestUriElement.INSTANCE;
         }
+        if (QueryStringElement.QUERY_STRING.equals(token)) {
+            return QueryStringElement.INSTANCE;
+        }
+        if (RequestedUrlPathElement.REQUESTED_URL_PATH.equals(token)) {
+            return RequestedUrlPathElement.INSTANCE;
+        }
         return null;
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/RequestedUrlPathElement.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/RequestedUrlPathElement.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.handler.accesslog.element;
+
+import io.micronaut.core.annotation.NonNull;
+import io.netty.handler.codec.http.HttpHeaders;
+
+import java.util.Set;
+
+/**
+ * RequestedUrlPathElement LogElement. The request URL path.
+ *
+ * @author yawkat
+ * @since 5.0.0
+ */
+final class RequestedUrlPathElement implements LogElement {
+    /**
+     * The requested URL path marker.
+     */
+    public static final String REQUESTED_URL_PATH = "U";
+
+    /**
+     * The RequestedUrlPathElement instance.
+     */
+    static final RequestedUrlPathElement INSTANCE = new RequestedUrlPathElement();
+
+    private RequestedUrlPathElement() {
+    }
+
+    @Override
+    public LogElement copy() {
+        return this;
+    }
+
+    @Override
+    public String onRequestHeaders(@NonNull ConnectionMetadata metadata,
+                                   @NonNull String method,
+                                   @NonNull HttpHeaders headers,
+                                   @NonNull String uri,
+                                   @NonNull String protocol) {
+        return extractPath(uri);
+    }
+
+    private static String extractPath(String uri) {
+        int pathStart = 0;
+        int schemeSeparator = uri.indexOf("://");
+        if (schemeSeparator >= 0) {
+            pathStart = uri.indexOf('/', schemeSeparator + 3);
+            if (pathStart < 0) {
+                return "/";
+            }
+        } else if (uri.startsWith("//")) {
+            pathStart = uri.indexOf('/', 2);
+            if (pathStart < 0) {
+                return "/";
+            }
+        }
+
+        int queryStart = uri.indexOf('?', pathStart);
+        int fragmentStart = uri.indexOf('#', pathStart);
+        int pathEnd = uri.length();
+        if (queryStart >= 0 && queryStart < pathEnd) {
+            pathEnd = queryStart;
+        }
+        if (fragmentStart >= 0 && fragmentStart < pathEnd) {
+            pathEnd = fragmentStart;
+        }
+        return uri.substring(pathStart, pathEnd);
+    }
+
+    @Override
+    public Set<Event> events() {
+        return Event.REQUEST_HEADERS_EVENTS;
+    }
+
+    @Override
+    public String toString() {
+        return '%' + REQUESTED_URL_PATH;
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParserSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParserSpec.groovy
@@ -92,6 +92,60 @@ class AccessLogFormatParserSpec extends Specification {
 
     }
 
+    def "test access log format parser supports query string marker"() {
+        when:
+        AccessLogFormatParser parser = new AccessLogFormatParser("%q")
+
+        then:
+        parser.toString() == "%q"
+
+        when:
+        def queryStringElement = new RequestUriElementBuilder().build("q", null)
+        def queryString = queryStringElement.onRequestHeaders(ConnectionMetadata.empty(), "GET", new DefaultHttpHeaders(), "/test?foo=bar&baz=qux", "HTTP/1.1")
+
+        then:
+        queryString == "foo=bar&baz=qux"
+
+        when:
+        queryString = queryStringElement.onRequestHeaders(ConnectionMetadata.empty(), "GET", new DefaultHttpHeaders(), "/test", "HTTP/1.1")
+
+        then:
+        queryString == ""
+    }
+
+    def "test access log format parser supports requested URL path marker"() {
+        when:
+        AccessLogFormatParser parser = new AccessLogFormatParser("%U")
+
+        then:
+        parser.toString() == "%U"
+
+        when:
+        def requestPathElement = new RequestUriElementBuilder().build("U", null)
+        def requestPath = requestPathElement.onRequestHeaders(ConnectionMetadata.empty(), "GET", new DefaultHttpHeaders(), "/test/path?foo=bar&baz=qux", "HTTP/1.1")
+
+        then:
+        requestPath == "/test/path"
+
+        when:
+        requestPath = requestPathElement.onRequestHeaders(ConnectionMetadata.empty(), "GET", new DefaultHttpHeaders(), "http://localhost:8080/test/path?foo=bar&baz=qux", "HTTP/1.1")
+
+        then:
+        requestPath == "/test/path"
+
+        when:
+        requestPath = requestPathElement.onRequestHeaders(ConnectionMetadata.empty(), "GET", new DefaultHttpHeaders(), "http://localhost:8080?foo=bar", "HTTP/1.1")
+
+        then:
+        requestPath == "/"
+
+        when:
+        requestPath = requestPathElement.onRequestHeaders(ConnectionMetadata.empty(), "GET", new DefaultHttpHeaders(), "/test/path", "HTTP/1.1")
+
+        then:
+        requestPath == "/test/path"
+    }
+
     def 'Test string escaping from header value'() {
         def headers = new DefaultHttpHeaders()
         headers.add("User-Agent", "test string  \" \\")


### PR DESCRIPTION
## Summary
- add `%q` support in Netty access log parsing and implement `QueryStringElement` (query string without the leading `?`)
- add `%U` support via `RequestedUrlPathElement`, returning the request path without query string and handling absolute-form request URIs
- extend `AccessLogFormatParserSpec` with regression coverage for `%q` and `%U`, including absolute URI host/path handling and no-path absolute URI fallback (`/`)

## Verification
- `./gradlew --no-daemon :micronaut-http-server-netty:test`

Fixes #10292 