### PR TITLE
fix(introspection): deduplicate duplicate interface properties

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -44,6 +44,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -52,7 +53,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.micronaut.core.util.StringUtils.EMPTY_STRING_ARRAY;
@@ -446,9 +449,14 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                                 PropertyElementQuery propertyElementQuery,
                                 ClassElement ce,
                                 BeanIntrospectionWriter writer) {
-        List<PropertyElement> beanProperties = ce.getBeanProperties(propertyElementQuery).stream()
+        List<PropertyElement> beanProperties = new ArrayList<>(ce.getBeanProperties(propertyElementQuery).stream()
             .filter(p -> !p.isExcluded())
-            .toList();
+            .collect(Collectors.toMap(
+                PropertyElement::getName,
+                Function.identity(),
+                (existing, replacement) -> existing,
+                LinkedHashMap::new
+            )).values());
         Optional<MethodElement> constructorElement = ce.getPrimaryConstructor();
         constructorElement.ifPresent(constructorEl -> {
             if (ArrayUtils.isNotEmpty(constructorEl.getParameters())) {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/Issue12262.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/Issue12262.kt
@@ -1,0 +1,16 @@
+package io.micronaut.core.beans
+
+import io.micronaut.core.annotation.Introspected
+
+interface Issue12262A {
+    val foo: String
+}
+
+interface Issue12262B {
+    val foo: String
+}
+
+@Introspected
+data class Issue12262Bean(
+    override val foo: String
+) : Issue12262A, Issue12262B

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/KotlinBeanIntrospectionSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/KotlinBeanIntrospectionSpec.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate.now
 import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 
 class KotlinBeanIntrospectionSpec {
 
@@ -233,4 +234,14 @@ class KotlinBeanIntrospectionSpec {
         assertEquals(bean.a38, attributes[38])
         assertEquals(bean.a39, attributes[39])
     }
+    @Test
+    fun testDuplicatePropertiesFromIndependentInterfaces() {
+        val introspection = BeanIntrospection.getIntrospection(Issue12262Bean::class.java)
+
+        assertArrayEquals(arrayOf("foo"), introspection.propertyNames)
+        val bean = introspection.instantiate("bar")
+        assertEquals("bar", bean.foo)
+        assertEquals("bar", introspection.getRequiredProperty("foo", String::class.java).get(bean))
+    }
+
 }


### PR DESCRIPTION
## Summary
- deduplicate bean property entries by name in `IntrospectedTypeElementVisitor` before introspection metadata method generation
- add Kotlin regression reproducer for an `@Introspected` class implementing two unrelated interfaces declaring the same property
- prevent duplicate `$property$...$metadata` methods that caused `ClassFormatError` during introspection service loading

## Validation
- `./gradlew -q :test-suite-kotlin:test --tests 'io.micronaut.core.beans.KotlinBeanIntrospectionSpec.testDuplicatePropertiesFromIndependentInterfaces'`
- `./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility`

Fixes #12262