### PR TITLE
test: add regression for @Bindable defaults on config interfaces

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationJsonSchemaDefaultsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationJsonSchemaDefaultsSpec.groovy
@@ -111,4 +111,33 @@ record ItfProps(
         ((Map) props.get('endpoint')).get('default') == 'http://default'
         ((Map) props.get('endpoint')).get('format') == 'uri'
     }
+
+    void "test @Bindable defaults are emitted for configuration properties interfaces"() {
+        when:
+        String schema = readSchemaFile(this, 'test.JMSConfigurationProperties', '''
+package test;
+import io.micronaut.context.annotation.*;
+import io.micronaut.core.bind.annotation.Bindable;
+import jakarta.validation.constraints.*;
+
+@ConfigurationProperties("micronaut.jms")
+interface JMSConfigurationProperties {
+  @NotNull
+  @Min(1)
+  @Bindable(defaultValue = "1")
+  Integer getInitialPoolSize();
+
+  @NotNull
+  @Min(1)
+  @Bindable(defaultValue = "50")
+  Integer getMaxPoolSize();
+}
+''')
+        then:
+        def m = parseJson(schema)
+        Map props = (Map) m.get('properties')
+        ((Map) props.get('initial-pool-size')).get('default') == 1
+        ((Map) props.get('max-pool-size')).get('default') == 50
+    }
+
 }


### PR DESCRIPTION
## Summary
- Add JSON schema regression coverage for `@ConfigurationProperties` interfaces that use `@Bindable(defaultValue=...)`.
- Verify schema defaults are emitted for `initial-pool-size` and `max-pool-size` using an interface shape matching the reported issue scenario.

## Testing
- `./gradlew :micronaut-inject-java:test --tests 'io.micronaut.inject.configuration.ConfigurationJsonSchemaDefaultsSpec.test @Bindable defaults are emitted for configuration properties interfaces' --rerun-tasks`
- `./gradlew :micronaut-inject-java:test --console=plain`