### PR TITLE
Handle long Lombok builder introspection names

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -119,7 +119,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     return;
                 }
                 int introspectionIndex = index.getAndIncrement();
-                processBuilderDefinition(ce, context, ce.findAnnotation(Introspected.class).orElse(introspected), introspectionIndex, targetPackage);
+                processBuilderDefinition(ce, context, ce.findAnnotation(Introspected.class).orElse(introspected), introspectionIndex, targetPackage, true);
                 final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                     targetPackage,
                     element.getName(),
@@ -150,7 +150,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                             continue;
                         }
                         int introspectionIndex = j++;
-                        processBuilderDefinition(classElement, context, classElement.findAnnotation(Introspected.class).orElse(introspected), introspectionIndex, targetPackage);
+                        processBuilderDefinition(classElement, context, classElement.findAnnotation(Introspected.class).orElse(introspected), introspectionIndex, targetPackage, true);
                         final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                             targetPackage,
                             element.getName(),
@@ -171,7 +171,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 }
             }
         } else {
-            processBuilderDefinition(element, context, introspected, 0, targetPackage);
+            processBuilderDefinition(element, context, introspected, 0, targetPackage, element.hasAnnotation(ImportedClass.class));
             final BeanIntrospectionWriter writer;
             if (element.hasAnnotation(ImportedClass.class)) {
                 ClassElement originatingElement = context.getClassElement(element.stringValue(ImportedClass.class, "originatingElement").orElseThrow()).orElseThrow();
@@ -197,7 +197,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         }
     }
 
-    private void processBuilderDefinition(ClassElement element, VisitorContext context, AnnotationValue<Introspected> introspected, int index, String targetPackage) {
+    private void processBuilderDefinition(ClassElement element, VisitorContext context, AnnotationValue<Introspected> introspected, int index, String targetPackage, boolean useLongBuilderName) {
         AnnotationValue<Introspected.IntrospectionBuilder> builder = introspected.getAnnotation("builder", Introspected.IntrospectionBuilder.class).orElse(null);
         if (builder != null) {
             String builderMethod = builder.stringValue("builderMethod").orElse(null);
@@ -214,7 +214,8 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 builderMethod,
                 creatorMethod,
                 writePrefixes,
-                builderClass
+                builderClass,
+                useLongBuilderName
             );
         } else if (element.hasDeclaredAnnotation(ANN_LOMBOK_BUILDER)) {
             AnnotationValue<Annotation> lombokBuilder = Objects.requireNonNull(element.getDeclaredAnnotation(ANN_LOMBOK_BUILDER));
@@ -243,12 +244,13 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 builderMethod,
                 creatorMethod,
                 writePrefixes,
-                null
+                null,
+                useLongBuilderName
             );
         }
     }
 
-    private void processBuilderDefinition(ClassElement element, VisitorContext context, AnnotationValue<Introspected> introspected, int index, String targetPackage, @Nullable String builderMethod, @Nullable String creatorMethod, String[] writePrefixes, @Nullable AnnotationClassValue<?> builderClass) {
+    private void processBuilderDefinition(ClassElement element, VisitorContext context, AnnotationValue<Introspected> introspected, int index, String targetPackage, @Nullable String builderMethod, @Nullable String creatorMethod, String[] writePrefixes, @Nullable AnnotationClassValue<?> builderClass, boolean useLongBuilderName) {
         if (builderMethod != null) {
             MethodElement methodElement = element
                 .getEnclosedElement(ElementQuery.ALL_METHODS.onlyStatic()
@@ -273,7 +275,8 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                         returnType,
                         methodMetadata,
                         index,
-                        targetPackage
+                        targetPackage,
+                        useLongBuilderName
                     );
                 } else {
                     throw new ProcessingException(methodElement, "Builder return type is not public. The method must be static and accessible.");
@@ -298,7 +301,8 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     builderClassElement,
                     builderClassElement.getTargetAnnotationMetadata(),
                     index,
-                    targetPackage);
+                    targetPackage,
+                    useLongBuilderName);
             } else {
                 throw new ProcessingException(element, "Builder class not found on compilation classpath: " + builderClass.getName());
             }
@@ -364,7 +368,9 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         @Nullable MethodElement defaultConstructor,
         ClassElement builderType,
         @Nullable AnnotationMetadata builderMetadata,
