### PR TITLE
fix(http-client): preserve request context for discovery client selection

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/loadbalance/DiscoveryClientRoundRobinLoadBalancer.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/loadbalance/DiscoveryClientRoundRobinLoadBalancer.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.http.client.loadbalance;
 
+import io.micronaut.core.async.propagation.ReactivePropagation;
 import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.discovery.DiscoveryClient;
 import io.micronaut.discovery.ServiceInstance;
 import org.jspecify.annotations.Nullable;
@@ -55,6 +57,10 @@ public class DiscoveryClientRoundRobinLoadBalancer extends AbstractRoundRobinLoa
 
     @Override
     public Publisher<ServiceInstance> select(@Nullable Object discriminator) {
-        return Publishers.map(discoveryClient.getInstances(serviceID), this::getNextAvailable);
+        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty();
+        return Publishers.map(
+            ReactivePropagation.propagate(propagatedContext, discoveryClient.getInstances(serviceID)),
+            this::getNextAvailable
+        );
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/context/DiscoveryClientRequestScopePropagationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/context/DiscoveryClientRequestScopePropagationSpec.groovy
@@ -1,0 +1,123 @@
+package io.micronaut.http.server.netty.context
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.discovery.DiscoveryClient
+import io.micronaut.discovery.ServiceInstance
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.http.scope.RequestScope
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DiscoveryClientRequestScopePropagationSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer backendServer = ApplicationContext.run(EmbeddedServer, [
+        'spec.name': 'DiscoveryClientRequestScopePropagationSpec.backend'
+    ])
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+        'spec.name': 'DiscoveryClientRequestScopePropagationSpec',
+        'micronaut.caches.discovery-client.enabled': false,
+        'reactor.enableAutomaticContextPropagation': true,
+        'backend.url': "http://localhost:$backendServer.port"
+    ])
+
+    @Shared
+    @AutoCleanup
+    HttpClient httpClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.URL)
+
+    @Shared
+    BlockingHttpClient client = httpClient.toBlocking()
+
+    void "request scope is available inside discovery client with automatic context propagation enabled"() {
+        expect:
+        client.retrieve('/test') == 'resolved'
+    }
+
+    @Requires(property = 'spec.name', value = 'DiscoveryClientRequestScopePropagationSpec')
+    @Controller
+    static class TestController {
+        @Inject
+        TestApiClient testApiClient
+
+        @Get('/test')
+        @ExecuteOn(TaskExecutors.BLOCKING)
+        String test() {
+            testApiClient.call()
+            return 'resolved'
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'DiscoveryClientRequestScopePropagationSpec')
+    @Client('test-service')
+    static interface TestApiClient {
+        @Get('/backend')
+        void call()
+    }
+
+    @Requires(property = 'spec.name', value = 'DiscoveryClientRequestScopePropagationSpec')
+    @Singleton
+    static class TestDiscoveryClient implements DiscoveryClient {
+        @Inject
+        RequestScopedBean requestScopedBean
+
+        @Value('${backend.url}')
+        String backendUrl
+
+        @Override
+        void close() {
+        }
+
+        @Override
+        @NonNull
+        String getDescription() {
+            'test'
+        }
+
+        @Override
+        Publisher<List<ServiceInstance>> getInstances(String serviceId) {
+            requestScopedBean.value()
+            return Mono.just([ServiceInstance.of(serviceId, new URL(backendUrl))])
+        }
+
+        @Override
+        Publisher<List<String>> getServiceIds() {
+            return Mono.just(['test-service'])
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'DiscoveryClientRequestScopePropagationSpec')
+    @RequestScope
+    static class RequestScopedBean {
+        String value() {
+            'ok'
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'DiscoveryClientRequestScopePropagationSpec.backend')
+    @Controller
+    static class BackendController {
+        @Get('/backend')
+        void backend() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- capture the current `PropagatedContext` in `DiscoveryClientRoundRobinLoadBalancer.select` and propagate it while subscribing to `discoveryClient.getInstances(serviceID)`
- add `DiscoveryClientRequestScopePropagationSpec` to reproduce the request-scope failure path reported in #12055 (`@Client` -> discovery resolution -> custom `DiscoveryClient` using `@RequestScope`)
- keep the fix scoped to discovery-based HTTP client load balancing without changing global discovery behavior

## Verification
- `./gradlew :micronaut-http-server-netty:test --tests io.micronaut.http.server.netty.context.DiscoveryClientRequestScopePropagationSpec -q --no-daemon -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process`

Fixes #12055