### PR TITLE
fix(inject-kotlin): support executable kotlin accessors

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -570,8 +570,7 @@ class DeclaredBeanElementCreator extends AbstractBeanElementCreator {
         if (!methodElement.hasStereotype(Executable.class)) {
             return false;
         }
-        if (methodElement.isSynthetic()) {
-            // Synthetic methods cannot be executable as @Executable cannot be put on a field
+        if (methodElement.isSynthetic() && !methodElement.getMethodAnnotationMetadata().hasDeclaredStereotype(Executable.class)) {
             return false;
         }
         if (methodElement.getMethodAnnotationMetadata().hasStereotype(Executable.class)) {

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/executable/ExecutableBeanSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/executable/ExecutableBeanSpec.groovy
@@ -163,6 +163,44 @@ class ExecutableBean1 {
         definition.findMethod("round", float.class).get().returnType.type == Integer[].class
     }
 
+    @Issue('#11867')
+    void "test executable annotation on kotlin getter and setter"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.FoobarSingleton','''\
+package test
+
+import io.micronaut.context.annotation.Executable
+
+@jakarta.inject.Singleton
+class FoobarSingleton {
+
+    @get:Executable
+    @set:Executable
+    var counter: Int = 0
+
+    @Executable
+    fun getCounter2(): Int = counter
+
+    @Executable
+    fun counterGet(): Int = counter
+
+    @Executable
+    fun counterSet(value: Int) {
+        this.counter = value
+    }
+}
+''')
+
+        expect:
+        definition != null
+        definition.executableMethods.size() == 5
+        definition.executableMethods.any { it.methodName == "getCounter" && it.argumentTypes.length == 0 }
+        definition.executableMethods.any { it.methodName == "setCounter" && it.argumentTypes == [int] as Class[] }
+        definition.executableMethods.any { it.methodName == "getCounter2" && it.argumentTypes.length == 0 }
+        definition.executableMethods.any { it.methodName == "counterGet" && it.argumentTypes.length == 0 }
+        definition.executableMethods.any { it.methodName == "counterSet" && it.argumentTypes == [int] as Class[] }
+    }
+
     @Issue('#2789')
     void "test don't generate executable methods for inherited protected or package private methods"() {
         given:


### PR DESCRIPTION
## Summary
- allow synthetic methods through executable processing when `@Executable` is declared on the method metadata
- add a regression test covering Kotlin `@get:Executable` and `@set:Executable` accessors

## Verification
- `GRADLE_USER_HOME=/home/yawkat/dev/agent-work/core11867/.gradle-pristine JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.8-amzn ./gradlew :micronaut-inject-kotlin:test --tests 'io.micronaut.kotlin.processing.beans.executable.ExecutableBeanSpec.test executable annotation on kotlin getter and setter' -q`
- `GRADLE_USER_HOME=/home/yawkat/dev/agent-work/core11867/.gradle-pristine JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.8-amzn ./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility` *(fails in `:micronaut-core-bom:checkBom` due to pre-existing BOM verification issues unrelated to this patch)*

Fixes #11867
