### PR TITLE
Skip failing optional type converter registrars

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -95,6 +95,9 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static io.micronaut.core.reflect.ReflectionUtils.EMPTY_CLASS_ARRAY;
 
 /**
@@ -104,6 +107,7 @@ import static io.micronaut.core.reflect.ReflectionUtils.EMPTY_CLASS_ARRAY;
  * @since 1.0
  */
 public class DefaultMutableConversionService implements MutableConversionService {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultMutableConversionService.class);
 
     private static final int CACHE_MAX = 256;
     private static final int CACHE_EVICTION_BATCH = 64;
@@ -1185,8 +1189,16 @@ public class DefaultMutableConversionService implements MutableConversionService
         SoftServiceLoader.load(TypeConverterRegistrar.class)
                 .disableFork()
                 .collectAll(registrars);
-        for (TypeConverterRegistrar registrar : registrars) {
+        registerInternalTypeConverters(registrars);
+    }
+
+    private void registerTypeConverterRegistrar(TypeConverterRegistrar registrar) {
+        try {
             registrar.register(internalMutableConversionService);
+        } catch (TypeNotPresentException | LinkageError e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Skipping type converter registrar [{}] because an optional dependency is not available", registrar.getClass().getName(), e);
+            }
         }
     }
 
@@ -1199,7 +1211,7 @@ public class DefaultMutableConversionService implements MutableConversionService
     @Internal
     public void registerInternalTypeConverters(Collection<TypeConverterRegistrar> registrars) {
         for (TypeConverterRegistrar registrar : registrars) {
-            registrar.register(internalMutableConversionService);
+            registerTypeConverterRegistrar(registrar);
         }
     }
 

--- a/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
@@ -12,6 +12,22 @@ import java.time.DayOfWeek
  */
 class DefaultConversionServiceSpec extends Specification {
 
+    void "test optional registrar linkage errors are ignored"() {
+        given:
+        def conversionService = new DefaultMutableConversionService()
+        def registrars = [
+            new FailingTypeConverterRegistrar(),
+            new WorkingTypeConverterRegistrar()
+        ]
+
+        when:
+        conversionService.registerInternalTypeConverters(registrars)
+
+        then:
+        conversionService.convert("123", Integer).get() == 123
+        conversionService.convert("ok", TestValue).get() == TestValue.OK
+    }
+
     void "test default conversion service converts a #sourceObject.class.name to a #targetType.name"() {
         given:
         ConversionService conversionService = new DefaultMutableConversionService()
@@ -118,5 +134,25 @@ class DefaultConversionServiceSpec extends Specification {
         "1,2"        | Iterable   | [T: Argument.of(Long, 'T')]    | [1l, 2l]
         "1"          | Optional   | [T: Argument.of(Long, 'T')]    | Optional.of(1L)
 
+    }
+
+    static final class FailingTypeConverterRegistrar implements TypeConverterRegistrar {
+        @Override
+        void register(MutableConversionService conversionService) {
+            throw new NoClassDefFoundError("org/apache/hc/core5/http/HttpHost")
+        }
+    }
+
+    static final class WorkingTypeConverterRegistrar implements TypeConverterRegistrar {
+        @Override
+        void register(MutableConversionService conversionService) {
+            conversionService.addConverter(String, TestValue) { value ->
+                value == 'ok' ? TestValue.OK : null
+            }
+        }
+    }
+
+    static enum TestValue {
+        OK
     }
 }


### PR DESCRIPTION
## Summary

`DefaultMutableConversionService` already relies on soft service loading for `TypeConverterRegistrar` implementations, but registration can still fail if a discovered registrar touches optional classes that are not present at runtime. In that case, initialization of the shared conversion service fails even though the affected converter is optional.

This change makes registrar registration tolerant of `TypeNotPresentException` and `LinkageError`, skipping the failing registrar and continuing with the remaining registrations. The skipped registrar is logged at debug level.

The included regression test covers the continuation behavior for a registrar that throws `NoClassDefFoundError` during registration.

This is a minimal defensive fix for 5.0.x. It does not attempt to fully reproduce every reported classpath combination, but it prevents a single optional registrar failure from breaking the shared conversion service.

## Validation

- `GRADLE_USER_HOME=/home/yawkat/dev/agent-work/core11882/.gradle-user-home-pr ./gradlew -q :micronaut-core:test --tests 'io.micronaut.core.convert.DefaultConversionServiceSpec'`
- `GRADLE_USER_HOME=/home/yawkat/dev/agent-work/core11882/.gradle-user-home-pr ./gradlew -q :micronaut-core:compileTestGroovy`

Fixes #11882
