### PR TITLE
Make ClassImport repeatable

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/visitors/ImportTypeElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ImportTypeElementSpec.groovy
@@ -83,6 +83,30 @@ class Test {}
             context?.close()
     }
 
+    void "test bean introspection annotate with repeated class import"() {
+        given:
+            ApplicationContext context = buildContext('test.Test', '''
+package test;
+
+import io.micronaut.context.annotation.ClassImport;
+import io.micronaut.core.annotation.Introspected;
+
+@ClassImport(classes = io.micronaut.visitors.MySimpleClass.class, annotate = Introspected.class)
+@ClassImport(classes = io.micronaut.visitors.MySimpleInterface.class, annotate = Introspected.class)
+class Test {}
+''')
+
+        when:"the context is built and a class import introspection is loaded"
+            def classIntrospection = context.classLoader.loadClass('test.$io_micronaut_visitors_MySimpleClass$Introspection')
+            BeanIntrospectionReference classReference = classIntrospection.newInstance()
+
+        then:"The repeated imports compile and generate introspection output"
+            classReference != null
+
+        cleanup:
+            context?.close()
+    }
+
     void 'test default'() {
         when:
             DefaultTypeElementVisitor.ENABLED = true

--- a/inject/src/main/java/io/micronaut/context/annotation/ClassImport.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/ClassImport.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Experimental;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -37,6 +38,7 @@ import java.lang.annotation.Target;
 @Experimental
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)
+@Repeatable(ClassImport.Repeated.class)
 public @interface ClassImport {
 
     /**


### PR DESCRIPTION
## Summary

Make `@ClassImport` directly repeatable on `5.0.x` and add regression coverage for repeated direct usage.

## Changes

- add `@Repeatable(ClassImport.Repeated.class)` to `ClassImport`
- add a regression test in `ImportTypeElementSpec` covering repeated direct `@ClassImport` usage

## Validation

- verified the new regression test fails without the production change
- verified `:micronaut-inject-java:test --tests 'io.micronaut.visitors.ImportTypeElementSpec.test bean introspection annotate with repeated class import'` passes with the production change

Fixes #11976
