### PR TITLE
Preserve source bean order for EachBean delegates

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
@@ -16,6 +16,10 @@
 package io.micronaut.inject.foreach
 
 import io.micronaut.context.ApplicationContext
+import jakarta.inject.Singleton
+import jakarta.inject.Named
+import io.micronaut.core.annotation.Order
+import io.micronaut.context.annotation.EachBean
 import io.micronaut.context.env.MapPropertySource
 import io.micronaut.context.env.PropertySource
 import io.micronaut.context.exceptions.NoSuchBeanException
@@ -356,6 +360,26 @@ class EachPropertySpec extends Specification {
         applicationContext.close()
     }
 
+    void "test each bean preserves order from source bean"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run()
+
+        when:
+        def lowSourceDefinition = applicationContext.getBeanDefinition(OrderedSource, Qualifiers.byName("low"))
+        def highSourceDefinition = applicationContext.getBeanDefinition(OrderedSource, Qualifiers.byName("high"))
+        def lowDerivedDefinition = applicationContext.getBeanDefinition(MyBeanWithOrder, Qualifiers.byName("low"))
+        def highDerivedDefinition = applicationContext.getBeanDefinition(MyBeanWithOrder, Qualifiers.byName("high"))
+
+        then:
+        lowSourceDefinition.order == -100
+        highSourceDefinition.order == 100
+        lowDerivedDefinition.order == -100
+        highDerivedDefinition.order == 100
+
+        cleanup:
+        applicationContext.close()
+    }
+
     void "test configuration properties binding by non bean type with primary"() {
         given:
         ApplicationContext applicationContext = ApplicationContext.builder("test").build()
@@ -574,5 +598,29 @@ class EachPropertySpec extends Specification {
         props.innerList.size() == 2
         props.innerList.any { it.age == 20 }
         props.innerList.any { it.age == 30 }
+    }
+}
+
+interface OrderedSource {
+}
+
+@Singleton
+@Named("low")
+@Order(-100)
+class LowOrderedSource implements OrderedSource {
+}
+
+@Singleton
+@Named("high")
+@Order(100)
+class HighOrderedSource implements OrderedSource {
+}
+
+@EachBean(OrderedSource)
+class MyBeanWithOrder {
+    final OrderedSource source
+
+    MyBeanWithOrder(OrderedSource source) {
+        this.source = source
     }
 }

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
@@ -34,6 +34,7 @@ import io.micronaut.inject.InjectionPoint;
 import io.micronaut.inject.InstantiatableBeanDefinition;
 import io.micronaut.inject.ParametrizedInstantiatableBeanDefinition;
 import io.micronaut.inject.ValidatedBeanDefinition;
+import io.micronaut.inject.qualifiers.EachBeanQualifier;
 import io.micronaut.inject.qualifiers.PrimaryQualifier;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
@@ -64,19 +65,29 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
     private final ConfigurationPath configurationPath;
 
     private final Map<String, List<Argument<?>>> typeArgumentsMap;
+    @Nullable
+    private final BeanDefinition<?> originatingDefinition;
 
     private BeanDefinitionDelegate(BeanDefinition<T> definition,
                                    @Nullable Qualifier<T> qualifier,
                                    @Nullable ConfigurationPath configurationPath,
-                                   Map<String, List<Argument<?>>> typeArgumentsMap) {
+                                   Map<String, List<Argument<?>>> typeArgumentsMap,
+                                   @Nullable BeanDefinition<?> originatingDefinition) {
         this.definition = definition;
         this.qualifier = qualifier;
         this.configurationPath = configurationPath;
         this.typeArgumentsMap = typeArgumentsMap;
+        this.originatingDefinition = originatingDefinition;
     }
 
     @Override
     public int getOrder() {
+        if (originatingDefinition != null) {
+            return originatingDefinition.getOrder();
+        }
+        if (qualifier instanceof EachBeanQualifier<?> eachBeanQualifier) {
+            return eachBeanQualifier.getBeanDefinition().getOrder();
+        }
         return definition.getOrder();
     }
 
