### PR TITLE
Relax FormBindingDeadlockTest JSON assertion

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormBindingDeadlockTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormBindingDeadlockTest.java
@@ -90,7 +90,9 @@ public class FormBindingDeadlockTest {
                     .assertResponse(httpResponse -> {
                         Optional<String> bodyOptional = httpResponse.getBody(String.class);
                         assertTrue(bodyOptional.isPresent());
-                        assertTrue(bodyOptional.get().contains(HALF_ASYNC_FAIL_MESSAGE), "error response should contain the deadlock message");
+                        String normalizedBody = bodyOptional.get().replace("\\n", "").replace("\n", "");
+                        String normalizedMessage = HALF_ASYNC_FAIL_MESSAGE.replace("\n", "");
+                        assertTrue(normalizedBody.contains(normalizedMessage), "error response should contain the deadlock message");
                     })
                     .build()))
             .run();

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormBindingDeadlockTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormBindingDeadlockTest.java
@@ -48,6 +48,7 @@ public class FormBindingDeadlockTest {
     private static final String SPEC_NAME = "FormBindingDeadlockTest";
     private static final String DID_NOT_FAIL = "did not fail";
     private static final String LARGE = "_".repeat(1024 * 1024);
+    private static final String HALF_ASYNC_FAIL_MESSAGE = "Argument [RawFormField asyncPart] not satisfied: This argument won't consume posted data until you subscribe to it in the controller. This prevents the following arguments from being bound:\n  [String syncPart] has not yet been received.";
 
     private static void test(String uri, String body, String expectedResponse) throws IOException {
         TestScenario.builder()
@@ -89,7 +90,7 @@ public class FormBindingDeadlockTest {
                     .assertResponse(httpResponse -> {
                         Optional<String> bodyOptional = httpResponse.getBody(String.class);
                         assertTrue(bodyOptional.isPresent());
-                        assertEquals("{\"message\":\"Bad Request\",\"_embedded\":{\"errors\":[{\"message\":\"Argument [RawFormField asyncPart] not satisfied: This argument won't consume posted data until you subscribe to it in the controller. This prevents the following arguments from being bound:\\n  [String syncPart] has not yet been received.\",\"path\":\"/asyncPart\"}]},\"_links\":{\"self\":{\"href\":\"/deadlock/half-async\",\"templated\":false}}}", bodyOptional.get());
+                        assertTrue(bodyOptional.get().contains(HALF_ASYNC_FAIL_MESSAGE), "error response should contain the deadlock message");
                     })
                     .build()))
             .run();


### PR DESCRIPTION
$## What\n- relax `FormBindingDeadlockTest.halfAsyncFail` to assert that the deadlock error message is present in the JSON response body\n- stop pinning the test to one exact JSON serialization shape\n\n## Why\n`halfAsyncFail` is intended to verify the form-binding deadlock behavior, but the previous assertion compared the full JSON string. That made the test brittle across equivalent serializers that encode the error payload differently while still including the same error message.\n\n## Verification\n- `./gradlew -q :micronaut-http-server-tck:test --tests 'io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest' --no-daemon`\n