### PR TITLE
Document custom HTTP client DNS resolver snippets

### DIFF
--- a/src/main/docs/guide/httpClient/lowLevelHttpClient/clientConfiguration.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelHttpClient/clientConfiguration.adoc
@@ -32,6 +32,22 @@ micronaut:
 
 - The `read-timeout` is applied to the `foo` client.
 
+For the Netty HTTP client, you can also plug in a custom DNS resolver by referencing a named Netty `AddressResolverGroup` bean with the `address-resolver-group-name` property. This is useful when you need custom name resolution behavior for a specific client.
+
+snippet::io.micronaut.docs.client.resolver.CustomAddressResolverGroupFactory[tags="class", indent=0, title="Define a named `AddressResolverGroup` bean"]
+
+<1> Name the resolver bean so clients can reference it.
+<2> Return the `AddressResolverGroup` instance used by the Netty client.
+
+In the test suites, the named client is configured programmatically with the same properties:
+
+snippet::io.micronaut.docs.client.resolver.AddressResolverClientConfiguration[tags="properties", indent=0, title="Programmatic client configuration example"]
+
+<1> Configure the service URL for the named client.
+<2> Reference the named resolver bean with `address-resolver-group-name`.
+
+The configured name must match an existing bean. When `address-resolver-group-name` is set, `dns-resolution-mode` is ignored.
+
 WARN: This client configuration can be used in conjunction with the `@Client` annotation, either by injecting an `HttpClient` directly or use on a client interface. In any case, all other attributes on the annotation *will be ignored* except the service id.
 
 Then, inject the named client configuration:

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/client/resolver/AddressResolverClientConfiguration.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/client/resolver/AddressResolverClientConfiguration.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.client.resolver
+
+class AddressResolverClientConfiguration {
+
+    // tag::properties[]
+    static Map<String, Object> serviceConfiguration() {
+        [
+            "micronaut.http.services.foo.urls[0]": "https://api.example.com", // <1>
+            "micronaut.http.services.foo.address-resolver-group-name": "custom" // <2>
+        ]
+    }
+    // end::properties[]
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/client/resolver/CustomAddressResolverGroupFactory.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/client/resolver/CustomAddressResolverGroupFactory.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.client.resolver
+
+// tag::class[]
+import io.micronaut.context.annotation.Factory
+import io.netty.resolver.AddressResolverGroup
+import io.netty.resolver.DefaultAddressResolverGroup
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+
+@Factory
+class CustomAddressResolverGroupFactory {
+
+    @Singleton
+    @Named("custom") // <1>
+    AddressResolverGroup<?> customAddressResolverGroup() {
+        DefaultAddressResolverGroup.INSTANCE // <2>
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/client/resolver/AddressResolverClientConfiguration.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/client/resolver/AddressResolverClientConfiguration.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.client.resolver
+
+object AddressResolverClientConfiguration {
+
+    // tag::properties[]
+    fun serviceConfiguration(): Map<String, Any> {
+        return mapOf(
+            "micronaut.http.services.foo.urls[0]" to "https://api.example.com", // <1>
+            "micronaut.http.services.foo.address-resolver-group-name" to "custom" // <2>
+        )
+    }
+    // end::properties[]
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/client/resolver/CustomAddressResolverGroupFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/client/resolver/CustomAddressResolverGroupFactory.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.client.resolver
+
+// tag::class[]
+import io.micronaut.context.annotation.Factory
+import io.netty.resolver.AddressResolverGroup
+import io.netty.resolver.DefaultAddressResolverGroup
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+
+@Factory
+class CustomAddressResolverGroupFactory {
+
+    @Singleton
+    @Named("custom") // <1>
+    fun customAddressResolverGroup(): AddressResolverGroup<*> {
+        return DefaultAddressResolverGroup.INSTANCE // <2>
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/client/resolver/AddressResolverClientConfiguration.java
+++ b/test-suite/src/test/java/io/micronaut/docs/client/resolver/AddressResolverClientConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.client.resolver;
+
+import java.util.Map;
+
+class AddressResolverClientConfiguration {
+
+    // tag::properties[]
+    static Map<String, Object> serviceConfiguration() {
+        return Map.of(
+            "micronaut.http.services.foo.urls[0]", "https://api.example.com", // <1>
+            "micronaut.http.services.foo.address-resolver-group-name", "custom" // <2>
+        );
+    }
+    // end::properties[]
+}

--- a/test-suite/src/test/java/io/micronaut/docs/client/resolver/CustomAddressResolverGroupFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/client/resolver/CustomAddressResolverGroupFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.client.resolver;
+
+// tag::class[]
+import io.micronaut.context.annotation.Factory;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultAddressResolverGroup;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Factory
+class CustomAddressResolverGroupFactory {
+
+    @Singleton
+    @Named("custom") // <1>
+    AddressResolverGroup<?> customAddressResolverGroup() {
+        return DefaultAddressResolverGroup.INSTANCE; // <2>
+    }
+}
+// end::class[]


### PR DESCRIPTION
## Summary
- add Java, Groovy, and Kotlin test-suite snippet sources for a named Netty `AddressResolverGroup` bean and matching named-client properties
- replace the inline docs block in the low-level HTTP client configuration guide with snippet-backed examples
- clarify that the second snippet is a programmatic test-suite configuration example while preserving precedence behavior notes

## Verification
- `./gradlew -q spotlessApply :test-suite:compileTestJava :test-suite-groovy:compileTestGroovy :test-suite-kotlin:compileTestKotlin`
- `./gradlew -q :test-suite:test --tests io.micronaut.docs.client.filter.BasicAuthFilterSpec :test-suite-groovy:test --tests io.micronaut.docs.client.filter.BasicAuthFilterSpec :test-suite-kotlin:test --tests io.micronaut.docs.client.filter.BasicAuthFilterSpec`

Fixes #12243