### PR TITLE
Fix request context availability in coroutine context factories

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -71,6 +71,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.context.ContextView;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
@@ -434,9 +435,8 @@ public final class RouteExecutor {
         if (executorService != null) {
             if (routeInfo.isSuspended()) {
                 executeMethodResponseFlow = ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(contextView -> {
-                        coroutineHelper.ifPresent(helper -> helper.setupCoroutineContext(request, contextView, propagatedContext));
                         return Mono.from(
-                            ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request)).toPublisher()
+                            ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request, true, contextView)).toPublisher()
                         );
                     }));
             } else if (routeInfo.isReactive()) {
@@ -447,9 +447,8 @@ public final class RouteExecutor {
         } else {
             if (routeInfo.isSuspended()) {
                 executeMethodResponseFlow = ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(contextView -> {
-                        coroutineHelper.ifPresent(helper -> helper.setupCoroutineContext(request, contextView, propagatedContext));
                         return Mono.from(
-                            ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request)).toPublisher()
+                            ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request, true, contextView)).toPublisher()
                         );
                     }));
             } else if (routeInfo.isReactive()) {
@@ -462,8 +461,20 @@ public final class RouteExecutor {
     }
 
     private ExecutionFlow<HttpResponse<?>> executeRouteAndConvertBody(PropagatedContext propagatedContext, RouteMatch<?> routeMatch, HttpRequest<?> httpRequest) {
-        try (PropagatedContext.Scope ignore = propagatedContext.plus(new ServerHttpRequestContext(httpRequest)).propagate()) {
+        return executeRouteAndConvertBody(propagatedContext, routeMatch, httpRequest, false, null);
+    }
+
+    private ExecutionFlow<HttpResponse<?>> executeRouteAndConvertBody(PropagatedContext propagatedContext,
+                                                                      RouteMatch<?> routeMatch,
+                                                                      HttpRequest<?> httpRequest,
+                                                                      boolean isKotlinCoroutine,
+                                                                      @Nullable ContextView contextView) {
+        PropagatedContext routePropagatedContext = propagatedContext.plus(new ServerHttpRequestContext(httpRequest));
+        try (PropagatedContext.Scope ignore = routePropagatedContext.propagate()) {
             try {
+                if (isKotlinCoroutine && contextView != null) {
+                    coroutineHelper.ifPresent(helper -> helper.setupCoroutineContext(httpRequest, contextView, routePropagatedContext));
+                }
                 requestArgumentSatisfier.fulfillArgumentRequirementsAfterFilters(routeMatch, httpRequest);
                 Object body = routeMatch.execute();
                 if (body instanceof Optional optional) {

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -440,9 +440,9 @@ public final class RouteExecutor {
                         );
                     }));
             } else if (routeInfo.isReactive()) {
-                executeMethodResponseFlow = ReactiveExecutionFlow.async(executorService, () -> executeRouteAndConvertBody(propagatedContext, routeMatch, request));
+                executeMethodResponseFlow = ReactiveExecutionFlow.async(executorService, () -> executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null));
             } else {
-                executeMethodResponseFlow = ExecutionFlow.async(executorService, () -> executeRouteAndConvertBody(propagatedContext, routeMatch, request));
+                executeMethodResponseFlow = ExecutionFlow.async(executorService, () -> executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null));
             }
         } else {
             if (routeInfo.isSuspended()) {
@@ -452,16 +452,12 @@ public final class RouteExecutor {
                         );
                     }));
             } else if (routeInfo.isReactive()) {
-                executeMethodResponseFlow = ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request));
+                executeMethodResponseFlow = ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null));
             } else {
-                executeMethodResponseFlow = executeRouteAndConvertBody(propagatedContext, routeMatch, request);
+                executeMethodResponseFlow = executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null);
             }
         }
         return executeMethodResponseFlow;
