### PR TITLE
build: graal & graalvm native dependency managed

### DIFF
--- a/buffer-netty/build.gradle.kts
+++ b/buffer-netty/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     api(projects.micronautCore)
     api(projects.micronautInject)
     api(libs.managed.netty.buffer)
-    compileOnly(libs.graal)
+    compileOnly(libs.managed.graalvm.nativeimage)
 
     annotationProcessor(projects.micronautInjectJava)
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     api(libs.managed.jspecify)
     compileOnly(libs.managed.jakarta.annotation.api)
     compileOnly(libs.jetbrains.annotations)
-    compileOnly(libs.graal)
+    compileOnly(libs.managed.graalvm.nativeimage)
     compileOnly(libs.managed.kotlin.stdlib)
     compileOnly(libs.managed.netty.common)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,8 +9,6 @@ classgraph = "4.8.184"
 compile-testing = "0.21.0"
 
 geb = "7.0"
-# be sure to update graal version in gradle.properties as well
-graal-svm = "25.0.2"
 h2 = "2.2.224"
 hibernate = "5.5.9.Final"
 htmlunit = "2.70.0"
@@ -77,6 +75,8 @@ jackson2 = "2.21.1"
 # Versions which start with managed- are managed by Micronaut in the sense
 # that they will appear in the Micronaut BOM as <properties>
 #
+# be sure to update graal version in gradle.properties as well
+managed-graal = "25.0.2"
 managed-groovy = "5.0.4"
 managed-jakarta-annotation-api = "2.1.1"
 managed-jackson = "3.1.0"
@@ -118,7 +118,7 @@ boms-micronaut-sourcegen = { module = "io.micronaut.sourcegen:micronaut-sourcege
 # Libraries which start with managed- are managed by Micronaut in the sense
 # that they will appear in the Micronaut BOM
 #
-
+managed-graalvm-nativeimage = { module = "org.graalvm.sdk:nativeimage", version.ref = "managed-graal" }
 managed-groovy = { module = "org.apache.groovy:groovy", version.ref = "managed-groovy" }
 managed-groovy-json = { module = "org.apache.groovy:groovy-json", version.ref = "managed-groovy" }
 managed-groovy-sql = { module = "org.apache.groovy:groovy-sql", version.ref = "managed-groovy" }
@@ -204,7 +204,6 @@ classgraph = { module = "io.github.classgraph:classgraph", version.ref= "classgr
 compile-testing = { module = "com.google.testing.compile:compile-testing", version.ref = "compile-testing" }
 
 geb-spock = { module = "org.gebish:geb-spock", version.ref = "geb" }
-graal = { module = "org.graalvm.sdk:nativeimage", version.ref = "graal-svm" }
 groovy-test-junit5 = { module = "org.apache.groovy:groovy-test-junit5", version.ref = "managed-groovy" }
 
 h2 = { module = "com.h2database:h2", version.ref = "h2" }

--- a/http-netty/build.gradle.kts
+++ b/http-netty/build.gradle.kts
@@ -12,7 +12,7 @@ micronautBuild {
 dependencies {
     annotationProcessor(projects.micronautInjectJava)
     annotationProcessor(projects.micronautGraal)
-    compileOnly(libs.graal)
+    compileOnly(libs.managed.graalvm.nativeimage)
     compileOnly(libs.managed.netty.transport.native.epoll)
     compileOnly(libs.managed.netty.transport.native.kqueue)
     compileOnly(libs.managed.netty.transport.native.iouring)

--- a/inject-java/build.gradle.kts
+++ b/inject-java/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.javax.annotation.api)
     testImplementation(libs.javax.inject)
-    testImplementation(libs.graal)
+    testImplementation(libs.managed.graalvm.nativeimage)
     testImplementation(libs.managed.snakeyaml)
     testImplementation(libs.managed.jspecify)
     testImplementation(libs.bytebuddy)

--- a/jackson-databind/build.gradle.kts
+++ b/jackson-databind/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
 
     api(projects.micronautJacksonCore)
 
-    compileOnly(libs.graal)
+    compileOnly(libs.managed.graalvm.nativeimage)
     compileOnly(libs.jackson2.databind)
     compileOnly(platform(libs.test.boms.micronaut.validation))
     compileOnly(libs.micronaut.validation) {

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
     implementation(libs.managed.reactor)
 
-    compileOnly(libs.graal)
+    compileOnly(libs.managed.graalvm.nativeimage)
     compileOnly(libs.jcache)
 
     compileOnly(libs.jakarta.el)


### PR DESCRIPTION
the goal is to define the Graalvm version supported by the framework in a single place. 