### PR TITLE
fix(inject-kotlin): preserve boxed getter signature for overridden primitive properties

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
@@ -553,13 +553,15 @@ internal abstract class AbstractKotlinElement<T : KotlinNativeElement>(
     protected fun newClassElement(
         owner: KotlinNativeElement?,
         type: KSType,
-        parentTypeArguments: Map<String, ClassElement> = emptyMap()
+        parentTypeArguments: Map<String, ClassElement> = emptyMap(),
+        allowPrimitive: Boolean = true
     ) = newClassElement(
         owner,
         type,
         type.declaration.getClassDeclaration(visitorContext),
         parentTypeArguments,
-        HashSet()
+        HashSet(),
+        allowPrimitive
     )
 
     private fun newTypeArgument(

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinPropertyElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinPropertyElement.kt
@@ -45,11 +45,21 @@ internal class KotlinPropertyElement(
     override val abstract = property.isAbstract()
 
     override val resolvedType: ClassElement by lazy {
-        newClassElement(nativeType, property.type.resolve(), emptyMap())
+        val getterReturnType = property.getter?.returnType?.resolve()
+        if (getterReturnType != null && getterReturnType != property.type.resolve()) {
+            newClassElement(nativeType, getterReturnType, emptyMap())
+        } else {
+            newClassElement(nativeType, property.type.resolve(), emptyMap())
+        }
     }
 
     override val resolvedGenericType: ClassElement by lazy {
-        newClassElement(nativeType, property.type.resolve(), declaringType.typeArguments)
+        val getterReturnType = property.getter?.returnType?.resolve()
+        if (getterReturnType != null && getterReturnType != property.type.resolve()) {
+            newClassElement(nativeType, getterReturnType, declaringType.typeArguments)
+        } else {
+            newClassElement(nativeType, property.type.resolve(), declaringType.typeArguments)
+        }
     }
 
     override val setter: Optional<MethodElement> by lazy {

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinPropertyGetterMethodElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinPropertyGetterMethodElement.kt
@@ -53,9 +53,23 @@ internal class KotlinPropertyGetterMethodElement(
         visitorContext
     )
 
-    override val internalReturnType: ClassElement = propertyElement.type
+    override val internalReturnType: ClassElement by lazy {
+        resolveReturnType(emptyMap(), propertyElement.type)
+    }
 
-    override val internalGenericReturnType: ClassElement = propertyElement.genericType
+    override val internalGenericReturnType: ClassElement by lazy {
+        resolveReturnType(declaringType.typeArguments, propertyElement.genericType)
+    }
+
+    private fun resolveReturnType(
+        parentTypeArguments: Map<String, ClassElement>,
+        fallback: ClassElement,
+    ): ClassElement {
+        val returnType = propertyGetter.returnType?.resolve() ?: return fallback
+        val overriddenReturnType = propertyElement.property.findOverridee()?.getter?.returnType?.resolve()
+        val keepBoxed = overriddenReturnType != null && returnType != overriddenReturnType
+        return newClassElement(nativeType, returnType, parentTypeArguments, !keepBoxed)
+    }
 
     override val resolvedParameters: List<ParameterElement> = presetParameters
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -1841,6 +1841,28 @@ enum class Test(val number: Int) {
         thrown(ClassNotFoundException)
     }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/12443")
+    void "test introspection getter for primitive override of Any uses boxed JVM signature"() {
+        BeanIntrospection introspection = buildBeanIntrospection('test.CmdIntPayload', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+interface InboundCommand {
+    val payload: Any?
+}
+
+@Introspected
+data class CmdIntPayload(
+    override val payload: Int
+) : InboundCommand
+''')
+
+        expect:
+        introspection != null
+        introspection.getRequiredProperty("payload", int).get(introspection.instantiate(123)) == 123
+    }
+
     void "test basic enum bean properties"() {
         BeanIntrospection introspection = buildBeanIntrospection('test.MyEnum', '''
 package test


### PR DESCRIPTION
## Summary
- Fix KSP bean introspection property resolution for Kotlin overrides where a primitive property (`Int`) overrides a boxed/interface getter type (`Any?`), so generated access matches the JVM getter signature.
- Add a regression test for issue #12443 (`CmdIntPayload` overriding `InboundCommand.payload`) that previously failed with `NoSuchMethodError`.
- Refactor getter return-type resolution in `KotlinPropertyGetterMethodElement` to share logic between `internalReturnType` and `internalGenericReturnType`.

## Testing
- `./gradlew :micronaut-inject-kotlin:test --no-daemon -Pkotlin.incremental=false --max-workers=1 -Djava.util.prefs.userRoot=$PWD/.tmp-java-prefs -Djava.util.prefs.systemRoot=$PWD/.tmp-java-prefs --tests "io.micronaut.kotlin.processing.visitor.BeanIntrospectionSpec.test introspection getter for primitive override of Any uses boxed JVM signature" --tests "io.micronaut.kotlin.processing.visitor.BeanIntrospectionSpec.test enum bean properties" --tests "io.micronaut.kotlin.processing.visitor.BeanIntrospectionSpec.test write bean introspection data" --tests "io.micronaut.kotlin.processing.visitor.BeanIntrospectionSpec.test bean introspection on a data class"`

Fixes #12443