### PR TITLE
Promote HTTP/3 support to stable

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -1131,10 +1131,9 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     }
 
     /**
-     * Configuration for the experimental HTTP/3 server.
+     * Configuration for the HTTP/3 server.
      */
     @ConfigurationProperties("http3")
-    @Experimental
     public static final class Http3Settings {
         private int initialMaxData = DEFAULT_HTTP3_INITIAL_MAX_DATA;
         private int initialMaxStreamDataBidirectionalLocal = DEFAULT_HTTP3_INITIAL_MAX_STREAM_DATA_BIDIRECTIONAL_LOCAL;

--- a/src/main/docs/guide/httpClient/clientHttp3.adoc
+++ b/src/main/docs/guide/httpClient/clientHttp3.adoc
@@ -1,4 +1,4 @@
-Since the Micronaut framework 4.x, Micronaut's Netty-based HTTP client can be configured to support HTTP/3. This support is experimental and may change without notice.
+Since Micronaut framework 4.x, Micronaut's Netty-based HTTP client can be configured to support HTTP/3.
 
 Instead of the TCP used for HTTP/1.1 and HTTP/2, HTTP/3 runs on UDP. If the client is configured with the special `h3` value for the `alpn-modes` property, the client will automatically use HTTP/3 over UDP instead of HTTP/1.1 or HTTP/2 over TCP. At this time, the client cannot fall back to TCP if the server does not support HTTP/3.
 

--- a/src/main/docs/guide/httpServer/http3Server.adoc
+++ b/src/main/docs/guide/httpServer/http3Server.adoc
@@ -1,4 +1,4 @@
-Since Micronaut framework 4.x, Micronaut's Netty-based HTTP server can be configured to support HTTP/3. This support is experimental and may change without notice.
+Since Micronaut framework 4.x, Micronaut's Netty-based HTTP server can be configured to support HTTP/3.
 
 ==== Configuring the Server for HTTP/3
 


### PR DESCRIPTION
## Summary
- Remove the remaining experimental API marker from Netty HTTP/3 server configuration (`Http3Settings`).
- Update HTTP/3 client/server guide pages to describe HTTP/3 support as stable.
- Keep runtime behavior unchanged; this is a support-status/docs/API-annotation update only.

## Verification
- `./gradlew -q :micronaut-http-server-netty:compileJava`
- `./gradlew -q :micronaut-http-server-netty:test --tests 'io.micronaut.http.server.netty.http2.Http3Spec'`
- `./gradlew -q :test-suite:test --tests 'io.micronaut.http.client.http2.Http3RequestSpec'`
- `./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility` *(fails in this environment due unrelated pre-existing test failures and a read-only filesystem write in `inject-kotlin/build`)*

Fixes #12375