### PR TITLE
Fix parsing of fully qualified type identifiers in ctx[...] expressions

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
@@ -507,16 +507,28 @@ public final class SingleEvaluatedExpressionParser implements EvaluatedExpressio
         }
 
         List<String> parts = new ArrayList<>();
-        parts.add(eat(IDENTIFIER).value());
+        parts.add(typeIdentifierPart().value());
         while (lookahead != null && lookahead.type() == DOT) {
             eat(DOT);
-            parts.add(eat(IDENTIFIER).value());
+            parts.add(typeIdentifierPart().value());
         }
 
         if (wrapped) {
             eat(R_PAREN);
         }
         return new TypeIdentifier(String.join(".", parts));
+    }
+
+    private Token typeIdentifierPart() {
+        if (lookahead == null) {
+            throw new ExpressionParsingException("Unexpected end of input. Expected: 'IDENTIFIER'");
+        }
+        if (!lookahead.type().isOneOf(IDENTIFIER, ENVIRONMENT)) {
+            throw new ExpressionParsingException("Unexpected token: " + lookahead.value() + ". Expected: 'IDENTIFIER'");
+        }
+        Token token = lookahead;
+        lookahead = tokenizer.getNextToken();
+        return token;
     }
 
     // ParenthesizedExpression

--- a/inject-groovy/src/test/groovy/io/micronaut/expressions/BeanContextAccessExpressionsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/expressions/BeanContextAccessExpressionsSpec.groovy
@@ -47,4 +47,56 @@ class BeanContextAccessExpressionsSpec extends AbstractEvaluatedExpressionsSpec 
         ctx.close()
     }
 
+    void "test bean context access for fqcn containing reserved token"() {
+        given:
+        def ctx = buildContext("""
+            package test
+
+            import io.micronaut.context.annotation.Value
+
+            @jakarta.inject.Singleton
+            class Expr {
+
+                @Value("#{ ctx[io.micronaut.context.env.Environment].activeNames.contains('test') }")
+                boolean active
+
+            }
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+        def bean = ctx.getBean(type)
+
+        expect:
+        bean.active
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "test bean context access for type reference containing reserved token"() {
+        given:
+        def ctx = buildContext("""
+            package test
+
+            import io.micronaut.context.annotation.Value
+
+            @jakarta.inject.Singleton
+            class Expr {
+
+                @Value("#{ ctx[T(io.micronaut.context.env.Environment)].activeNames.contains('test') }")
+                boolean active
+
+            }
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+        def bean = ctx.getBean(type)
+
+        expect:
+        bean.active
+
+        cleanup:
+        ctx.close()
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/expressions/BeanContextAccessExpressionsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/BeanContextAccessExpressionsSpec.groovy
@@ -47,4 +47,56 @@ class BeanContextAccessExpressionsSpec extends AbstractEvaluatedExpressionsSpec 
         ctx.close()
     }
 
+    void "test bean context access for fqcn containing reserved token"() {
+        given:
+        def ctx = buildContext("""
+            package test;
+
+            import io.micronaut.context.annotation.Value;
+
+            @jakarta.inject.Singleton
+            class Expr {
+
+                @Value("#{ ctx[io.micronaut.context.env.Environment].activeNames.contains('test') }")
+                public boolean active;
+
+            }
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+        def bean = ctx.getBean(type)
+
+        expect:
+        bean.active
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "test bean context access for type reference containing reserved token"() {
+        given:
+        def ctx = buildContext("""
+            package test;
+
+            import io.micronaut.context.annotation.Value;
+
+            @jakarta.inject.Singleton
+            class Expr {
+
+                @Value("#{ ctx[T(io.micronaut.context.env.Environment)].activeNames.contains('test') }")
+                public boolean active;
+
+            }
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+        def bean = ctx.getBean(type)
+
+        expect:
+        bean.active
+
+        cleanup:
+        ctx.close()
+    }
+
 }


### PR DESCRIPTION
## Summary
- Fix `SingleEvaluatedExpressionParser` parsing for fully qualified type identifiers used in `ctx[...]` expressions.
- Add Java and Groovy regression tests covering `ctx[io.micronaut.context.env.Environment]`.
- Addresses the parsing failure reported in #11410.

## Validation
- Passed `./gradlew :micronaut-inject-java:test --tests io.micronaut.expressions.BeanContextAccessExpressionsSpec -q`
- Passed `./gradlew :micronaut-inject-groovy:test --tests io.micronaut.expressions.BeanContextAccessExpressionsSpec -q`
- Broader build validation was attempted, but unrelated failures occurred, and later reruns hit Gradle cache lock contention.
- This PR does not claim a clean full-build result from the current environment.

Fixes #11410