### PR TITLE
Clarify PostConstruct lifecycle for createBean and registerSingleton

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
@@ -21,6 +21,7 @@ import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Type
 import io.micronaut.core.type.Argument
 import io.micronaut.inject.qualifiers.Qualifiers
+import jakarta.annotation.PostConstruct
 import jakarta.inject.Named
 import jakarta.inject.Singleton
 import spock.lang.Issue
@@ -109,6 +110,40 @@ class RegisterSingletonSpec extends Specification {
         context.close()
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/11656')
+    void "test createBean followed by registerSingleton invokes post construct twice"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when:
+        def bean = context.createBean(DoublePostConstructBean)
+        context.registerSingleton(bean)
+
+        then:
+        bean.postConstructCalls == 2
+        context.getBean(DoublePostConstructBean).is(bean)
+
+        cleanup:
+        context.close()
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/11656')
+    void "test createBean followed by registerSingleton with inject false does not invoke post construct again"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when:
+        def bean = context.createBean(DoublePostConstructBean)
+        context.registerSingleton(bean, false)
+
+        then:
+        bean.postConstructCalls == 1
+        context.getBean(DoublePostConstructBean).is(bean)
+
+        cleanup:
+        context.close()
+    }
+
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/1851')
     void "test register singleton with type qualifier"() {
         when:
@@ -172,4 +207,14 @@ class RegisterSingletonSpec extends Specification {
     static interface Reporter<B> {}
     static class Span {}
     static class TestReporter implements Reporter<Span> {}
+
+    @Singleton
+    static class DoublePostConstructBean {
+        int postConstructCalls
+
+        @PostConstruct
+        void init() {
+            postConstructCalls++
+        }
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/BeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanContext.java
@@ -77,7 +77,8 @@ public interface BeanContext extends
     <T> T inject(T instance);
 
     /**
-     * Creates a new instance of the given bean performing dependency injection and returning a new instance.
+     * Creates a new instance of the given bean performing dependency injection, invoking any
+     * {@link jakarta.annotation.PostConstruct} hooks, and returning a new instance.
      * <p>
      * Note that the instance returned is not saved as a singleton in the context.
      *
@@ -90,7 +91,8 @@ public interface BeanContext extends
     }
 
     /**
-     * Creates a new instance of the given bean performing dependency injection and returning a new instance.
+     * Creates a new instance of the given bean performing dependency injection, invoking any
+     * {@link jakarta.annotation.PostConstruct} hooks, and returning a new instance.
      * <p>
      * Note that the instance returned is not saved as a singleton in the context.
      *
@@ -102,7 +104,8 @@ public interface BeanContext extends
     <T> T createBean(Class<T> beanType, @Nullable Qualifier<T> qualifier);
 
     /**
-     * <p>Creates a new instance of the given bean performing dependency injection and returning a new instance.</p>
+     * <p>Creates a new instance of the given bean performing dependency injection, invoking any
+     * {@link jakarta.annotation.PostConstruct} hooks, and returning a new instance.</p>
      *
      * <p>If the bean defines any {@link io.micronaut.context.annotation.Parameter} values then the values passed
      * in the {@code argumentValues} parameter will be used</p>
@@ -118,7 +121,8 @@ public interface BeanContext extends
     <T> T createBean(Class<T> beanType, @Nullable Qualifier<T> qualifier, @Nullable Map<String, Object> argumentValues);
 
     /**
-     * <p>Creates a new instance of the given bean performing dependency injection and returning a new instance.</p>
+     * <p>Creates a new instance of the given bean performing dependency injection, invoking any
+     * {@link jakarta.annotation.PostConstruct} hooks, and returning a new instance.</p>
      *
      * <p>If the bean defines any {@link io.micronaut.context.annotation.Parameter} values then the values passed in
      * the {@code argumentValues} parameter will be used</p>
@@ -134,7 +138,8 @@ public interface BeanContext extends
     <T> T createBean(Class<T> beanType, @Nullable Qualifier<T> qualifier, @Nullable Object... args);
 
     /**
-     * <p>Creates a new instance of the given bean performing dependency injection and returning a new instance.</p>
+     * <p>Creates a new instance of the given bean performing dependency injection, invoking any
+     * {@link jakarta.annotation.PostConstruct} hooks, and returning a new instance.</p>
      *
      * <p>If the bean defines any {@link io.micronaut.context.annotation.Parameter} values then the values passed in
      * the {@code argumentValues} parameter will be used</p>
@@ -151,7 +156,8 @@ public interface BeanContext extends
     }
 
     /**
-     * <p>Creates a new instance of the given bean performing dependency injection and returning a new instance.</p>
+     * <p>Creates a new instance of the given bean performing dependency injection, invoking any
+     * {@link jakarta.annotation.PostConstruct} hooks, and returning a new instance.</p>
      *
      * <p>If the bean defines any {@link io.micronaut.context.annotation.Parameter} values then the values passed in
      * the {@code argumentValues} parameter will be used</p>

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -111,8 +111,8 @@ public interface BeanDefinitionRegistry {
      * <p>Registers a new singleton bean at runtime. This method expects that the bean definition data will have been
      * compiled ahead of time.</p>
      *
-     * <p>If bean definition data is found the method will perform dependency injection on the instance followed by
-     * invoking any {@link jakarta.annotation.PostConstruct} hooks.</p>
+     * <p>If bean definition data is found and injection is enabled, the method will perform dependency injection on
+     * the instance followed by invoking any {@link jakarta.annotation.PostConstruct} hooks.</p>
      *
      * <p>If no bean definition data is found the bean is registered as is.</p>
      *
@@ -515,8 +515,8 @@ public interface BeanDefinitionRegistry {
      * <p>Registers a new singleton bean at runtime. This method expects that the bean definition data will have been
      * compiled ahead of time.</p>
      *
-     * <p>If bean definition data is found the method will perform dependency injection on the instance followed by
-     * invoking any {@link jakarta.annotation.PostConstruct} hooks.</p>
+     * <p>If bean definition data is found and injection is enabled, the method will perform dependency injection on
+     * the instance followed by invoking any {@link jakarta.annotation.PostConstruct} hooks.</p>
      *
      * <p>If no bean definition data is found the bean is registered as is.</p>
      *


### PR DESCRIPTION
## Summary
- document that `BeanContext#createBean(...)` invokes `@PostConstruct` hooks
- clarify that `registerSingleton(..., inject)` only reinvokes lifecycle callbacks when injection is enabled
- add regression tests covering both the default `registerSingleton(...)` path and `registerSingleton(..., false)`

## Verification
- `./gradlew :micronaut-inject:compileJava :micronaut-inject-java:test --tests 'io.micronaut.inject.context.RegisterSingletonSpec' -q`

Fixes #11656