-        int index, String targetPackage) {
+        int index,
+        String targetPackage,
+        boolean useLongBuilderName) {
         if (builderMetadata == null) {
             builderMetadata = AnnotationMetadata.EMPTY_METADATA;
         }
@@ -380,15 +386,25 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
 
             MethodElement creatorMethodElement = builderType.getEnclosedElement(buildMethodQuery).orElse(null);
             if (creatorMethodElement != null) {
-                final BeanIntrospectionWriter builderWriter = new BeanIntrospectionWriter(
-                    targetPackage,
-                    builderType.getName(),
-                    index,
-                    classToBuild,
-                    builderType,
-                    builderMetadata,
-                    context
-                );
+                final BeanIntrospectionWriter builderWriter;
+                if (useLongBuilderName) {
+                    builderWriter = new BeanIntrospectionWriter(
+                        targetPackage,
+                        builderType.getName(),
+                        index,
+                        classToBuild,
+                        builderType,
+                        builderMetadata,
+                        context
+                    );
+                } else {
+                    builderWriter = new BeanIntrospectionWriter(
+                        targetPackage,
+                        builderType,
+                        builderMetadata,
+                        context
+                    );
+                }
                 ClassElement callingType = ClassElement.of(builderWriter.getIntrospectionName());
                 if (defaultConstructor != null) {
                     if (defaultConstructor.isAccessible(callingType)) {

--- a/test-suite/src/test/java/io/micronaut/test/lombok/Issue12015LongLombokBuilderIntrospectionTest.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/Issue12015LongLombokBuilderIntrospectionTest.java
@@ -1,0 +1,55 @@
+package io.micronaut.test.lombok;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.beans.BeanIntrospection;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Issue12015LongLombokBuilderIntrospectionTest {
+
+    @Test
+    void testLongLombokBuilderIntrospectionUsesShortDescriptorName() {
+        BeanIntrospection<MyLovelyOtherServiceVeryBeautifulEndpointVeryImportantResponseDto> introspection = BeanIntrospection.getIntrospection(MyLovelyOtherServiceVeryBeautifulEndpointVeryImportantResponseDto.class);
+
+        assertTrue(introspection.hasBuilder());
+        MyLovelyOtherServiceVeryBeautifulEndpointVeryImportantResponseDto bean = introspection.builder()
+            .with("result", "ok")
+            .build();
+        assertEquals("ok", bean.getResult());
+
+        Path descriptorsDirectory = Path.of("build", "classes", "java", "test", "META-INF", "micronaut", "io.micronaut.core.beans.BeanIntrospectionReference");
+        String builderDescriptorName = findDescriptorName(descriptorsDirectory, "MyLovelyOtherServiceVeryBeautifulEndpointVeryImportantResponseDtoBuilder");
+        assertTrue(builderDescriptorName.length() < 240, () -> "Expected shortened builder descriptor name, got length " + builderDescriptorName.length() + ": " + builderDescriptorName);
+        assertTrue(builderDescriptorName.contains("$MyLovelyOtherServiceVeryBeautifulEndpointVeryImportantResponseDtoBuilder$Introspection"));
+        assertTrue(!builderDescriptorName.contains("$io_micronaut_test_lombok_"), () -> "Descriptor should not contain underscored package prefix: " + builderDescriptorName);
+    }
+
+    @Introspected
+    @lombok.Builder
+    @lombok.Value
+    @lombok.NoArgsConstructor(force = true, access = lombok.AccessLevel.PRIVATE)
+    @lombok.AllArgsConstructor
+    static class MyLovelyOtherServiceVeryBeautifulEndpointVeryImportantResponseDto {
+        String result;
+    }
+
+    private static String findDescriptorName(Path descriptorsDirectory, String contains) {
+        try (var stream = Files.list(descriptorsDirectory)) {
+            List<String> names = stream
+                .map(path -> path.getFileName().toString())
+                .filter(name -> name.contains(contains))
+                .toList();
+            assertEquals(1, names.size(), () -> "Expected exactly one descriptor containing '" + contains + "' but found: " + names);
+            return names.getFirst();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to inspect generated introspection descriptors", e);
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
+++ b/test-suite/src/test/java/io/micronaut/test/lombok/LombokIntrospectedBuilderTest.java
@@ -8,7 +8,11 @@ import io.micronaut.test.lombok.importtest.VersionManifest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,6 +29,25 @@ public class LombokIntrospectedBuilderTest {
         assertNotNull(entry);
         assertEquals("test", entry.getName());
         assertEquals(1, entry.getMajorVersion());
+    }
+
+    @Test
+    void testImportedBuilderIntrospectionUsesLongDescriptorName() {
+        BeanIntrospection<VersionManifest.VersionManifestEntry> introspection = BeanIntrospection.getIntrospection(VersionManifest.VersionManifestEntry.class);
+        assertTrue(introspection.hasBuilder());
+        VersionManifest.VersionManifestEntry entry = introspection.builder()
+            .with("name", "test")
+            .with("majorVersion", 1)
+            .with("minorVersion", 2)
+            .build();
+        assertEquals("test", entry.getName());
+
+        Path descriptorsDirectory = Path.of("build", "classes", "java", "test", "META-INF", "micronaut", "io.micronaut.core.beans.BeanIntrospectionReference");
+        String builderDescriptorName = findDescriptorName(descriptorsDirectory, "VersionManifestEntryBuilder");
+        assertTrue(
+            builderDescriptorName.contains("$io_micronaut_test_lombok_importtest_VersionManifest$VersionManifestEntry$VersionManifestEntryBuilder$Introspection"),
+            () -> "Expected imported builder descriptor to keep long naming, got: " + builderDescriptorName
+        );
     }
 
     @Test
@@ -172,5 +195,18 @@ public class LombokIntrospectedBuilderTest {
 
         assertEquals("c1", innerClassEntity.getCompartmentId());
         assertEquals(current, innerClassEntity.getTimeCreated());
+    }
+
+    private static String findDescriptorName(Path descriptorsDirectory, String contains) {
+        try (var stream = Files.list(descriptorsDirectory)) {
+            List<String> names = stream
+                .map(path -> path.getFileName().toString())
+                .filter(name -> name.contains(contains))
+                .toList();
+            assertEquals(1, names.size(), () -> "Expected exactly one descriptor containing '" + contains + "' but found: " + names);
+            return names.getFirst();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to inspect generated introspection descriptors", e);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- shorten Lombok builder introspection descriptor naming for direct long-name cases
- preserve long descriptor naming for imported builder introspections
- add regression coverage for issue #12015 and imported builder compatibility

## Verification
- `./gradlew :test-suite:test --tests 'io.micronaut.test.lombok.Issue12015LongLombokBuilderIntrospectionTest'` ✅ on a warmed build during investigation
- `./gradlew :test-suite:test --tests 'io.micronaut.test.lombok.LombokIntrospectedBuilderTest.testImportedBuilderIntrospectionUsesLongDescriptorName'` ✅
- cold rebuild attempts hit unrelated module compilation failures in this checkout, so full fail-before/pass-after proof was only partially reproducible here

Fixes #12015