### PR TITLE
Harden MdcPropagationContext snapshots

### DIFF
--- a/context-propagation/src/main/java/io/micronaut/context/propagation/slf4j/MdcPropagationContext.java
+++ b/context-propagation/src/main/java/io/micronaut/context/propagation/slf4j/MdcPropagationContext.java
@@ -32,13 +32,17 @@ import java.util.Map;
 @Experimental
 public record MdcPropagationContext(Map<String, String> state) implements ThreadPropagatedContextElement<Map<String, String>> {
 
+    public MdcPropagationContext {
+        state = snapshot(state);
+    }
+
     public MdcPropagationContext() {
         this(MDC.getCopyOfContextMap());
     }
 
     @Override
-    public Map<String, String> updateThreadContext() {
-        Map<String, String> oldState = MDC.getCopyOfContextMap();
+    public @Nullable Map<String, String> updateThreadContext() {
+        Map<String, String> oldState = snapshot(MDC.getCopyOfContextMap());
         setCurrent(state);
         return oldState;
     }
@@ -54,5 +58,9 @@ public record MdcPropagationContext(Map<String, String> state) implements Thread
         } else {
             MDC.setContextMap(contextMap);
         }
+    }
+
+    private static @Nullable Map<String, String> snapshot(@Nullable Map<String, String> contextMap) {
+        return contextMap == null ? null : Map.copyOf(contextMap);
     }
 }

--- a/context-propagation/src/test/kotlin/io/micronaut/context/propagation/mdc/MdcPropagationSpec.kt
+++ b/context-propagation/src/test/kotlin/io/micronaut/context/propagation/mdc/MdcPropagationSpec.kt
@@ -35,8 +35,19 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.net.URI
 import java.util.*
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class MdcPropagationSpec {
+
+    @Test
+    fun constructorSnapshotsProvidedState() {
+        val state = mutableMapOf(TRACKING_ID to "initial")
+        val context = MdcPropagationContext(state)
+
+        state[TRACKING_ID] = "updated"
+
+        assertEquals("initial", context.state()[TRACKING_ID])
+    }
 
     @Test
     fun testKotlinPropagation() {


### PR DESCRIPTION
## Description
This change hardens `MdcPropagationContext` by snapshotting captured MDC state with `Map.copyOf(...)` both when constructing the propagation element and when capturing the previous thread context for restore.

That ensures Micronaut stores detached snapshots instead of keeping references to mutable caller/backend maps.

A focused regression test was added to verify that constructing `MdcPropagationContext` from a mutable map does not retain a live reference.

## Notes
- This is defensive hardening around mutable MDC state; it is not presented as proof that Micronaut is the root cause of the underlying issue.
- `Map.copyOf(...)` tightens behavior by rejecting null keys or values.
- I attempted targeted local verification for `:micronaut-context-propagation:test`, but this checkout currently fails earlier due to unrelated `:micronaut-aop` compile errors.

Fixes #11639