### PR TITLE
Fix request scope propagation after suspend client calls

### DIFF
--- a/aop/build.gradle.kts
+++ b/aop/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     compileOnly(projects.micronautCoreReactive)
     compileOnly(libs.managed.kotlinx.coroutines.core)
     compileOnly(libs.managed.reactor)
+    testImplementation(libs.managed.kotlin.stdlib)
 }
 
 tasks {

--- a/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
+++ b/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
@@ -20,7 +20,6 @@ import io.micronaut.core.annotation.Internal
 import io.micronaut.core.propagation.PropagatedContext
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CompletionStage
-import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 /**
@@ -37,24 +36,26 @@ internal object KotlinInterceptedMethodHelper {
         suspendCoroutine { continuation ->
             val propagatedContext = PropagatedContext.find().orElse(null)
             result.whenComplete { value: Any?, throwable: Throwable? ->
-                val resume = {
-                    if (throwable == null) {
-                        val res = Result.success(value ?: if (isUnitValueType) Unit else null)
-                        continuation.resumeWith(res)
-                    } else {
-                        val exception = if (throwable is CompletionException) {
-                            throwable.cause ?: throwable
-                        } else {
-                            throwable
-                        }
-                        continuation.resumeWithException(exception)
-                    }
-                }
+                val resumedResult = toCoroutineResult(value, throwable, isUnitValueType)
                 if (propagatedContext == null) {
-                    resume()
+                    continuation.resumeWith(resumedResult)
                 } else {
-                    propagatedContext.propagate { resume() }
+                    propagatedContext.propagate { continuation.resumeWith(resumedResult) }
                 }
             }
+        }
+
+    private fun toCoroutineResult(value: Any?, throwable: Throwable?, isUnitValueType: Boolean): Result<Any?> =
+        if (throwable == null) {
+            Result.success(value ?: if (isUnitValueType) Unit else null)
+        } else {
+            Result.failure(unwrapCompletionException(throwable))
+        }
+
+    private fun unwrapCompletionException(throwable: Throwable): Throwable =
+        if (throwable is CompletionException) {
+            throwable.cause ?: throwable
+        } else {
+            throwable
         }
 }

--- a/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
+++ b/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
@@ -17,6 +17,7 @@ package io.micronaut.aop.util
 
 import io.micronaut.core.annotation.Experimental
 import io.micronaut.core.annotation.Internal
+import io.micronaut.core.propagation.PropagatedContext
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CompletionStage
 import kotlin.coroutines.resumeWithException
@@ -34,17 +35,25 @@ internal object KotlinInterceptedMethodHelper {
     @JvmStatic
     suspend fun handleResult(result: CompletionStage<*>, isUnitValueType: Boolean): Any? =
         suspendCoroutine { continuation ->
+            val propagatedContext = PropagatedContext.find().orElse(null)
             result.whenComplete { value: Any?, throwable: Throwable? ->
-                if (throwable == null) {
-                    val res = Result.success(value ?: if (isUnitValueType) Unit else null)
-                    continuation.resumeWith(res)
-                } else {
-                    val exception = if (throwable is CompletionException) {
-                        throwable.cause ?: throwable
+                val resume = {
+                    if (throwable == null) {
+                        val res = Result.success(value ?: if (isUnitValueType) Unit else null)
+                        continuation.resumeWith(res)
                     } else {
-                        throwable
+                        val exception = if (throwable is CompletionException) {
+                            throwable.cause ?: throwable
+                        } else {
+                            throwable
+                        }
+                        continuation.resumeWithException(exception)
                     }
-                    continuation.resumeWithException(exception)
+                }
+                if (propagatedContext == null) {
+                    resume()
+                } else {
+                    propagatedContext.propagate().use { resume() }
                 }
             }
         }

--- a/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
+++ b/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
@@ -53,7 +53,7 @@ internal object KotlinInterceptedMethodHelper {
                 if (propagatedContext == null) {
                     resume()
                 } else {
-                    propagatedContext.propagate().use { resume() }
+                    propagatedContext.propagate { resume() }
                 }
             }
         }

--- a/aop/src/test/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelperTest.kt
+++ b/aop/src/test/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelperTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.util
+
+import io.micronaut.core.propagation.PropagatedContext
+import io.micronaut.core.propagation.ThreadPropagatedContextElement
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+
+class KotlinInterceptedMethodHelperTest {
+
+    @Test
+    fun handleResultReturnsValueWithoutContext() {
+        val result = runSuspend {
+            KotlinInterceptedMethodHelper.handleResult(CompletableFuture.completedFuture("ok"), false)
+        }
+
+        assertEquals("ok", result)
+    }
+
+    @Test
+    fun handleResultUnwrapsCompletionException() {
+        val future = CompletableFuture<Any?>().also {
+            it.completeExceptionally(CompletionException(IllegalStateException("boom")))
+        }
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            runSuspend {
+                KotlinInterceptedMethodHelper.handleResult(future, false)
+            }
+        }
+
+        assertEquals("boom", exception.message)
+    }
+
+    @Test
+    fun handleResultResumesWithPropagatedContext() {
+        val marker = ThreadLocal.withInitial { 0 }
+        val future = CompletableFuture<String>()
+
+        val resumedMarker = PropagatedContext.getOrEmpty()
+            .plus(ThreadLocalMarker(marker, 42))
+            .propagate {
+                val completingThread = Thread {
+                    Thread.sleep(20)
+                    future.complete("done")
+                }
+                completingThread.start()
+                try {
+                    runSuspend {
+                        KotlinInterceptedMethodHelper.handleResult(future, false)
+                        marker.get()
+                    }
+                } finally {
+                    completingThread.join()
+                }
+            }
+
+        assertEquals(42, resumedMarker)
+        assertEquals(0, marker.get())
+    }
+
+    private fun <T> runSuspend(block: suspend () -> T): T {
+        val result = CompletableFuture<T>()
+        block.startCoroutine(object : Continuation<T> {
+            override val context: CoroutineContext = EmptyCoroutineContext
+
+            override fun resumeWith(resumeResult: Result<T>) {
+                resumeResult
+                    .onSuccess(result::complete)
+                    .onFailure(result::completeExceptionally)
+            }
+        })
+        return try {
+            result.join()
+        } catch (e: CompletionException) {
+            throw (e.cause ?: e)
+        }
+    }
+
+    private data class ThreadLocalMarker(
+        private val threadLocal: ThreadLocal<Int>,
+        private val value: Int,
+    ) : ThreadPropagatedContextElement<Int> {
+        override fun updateThreadContext(): Int {
+            val old = threadLocal.get()
+            threadLocal.set(value)
+            return old
+        }
+
+        override fun restoreThreadContext(oldState: Int?) {
+            threadLocal.set(oldState)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ micronaut-rxjava2 = "2.9.0"
 micronaut-rxjava3 = "4.0.0-M1"
 micronaut-reactor = "4.0.0-M1"
 micronaut-kotlin = "4.7.0"
+micrometer-context-propagation = "1.1.3"
 native-gradle-plugin = "0.11.4"
 neo4j-java-driver = "5.17.0"
 selenium = "4.27.0"
@@ -260,6 +261,8 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 
 logbook-netty = { module = "org.zalando:logbook-netty", version.ref = "logbook-netty" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
+
+micrometer-context-propagation = { module = "io.micrometer:context-propagation", version.ref = "micrometer-context-propagation" }
 
 micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
 micronaut-build-plugins = { module = "io.micronaut.build.internal:micronaut-gradle-plugins", version.ref="micronaut-build-plugins"}

--- a/test-suite-kotlin/build.gradle.kts
+++ b/test-suite-kotlin/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     testImplementation(libs.bcpkix)
 
     testImplementation(libs.managed.reactor)
+    testImplementation(libs.micrometer.context.propagation)
 
     testImplementation(libs.javax.persistence)
     testImplementation(libs.jakarta.persistence)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendClient.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendClient.kt
@@ -44,4 +44,7 @@ interface SuspendClient {
     @Get("/illegal", consumes = [MediaType.ALL])
     suspend fun errorCallResponse(): HttpResponse<String>
 
+    @Get("/keepRequestScopeAfterClientCall", consumes = [MediaType.TEXT_PLAIN])
+    suspend fun keepRequestScopeAfterClientCall(): String
+
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendController.kt
@@ -29,7 +29,8 @@ import org.slf4j.MDC
 class SuspendController(
     @Named(TaskExecutors.IO) private val executor: ExecutorService,
     private val suspendService: SuspendService,
-    private val suspendRequestScopedService: SuspendRequestScopedService
+    private val suspendRequestScopedService: SuspendRequestScopedService,
+    private val suspendClient: SuspendClient
 ) {
 
     private val coroutineDispatcher: CoroutineDispatcher
@@ -141,6 +142,14 @@ class SuspendController(
     @Get("/requestContext")
     suspend fun requestContext(): String {
         return suspendService.requestContext()
+    }
+
+    @Get("/keepRequestScopeAfterClientCall")
+    suspend fun keepRequestScopeAfterClientCall(): String {
+        val before = "${suspendRequestScopedService.requestId},${Thread.currentThread().id}"
+        suspendClient.simple()
+        val after = "${suspendRequestScopedService.requestId},${Thread.currentThread().id}"
+        return "$before,$after"
     }
 
     @Get("/requestContext2")

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendControllerSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendControllerSpec.kt
@@ -230,6 +230,15 @@ class SuspendControllerSpec : StringSpec() {
             response.status shouldBe HttpStatus.OK
         }
 
+        "test keeping request scope after suspend client call" {
+            val response = client.exchange(GET<Any>("/suspend/keepRequestScopeAfterClientCall"), String::class.java).awaitSingle()
+            val body = response.body.get()
+            val (beforeRequestId, beforeThreadId, afterRequestId, afterThreadId) = body.split(',')
+            beforeRequestId shouldBe afterRequestId
+            beforeThreadId shouldNotBe afterThreadId
+            response.status shouldBe HttpStatus.OK
+        }
+
         "test request context is available" {
             val response = client.exchange(GET<String>("/suspend/requestContext"), String::class.java).awaitSingle()
             val body = response.body.get()

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendControllerSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendControllerSpec.kt
@@ -233,9 +233,8 @@ class SuspendControllerSpec : StringSpec() {
         "test keeping request scope after suspend client call" {
             val response = client.exchange(GET<Any>("/suspend/keepRequestScopeAfterClientCall"), String::class.java).awaitSingle()
             val body = response.body.get()
-            val (beforeRequestId, beforeThreadId, afterRequestId, afterThreadId) = body.split(',')
+            val (beforeRequestId, _, afterRequestId, _) = body.split(',')
             beforeRequestId shouldBe afterRequestId
-            beforeThreadId shouldNotBe afterThreadId
             response.status shouldBe HttpStatus.OK
         }
 


### PR DESCRIPTION
## Summary
- add a Kotlin suspend regression in `test-suite-kotlin` that reproduces request-scope loss after a declarative suspend HTTP client call when Micrometer context propagation is on the classpath
- preserve `PropagatedContext` while resuming `CompletionStage` results in `KotlinInterceptedMethodHelper`, so request scope remains available after the client call resumes
- wire Micrometer context-propagation through the version catalog (`libs.versions.toml`) and consume it via `libs.micrometer.context.propagation`

## Verification
- `./gradlew :test-suite-kotlin:test --tests '*SuspendControllerSpec' -q`

Fixes #12399