### PR TITLE
Add 5.0.x regression test for #11826 Kotlin inherited default @Client methods

### DIFF
--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/KotlinInheritedDefaultClient.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/KotlinInheritedDefaultClient.kt
@@ -1,0 +1,22 @@
+package io.micronaut.http.client
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+
+interface KotlinInheritedDefaultApi {
+    @Get("/inherited-default")
+    fun index(): String
+
+    fun inheritedDefault(): String = index() + " from default"
+}
+
+@Client("/")
+interface KotlinInheritedDefaultClient : KotlinInheritedDefaultApi
+
+@Requires(property = "spec.name", value = "KotlinInheritedDefaultClientSpec")
+@Controller
+class KotlinInheritedDefaultClientController : KotlinInheritedDefaultApi {
+    override fun index(): String = "success"
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/KotlinInheritedDefaultClientSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/KotlinInheritedDefaultClientSpec.kt
@@ -1,0 +1,20 @@
+package io.micronaut.http.client
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KotlinInheritedDefaultClientSpec {
+    @Test
+    fun testInheritedDefaultMethodOnClient() {
+        val server = ApplicationContext.run(
+            EmbeddedServer::class.java,
+            mapOf("spec.name" to "KotlinInheritedDefaultClientSpec")
+        )
+        server.use {
+            val client = server.applicationContext.getBean(KotlinInheritedDefaultClient::class.java)
+            assertEquals("success from default", client.inheritedDefault())
+        }
+    }
+}


### PR DESCRIPTION
$Adds a regression test on 5.0.x for #11826.\n\nThis PR is test-only. It adds coverage in `test-suite-kotlin` for a Micronaut `@Client` interface inheriting a Kotlin default method from a parent interface.\n\nFiles added:\n- `test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/KotlinInheritedDefaultClient.kt`\n- `test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/KotlinInheritedDefaultClientSpec.kt`\n\nVerification:\n- Ran `./gradlew :test-suite-kotlin:test --tests 'io.micronaut.http.client.KotlinInheritedDefaultClientSpec' --stacktrace`\n- Confirmed the focused test passes on `5.0.x`\n\n
Fixes #11826