### PR TITLE
test: add GOAWAY next-request connection regression

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
@@ -1017,6 +1017,43 @@ class ConnectionManagerSpec extends Specification {
         ctx.close()
     }
 
+    def 'http2 goaway before next request opens a new connection'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
+                'spec.name': ConnectionManagerSpec.simpleName,
+        ])
+        def client = ctx.getBean(DefaultHttpClient)
+
+        def conn1 = new EmbeddedTestConnectionHttp2()
+        conn1.setupHttp2Tls()
+        def conn2 = new EmbeddedTestConnectionHttp2()
+        conn2.setupHttp2Tls()
+        patch(client, conn1, conn2)
+
+        when:
+        def first = conn1.testExchangeRequest(client)
+        conn1.exchangeSettings()
+        conn1.testExchangeResponse(first)
+
+        and:
+        conn1.serverChannel.writeOutbound(new DefaultHttp2GoAwayFrame(Http2Error.NO_ERROR, Unpooled.EMPTY_BUFFER))
+        conn1.advance()
+
+        def second = conn2.testExchangeRequest(client)
+        conn2.exchangeSettings()
+
+        then:
+        conn1.serverChannel.readInbound() instanceof DefaultHttp2GoAwayFrame
+        conn1.serverChannel.readInbound() == null
+        conn2.testExchangeResponse(second)
+        assertPoolConnections(client, 1)
+
+        cleanup:
+        client.close()
+        ctx.close()
+    }
+
     @Ignore("EmbeddedChannel.close cancels the scheduled task that runs the timeout")
     def 'http2 channel inactive but fire inactive channel scheduled after acquire'() {
         def ctx = ApplicationContext.run([


### PR DESCRIPTION
## Summary
- add a focused HTTP/2 regression test for issue #12177 in `ConnectionManagerSpec`
- verify that after receiving GOAWAY, the next request is dispatched on a new connection rather than the wound-down one
- keep production code unchanged and document current expected behavior through test coverage

## Testing
- `./gradlew :micronaut-http-client:test --tests 'io.micronaut.http.client.netty.ConnectionManagerSpec.http2 goaway before next request opens a new connection' --console=plain -q`

Fixes #12177