### PR TITLE
fix: preserve compatible SequencedSet @Parameter values in createBean

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/ParametrizedFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/ParametrizedFactorySpec.groovy
@@ -19,6 +19,8 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.exceptions.BeanInstantiationException
 import spock.lang.Specification
 
+import java.util.LinkedHashSet
+
 /**
  * @author Graeme Rocher
  * @since 1.0
@@ -83,4 +85,22 @@ class ParametrizedFactorySpec extends Specification  {
         cleanup:
         context.close()
     }
+    void "test createBean accepts compatible sequenced set parameter"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        def input = new LinkedHashSet<Integer>()
+        input.add(1)
+        input.add(2)
+
+        when:
+        SequencedSetParamBean bean = context.createBean(SequencedSetParamBean, input)
+
+        then:
+        bean != null
+        bean.set.is(input)
+
+        cleanup:
+        context.close()
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/SequencedSetParamBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/SequencedSetParamBean.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.factory.parameterizedfactory;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Prototype;
+
+import java.util.SequencedSet;
+
+@Prototype
+public final class SequencedSetParamBean {
+    private final SequencedSet<Integer> set;
+
+    public SequencedSetParamBean(@Parameter SequencedSet<Integer> set) {
+        this.set = set;
+    }
+
+    public SequencedSet<Integer> getSet() {
+        return set;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1058,7 +1058,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 if (args.length > i) {
                     Object val = args[i];
                     if (val != null) {
-                        if (argumentType.isInstance(val) && !CollectionUtils.isIterableOrMap(argumentType)) {
+                        if (argumentType.isInstance(val)) {
                             argumentValues.put(requiredArgument.getName(), val);
                         } else {
                             argumentValues.put(requiredArgument.getName(), conversionService.convert(val, requiredArgument).orElseThrow(() ->


### PR DESCRIPTION
## Summary
- Preserve constructor arguments in `DefaultBeanContext#createBean` when the runtime value already matches the declared argument type, instead of forcing conversion for iterable/map raw types.
- Add a regression case in `ParametrizedFactorySpec` that reproduces `LinkedHashSet` -> `@Parameter SequencedSet<Integer>` and verifies identity preservation.
- Add `SequencedSetParamBean` test fixture used by the new regression.

## Potential impact
- **Behavioral change scope:** only affects `createBean(...args)` paths where a provided argument is already assignable to the declared parameter type.
- **Positive impact:** avoids unnecessary collection conversion and fixes valid Java 21 `SequencedSet` inputs that previously failed with "Cannot convert object ... to required type: SequencedSet".
- **Compatibility risk:** low-to-moderate; code that implicitly depended on forced conversion side-effects (e.g., wrapping/copying assignable iterable/map instances) will now keep the original instance.
- **Release targeting:** because this is a bug fix with focused scope and regression coverage, it is suitable for `5.0.x`.

## Verification
- `./gradlew :micronaut-inject-java:test --tests io.micronaut.inject.factory.parameterizedfactory.ParametrizedFactorySpec -q --no-daemon --max-workers=1 -Dorg.gradle.warning.mode=none -Dorg.gradle.jvmargs='-Xmx2g -XX:MaxMetaspaceSize=768m'`
- New test in `ParametrizedFactorySpec` passes and reproduces the issue on old logic.

Fixes #12232