### PR TITLE
Run websocket upgrade completion on event loop

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
@@ -184,8 +184,13 @@ public final class NettyServerWebSocketUpgradeHandler implements RequestHandler 
                 }
             });
             responseFlow.onComplete((response, throwable) -> {
-                if (response != null) {
+                if (response == null) {
+                    return;
+                }
+                if (ctx.executor().inEventLoop()) {
                     writeResponse(ctx, msg, requestLifecycle.shouldProceedNormally, response, outboundAccess);
+                } else {
+                    ctx.executor().execute(() -> writeResponse(ctx, msg, requestLifecycle.shouldProceedNormally, response, outboundAccess));
                 }
             });
         } else {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebSocketSpec.groovy
@@ -22,6 +22,8 @@ import io.netty.handler.codec.http.HttpClientCodec
 import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpObjectAggregator
 import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory
 import io.netty.handler.codec.http.websocketx.WebSocketFrame
@@ -35,6 +37,8 @@ import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class WebSocketSpec extends Specification {
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/7920')
@@ -180,6 +184,58 @@ class WebSocketSpec extends Specification {
         ctx.close()
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/11252')
+    def 'websocket upgrade completion off event loop does not race with immediate ping'() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run([
+                'spec.name': 'WebSocketSpec3',
+        ])
+        def embeddedServer = (NettyHttpServer) ctx.getBean(EmbeddedServer)
+        def delayingFilter = ctx.getBean(OffEventLoopDelayingFilter)
+
+        def serverEmbeddedChannel = embeddedServer.buildEmbeddedChannel(false)
+        def clientEmbeddedChannel = new EmbeddedChannel()
+
+        EmbeddedTestUtil.connect(serverEmbeddedChannel, clientEmbeddedChannel)
+
+        def handshaker = WebSocketClientHandshakerFactory.newHandshaker(
+                URI.create('http://localhost/WebSocketSpec3'),
+                WebSocketVersion.V13,
+                null,
+                false,
+                new DefaultHttpHeaders()
+        )
+        clientEmbeddedChannel.pipeline()
+                .addLast(new HttpClientCodec())
+                .addLast(new HttpObjectAggregator(4096))
+
+        when:
+        handshaker.handshake(clientEmbeddedChannel)
+        EmbeddedTestUtil.advance(serverEmbeddedChannel, clientEmbeddedChannel)
+        assert delayingFilter.started.await(3, TimeUnit.SECONDS)
+        delayingFilter.delay.complete(null)
+        assert delayingFilter.finished.await(3, TimeUnit.SECONDS)
+        EmbeddedTestUtil.advance(serverEmbeddedChannel, clientEmbeddedChannel)
+
+        def handshakeResponse = (FullHttpResponse) clientEmbeddedChannel.readInbound()
+        try {
+            handshaker.finishHandshake(clientEmbeddedChannel, handshakeResponse)
+        } finally {
+            handshakeResponse.release()
+        }
+        clientEmbeddedChannel.writeOutbound(new PingWebSocketFrame())
+        EmbeddedTestUtil.advance(serverEmbeddedChannel, clientEmbeddedChannel)
+
+        then:
+        noExceptionThrown()
+        clientEmbeddedChannel.readInbound() instanceof PongWebSocketFrame
+
+        cleanup:
+        clientEmbeddedChannel.close()
+        serverEmbeddedChannel.close()
+        ctx.close()
+    }
+
     @ServerWebSocket('/ServerSocket')
     @Requires(property = 'spec.name', value = 'WebSocketSpec2')
     static class ServerSocket {
@@ -188,6 +244,39 @@ class WebSocketSpec extends Specification {
             def text = ((TextWebSocketFrame) message).text()
             message.release()
             return session.send('reply: ' + text)
+        }
+    }
+
+    @ServerWebSocket('/WebSocketSpec3')
+    @Requires(property = 'spec.name', value = 'WebSocketSpec3')
+    static class ServerSocket3 {
+        @OnMessage
+        def onMessage(String message, WebSocketSession session) {
+            return session.send('reply: ' + message)
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'WebSocketSpec3')
+    @Singleton
+    @Filter('/WebSocketSpec3')
+    static class OffEventLoopDelayingFilter implements HttpFilter {
+        final CountDownLatch started = new CountDownLatch(1)
+        final CountDownLatch finished = new CountDownLatch(1)
+        final CompletableFuture<Void> delay = new CompletableFuture<>()
+
+        @Override
+        Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
+            return Mono.create { sink ->
+                Thread.start {
+                    started.countDown()
+                    delay.join()
+                    try {
+                        sink.success(Mono.from(chain.proceed(request)).block())
+                    } finally {
+                        finished.countDown()
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## What changed

Ensure websocket upgrade completion is executed on the channel event loop.

`NettyServerWebSocketUpgradeHandler` was invoking `writeResponse(...)` directly from the `ExecutionFlow.onComplete(...)` callback. That callback may resume off the Netty event loop, which creates a race between:

1. writing the successful websocket handshake response, and
2. mutating the pipeline to install `NettyServerWebSocketHandler` and remove the old HTTP upgrade path.

If a client sends a websocket frame immediately after receiving the handshake response, that frame can be observed by the still-active HTTP pipeline before the websocket handler is installed.

This patch keeps the existing fast path when already on the event loop, and otherwise marshals `writeResponse(...)` onto `ctx.executor()` so the handshake write and pipeline mutation stay serialized with subsequent reads.

## Tests

Added a regression to `WebSocketSpec` that forces the websocket filter chain to resume from a plain thread, making the completion callback run off-event-loop, then:

- completes the websocket handshake,
- sends an immediate `PingWebSocketFrame`,
- verifies the connection responds with `PongWebSocketFrame`.

## Verification

Passed:

- `./gradlew --no-daemon :micronaut-http-server-netty:test --tests 'io.micronaut.http.server.netty.websocket.WebSocketSpec'`
- `./gradlew --no-daemon :micronaut-http-server-netty:test --tests 'io.micronaut.http.server.netty.websocket.WebSocketSpec' --tests 'io.micronaut.http.server.netty.handler.PipeliningServerHandlerSpec'`

A broader `:micronaut-http-server-netty:check` run previously hit a separate order-sensitive leak failure in `MaxRequestSizeSpec.test max buffer`, but that test passed in isolation and did not reproduce as a deterministic regression from this patch.

Fixes #11252