### PR TITLE
Expose additional Netty HTTP client parser limits

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -170,6 +170,10 @@ public abstract class HttpClientConfiguration {
 
     private int maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
 
+    private int maxInitialLineLength = DEFAULT_MAX_INITIAL_LINE_LENGTH;
+
+    private int maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
+
     private Proxy.Type proxyType = Proxy.Type.DIRECT;
 
     @Nullable
@@ -256,6 +260,8 @@ public abstract class HttpClientConfiguration {
             this.loggerName = copy.loggerName;
             this.maxContentLength = copy.maxContentLength;
             this.maxHeaderSize = copy.maxHeaderSize;
+            this.maxInitialLineLength = copy.maxInitialLineLength;
+            this.maxChunkSize = copy.maxChunkSize;
             this.proxyAddress = copy.proxyAddress;
             this.proxyPassword = copy.proxyPassword;
             this.proxySelector = copy.proxySelector;
@@ -690,12 +696,48 @@ public abstract class HttpClientConfiguration {
     }
 
     /**
+     * [available in the Netty HTTP client].
+     *
+     * @return The maximum initial line length the client can handle
+     */
+    public int getMaxInitialLineLength() {
+        return maxInitialLineLength;
+    }
+
+    /**
+     * [available in the Netty HTTP client].
+     *
+     * @return The maximum chunk size the client can handle
+     */
+    public int getMaxChunkSize() {
+        return maxChunkSize;
+    }
+
+    /**
      * Sets the maximum header size the client can handle. Default value ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_MAX_HEADER_SIZE}).
      *
      * @param maxHeaderSize The maximum header size the client can handle
      */
     public void setMaxHeaderSize(@ReadableBytes int maxHeaderSize) {
         this.maxHeaderSize = maxHeaderSize;
+    }
+
+    /**
+     * Sets the maximum initial line length the client can handle. Default value ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_MAX_INITIAL_LINE_LENGTH}).
+     *
+     * @param maxInitialLineLength The maximum initial line length the client can handle
+     */
+    public void setMaxInitialLineLength(@ReadableBytes int maxInitialLineLength) {
+        this.maxInitialLineLength = maxInitialLineLength;
+    }
+
+    /**
+     * Sets the maximum chunk size the client can handle. Default value ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_MAX_CHUNK_SIZE}).
+     *
+     * @param maxChunkSize The maximum chunk size the client can handle
+     */
+    public void setMaxChunkSize(@ReadableBytes int maxChunkSize) {
+        this.maxChunkSize = maxChunkSize;
     }
 
     /**

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -699,7 +699,7 @@ public abstract class HttpClientConfiguration {
      * [available in the Netty HTTP client].
      *
      * @return The maximum initial line length the client can handle
-     * @since 5.0.1
+     * @since 5.0.0
      */
     public int getMaxInitialLineLength() {
         return maxInitialLineLength;
@@ -709,7 +709,7 @@ public abstract class HttpClientConfiguration {
      * [available in the Netty HTTP client].
      *
      * @return The maximum chunk size the client can handle
-     * @since 5.0.1
+     * @since 5.0.0
      */
     public int getMaxChunkSize() {
         return maxChunkSize;
@@ -728,7 +728,7 @@ public abstract class HttpClientConfiguration {
      * Sets the maximum initial line length the client can handle. Default value ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_MAX_INITIAL_LINE_LENGTH}).
      *
      * @param maxInitialLineLength The maximum initial line length the client can handle
-     * @since 5.0.1
+     * @since 5.0.0
      */
     public void setMaxInitialLineLength(@ReadableBytes int maxInitialLineLength) {
         this.maxInitialLineLength = maxInitialLineLength;
@@ -738,7 +738,7 @@ public abstract class HttpClientConfiguration {
      * Sets the maximum chunk size the client can handle. Default value ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_MAX_CHUNK_SIZE}).
      *
      * @param maxChunkSize The maximum chunk size the client can handle
-     * @since 5.0.1
+     * @since 5.0.0
      */
     public void setMaxChunkSize(@ReadableBytes int maxChunkSize) {
         this.maxChunkSize = maxChunkSize;

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -699,6 +699,7 @@ public abstract class HttpClientConfiguration {
      * [available in the Netty HTTP client].
      *
      * @return The maximum initial line length the client can handle
+     * @since 5.0.1
      */
     public int getMaxInitialLineLength() {
         return maxInitialLineLength;
@@ -708,6 +709,7 @@ public abstract class HttpClientConfiguration {
      * [available in the Netty HTTP client].
      *
      * @return The maximum chunk size the client can handle
+     * @since 5.0.1
      */
     public int getMaxChunkSize() {
         return maxChunkSize;
@@ -726,6 +728,7 @@ public abstract class HttpClientConfiguration {
      * Sets the maximum initial line length the client can handle. Default value ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_MAX_INITIAL_LINE_LENGTH}).
      *
      * @param maxInitialLineLength The maximum initial line length the client can handle
+     * @since 5.0.1
      */
     public void setMaxInitialLineLength(@ReadableBytes int maxInitialLineLength) {
         this.maxInitialLineLength = maxInitialLineLength;
@@ -735,6 +738,7 @@ public abstract class HttpClientConfiguration {
      * Sets the maximum chunk size the client can handle. Default value ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_MAX_CHUNK_SIZE}).
      *
      * @param maxChunkSize The maximum chunk size the client can handle
+     * @since 5.0.1
      */
     public void setMaxChunkSize(@ReadableBytes int maxChunkSize) {
         this.maxChunkSize = maxChunkSize;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -567,9 +567,9 @@ public class ConnectionManager {
 
                 ch.pipeline()
                     .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, new HttpClientCodec(
-                        HttpClientConfiguration.DEFAULT_MAX_INITIAL_LINE_LENGTH,
+                        configuration.getMaxInitialLineLength(),
                         configuration.getMaxHeaderSize(),
-                        HttpClientConfiguration.DEFAULT_MAX_CHUNK_SIZE))
+                        configuration.getMaxChunkSize()))
                     .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_AGGREGATOR, new HttpObjectAggregator(configuration.getMaxContentLength()));
 
                 Optional<Duration> readIdleTime = configuration.getReadIdleTimeout();
@@ -696,9 +696,9 @@ public class ConnectionManager {
 
         ChannelPipeline pipeline = ch.pipeline();
         pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, new HttpClientCodec(
-            HttpClientConfiguration.DEFAULT_MAX_INITIAL_LINE_LENGTH,
+            configuration.getMaxInitialLineLength(),
             configuration.getMaxHeaderSize(),
-            HttpClientConfiguration.DEFAULT_MAX_CHUNK_SIZE));
+            configuration.getMaxChunkSize()));
         if (configuration.isDecompressionEnabled()) {
             pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_DECODER, new HttpContentDecompressor());
         }
@@ -1000,9 +1000,9 @@ public class ConnectionManager {
             Http2FrameCodec frameCodec = makeFrameCodec();
 
             HttpClientCodec sourceCodec = new HttpClientCodec(
-                HttpClientConfiguration.DEFAULT_MAX_INITIAL_LINE_LENGTH,
+                configuration.getMaxInitialLineLength(),
                 configuration.getMaxHeaderSize(),
-                HttpClientConfiguration.DEFAULT_MAX_CHUNK_SIZE);
+                configuration.getMaxChunkSize());
             Http2ClientUpgradeCodec upgradeCodec = new Http2ClientUpgradeCodec(frameCodec,
                 new ChannelInitializer<Channel>() {
                     @Override

--- a/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
@@ -38,6 +38,8 @@ class DefaultHttpClientConfigurationSpec extends Specification {
         'shutdown-timeout'          | 'shutdownTimeout'        | '15s'   | Optional.of(Duration.ofSeconds(15))
         'follow-redirects'          | 'followRedirects'        | 'false' | false
         'max-header-size'           | 'maxHeaderSize'          | '16384' | 16384
+        'max-initial-line-length'   | 'maxInitialLineLength'   | '8192'  | 8192
+        'max-chunk-size'            | 'maxChunkSize'           | '16384' | 16384
     }
 
     void "test pool config"() {


### PR DESCRIPTION
## Summary
- expose `micronaut.http.client.max-initial-line-length`
- expose `micronaut.http.client.max-chunk-size`
- wire both properties through all `HttpClientCodec` construction sites and cover binding in config tests

## Context
Micronaut already exposed the server-side HTTP/1 parser limits and the client `max-header-size`, but the client still hardcoded Netty's initial-line and chunk-size limits. This change makes those existing Netty HTTP/1 parser knobs configurable on the client side as well.

## Verification
- `./gradlew :micronaut-http-client-core:compileJava :micronaut-http-client:test --tests 'io.micronaut.http.client.config.DefaultHttpClientConfigurationSpec' -q`

Fixes #11629