@@ -322,7 +333,7 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
      * @return The new bean definition
      */
     static <T> BeanDefinitionDelegate<T> create(BeanDefinition<T> definition, @Nullable Qualifier<T> qualifier) {
-        return create(definition, qualifier, null, Map.of());
+        return create(definition, qualifier, null, Map.of(), null);
     }
 
     /**
@@ -337,7 +348,15 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
                                                 @Nullable
                                                 Qualifier<T> qualifier,
                                                 Map<String, List<Argument<?>>> typeArgumentsMap) {
-        return create(definition, qualifier, null, typeArgumentsMap);
+        return create(definition, qualifier, null, typeArgumentsMap, null);
+    }
+
+    static <T> BeanDefinitionDelegate<T> create(BeanDefinition<T> definition,
+                                                @Nullable
+                                                Qualifier<T> qualifier,
+                                                Map<String, List<Argument<?>>> typeArgumentsMap,
+                                                @Nullable BeanDefinition<?> originatingDefinition) {
+        return create(definition, qualifier, null, typeArgumentsMap, originatingDefinition);
     }
 
     /**
@@ -354,16 +373,26 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
                                                 @Nullable
                                                 ConfigurationPath path,
                                                 Map<String, List<Argument<?>>> typeArgumentsMap) {
+        return create(definition, qualifier, path, typeArgumentsMap, null);
+    }
+
+    static <T> BeanDefinitionDelegate<T> create(BeanDefinition<T> definition,
+                                                @Nullable
+                                                Qualifier<T> qualifier,
+                                                @Nullable
+                                                ConfigurationPath path,
+                                                Map<String, List<Argument<?>>> typeArgumentsMap,
+                                                @Nullable BeanDefinition<?> originatingDefinition) {
         if (definition instanceof InitializingBeanDefinition || definition instanceof DisposableBeanDefinition) {
             if (definition instanceof ValidatedBeanDefinition) {
-                return new LifeCycleValidatingDelegate<>(definition, qualifier, path, typeArgumentsMap);
+                return new LifeCycleValidatingDelegate<>(definition, qualifier, path, typeArgumentsMap, originatingDefinition);
             } else {
-                return new LifeCycleDelegate<>(definition, qualifier, path, typeArgumentsMap);
+                return new LifeCycleDelegate<>(definition, qualifier, path, typeArgumentsMap, originatingDefinition);
             }
         } else if (definition instanceof ValidatedBeanDefinition) {
-            return new ValidatingDelegate<>(definition, qualifier, path, typeArgumentsMap);
+            return new ValidatingDelegate<>(definition, qualifier, path, typeArgumentsMap, originatingDefinition);
         }
-        return new BeanDefinitionDelegate<>(definition, qualifier, path, typeArgumentsMap);
+        return new BeanDefinitionDelegate<>(definition, qualifier, path, typeArgumentsMap, originatingDefinition);
     }
 
     /**
@@ -376,7 +405,7 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
     static <T> BeanDefinitionDelegate<T> create(BeanDefinition<T> definition,
                                                 Qualifier<T> qualifier,
                                                 ConfigurationPath path) {
-        return create(definition, qualifier, path, Map.of());
+        return create(definition, qualifier, path, Map.of(), null);
     }
 
     @Override
@@ -444,8 +473,8 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
      * @param <T> The bean definition type
      */
     private static final class LifeCycleDelegate<T> extends BeanDefinitionDelegate<T> implements ProxyInitializingBeanDefinition<T>, ProxyDisposableBeanDefinition<T> {
-        private LifeCycleDelegate(BeanDefinition<T> definition, @Nullable Qualifier qualifier, @Nullable ConfigurationPath path, Map<String, List<Argument<?>>> typeArgumentsMap) {
-            super(definition, qualifier, path, typeArgumentsMap);
+        private LifeCycleDelegate(BeanDefinition<T> definition, @Nullable Qualifier qualifier, @Nullable ConfigurationPath path, Map<String, List<Argument<?>>> typeArgumentsMap, @Nullable BeanDefinition<?> originatingDefinition) {
+            super(definition, qualifier, path, typeArgumentsMap, originatingDefinition);
         }
     }
 
@@ -453,8 +482,8 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
      * @param <T> The bean definition type
      */
     private static final class ValidatingDelegate<T> extends BeanDefinitionDelegate<T> implements ProxyValidatingBeanDefinition<T> {
-        private ValidatingDelegate(BeanDefinition<T> definition, @Nullable Qualifier qualifier, @Nullable ConfigurationPath path, Map<String, List<Argument<?>>> typeArgumentsMap) {
-            super(definition, qualifier, path, typeArgumentsMap);
+        private ValidatingDelegate(BeanDefinition<T> definition, @Nullable Qualifier qualifier, @Nullable ConfigurationPath path, Map<String, List<Argument<?>>> typeArgumentsMap, @Nullable BeanDefinition<?> originatingDefinition) {
+            super(definition, qualifier, path, typeArgumentsMap, originatingDefinition);
         }
     }
 
@@ -462,8 +491,8 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
      * @param <T> The bean definition type
      */
     private static final class LifeCycleValidatingDelegate<T> extends BeanDefinitionDelegate<T> implements ProxyValidatingBeanDefinition<T>, ProxyInitializingBeanDefinition<T>, ProxyDisposableBeanDefinition<T> {
-        private LifeCycleValidatingDelegate(BeanDefinition<T> definition, @Nullable Qualifier qualifier, @Nullable ConfigurationPath path, Map<String, List<Argument<?>>> typeArgumentsMap) {
-            super(definition, qualifier, path, typeArgumentsMap);
+        private LifeCycleValidatingDelegate(BeanDefinition<T> definition, @Nullable Qualifier qualifier, @Nullable ConfigurationPath path, Map<String, List<Argument<?>>> typeArgumentsMap, @Nullable BeanDefinition<?> originatingDefinition) {
+            super(definition, qualifier, path, typeArgumentsMap, originatingDefinition);
         }
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -617,7 +617,7 @@ final class DefaultApplicationContext extends DefaultBeanContext implements Conf
                         }
                         delegateTypeArguments = typeArguments;
                     }
-                    BeanDefinitionDelegate<?> delegate = BeanDefinitionDelegate.create(originBeanDefinition, (Qualifier<T>) qualifier, delegateTypeArguments);
+                    BeanDefinitionDelegate<?> delegate = BeanDefinitionDelegate.create(originBeanDefinition, (Qualifier<T>) qualifier, delegateTypeArguments, dependentCandidate);
                     if (delegate.isEnabled(this, resolutionContext) && delegate.isCandidateBean(beanType)) {
                         transformedCandidates.add((BeanDefinition<T>) delegate);
                     }

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/EachBeanQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/EachBeanQualifier.java
@@ -35,6 +35,10 @@ public final class EachBeanQualifier<T> extends FilteringQualifier<T> {
         this.beanDefinition = beanDefinition;
     }
 
+    public BeanDefinition<?> getBeanDefinition() {
+        return beanDefinition;
+    }
+
     @Override
     public boolean doesQualify(Class<T> beanType, BeanType<T> candidate) {
         return candidate.equals(beanDefinition);


### PR DESCRIPTION
## Description
- preserve the originating bean definition when creating `@EachBean` delegates
- resolve delegate order from the originating bean definition when present
- add a regression test covering named ordered source beans

## Verification
- `./gradlew :micronaut-inject:jar :micronaut-inject-java:test --tests 'io.micronaut.inject.foreach.EachPropertySpec.test each bean preserves order from source bean' --no-build-cache`

Fixes #11392