### PR TITLE
fix: avoid containsBean cache race during concurrent cache clears

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -771,15 +771,15 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     public <T> boolean containsBean(Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);
-        if (containsBeanCache.containsKey(beanKey)) {
-            return containsBeanCache.get(beanKey);
-        } else {
-            boolean result = singletonScope.containsBean(beanType, qualifier) ||
-                isCandidatePresent(beanKey.beanType, qualifier);
-
-            containsBeanCache.put(beanKey, result);
+        Boolean result = containsBeanCache.get(beanKey);
+        if (result != null) {
             return result;
         }
+        result = singletonScope.containsBean(beanType, qualifier) ||
+            isCandidatePresent(beanKey.beanType, qualifier);
+
+        containsBeanCache.put(beanKey, result);
+        return result;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -183,7 +183,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     private final Map<String, List<String>> disabledConfigurations = new ConcurrentHashMap<>(5);
     private final Map<String, BeanConfiguration> beanConfigurations = new HashMap<>(10);
 
-    private final Map<BeanKey, Boolean> containsBeanCache = new ConcurrentHashMap<>(30);
+    final Map<BeanKey, Boolean> containsBeanCache = new ConcurrentHashMap<>(30);
     private final Map<CharSequence, Object> attributes = Collections.synchronizedMap(new HashMap<>(5));
 
     private final Map<BeanKey, CollectionHolder> singletonBeanRegistrations = new ConcurrentHashMap<>(50);

--- a/inject/src/test/java/io/micronaut/context/DefaultBeanContextContainsBeanRaceTest.java
+++ b/inject/src/test/java/io/micronaut/context/DefaultBeanContextContainsBeanRaceTest.java
@@ -1,0 +1,65 @@
+package io.micronaut.context;
+
+import org.junit.jupiter.api.Test;
+import spock.lang.Issue;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DefaultBeanContextContainsBeanRaceTest {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11768")
+    @Test
+    void containsBeanDoesNotThrowWhenCacheIsClearedConcurrently() throws Exception {
+        ApplicationContext context = ApplicationContext.run();
+        @SuppressWarnings("unchecked")
+        Map<Object, Boolean> containsBeanCache = (Map<Object, Boolean>) getField(context, "containsBeanCache");
+        context.containsBean(MissingBean.class);
+
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean running = new AtomicBoolean(true);
+
+        Thread lookupThread = new Thread(() -> {
+            while (running.get()) {
+                try {
+                    context.containsBean(MissingBean.class);
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                    break;
+                }
+            }
+        });
+        Thread clearThread = new Thread(() -> {
+            while (running.get()) {
+                containsBeanCache.clear();
+            }
+        });
+
+        lookupThread.start();
+        clearThread.start();
+
+        for (int i = 0; i < 50000 && failure.get() == null; i++) {
+            context.containsBean(MissingBean.class);
+        }
+
+        running.set(false);
+        lookupThread.join();
+        clearThread.join();
+        context.stop();
+
+        assertNull(failure.get());
+    }
+
+    private static Object getField(Object target, String fieldName) throws Exception {
+        Field field = DefaultBeanContext.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+    static class MissingBean {
+    }
+}

--- a/inject/src/test/java/io/micronaut/context/DefaultBeanContextContainsBeanRaceTest.java
+++ b/inject/src/test/java/io/micronaut/context/DefaultBeanContextContainsBeanRaceTest.java
@@ -5,7 +5,6 @@ import spock.lang.Issue;
 
 import java.lang.reflect.Field;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/inject/src/test/java/io/micronaut/context/DefaultBeanContextContainsBeanRaceTest.java
+++ b/inject/src/test/java/io/micronaut/context/DefaultBeanContextContainsBeanRaceTest.java
@@ -3,7 +3,6 @@ package io.micronaut.context;
 import org.junit.jupiter.api.Test;
 import spock.lang.Issue;
 
-import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -14,10 +13,9 @@ class DefaultBeanContextContainsBeanRaceTest {
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11768")
     @Test
-    void containsBeanDoesNotThrowWhenCacheIsClearedConcurrently() throws Exception {
-        ApplicationContext context = ApplicationContext.run();
-        @SuppressWarnings("unchecked")
-        Map<Object, Boolean> containsBeanCache = (Map<Object, Boolean>) getField(context, "containsBeanCache");
+    void containsBeanDoesNotThrowWhenCacheIsClearedConcurrently() throws InterruptedException {
+        DefaultBeanContext context = (DefaultBeanContext) ApplicationContext.run();
+        Map<?, Boolean> containsBeanCache = context.containsBeanCache;
         context.containsBean(MissingBean.class);
 
         AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -54,11 +52,6 @@ class DefaultBeanContextContainsBeanRaceTest {
         assertNull(failure.get());
     }
 
-    private static Object getField(Object target, String fieldName) throws Exception {
-        Field field = DefaultBeanContext.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        return field.get(target);
-    }
     static class MissingBean {
     }
 }


### PR DESCRIPTION
## Summary
- replace `containsBeanCache.containsKey(...)` + `get(...)` with an atomic `get`-first path in `DefaultBeanContext.containsBean` to avoid a race where concurrent cache clears can lead to a null-unboxing NPE
- add a regression test that stresses concurrent `containsBean` lookups with cache clears to reproduce the race on old code and verify the fix
- validate with targeted and full `:micronaut-inject:test` runs on JDK 21

Fixes #11768