### PR TITLE
Handle health monitor scheduler rejection during shutdown

### DIFF
--- a/management/src/main/java/io/micronaut/management/health/monitor/HealthMonitorTask.java
+++ b/management/src/main/java/io/micronaut/management/health/monitor/HealthMonitorTask.java
@@ -88,12 +88,6 @@ public class HealthMonitorTask {
 
         Flux.merge(resultPublishers)
             .collectList()
-            .doOnError(e -> {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Health monitor check failed with exception: {}", e.getMessage(), e);
-                }
-                currentHealthStatus.update(HealthStatus.DOWN.describe("Error occurred running health check: " + e.getMessage()));
-            })
             .subscribe(healthResults -> {
                 if (LOG.isTraceEnabled() || LOG.isDebugEnabled()) {
                     healthResults.forEach(healthResult -> {
@@ -115,6 +109,13 @@ public class HealthMonitorTask {
                 } else {
                     currentHealthStatus.update(HealthStatus.UP);
                 }
-            });
+            }, this::onError);
+    }
+
+    private void onError(Throwable e) {
+        if (LOG.isErrorEnabled()) {
+            LOG.error("Health monitor check failed with exception: {}", e.getMessage(), e);
+        }
+        currentHealthStatus.update(HealthStatus.DOWN.describe("Error occurred running health check: " + e.getMessage()));
     }
 }

--- a/management/src/test/groovy/io/micronaut/management/health/monitor/HealthMonitorTaskSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/health/monitor/HealthMonitorTaskSpec.groovy
@@ -1,5 +1,8 @@
 package io.micronaut.management.health.monitor
 
+import io.micronaut.health.HealthStatus
+import io.micronaut.management.health.indicator.HealthIndicator
+import io.micronaut.management.health.indicator.HealthResult
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
@@ -9,8 +12,16 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.core.util.StringUtils
 import io.micronaut.runtime.server.EmbeddedServer
 import org.slf4j.LoggerFactory
+import reactor.core.publisher.Hooks
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 import static java.util.Collections.sort
 
@@ -76,6 +87,40 @@ class HealthMonitorTaskSpec extends Specification {
         logLevel << [Level.INFO, Level.DEBUG, Level.TRACE]
     }
 
+    void "test monitor handles rejected scheduler errors without dropping them"() {
+        given:
+        def currentHealthStatus = Mock(io.micronaut.health.CurrentHealthStatus)
+        AtomicReference<Throwable> droppedError = new AtomicReference<>()
+        CountDownLatch droppedErrorLatch = new CountDownLatch(1)
+        Hooks.onErrorDropped { Throwable throwable ->
+            droppedError.set(throwable)
+            droppedErrorLatch.countDown()
+        }
+
+        def executor = Executors.newSingleThreadExecutor()
+        HealthIndicator indicator = Stub(HealthIndicator) {
+            getResult() >> Mono
+                .fromCallable { HealthResult.builder('schedulerFailure', HealthStatus.UP).build() }
+                .subscribeOn(Schedulers.fromExecutorService(executor))
+        }
+        HealthMonitorTask monitorTask = new HealthMonitorTask(currentHealthStatus, indicator)
+        executor.shutdownNow()
+
+        when:
+        monitorTask.monitor()
+
+        then:
+        1 * currentHealthStatus.update({ HealthStatus status ->
+            status == HealthStatus.DOWN && status.description.orElse('').contains('Scheduler unavailable')
+        })
+        !droppedErrorLatch.await(1, TimeUnit.SECONDS)
+        droppedError.get() == null
+
+        cleanup:
+        Hooks.resetOnErrorDropped()
+        executor.shutdownNow()
+    }
+
     @Requires(property = 'spec.name', value = 'HealthMonitorTask')
     class MemoryAppender extends AppenderBase<ILoggingEvent> {
         List<String> events = []
@@ -86,4 +131,3 @@ class HealthMonitorTaskSpec extends Specification {
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- consume terminal health monitor errors with an explicit subscriber error handler
- add a regression test for rejected scheduler execution during health monitoring
- avoid dropped Reactor errors during shutdown races

## Verification
- ran `./gradlew :micronaut-management:test --tests 'io.micronaut.management.health.monitor.HealthMonitorTaskSpec.test monitor handles rejected scheduler errors without dropping them' --stacktrace`
- verified the regression fails on `5.0.x` when the production fix is temporarily reverted
- ran `./gradlew :micronaut-management:test --stacktrace`

Fixes #11241