### PR TITLE
Preserve annotation class names in string metadata values

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -1020,6 +1020,9 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
             return Optional.empty();
         }
         Object o = getRawSingleValue(member, valueMapper);
+        if (o instanceof AnnotationClassValue<?> annotationClassValue) {
+            return Optional.of(annotationClassValue.getName());
+        }
         if (o != null) {
             return Optional.of(o.toString());
         }
@@ -1038,6 +1041,9 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
             return Optional.empty();
         }
         Object o = getRawSingleValue(member, valueMapper);
+        if (o instanceof AnnotationClassValue<?> annotationClassValue) {
+            return Optional.of(annotationClassValue.getName());
+        }
         if (o != null) {
             return Optional.of(o.toString());
         }

--- a/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
@@ -1,5 +1,7 @@
 package io.micronaut.test.lombok;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.beans.BeanConstructor;
 import io.micronaut.core.beans.BeanIntrospection;
@@ -34,6 +36,15 @@ public class LombokIntrospectedBuilderTest {
 
         Assertions.assertEquals("Name", foo.getName());
         Assertions.assertNotNull(introspection);
+    }
+
+    @Test
+    void testJacksonBuilderAnnotationsVisibleInIntrospection() {
+        BeanIntrospection<Bar> introspection = BeanIntrospection.getIntrospection(Bar.class);
+
+        assertTrue(introspection.hasAnnotation(JsonIgnoreProperties.class));
+        assertTrue(introspection.hasAnnotation(JsonDeserialize.class));
+        assertEquals(Foo.FooBuilder.class.getName(), introspection.stringValue(JsonDeserialize.class, "builder").orElse(null));
     }
 
     @Test


### PR DESCRIPTION
$## Summary
- return the stored class name when reading annotation string values backed by AnnotationClassValue
- add a regression test for Jackson builder metadata on Lombok introspections

## Verification
- attempted targeted Gradle verification locally on 5.0.x, but the workspace hit inconsistent environment-specific Gradle/compiler issues unrelated to the touched files

Fixes #11983