### PR TITLE
Honor @Fallback includes and excludes

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/CompletableFutureFallbackSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/CompletableFutureFallbackSpec.groovy
@@ -17,8 +17,10 @@ package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.*
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.retry.annotation.Fallback
 import io.micronaut.retry.annotation.Recoverable
 import io.micronaut.runtime.server.EmbeddedServer
@@ -26,6 +28,7 @@ import spock.lang.AutoCleanup
 import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -87,6 +90,24 @@ class CompletableFutureFallbackSpec extends Specification {
         book.title == "Fallback Book"
     }
 
+    void "test fallback excludes and includes are honored for CompletableFuture responses"() {
+        given:
+        ConditionalBookClient conditionalClient = server.applicationContext.getBean(ConditionalBookClient)
+
+        when:
+        conditionalClient.excluded(99).get()
+
+        then:
+        def e = thrown(ExecutionException)
+        e.cause instanceof HttpClientResponseException
+
+        when:
+        Book included = conditionalClient.included(99).get()
+
+        then:
+        included.title == "Fallback Book"
+    }
+
 
     @Client('/future/fallback/books')
     @Recoverable
@@ -94,9 +115,15 @@ class CompletableFutureFallbackSpec extends Specification {
     static interface BookClient extends BookApi {
     }
 
+    @Client('/future/fallback/books')
+    @Recoverable
+    @Requires(property = 'spec.name', value = 'CompletableFutureFallbackSpec')
+    static interface ConditionalBookClient extends ConditionalBookApi {
+    }
+
     @Fallback
     @Requires(property = 'spec.name', value = 'CompletableFutureFallbackSpec')
-    static class BookFallback implements BookApi {
+    static class BookFallback implements BookApi, ConditionalBookApi {
 
         @Override
         CompletableFuture<Book> get(Long id) {
@@ -122,11 +149,23 @@ class CompletableFutureFallbackSpec extends Specification {
         CompletableFuture<Book> update(Long id, String title) {
             return CompletableFuture.completedFuture(new Book(title: "Fallback Book"))
         }
+
+        @Override
+        @Fallback(excludes = [HttpClientResponseException])
+        CompletableFuture<Book> excluded(Long id) {
+            return CompletableFuture.completedFuture(new Book(title: "Fallback Book"))
+        }
+
+        @Override
+        @Fallback(includes = [HttpClientResponseException])
+        CompletableFuture<Book> included(Long id) {
+            return CompletableFuture.completedFuture(new Book(title: "Fallback Book"))
+        }
     }
 
     @Controller("/future/fallback/books")
     @Requires(property = 'spec.name', value = 'CompletableFutureFallbackSpec')
-    static class BookController implements BookApi {
+    static class BookController implements BookApi, ConditionalBookApi {
 
         Map<Long, Book> books = new LinkedHashMap<>()
         AtomicLong currentId = new AtomicLong(0)
@@ -165,6 +204,20 @@ class CompletableFutureFallbackSpec extends Specification {
             f.completeExceptionally(new RuntimeException("bad"))
             return f
         }
+
+        @Override
+        CompletableFuture<Book> excluded(Long id) {
+            CompletableFuture<Book> future = new CompletableFuture<>()
+            future.completeExceptionally(new HttpClientResponseException("Not Found", HttpResponse.notFound()))
+            return future
+        }
+
+        @Override
+        CompletableFuture<Book> included(Long id) {
+            CompletableFuture<Book> future = new CompletableFuture<>()
+            future.completeExceptionally(new HttpClientResponseException("Not Found", HttpResponse.notFound()))
+            return future
+        }
     }
 
     static interface BookApi {
@@ -185,10 +238,18 @@ class CompletableFutureFallbackSpec extends Specification {
         CompletableFuture<Book> update(Long id, String title)
     }
 
+    static interface ConditionalBookApi {
+
+        @Get("/excluded/{id}")
+        CompletableFuture<Book> excluded(Long id)
+
+        @Get("/included/{id}")
+        CompletableFuture<Book> included(Long id)
+    }
+
 
     static class Book {
         Long id
         String title
     }
 }
-

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/ReactorJavaFallbackSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/ReactorJavaFallbackSpec.groovy
@@ -2,7 +2,10 @@ package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.async.annotation.SingleResult
+import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.*
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Fallback
 import io.micronaut.retry.annotation.Recoverable
@@ -13,13 +16,12 @@ import reactor.core.publisher.Mono
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
-import io.micronaut.core.async.annotation.SingleResult
 
 /**
  * @author graemerocher
  * @since 1.0
  */
-class ReactorJavaFallbackSpec extends Specification{
+class ReactorJavaFallbackSpec extends Specification {
     @Shared
     @AutoCleanup
     EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': 'ReactorJavaFallbackSpec'])
@@ -77,6 +79,23 @@ class ReactorJavaFallbackSpec extends Specification{
         book.title == "Fallback Book"
     }
 
+    void "test fallback excludes and includes are honored for reactive responses"() {
+        given:
+        ConditionalBookClient client = embeddedServer.applicationContext.getBean(ConditionalBookClient)
+
+        when:
+        Mono.from(client.excluded(99)).block()
+
+        then:
+        thrown(HttpClientResponseException)
+
+        when:
+        Book included = Mono.from(client.included(99)).block()
+
+        then:
+        included.title == "Fallback Book"
+    }
+
     @Requires(property = 'spec.name', value = 'ReactorJavaFallbackSpec')
     @Client('/rxjava/fallback/books')
     @Recoverable
@@ -84,8 +103,14 @@ class ReactorJavaFallbackSpec extends Specification{
     }
 
     @Requires(property = 'spec.name', value = 'ReactorJavaFallbackSpec')
+    @Client('/rxjava/fallback/books')
+    @Recoverable
+    static interface ConditionalBookClient extends ConditionalBookApi {
+    }
+
+    @Requires(property = 'spec.name', value = 'ReactorJavaFallbackSpec')
     @Fallback
-    static class BookFallback implements BookApi {
+    static class BookFallback implements BookApi, ConditionalBookApi {
 
         @Override
         @SingleResult
@@ -121,13 +146,25 @@ class ReactorJavaFallbackSpec extends Specification{
         Publisher<Book> update(Long id, String title) {
             return Mono.just(new Book(title: "Fallback Book"))
         }
+
+        @Override
+        @SingleResult
+        @Fallback(excludes = [HttpClientResponseException])
+        Publisher<Book> excluded(Long id) {
+            return Mono.just(new Book(title: "Fallback Book"))
+        }
+
+        @Override
+        @SingleResult
+        @Fallback(includes = [HttpClientResponseException])
+        Publisher<Book> included(Long id) {
+            return Mono.just(new Book(title: "Fallback Book"))
+        }
     }
 
     @Requires(property = 'spec.name', value = 'ReactorJavaFallbackSpec')
     @Controller("/rxjava/fallback/books")
-    static class BookController implements BookApi {
-
-        Map<Long, Book> books = new LinkedHashMap<>()
+    static class BookController implements BookApi, ConditionalBookApi {
 
         @Override
         @SingleResult
@@ -163,6 +200,18 @@ class ReactorJavaFallbackSpec extends Specification{
         Publisher<Book> update(Long id, String title) {
             Mono.error(new RuntimeException("bad"))
         }
+
+        @Override
+        @SingleResult
+        Publisher<Book> excluded(Long id) {
+            Mono.error(new HttpClientResponseException("Not Found", HttpResponse.notFound()))
+        }
+
+        @Override
+        @SingleResult
+        Publisher<Book> included(Long id) {
+            Mono.error(new HttpClientResponseException("Not Found", HttpResponse.notFound()))
+        }
     }
 
     static interface BookApi {
@@ -189,6 +238,17 @@ class ReactorJavaFallbackSpec extends Specification{
         @Patch("/{id}")
         @SingleResult
         Publisher<Book> update(Long id, String title)
+    }
+
+    static interface ConditionalBookApi {
+
+        @Get("/excluded/{id}")
+        @SingleResult
+        Publisher<Book> excluded(Long id)
+
+        @Get("/included/{id}")
+        @SingleResult
+        Publisher<Book> included(Long id)
     }
 
     static class Book {

--- a/retry/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
@@ -20,10 +20,12 @@ import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.retry.annotation.DefaultRetryPredicate;
 import io.micronaut.retry.annotation.Fallback;
 import io.micronaut.retry.annotation.Recoverable;
 import io.micronaut.retry.exception.FallbackException;
@@ -34,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -47,6 +50,11 @@ import java.util.concurrent.CompletionStage;
  */
 @Singleton
 public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
+
+    private record FallbackResult(MethodExecutionHandle<?, Object> handle,
+                                  AnnotationValue<Fallback> beanAnnotation,
+                                  AnnotationValue<Fallback> methodAnnotation) {
+    }
 
     /**
      * Positioned before the {@link io.micronaut.retry.annotation.Retryable} interceptor.
@@ -114,9 +122,13 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
     @SuppressWarnings("unchecked")
     private Publisher<?> fallbackForReactiveType(MethodInvocationContext<Object, Object> context, Publisher<?> publisher) {
         return Flux.from(publisher).onErrorResume(throwable -> {
-            Optional<? extends MethodExecutionHandle<?, Object>> fallbackMethod = findFallbackMethod(context);
+            Optional<FallbackResult> fallbackMethod = findFallbackMethod(context);
             if (fallbackMethod.isPresent()) {
-                MethodExecutionHandle<?, Object> fallbackHandle = fallbackMethod.get();
+                FallbackResult fallback = fallbackMethod.get();
+                MethodExecutionHandle<?, Object> fallbackHandle = fallback.handle();
+                if (!canFallback(fallback.beanAnnotation(), fallback.methodAnnotation(), throwable)) {
+                    return Flux.error(throwable);
+                }
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Type [{}] resolved fallback: {}", context.getTarget().getClass(), fallbackHandle);
                 }
@@ -144,7 +156,7 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
      * @param context The context
      * @return The fallback method if it is present
      */
-    public Optional<? extends MethodExecutionHandle<?, Object>> findFallbackMethod(MethodInvocationContext<Object, Object> context) {
+    public Optional<FallbackResult> findFallbackMethod(MethodInvocationContext<Object, Object> context) {
         Class<?> declaringType = context.classValue(Recoverable.class, "api").orElseGet(context::getDeclaringType);
         BeanDefinition<?> beanDefinition = beanContext.findBeanDefinition(declaringType, Qualifiers.byStereotype(Fallback.class)).orElse(null);
         if (beanDefinition != null) {
@@ -152,11 +164,40 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
                 beanDefinition.findMethod(context.getMethodName(), context.getArgumentTypes()).orElse(null);
             if (fallBackMethod != null) {
                 MethodExecutionHandle<?, Object> executionHandle = beanContext.createExecutionHandle(beanDefinition, (ExecutableMethod<Object, ?>) fallBackMethod);
-                return Optional.of(executionHandle);
+                AnnotationValue<Fallback> beanAnnotation = beanDefinition.findAnnotation(Fallback.class)
+                    .orElse(AnnotationValue.builder(Fallback.class).build());
+                AnnotationValue<Fallback> methodAnnotation = fallBackMethod.findAnnotation(Fallback.class)
+                    .orElse(AnnotationValue.builder(Fallback.class).build());
+                return Optional.of(new FallbackResult(executionHandle, beanAnnotation, methodAnnotation));
             }
         }
-        context.setAttribute(FALLBACK_NOT_FOUND, Boolean.TRUE);
+        context.setAttribute(FALLBACK_NOT_FOUND, true);
         return Optional.empty();
+    }
+
+    private boolean canFallback(AnnotationValue<Fallback> beanFallback,
+                                AnnotationValue<Fallback> methodFallback,
+                                Throwable throwable) {
+        List<Class<? extends Throwable>> includes = mergeIncludes(beanFallback, methodFallback);
+        List<Class<? extends Throwable>> excludes = mergeExcludes(beanFallback, methodFallback);
+        return new DefaultRetryPredicate(includes, excludes).test(throwable);
+    }
+
+    private static List<Class<? extends Throwable>> mergeIncludes(AnnotationValue<Fallback> beanFallback,
+                                                                  AnnotationValue<Fallback> methodFallback) {
+        List<Class<? extends Throwable>> methodIncludes = resolveThrowableClasses(methodFallback, "includes");
+        return methodIncludes.isEmpty() ? resolveThrowableClasses(beanFallback, "includes") : methodIncludes;
+    }
+
+    private static List<Class<? extends Throwable>> mergeExcludes(AnnotationValue<Fallback> beanFallback,
+                                                                  AnnotationValue<Fallback> methodFallback) {
+        List<Class<? extends Throwable>> methodExcludes = resolveThrowableClasses(methodFallback, "excludes");
+        return methodExcludes.isEmpty() ? resolveThrowableClasses(beanFallback, "excludes") : methodExcludes;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static List<Class<? extends Throwable>> resolveThrowableClasses(AnnotationValue<Fallback> fallback, String member) {
+        return (List) List.of(fallback.classValues(member));
     }
 
     @SuppressWarnings("unchecked")
@@ -166,9 +207,14 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
             if (throwable == null) {
                 newFuture.complete(o);
             } else {
-                Optional<? extends MethodExecutionHandle<?, Object>> fallbackMethod = findFallbackMethod(context);
+                Optional<FallbackResult> fallbackMethod = findFallbackMethod(context);
                 if (fallbackMethod.isPresent()) {
-                    MethodExecutionHandle<?, Object> fallbackHandle = fallbackMethod.get();
+                    FallbackResult fallbackResult = fallbackMethod.get();
+                    MethodExecutionHandle<?, Object> fallbackHandle = fallbackResult.handle();
+                    if (!canFallback(fallbackResult.beanAnnotation(), fallbackResult.methodAnnotation(), throwable)) {
+                        newFuture.completeExceptionally(throwable);
+                        return;
+                    }
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Type [{}] resolved fallback: {}", context.getTarget().getClass(), fallbackHandle);
                     }
@@ -209,9 +255,14 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
             if (throwable == null) {
                 newFuture.complete(o);
             } else {
-                Optional<? extends MethodExecutionHandle<?, Object>> fallbackMethod = findFallbackMethod(context);
+                Optional<FallbackResult> fallbackMethod = findFallbackMethod(context);
                 if (fallbackMethod.isPresent()) {
-                    MethodExecutionHandle<?, Object> fallbackHandle = fallbackMethod.get();
+                    FallbackResult fallbackResult = fallbackMethod.get();
+                    MethodExecutionHandle<?, Object> fallbackHandle = fallbackResult.handle();
+                    if (!canFallback(fallbackResult.beanAnnotation(), fallbackResult.methodAnnotation(), throwable)) {
+                        newFuture.completeExceptionally(throwable);
+                        return;
+                    }
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Type [{}] resolved fallback: {}", context.getTarget().getClass(), fallbackHandle);
                     }
@@ -242,9 +293,13 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
             LOG.error("Type [{}] executed with error: {}", context.getTarget().getClass().getName(), exception.getMessage(), exception);
         }
 
-        Optional<? extends MethodExecutionHandle<?, Object>> fallback = findFallbackMethod(context);
+        Optional<FallbackResult> fallback = findFallbackMethod(context);
         if (fallback.isPresent()) {
-            MethodExecutionHandle<?, Object> fallbackMethod = fallback.get();
+            FallbackResult fallbackResult = fallback.get();
+            MethodExecutionHandle<?, Object> fallbackMethod = fallbackResult.handle();
+            if (!canFallback(fallbackResult.beanAnnotation(), fallbackResult.methodAnnotation(), exception)) {
+                throw exception;
+            }
             try {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Type [{}] resolved fallback: {}", context.getTarget().getClass().getName(), fallbackMethod);


### PR DESCRIPTION
## What this does
- honor `@Fallback` `includes`/`excludes` before invoking fallback handlers
- apply the same behavior across synchronous, reactive, `CompletionStage`, and suspend flows
- add regression coverage for reactive and `CompletableFuture` declarative HTTP clients

## Verification
- `./gradlew -q :micronaut-retry:compileJava :micronaut-http-client:compileTestJava :micronaut-http-client:compileTestGroovy`
- `./gradlew :micronaut-http-client:test --tests 'io.micronaut.http.client.aop.ReactorJavaFallbackSpec' --tests 'io.micronaut.http.client.aop.CompletableFutureFallbackSpec'`
- `./gradlew :micronaut-retry:test`

Fixes #11255