### PR TITLE
fix(http-client-jdk): honor named service SSL config in JDK client

### DIFF
--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/AbstractJdkHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/AbstractJdkHttpClient.java
@@ -50,7 +50,7 @@ import io.micronaut.http.filter.HttpClientFilterResolver;
 import io.micronaut.http.filter.HttpFilterResolver;
 import io.micronaut.http.reactive.execution.ReactiveExecutionFlow;
 import io.micronaut.http.ssl.ClientAuthentication;
-import io.micronaut.http.ssl.ClientSslConfiguration;
+import io.micronaut.http.ssl.AbstractClientSslConfiguration;
 import io.micronaut.http.util.HttpHeadersUtil;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -236,8 +236,8 @@ abstract class AbstractJdkHttpClient {
             builder = configureProxy(builder, socketAddress, configuration.getProxyUsername().orElse(null), configuration.getProxyPassword().orElse(null));
         }
 
-        if (configuration.getSslConfiguration() instanceof ClientSslConfiguration clientSslConfiguration) {
-            configureSsl(builder, clientSslConfiguration);
+        if (configuration.getSslConfiguration() instanceof AbstractClientSslConfiguration sslConfiguration) {
+            configureSsl(builder, sslConfiguration);
         }
 
         this.client = builder.build();
@@ -293,18 +293,18 @@ abstract class AbstractJdkHttpClient {
         return builder;
     }
 
-    private void configureSsl(HttpClient.Builder builder, ClientSslConfiguration clientSslConfiguration) {
-        sslBuilder.build(clientSslConfiguration).ifPresent(builder::sslContext);
+    private void configureSsl(HttpClient.Builder builder, AbstractClientSslConfiguration sslConfiguration) {
+        sslBuilder.build(sslConfiguration).ifPresent(builder::sslContext);
         SSLParameters sslParameters = new SSLParameters();
-        clientSslConfiguration.getClientAuthentication().ifPresent(a -> {
+        sslConfiguration.getClientAuthentication().ifPresent(a -> {
             if (a == ClientAuthentication.WANT) {
                 sslParameters.setWantClientAuth(true);
             } else if (a == ClientAuthentication.NEED) {
                 sslParameters.setNeedClientAuth(true);
             }
         });
-        clientSslConfiguration.getProtocols().ifPresent(sslParameters::setProtocols);
-        clientSslConfiguration.getCiphers().ifPresent(sslParameters::setCipherSuites);
+        sslConfiguration.getProtocols().ifPresent(sslParameters::setProtocols);
+        sslConfiguration.getCiphers().ifPresent(sslParameters::setCipherSuites);
         builder.sslParameters(sslParameters);
     }
 

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/JdkClientSslBuilder.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/JdkClientSslBuilder.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.Nullable;
 import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.http.HttpVersion;
 import io.micronaut.http.client.HttpVersionSelection;
-import io.micronaut.http.ssl.ClientSslConfiguration;
+import io.micronaut.http.ssl.AbstractClientSslConfiguration;
 import io.micronaut.http.ssl.SslBuilder;
 import io.micronaut.http.ssl.SslConfiguration;
 import io.micronaut.http.ssl.SslConfigurationException;
@@ -87,7 +87,7 @@ public final class JdkClientSslBuilder extends SslBuilder<SSLContext> {
                 trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             }
             TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
-            if (ssl instanceof ClientSslConfiguration clientSslConfiguration && clientSslConfiguration.isInsecureTrustAllCertificates()) {
+            if (ssl instanceof AbstractClientSslConfiguration clientSslConfiguration && clientSslConfiguration.isInsecureTrustAllCertificates()) {
                 if (LOG.isWarnEnabled()) {
                     LOG.warn("Trust all certificates is enabled. This is insecure and should not be used in production");
                 }

--- a/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/Issue12244Spec.groovy
+++ b/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/Issue12244Spec.groovy
@@ -1,0 +1,54 @@
+package io.micronaut.http.client.jdk
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.core.io.socket.SocketUtils
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClientRegistry
+import io.micronaut.http.client.HttpVersionSelection
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+@Issue("https://github.com/micronaut-projects/micronaut-core/issues/12244")
+class Issue12244Spec extends Specification {
+    @Shared
+    String host = Optional.ofNullable(System.getenv(Environment.HOSTNAME)).orElse(SocketUtils.LOCALHOST)
+
+    @AutoCleanup
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+        'spec.name': 'Issue12244Spec',
+        'micronaut.ssl.enabled': true,
+        'micronaut.server.ssl.buildSelfSigned': true,
+        'micronaut.server.ssl.port': -1,
+    ])
+
+    @AutoCleanup
+    ApplicationContext clientCtx = ApplicationContext.run([
+        'spec.name': 'Issue12244Spec',
+        'micronaut.http.services.myclient.url': server.getURL().toString(),
+        'micronaut.http.services.myclient.ssl.enabled': true,
+        'micronaut.http.services.myclient.ssl.insecure-trust-all-certificates': true,
+    ])
+
+    def 'named jdk client applies service ssl configuration'() {
+        given:
+        def client = clientCtx.getBean(HttpClientRegistry).getClient(HttpVersionSelection.forLegacyVersion(io.micronaut.http.HttpVersion.HTTP_1_1), 'myclient', null)
+
+        expect:
+        client.toBlocking().retrieve('/ssl') == 'Hello'
+    }
+
+    @Requires(property = 'spec.name', value = 'Issue12244Spec')
+    @Controller('/')
+    static class TestController {
+        @Get('/ssl')
+        String simple() {
+            'Hello'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- apply service SSL settings in the JDK HTTP client when the client configuration is a named service (`ServiceSslClientConfiguration`), not only the global `ClientSslConfiguration`
- update JDK SSL builder type checks to consistently accept `AbstractClientSslConfiguration`
- add `Issue12244Spec` regression coverage for named JDK client SSL config against a self-signed HTTPS server

## Verification
- `:micronaut-http-client-jdk:test --tests io.micronaut.http.client.jdk.Issue12244Spec`
- `:micronaut-http-client-jdk:test --tests io.micronaut.http.client.jdk.SslSelfSignedSpec`

Fixes #12244