### PR TITLE
Fix deep-object query conversion errors

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/converters/MultiValuesConverterFactory.java
+++ b/core/src/main/java/io/micronaut/core/convert/converters/MultiValuesConverterFactory.java
@@ -528,8 +528,12 @@ public class MultiValuesConverterFactory {
                     Argument<?> argument = constructorArguments[i];
                     String name = argument.getAnnotationMetadata().stringValue(Bindable.class)
                             .orElse(argument.getName());
-                    constructorParameters[i] = conversionService.convert(values.get(name), ConversionContext.of(argument))
+                    ArgumentConversionContext<?> argumentConversionContext = context.with(argument);
+                    constructorParameters[i] = conversionService.convert(values.get(name), argumentConversionContext)
                             .orElse(null);
+                    if (argumentConversionContext.hasErrors()) {
+                        return Optional.empty();
+                    }
                 }
                 Object result = constructor.instantiate(constructorParameters);
 
@@ -539,8 +543,12 @@ public class MultiValuesConverterFactory {
                     String name = property.getName();
 
                     if (!property.isReadOnly() && values.containsKey(name)) {
-                        conversionService.convert(values.get(name), ConversionContext.of(property.asArgument()))
+                        ArgumentConversionContext<?> propertyConversionContext = context.with(property.asArgument());
+                        conversionService.convert(values.get(name), propertyConversionContext)
                                 .ifPresent(v -> property.set(result, v));
+                        if (propertyConversionContext.hasErrors()) {
+                            return Optional.empty();
+                        }
                     }
                 }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/QueryParameterFormattingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/QueryParameterFormattingSpec.groovy
@@ -6,15 +6,19 @@ import io.micronaut.core.convert.format.Format
 import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.server.netty.AbstractMicronautSpec
+import jakarta.annotation.Nullable
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import spock.lang.Unroll
+
+import java.util.UUID
 
 public class QueryParameterFormattingSpec extends AbstractMicronautSpec {
     private static String PIPE = "%7C";
@@ -68,6 +72,18 @@ public class QueryParameterFormattingSpec extends AbstractMicronautSpec {
         Flux.from(exchange).blockFirst()
         then:
         var e = thrown(HttpClientResponseException)
+    }
+
+    void "test deep-object object conversion error returns bad request"() {
+        when:
+        HttpRequest<?> req = HttpRequest.create(HttpMethod.GET, '/formatted/o/deep-error?filter[id]=blah')
+        Publisher<HttpResponse<?>> exchange = httpClient.exchange(req, String)
+        Flux.from(exchange).blockFirst()
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.response.status == HttpStatus.BAD_REQUEST
+        e.response.getBody(String).orElse('').contains('Failed to convert argument [filter]')
     }
 
     @Requires(property = 'spec.name', value = 'QueryParameterFormattingSpec')
@@ -146,6 +162,20 @@ public class QueryParameterFormattingSpec extends AbstractMicronautSpec {
         @Get("o/deep")
         String deepObject(@QueryValue("v") @Format("DEEP_OBJECT") Dog param) {
             return param.inspect()
+        }
+
+        @Get("o/deep-error")
+        String deepObjectError(@QueryValue("filter") @Format("DEEP_OBJECT") RequestFilter filter) {
+            return String.valueOf(filter.id)
+        }
+    }
+
+    @Introspected
+    static class RequestFilter {
+        final UUID id
+
+        RequestFilter(@Nullable UUID id) {
+            this.id = id
         }
     }
 

--- a/http/src/main/java/io/micronaut/http/bind/binders/QueryValueArgumentBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/QueryValueArgumentBinder.java
@@ -98,7 +98,7 @@ public class QueryValueArgumentBinder<T> extends AbstractArgumentBinder<T> imple
         }
 
         BindingResult<T> bindSimpleResult = bindSimple(context, source, annotationMetadata, parameters, argument);
-        if (bindSimpleResult.isSatisfied()) {
+        if (!bindSimpleResult.getConversionErrors().isEmpty() || bindSimpleResult.isSatisfied()) {
             return bindSimpleResult;
         }
         return bindPojo(context, parameters, argument);

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -36,6 +36,14 @@ Check https://groovy-lang.org/releasenotes/groovy-5.0.html#Groovy5.0-breaking[Gr
 
 The Micronaut APIs use <<jspecify, JSpecify Annotations>>, and we recommend users to embrace JSpecify nullability annotations.
 
+==== Invalid `deep-object` query members now fail conversion instead of binding as absent
+
+When binding `@QueryValue @Format("deep-object")` objects, Micronaut now treats a provided but invalid nested value as a conversion error.
+
+For example, if a request contains `filter[id]=blah` and `id` is declared as `UUID`, Micronaut now returns a conversion error instead of binding `id` as `null` and proceeding as though the field had been omitted.
+
+This change preserves the distinction between missing optional query fields and malformed provided values.
+
 ==== Bean context changes
 
 The default implementations of api:context.BeanContext[BeanContext], api:context.ApplicationContext[ApplicationContext] and api:context.env.Environment[Environment] are no longer public and non-final.


### PR DESCRIPTION
## What changed
- preserve nested conversion errors when binding `@QueryValue @Format("deep-object")` objects
- stop `QueryValueArgumentBinder` from falling through when the formatted binding path already contains conversion errors
- add a regression test for invalid deep-object UUID input returning `400 Bad Request`
- document the behavior change in `src/main/docs/guide/appendix/breaks.adoc`

## Verification
- `./gradlew -q :micronaut-http-server-netty:test --tests 'io.micronaut.http.server.netty.binding.QueryParameterFormattingSpec'`
- `./gradlew -q :micronaut-http-server-netty:test --tests 'io.micronaut.http.server.netty.binding.ParameterBindingSpec.test conversion error for simple binding' --tests 'io.micronaut.http.server.netty.binding.ParameterBindingSpec.test conversion error for object binding'`

## Notes
The repository-wide `./gradlew -q spotlessApply check -x japiCmp -x checkVersionCatalogCompatibility` run was not clean on this checkout due to unrelated failures in `:micronaut-http-server-netty:test` (`FileCertificateProviderTest`, TLS/certificate-required failure) and `:micronaut-context-propagation:test` (`MDCRxJava3Spec`, read timeout).

Fixes #11331