### PR TITLE
test: reproduce nullable @Pattern query regression with introspected String

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ParameterBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ParameterBindingSpec.groovy
@@ -84,6 +84,7 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
         '/java/parameter/optional?max=20'                                | "Parameter Value: 20"       | HttpStatus.OK
         '/java/parameter/nullable'                                       | "Parameter Value: null"     | HttpStatus.OK
         '/java/parameter/nullable?max=20'                                | "Parameter Value: 20"       | HttpStatus.OK
+        '/java/parameter/nullable-pattern'                               | "Parameter Value: null"     | HttpStatus.OK
         HttpRequest.POST('/java/parameter/nullable-body', '{}')          | "Body Value: null"          | HttpStatus.OK
         HttpRequest.POST('/java/parameter/nullable-body', '{"max": 20}') | "Body Value: 20"            | HttpStatus.OK
         HttpRequest.POST('/java/parameter/requires-body', '{}')          | null                        | HttpStatus.BAD_REQUEST

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ParameterController.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ParameterController.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.netty.java;
 
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.http.HttpParameters;
 import io.micronaut.http.MediaType;
@@ -23,6 +24,7 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
+import jakarta.validation.constraints.Pattern;
 
 import java.util.List;
 import java.util.Map;
@@ -60,6 +62,11 @@ public class ParameterController {
         return "Parameter Value: " + (max != null ? max : "null");
     }
 
+    @Get("/nullable-pattern")
+    String nullablePattern(@QueryValue("name") @Nullable @Pattern(regexp = "^(alice|bob)$") String name) {
+        return "Parameter Value: " + (name != null ? name : "null");
+    }
+
     @Post(value = "/nullable-body", consumes = MediaType.APPLICATION_JSON)
     String nullableBody(@Nullable Integer max) {
         return "Body Value: " + (max != null ? max : "null");
@@ -95,4 +102,12 @@ public class ParameterController {
             return "Parameter Value: none";
         }
     }
+}
+
+@Introspected(
+    visibility = Introspected.Visibility.PUBLIC,
+    classes = {
+        String.class
+    })
+class IntrospectedAnnotationAppender {
 }


### PR DESCRIPTION
## Summary
- add a Java test route combining `@QueryValue(\"name\")`, nullable `String`, and `@Pattern(regexp = \"^(alice|bob)$\")`
- add `@Introspected(classes = { String.class })` test metadata to mirror the attached reproducer setup
- extend `io.micronaut.http.server.netty.java.ParameterBindingSpec` with `/java/parameter/nullable-pattern` expecting `200` and `Parameter Value: null`

## Verification
- ran: `./gradlew :micronaut-http-server-netty:test --tests 'io.micronaut.http.server.netty.java.ParameterBindingSpec' --stacktrace`
- result on `5.0.x`: fails in `test bind HTTP parameters for URI /java/parameter/nullable-pattern` with `body == null` (non-200 path), reproducing the regression

Related: #12203