### PR TITLE
Return 400 for malformed WebSocket upgrade URIs

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
@@ -22,15 +22,18 @@ import io.micronaut.core.execution.ExecutionFlow;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpMethod;
-import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.server.exceptions.response.ErrorContext;
 import io.micronaut.http.body.CloseableByteBody;
 import io.micronaut.http.context.ServerHttpRequestContext;
 import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.netty.NettyHttpHeaders;
+import io.micronaut.http.netty.body.NettyByteBodyFactory;
 import io.micronaut.http.netty.channel.ChannelPipelineCustomizer;
 import io.micronaut.http.netty.websocket.WebSocketSessionRepository;
 import io.micronaut.http.server.RequestLifecycle;
@@ -56,6 +59,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -137,7 +141,37 @@ public final class NettyServerWebSocketUpgradeHandler implements RequestHandler 
     @Override
     public void accept(ChannelHandlerContext ctx, io.netty.handler.codec.http.HttpRequest request, CloseableByteBody body, OutboundAccess outboundAccess) {
         if (isWebSocketUpgrade(request)) {
-            NettyHttpRequest<?> msg = new NettyHttpRequest<>(request, body, ctx, conversionService, serverConfiguration);
+            final NettyHttpRequest<?> msg;
+            try {
+                msg = new NettyHttpRequest<>(request, body, ctx, conversionService, serverConfiguration);
+            } catch (IllegalArgumentException e) {
+                body.close();
+
+                NettyHttpRequest<Object> errorRequest = new NettyHttpRequest<>(
+                    new DefaultHttpRequest(request.protocolVersion(), request.method(), "/"),
+                    NettyByteBodyFactory.empty(),
+                    ctx,
+                    conversionService,
+                    serverConfiguration
+                );
+                outboundAccess.attachment(errorRequest);
+                outboundAccess.closeAfterWrite();
+                try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty().plus(new ServerHttpRequestContext(errorRequest)).propagate()) {
+                    Throwable cause = e.getCause() == null ? e : e.getCause();
+                    MutableHttpResponse<?> response = routeExecutor.getErrorResponseProcessor().processResponse(
+                        ErrorContext.builder(errorRequest)
+                            .cause(cause)
+                            .errorMessage("Malformed URI")
+                            .build(),
+                        io.micronaut.http.HttpResponse.badRequest()
+                    );
+                    if (response.getContentType().isEmpty() && errorRequest.getMethod() != HttpMethod.HEAD) {
+                        response.contentType(MediaType.APPLICATION_JSON_TYPE);
+                    }
+                    Objects.requireNonNull(next).writeResponse(outboundAccess, errorRequest, response, null);
+                }
+                return;
+            }
 
             Optional<UriRouteMatch<Object, Object>> optionalRoute = router.find(HttpMethod.GET, msg.getPath(), msg)
                 .filter(rm -> rm.isAnnotationPresent(OnMessage.class) || rm.isAnnotationPresent(OnOpen.class))

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebSocketSpec.groovy
@@ -17,8 +17,11 @@ import io.micronaut.websocket.annotation.OnMessage
 import io.micronaut.websocket.annotation.ServerWebSocket
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http.DefaultHttpHeaders
+import io.netty.handler.codec.http.FullHttpResponse
 import io.netty.handler.codec.http.HttpClientCodec
+import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpObjectAggregator
+import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory
 import io.netty.handler.codec.http.websocketx.WebSocketFrame
@@ -100,6 +103,58 @@ class WebSocketSpec extends Specification {
             delay = Sinks.empty()
             return Flux.concat(delay.asMono(), Flux.defer(() -> chain.proceed(request)))
         }
+    }
+
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/11572')
+    def 'malformed websocket URI returns 400 and closes connection'() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run([
+                'spec.name': 'WebSocketSpec11572',
+        ])
+        def embeddedServer = (NettyHttpServer) ctx.getBean(EmbeddedServer)
+
+        def serverEmbeddedChannel = embeddedServer.buildEmbeddedChannel(false)
+        def clientEmbeddedChannel = new EmbeddedChannel()
+        clientEmbeddedChannel.config().setAutoRead(true)
+
+        EmbeddedTestUtil.connect(serverEmbeddedChannel, clientEmbeddedChannel)
+
+        clientEmbeddedChannel.pipeline()
+                .addLast(new HttpClientCodec())
+                .addLast(new HttpObjectAggregator(1024))
+
+        def request = WebSocketClientHandshakerFactory.newHandshaker(
+                URI.create('http://localhost/%7Btest%7D'),
+                WebSocketVersion.V13,
+                null,
+                false,
+                new DefaultHttpHeaders()
+        ).newHandshakeRequest()
+        request.setUri('/{test}')
+        request.headers().set(HttpHeaderNames.HOST, 'localhost')
+
+        when:
+        clientEmbeddedChannel.writeOneOutbound(request)
+        clientEmbeddedChannel.flushOutbound()
+        EmbeddedTestUtil.advance(serverEmbeddedChannel, clientEmbeddedChannel)
+
+        then:
+        FullHttpResponse response = clientEmbeddedChannel.readInbound()
+        response.status() == HttpResponseStatus.BAD_REQUEST
+        response.headers().get(HttpHeaderNames.CONNECTION) == 'close'
+
+        when:
+        EmbeddedTestUtil.advance(serverEmbeddedChannel, clientEmbeddedChannel)
+
+        then:
+        !serverEmbeddedChannel.isOpen()
+
+        cleanup:
+        response?.release()
+        clientEmbeddedChannel.finishAndReleaseAll()
+        serverEmbeddedChannel.finishAndReleaseAll()
+        ctx.close()
     }
 
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/11506')


### PR DESCRIPTION
## What this does
- catch malformed WebSocket upgrade URIs during `NettyHttpRequest` creation
- return `400 Bad Request` instead of leaving the connection hanging
- close the connection after writing the error response
- add a regression test for a malformed upgrade request path

## Verification
- ran `./gradlew --no-daemon :micronaut-http-server-netty:test --tests 'io.micronaut.http.server.netty.websocket.WebSocketSpec.malformed websocket URI returns 400 and closes connection' -q`
- verified `WebSocketSpec` passes with the new regression case

Fixes #11572