-    }
-
-    private ExecutionFlow<HttpResponse<?>> executeRouteAndConvertBody(PropagatedContext propagatedContext, RouteMatch<?> routeMatch, HttpRequest<?> httpRequest) {
-        return executeRouteAndConvertBody(propagatedContext, routeMatch, httpRequest, false, null);
     }
 
     private ExecutionFlow<HttpResponse<?>> executeRouteAndConvertBody(PropagatedContext propagatedContext,

--- a/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
+++ b/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
@@ -62,9 +62,17 @@ class ContinuationArgumentBinder : TypedRequestArgumentBinder<Continuation<*>> {
                 if (reactorContextPresent) {
                     coroutineContext += propagateReactorContext(contextView)
                 }
-                coroutineContext = KotlinCoroutinePropagation.addPropagatedContext(coroutineContext, propagatedContext)
-                continuationArgumentBinderCoroutineContextFactories.forEach {
-                    coroutineContext += it.create()
+                val coroutinePropagatedContext = propagatedContext.plus(io.micronaut.http.context.ServerHttpRequestContext(source))
+                coroutineContext = KotlinCoroutinePropagation.addPropagatedContext(coroutineContext, coroutinePropagatedContext)
+                val factoryContext = try {
+                    coroutinePropagatedContext.propagate()
+                } catch (e: Exception) {
+                    throw IllegalStateException("Failed to propagate request context for coroutine setup", e)
+                }
+                factoryContext.use {
+                    continuationArgumentBinderCoroutineContextFactories.forEach {
+                        coroutineContext += it.create()
+                    }
                 }
                 customContinuation.context.delegatingCoroutineContext = coroutineContext
             }

--- a/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
+++ b/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
@@ -62,17 +62,9 @@ class ContinuationArgumentBinder : TypedRequestArgumentBinder<Continuation<*>> {
                 if (reactorContextPresent) {
                     coroutineContext += propagateReactorContext(contextView)
                 }
-                val coroutinePropagatedContext = propagatedContext.plus(io.micronaut.http.context.ServerHttpRequestContext(source))
-                coroutineContext = KotlinCoroutinePropagation.addPropagatedContext(coroutineContext, coroutinePropagatedContext)
-                val factoryContext = try {
-                    coroutinePropagatedContext.propagate()
-                } catch (e: Exception) {
-                    throw IllegalStateException("Failed to propagate request context for coroutine setup", e)
-                }
-                factoryContext.use {
-                    continuationArgumentBinderCoroutineContextFactories.forEach {
-                        coroutineContext += it.create()
-                    }
+                coroutineContext = KotlinCoroutinePropagation.addPropagatedContext(coroutineContext, propagatedContext)
+                continuationArgumentBinderCoroutineContextFactories.forEach {
+                    coroutineContext += it.create()
                 }
                 customContinuation.context.delegatingCoroutineContext = coroutineContext
             }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendController.kt
@@ -18,6 +18,7 @@ package io.micronaut.docs.server.suspend
 import io.micronaut.http.*
 import io.micronaut.http.annotation.*
 import io.micronaut.http.context.ServerRequestContext
+import io.micronaut.http.multipart.CompletedFileUpload
 import io.micronaut.scheduling.TaskExecutors
 import kotlinx.coroutines.*
 import java.util.concurrent.ExecutorService
@@ -29,7 +30,8 @@ import org.slf4j.MDC
 class SuspendController(
     @Named(TaskExecutors.IO) private val executor: ExecutorService,
     private val suspendService: SuspendService,
-    private val suspendRequestScopedService: SuspendRequestScopedService
+    private val suspendRequestScopedService: SuspendRequestScopedService,
+    private val coroutineFactoryState: SuspendCoroutineFactoryState
 ) {
 
     private val coroutineDispatcher: CoroutineDispatcher
@@ -136,6 +138,14 @@ class SuspendController(
         delay(10) // suspend
         val after = "${suspendRequestScopedService.requestId},${Thread.currentThread().id}"
         return "$before,$after"
+    }
+
+    @Post(value = "/completedUpload", consumes = [MediaType.MULTIPART_FORM_DATA], produces = [MediaType.TEXT_PLAIN])
+    suspend fun completedUpload(file: CompletedFileUpload): String {
+        require(coroutineFactoryState.currentRequestPresent == true) {
+            "Request was not available in HttpCoroutineContextFactory"
+        }
+        return file.filename
     }
 
     @Get("/requestContext")

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendControllerSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendControllerSpec.kt
@@ -28,6 +28,7 @@ import io.micronaut.http.HttpRequest.GET
 import io.micronaut.http.HttpRequest.OPTIONS
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.multipart.MultipartBody
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import kotlinx.coroutines.reactive.awaitSingle
@@ -228,6 +229,20 @@ class SuspendControllerSpec : StringSpec() {
             beforeRequestId shouldBe afterRequestId
             beforeThreadId shouldNotBe afterThreadId // it will be the default co-routine dispatcher
             response.status shouldBe HttpStatus.OK
+        }
+
+        "test request context is available for completed upload coroutine factory" {
+            val body = MultipartBody.builder()
+                .addPart("file", "file.json", io.micronaut.http.MediaType.APPLICATION_JSON_TYPE, "{\"title\":\"Foo\"}".toByteArray())
+                .build()
+            val response = client.exchange(
+                io.micronaut.http.HttpRequest.POST("/suspend/completedUpload", body)
+                    .contentType(io.micronaut.http.MediaType.MULTIPART_FORM_DATA)
+                    .accept(io.micronaut.http.MediaType.TEXT_PLAIN_TYPE),
+                String::class.java
+            ).awaitSingle()
+            response.status shouldBe HttpStatus.OK
+            response.body.get() shouldBe "file.json"
         }
 
         "test request context is available" {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendCoroutineFactoryState.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendCoroutineFactoryState.kt
@@ -1,0 +1,26 @@
+package io.micronaut.docs.server.suspend
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.http.bind.binders.HttpCoroutineContextFactory
+import io.micronaut.http.context.ServerRequestContext
+import jakarta.inject.Singleton
+import kotlin.coroutines.EmptyCoroutineContext
+
+@Singleton
+class SuspendCoroutineFactoryState {
+    @Volatile
+    var currentRequestPresent: Boolean? = null
+}
+
+@Factory
+class SuspendCoroutineFactory {
+    @Singleton
+    fun suspendCoroutineContextFactory(state: SuspendCoroutineFactoryState): HttpCoroutineContextFactory<EmptyCoroutineContext> {
+        return object : HttpCoroutineContextFactory<EmptyCoroutineContext> {
+            override fun create(): EmptyCoroutineContext {
+                state.currentRequestPresent = ServerRequestContext.currentRequest<Any>().isPresent
+                return EmptyCoroutineContext
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move coroutine context setup into `executeRouteAndConvertBody(...)` and run it before `requestArgumentSatisfier.fulfillArgumentRequirementsAfterFilters(...)`
- for suspended routes, pass `isKotlinCoroutine=true` and `ContextView` into `executeRouteAndConvertBody(...)`
- keep `ContinuationArgumentBinder` simple (no extra factory-time propagation wrapper)
- retain suspend + `CompletedFileUpload` regression coverage for request context availability

## Why this is necessary
The timing issue remains the root cause:
- suspended routes previously called `setupCoroutineContext(...)` before entering the request-scoped propagation in `executeRouteAndConvertBody(...)`
- `HttpCoroutineContextFactory.create()` can call `ServerRequestContext.currentRequest()`
- at that moment, request context was not yet in scope

This alternative fix applies the suggestion from PR comments by moving coroutine setup into the request-scoped execution path, so factory creation naturally sees the request context.

## Verification
- `./gradlew :test-suite-kotlin:test --tests 'io.micronaut.docs.server.suspend.SuspendControllerSpec' --no-daemon -q`
- `./gradlew :micronaut-http:compileKotlin :micronaut-http-server:compileJava :test-suite-kotlin:test --tests 'io.micronaut.docs.server.suspend.SuspendControllerSpec' --no-daemon -q`

Fixes #12373