### PR TITLE
Clarify maxHeaderSize documentation

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -403,9 +403,9 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     }
 
     /**
-     * The maximum size of an individual HTTP setter. Defaults to 8192.
+     * The maximum header size. Defaults to 8192.
      *
-     * @return The maximum size of an individual HTTP setter
+     * @return The maximum header size
      */
     public int getMaxHeaderSize() {
         return maxHeaderSize;
@@ -602,8 +602,8 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     }
 
     /**
-     * Sets the maximum size of any one header. Default value ({@value #DEFAULT_MAXHEADERSIZE}).
-     * @param maxHeaderSize The max header size
+     * Sets the maximum header size. Default value ({@value #DEFAULT_MAXHEADERSIZE}).
+     * @param maxHeaderSize The maximum header size
      */
     public void setMaxHeaderSize(@ReadableBytes int maxHeaderSize) {
         this.maxHeaderSize = maxHeaderSize;

--- a/src/main/docs/guide/httpServer/serverConfiguration.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration.adoc
@@ -17,7 +17,7 @@ micronaut:
         autoRead: true
 ----
 - By default, Micronaut framework binds to all network interfaces. Use `localhost` to bind only to loopback network interface
-- `maxHeaderSize` sets the maximum size for headers
+- `maxHeaderSize` sets the maximum header size
 - `worker.threads` specifies the number of Netty worker threads
 - `autoRead` enables request body auto read
 


### PR DESCRIPTION
## What changed

This updates the documentation for `micronaut.server.netty.max-header-size` to remove wording that implied the setting applies to any individual header.

The updated wording is now the more neutral:

- `maximum header size`

## Why

Issue #11626 reported that the current documentation says the setting controls the maximum size of "any one header".

Micronaut forwards this setting into Netty's HTTP codec, and the Micronaut code here does not establish that stronger per-header guarantee. This change keeps the docs accurate without making claims that are not supported by the implementation.

## Files changed

- `http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java`
- `src/main/docs/guide/httpServer/serverConfiguration.adoc`

## Verification

- Confirmed the misleading phrases are removed from the updated sources
- Ran `./gradlew docs`

Fixes #11626