### PR TITLE
Add FileCustomizableResponseType body writer

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
@@ -5,6 +5,8 @@ import tools.jackson.databind.node.JsonNodeFactory
 import tools.jackson.databind.node.ObjectNode
 import groovy.transform.CompileStatic
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.MutableHeaders
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
@@ -12,14 +14,18 @@ import io.micronaut.http.MediaType
 import io.micronaut.http.MutableHttpRequest
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.body.MessageBodyWriter
 import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.codec.CodecException
 import io.micronaut.http.server.netty.AbstractMicronautSpec
 import io.micronaut.http.server.types.files.FileCustomizableResponseType
 import io.micronaut.http.server.types.files.StreamedFile
 import io.micronaut.http.server.types.files.SystemFile
 import jakarta.inject.Inject
 import jakarta.inject.Named
+import jakarta.inject.Singleton
 import reactor.core.publisher.Mono
 import spock.lang.IgnoreIf
 
@@ -30,6 +36,7 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.ExecutorService
+import java.io.OutputStream
 
 import static io.micronaut.http.HttpHeaders.ACCEPT_RANGES
 import static io.micronaut.http.HttpHeaders.CACHE_CONTROL
@@ -239,6 +246,37 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         file.delete()
     }
 
+    void "test when HttpResponse FileCustomizableResponseType returns StreamedFile with JSON media type"() {
+        when:
+        def response = httpClient.toBlocking().exchange('/test-stream/response-json-stream', String)
+
+        then:
+        response.code() == HttpStatus.OK.code
+        response.header(CONTENT_TYPE) == MediaType.APPLICATION_JSON
+        response.body() == tempFileContents
+    }
+
+    void "test when HttpResponse FileCustomizableResponseType returns SystemFile with JSON media type"() {
+        when:
+        def response = httpClient.toBlocking().exchange('/test-stream/response-json-system', String)
+
+        then:
+        response.code() == HttpStatus.OK.code
+        response.header(CONTENT_TYPE) == MediaType.APPLICATION_JSON
+        Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
+        response.body() == tempFileContents
+    }
+
+    void "test when HttpResponse FileCustomizableResponseType returns custom type with custom writer"() {
+        when:
+        def response = httpClient.toBlocking().exchange('/test-stream/response-json-custom', String)
+
+        then:
+        response.code() == HttpStatus.OK.code
+        response.header(CONTENT_TYPE) == MediaType.APPLICATION_JSON
+        response.body() == "custom-body"
+    }
+
     void "test when an attached file is returned with a name"() {
         when:
         def response = httpClient.toBlocking().exchange('/test/different-name', String)
@@ -420,6 +458,60 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         @Get('/reactive-system')
         Mono<FileCustomizableResponseType> reactiveStream(@QueryValue Path path) {
             Mono.just(new SystemFile(path.toFile(), MediaType.TEXT_PLAIN_TYPE))
+        }
+
+        @Get('/response-json-stream')
+        HttpResponse<FileCustomizableResponseType> responseJsonStream() {
+            def stream = new ByteArrayInputStream(tempFileContents.bytes)
+            HttpResponse.ok(new StreamedFile(stream, MediaType.APPLICATION_JSON_TYPE))
+        }
+
+        @Get('/response-json-system')
+        HttpResponse<FileCustomizableResponseType> responseJsonSystem() {
+            HttpResponse.ok(new SystemFile(tempFile, MediaType.APPLICATION_JSON_TYPE))
+        }
+
+        @Get('/response-json-custom')
+        HttpResponse<FileCustomizableResponseType> responseJsonCustom() {
+            HttpResponse.ok(new CustomFileResponseType("custom-body")).contentType(MediaType.APPLICATION_JSON_TYPE)
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'FileTypeHandlerSpec')
+    @Singleton
+    @Produces(MediaType.APPLICATION_JSON)
+    static class CustomFileResponseTypeBodyWriter implements MessageBodyWriter<CustomFileResponseType> {
+
+        @Override
+        void writeTo(Argument<CustomFileResponseType> type,
+                     MediaType mediaType,
+                     CustomFileResponseType object,
+                     MutableHeaders outgoingHeaders,
+                     OutputStream outputStream) throws CodecException {
+            outputStream.write(object.content.bytes)
+        }
+    }
+
+    static class CustomFileResponseType implements FileCustomizableResponseType {
+        final String content
+
+        CustomFileResponseType(String content) {
+            this.content = content
+        }
+
+        @Override
+        long getLastModified() {
+            return 0
+        }
+
+        @Override
+        long getLength() {
+            return content.bytes.length
+        }
+
+        @Override
+        MediaType getMediaType() {
+            return MediaType.APPLICATION_JSON_TYPE
         }
     }
 

--- a/http-server/src/main/java/io/micronaut/http/server/body/FileCustomizableResponseTypeBodyWriter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/body/FileCustomizableResponseTypeBodyWriter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.body;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.MutableHeaders;
+import io.micronaut.http.ByteBodyHttpResponse;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.body.ByteBodyFactory;
+import io.micronaut.http.body.CloseableByteBody;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.http.body.MessageBodyWriter;
+import io.micronaut.http.body.ResponseBodyWriter;
+import io.micronaut.http.codec.CodecException;
+import io.micronaut.http.server.types.files.FileCustomizableResponseType;
+import jakarta.inject.Singleton;
+
+import java.io.OutputStream;
+
+@Internal
+@Experimental
+@Singleton
+@Order(-11)
+public final class FileCustomizableResponseTypeBodyWriter implements ResponseBodyWriter<FileCustomizableResponseType> {
+    private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
+
+    FileCustomizableResponseTypeBodyWriter(MessageBodyHandlerRegistry messageBodyHandlerRegistry) {
+        this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
+    }
+
+    @Override
+    public ByteBodyHttpResponse<?> write(ByteBodyFactory bodyFactory,
+                                         HttpRequest<?> request,
+                                         MutableHttpResponse<FileCustomizableResponseType> outgoingResponse,
+                                         Argument<FileCustomizableResponseType> type,
+                                         MediaType mediaType,
+                                         FileCustomizableResponseType object) throws CodecException {
+        return findResponseWriter(object, mediaType).write(bodyFactory, request, outgoingResponse, runtimeType(object), mediaType, object);
+    }
+
+    @Override
+    public CloseableByteBody writePiece(ByteBodyFactory bodyFactory,
+                                        HttpRequest<?> request,
+                                        HttpResponse<?> response,
+                                        Argument<FileCustomizableResponseType> type,
+                                        MediaType mediaType,
+                                        FileCustomizableResponseType object) {
+        return findResponseWriter(object, mediaType).writePiece(bodyFactory, request, response, runtimeType(object), mediaType, object);
+    }
+
+    @Override
+    public void writeTo(Argument<FileCustomizableResponseType> type,
+                        MediaType mediaType,
+                        FileCustomizableResponseType object,
+                        MutableHeaders outgoingHeaders,
+                        OutputStream outputStream) throws CodecException {
+        findResponseWriter(object, mediaType).writeTo(runtimeType(object), mediaType, object, outgoingHeaders, outputStream);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return true;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ResponseBodyWriter<FileCustomizableResponseType> findResponseWriter(FileCustomizableResponseType object,
+                                                                                 MediaType mediaType) {
+        Argument<FileCustomizableResponseType> runtimeType = runtimeType(object);
+        MessageBodyWriter<FileCustomizableResponseType> writer = messageBodyHandlerRegistry.findWriter(runtimeType, mediaType)
+            .orElse(null);
+        if (writer == null || writer instanceof FileCustomizableResponseTypeBodyWriter) {
+            throw new CodecException("Cannot encode FileCustomizableResponseType runtime type [" + runtimeType + "] for media type [" + mediaType + "]");
+        }
+        return (ResponseBodyWriter) ResponseBodyWriter.wrap(writer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Argument<FileCustomizableResponseType> runtimeType(FileCustomizableResponseType object) {
+        return (Argument<FileCustomizableResponseType>) Argument.of(object.getClass());
+    }
+}

--- a/http-server/src/main/java/io/micronaut/http/server/body/FileCustomizableResponseTypeBodyWriter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/body/FileCustomizableResponseTypeBodyWriter.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.server.body;
 
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.core.type.Argument;
@@ -37,13 +36,15 @@ import jakarta.inject.Singleton;
 import java.io.OutputStream;
 
 @Internal
-@Experimental
 @Singleton
 @Order(-11)
 /**
  * Delegates {@link FileCustomizableResponseType} responses to the writer for the runtime subtype.
  * This avoids preselecting the generic JSON writer for declared
  * {@code HttpResponse<FileCustomizableResponseType>} responses.
+ *
+ * @author Jonas Konrad
+ * @since 5.0.0
  */
 final class FileCustomizableResponseTypeBodyWriter implements ResponseBodyWriter<FileCustomizableResponseType> {
     private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;

--- a/http-server/src/main/java/io/micronaut/http/server/body/FileCustomizableResponseTypeBodyWriter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/body/FileCustomizableResponseTypeBodyWriter.java
@@ -40,7 +40,12 @@ import java.io.OutputStream;
 @Experimental
 @Singleton
 @Order(-11)
-public final class FileCustomizableResponseTypeBodyWriter implements ResponseBodyWriter<FileCustomizableResponseType> {
+/**
+ * Delegates {@link FileCustomizableResponseType} responses to the writer for the runtime subtype.
+ * This avoids preselecting the generic JSON writer for declared
+ * {@code HttpResponse<FileCustomizableResponseType>} responses.
+ */
+final class FileCustomizableResponseTypeBodyWriter implements ResponseBodyWriter<FileCustomizableResponseType> {
     private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
 
     FileCustomizableResponseTypeBodyWriter(MessageBodyHandlerRegistry messageBodyHandlerRegistry) {


### PR DESCRIPTION
## Summary
- add a `FileCustomizableResponseType` response body writer that delegates to the writer for the runtime subtype
- keep the route-level declared-type writer selection flow intact while avoiding incorrect JSON serialization for `StreamedFile`, `SystemFile`, and custom file response types
- add regression coverage for `HttpResponse<FileCustomizableResponseType>` with JSON media type

## Why
For routes declared as `HttpResponse<FileCustomizableResponseType>`, Micronaut can preselect a writer from the declared type before the runtime subtype is known. With JSON media type, that can lock in the JSON writer and bypass the file-specific handling for `StreamedFile` and `SystemFile`.

This change makes the declared type select a dedicated dispatcher writer for `FileCustomizableResponseType`, and that writer then resolves the actual runtime subtype writer when writing the response.

## Tests
- added `FileTypeHandlerSpec` coverage for:
  - `StreamedFile` returned as `HttpResponse<FileCustomizableResponseType>` with JSON media type
  - `SystemFile` returned as `HttpResponse<FileCustomizableResponseType>` with JSON media type
  - custom `FileCustomizableResponseType` with a custom writer and JSON media type
- fail-before / pass-after was verified for those new cases
- full `FileTypeHandlerSpec` passed locally

## Validation notes
A broader `:micronaut-http-server-netty:test` run was not fully green locally because of an unrelated failure in:
- `io.micronaut.http.server.netty.stream.StreamPressureSpec > consumer pressure`

That failure was:
- `java.io.IOException: Read end dead`

This appears to be outside the file response path touched by this patch.

## Semantics note
This is intentionally narrow in scope: the declared response type still selects the route writer, but for `FileCustomizableResponseType` that selected writer is now a dispatcher that performs runtime subtype selection.
