### PR TITLE
fix: preserve suspend lambda type arguments in BeanDefinition.asArgument

### DIFF
--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanRegistrationSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanRegistrationSpec.groovy
@@ -67,4 +67,37 @@ class Foo2: Foo
         cleanup:
         context.close()
     }
+
+    void 'test inject bean registration for suspend lambda bean from factory'() {
+        given:
+        def className = 'beanreg.SuspendConsumer'
+        def context = buildContext('''
+package beanreg
+
+import io.micronaut.context.BeanRegistration
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Singleton
+
+interface Bar
+
+@Singleton
+class SuspendConsumer(val registration: BeanRegistration<suspend (Bar) -> Unit>)
+
+@Factory
+class SuspendFactory {
+    @Singleton
+    fun barLambda(): suspend (Bar) -> Unit = { _ -> }
+}
+''')
+
+        when:
+        def bean = getBean(context, className)
+
+        then:
+        bean.registration != null
+        bean.registration.bean != null
+
+        cleanup:
+        context.close()
+    }
 }

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -369,6 +369,14 @@ public interface BeanDefinition<T> extends QualifiedBeanType<T>, Named, BeanType
 
     @Override
     default Argument<T> asArgument() {
+        List<Argument<?>> typeArguments = getTypeArguments(getBeanType());
+        if (!typeArguments.isEmpty()) {
+            return Argument.of(
+                getBeanType(),
+                getAnnotationMetadata(),
+                typeArguments.toArray(Argument.ZERO_ARGUMENTS)
+            );
+        }
         return Argument.of(
                 getBeanType(),
                 getAnnotationMetadata(),


### PR DESCRIPTION
## Summary
- preserve full bean type arguments in `BeanDefinition.asArgument()` by using `getTypeArguments(getBeanType())` when present
- add a regression test for injecting `BeanRegistration<suspend (Bar) -> Unit>` from a Kotlin `@Factory` bean
- fixes `Type parameter length does not match` during bean registration for suspend lambda beans

## Verification
- `./gradlew --no-daemon :micronaut-inject-kotlin:test --tests 'io.micronaut.kotlin.processing.beans.BeanRegistrationSpec.test inject bean registration for suspend lambda bean from factory' -q`
- `./gradlew --no-daemon :micronaut-inject-kotlin:compileTestKotlin :micronaut-inject-kotlin:compileTestGroovy -q`

Fixes #12226