### PR TITLE
Clarify Retryable capturedException Javadoc

### DIFF
--- a/retry/src/main/java/io/micronaut/retry/annotation/Retryable.java
+++ b/retry/src/main/java/io/micronaut/retry/annotation/Retryable.java
@@ -88,7 +88,9 @@ public @interface Retryable {
     Class<? extends RetryPredicate> predicate() default DefaultRetryPredicate.class;
 
     /**
-     * @return The capture exception types (defaults to RuntimeException)
+     * @return The exception type that should be intercepted for retry handling. Once an exception is captured,
+     * it is still evaluated by {@link Retryable#includes}, {@link Retryable#excludes}, or
+     * {@link Retryable#predicate()} to decide whether to retry. Defaults to {@link RuntimeException}.
      */
     Class<? extends Throwable> capturedException() default RuntimeException.class;
 


### PR DESCRIPTION
## Summary
- clarify what `@Retryable(capturedException)` controls in the public API JavaDoc
- explain that captured exceptions are still filtered by `includes`, `excludes`, or `predicate`
- keep the change limited to documentation because existing retry behavior and tests already cover the distinction

## Verification
- `./gradlew :micronaut-retry:test -q --tests io.micronaut.retry.intercept.SimpleRetrySpec`
- `./gradlew :micronaut-retry:javadoc -q`


Fixes #11750