### PR TITLE
Fix nested each property camelCase config prefix

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/configuration/ConfigurationUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/configuration/ConfigurationUtils.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ClassElement;
 import org.jspecify.annotations.Nullable;
@@ -102,7 +103,18 @@ public final class ConfigurationUtils {
         if (prefix == null) {
             return StringUtils.EMPTY_STRING;
         }
-        return prefix;
+        return normalizeConfigurationPrefix(prefix);
+    }
+
+    private static String normalizeConfigurationPrefix(String prefix) {
+        String[] segments = prefix.split("\\.");
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+            if (!segment.isEmpty() && !segment.endsWith(EACH_PROPERTY_LIST_SUFFIX) && !segment.endsWith(EACH_PROPERTY_MAP_SUFFIX)) {
+                segments[i] = NameUtils.hyphenate(segment, true);
+            }
+        }
+        return String.join(".", segments);
     }
 
     private static String computeIterablePrefix(AnnotationMetadata annotationMetadata, @Nullable String prefix) {

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertyNestedCamelCaseIssue11988Spec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertyNestedCamelCaseIssue11988Spec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.inject.foreach
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.context.annotation.EachProperty
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Issue
+import spock.lang.Specification
+
+class EachPropertyNestedCamelCaseIssue11988Spec extends Specification {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11988")
+    void "nested camelCase @ConfigurationProperties under @EachProperty(list=true)"() {
+        given:
+        def context = ApplicationContext.run(
+                "foo.bar[0].bloomFilter.expectedSize": '1000',
+                "foo.bar[0].bloomFilter.fpp": '0.01'
+        )
+
+        when:
+        def bean = context.getBean(CamelCaseEachAggregatorConfig, Qualifiers.byName("0"))
+
+        then:
+        bean.bloomFilter.expectedSize == 1000
+        bean.bloomFilter.fpp == 0.01d
+
+        cleanup:
+        context.close()
+    }
+
+    void "nested kebab-case @ConfigurationProperties under @EachProperty(list=true)"() {
+        given:
+        def context = ApplicationContext.run(
+                "foo.bar[0].bloom-filter.expectedSize": '1000',
+                "foo.bar[0].bloom-filter.fpp": '0.01'
+        )
+
+        when:
+        def bean = context.getBean(KebabCaseEachAggregatorConfig, Qualifiers.byName("0"))
+
+        then:
+        bean.bloomFilter.expectedSize == 1000
+        bean.bloomFilter.fpp == 0.01d
+
+        cleanup:
+        context.close()
+    }
+
+    @EachProperty(value = "foo.bar", list = true)
+    static interface CamelCaseEachAggregatorConfig {
+        CamelCaseBloomConfig getBloomFilter()
+
+        @ConfigurationProperties("bloomFilter")
+        static interface CamelCaseBloomConfig {
+            int getExpectedSize()
+            double getFpp()
+        }
+    }
+
+    @EachProperty(value = "foo.bar", list = true)
+    static interface KebabCaseEachAggregatorConfig {
+        KebabCaseBloomConfig getBloomFilter()
+
+        @ConfigurationProperties("bloom-filter")
+        static interface KebabCaseBloomConfig {
+            int getExpectedSize()
+            double getFpp()
+        }
+    }
+}


### PR DESCRIPTION
$## Summary\n- normalize calculated nested configuration prefixes in `ConfigurationUtils` so runtime bean metadata matches relaxed property naming\n- add a regression test for nested `@ConfigurationProperties("bloomFilter")` under `@EachProperty(list = true)`\n\n## Verification\n- `./gradlew :micronaut-inject-java:test --tests "io.micronaut.inject.foreach.EachPropertyNestedCamelCaseIssue11988Spec" --no-daemon`\n- `./gradlew :micronaut-inject-java:test --tests "io.micronaut.inject.foreach.EachPropertyInterfaceSpec" --no-daemon`\n\n
Fixes #11988