### PR TITLE
Clarify JsonMapper and ObjectMapper guidance

### DIFF
--- a/src/main/docs/guide/httpClient/clientAnnotation/clientJackson.adoc
+++ b/src/main/docs/guide/httpClient/clientAnnotation/clientJackson.adoc
@@ -1,5 +1,7 @@
 As mentioned previously, Jackson is used for message encoding to JSON. A default Jackson `ObjectMapper` is configured and used by Micronaut HTTP clients.
 
+This section covers Jackson-specific configuration. If your code should remain portable across Micronaut JSON implementations, prefer depending on api:json.JsonMapper[] instead of Jackson's `ObjectMapper`.
+
 You can override the settings used to construct the `ObjectMapper` with properties defined by the api:jackson.JacksonConfiguration[] class in your configuration file (e.g `application.yml`).
 
 For example, the following configuration enables indented output for Jackson:

--- a/src/main/docs/guide/httpServer/jsonBinding/jacksonConfiguration.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding/jacksonConfiguration.adoc
@@ -1,7 +1,7 @@
 :jackson-annotations: https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
 :jackson-databind: https://fasterxml.github.io/jackson-databind/javadoc/2.9/
 
-If you use <<jsonBinding, `micronaut-jackson-databind`>>, the Jackson's `ObjectMapper` can be configured through configuration with the api:io.micronaut.jackson.JacksonConfiguration[] class.
+If you use <<jsonBinding, `micronaut-jackson-databind`>>, the Jackson `ObjectMapper` can be configured through configuration with the api:io.micronaut.jackson.JacksonConfiguration[] class. This section is specific to the Jackson implementation; for application code that should remain portable across Micronaut JSON implementations, prefer depending on api:json.JsonMapper[].
 
 All Jackson configuration keys start with `jackson`.
 

--- a/src/main/docs/guide/httpServer/jsonBinding/jsonMapper.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding/jsonMapper.adoc
@@ -1,3 +1,5 @@
-You may be used to work with https://fasterxml.github.io/jackson-databind/javadoc/2.7/com/fasterxml/jackson/databind/ObjectMapper.html[Jackson's `ObjectMapper`]. However, we don't recommend using Jackson's `ObjectMapper` directly; instead you should use api:json.JsonMapper[], an API almost identical to Jackson's `ObjectMapper`. Moreover, both <<jsonBinding, Micronaut Serialization and Micronaut Jackson Databind>> implement api:json.JsonMapper[].
+You may be familiar with https://fasterxml.github.io/jackson-databind/javadoc/2.7/com/fasterxml/jackson/databind/ObjectMapper.html[Jackson's `ObjectMapper`]. For implementation-agnostic application code, we recommend depending on api:json.JsonMapper[], which is Micronaut's JSON abstraction for common mapping operations. <<jsonBinding, Micronaut Serialization and Micronaut Jackson Databind>> both provide implementations of api:json.JsonMapper[], and Micronaut Serialization also defines its own `ObjectMapper` interface that extends api:json.JsonMapper[].
+
+If you are intentionally writing implementation-specific code, you can still use the corresponding implementation API such as Jackson's `ObjectMapper` or Micronaut Serialization's `ObjectMapper`.
 
 You can inject a bean of type `JsonMapper` or manually instantiate one via `JsonMapper.createDefault()`.


### PR DESCRIPTION
## Summary
- clarify that `JsonMapper` is the recommended abstraction for implementation-agnostic application code
- note that Micronaut Serialization provides its own `ObjectMapper` interface extending `JsonMapper`
- mark the Jackson configuration docs as implementation-specific to avoid conflicting guidance

## Verification
- reviewed the updated AsciiDoc files and final diff locally
- tightened wording after an Oracle review to avoid overstating equivalence with Jackson's API

Fixes #11248