### PR TITLE
Add regression coverage for blank form request bean values

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
@@ -33,6 +33,7 @@ import io.micronaut.http.tck.TestScenario;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,11 +56,17 @@ public class FormsJacksonAnnotationsTest {
 
         body = "title=Building+Microservices&pages=";
         assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&publishedAt=";
+        assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&category=";
+        assertWithBody(body, JSON_WITHOUT_PAGES);
     }
 
     @Test
     public void httpClientFormSubmissionsDoesNotSupportJacksonAnnotations() throws IOException {
-        Book book = new Book("Building Microservices", 100);
+        Book book = new Book("Building Microservices", 100, null, null);
         // Jackson annotations (@JsonProperty) are not supported by the HTTP Client and form-url encoded payload.
         assertWithBody(book, JSON_WITHOUT_PAGES);
     }
@@ -92,7 +99,10 @@ public class FormsJacksonAnnotationsTest {
 
     @Introspected
     @ReflectiveAccess
-    record Book(@JsonProperty("title") String title, @JsonProperty("paginas") @Nullable Integer pages) {
+    record Book(@JsonProperty("title") String title, @JsonProperty("paginas") @Nullable Integer pages, @JsonProperty("publishedAt") @Nullable LocalDateTime publishedAt, @JsonProperty("category") @Nullable Category category) {
     }
 
+    enum Category {
+        TECHNICAL
+    }
 }

--- a/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
@@ -125,16 +125,17 @@ public class RequestBeanAnnotationBinder<T> implements AnnotatedRequestArgumentB
             throw new UnsatisfiedArgumentException(argument);
         }
         BindingResult<Object> result = binder.get().bind(conversionContext, source);
-        if (!result.isSatisfied() || !result.getConversionErrors().isEmpty()) {
-            List<ConversionError> errors = result.getConversionErrors();
-            if (!errors.isEmpty()) {
-                throw new ConversionErrorException(argument, errors.iterator().next());
-            }
+        List<ConversionError> errors = result.getConversionErrors();
+        if (!errors.isEmpty()) {
+            throw new ConversionErrorException(argument, errors.iterator().next());
         }
-        if (!result.isPresentAndSatisfied() && !argument.isNullable() && !argument.getType().isAssignableFrom(Optional.class)) {
-            throw new UnsatisfiedArgumentException(argument);
+        if (result.isPresentAndSatisfied()) {
+            return result.getValue();
         }
-        return result.getValue();
+        if (result.isSatisfied() && (argument.isNullable() || argument.isOptional())) {
+            return result.getValue();
+        }
+        throw new UnsatisfiedArgumentException(argument);
     }
 
 }

--- a/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
@@ -125,17 +125,16 @@ public class RequestBeanAnnotationBinder<T> implements AnnotatedRequestArgumentB
             throw new UnsatisfiedArgumentException(argument);
         }
         BindingResult<Object> result = binder.get().bind(conversionContext, source);
-        List<ConversionError> errors = result.getConversionErrors();
-        if (!errors.isEmpty()) {
-            throw new ConversionErrorException(argument, errors.iterator().next());
+        if (!result.isSatisfied() || !result.getConversionErrors().isEmpty()) {
+            List<ConversionError> errors = result.getConversionErrors();
+            if (!errors.isEmpty()) {
+                throw new ConversionErrorException(argument, errors.iterator().next());
+            }
         }
-        if (result.isPresentAndSatisfied()) {
-            return result.getValue();
+        if (!result.isPresentAndSatisfied() && !argument.isNullable() && !argument.getType().isAssignableFrom(Optional.class)) {
+            throw new UnsatisfiedArgumentException(argument);
         }
-        if (result.isSatisfied() && (argument.isNullable() || argument.isOptional())) {
-            return result.getValue();
-        }
-        throw new UnsatisfiedArgumentException(argument);
+        return result.getValue();
     }
 
 }


### PR DESCRIPTION
## Summary
- add server-side regression coverage for blank form-url-encoded non-String values on `@Body` beans
- verify blank `LocalDateTime` and enum fields are treated as absent instead of failing request conversion
- keep the patch test-only because current `5.0.x` already satisfies the reported behavior

## Verification
- `./gradlew :micronaut-http-client:test --tests 'io.micronaut.http.client.aop.RequestBeanSpec'`
- `./gradlew :micronaut-http-server-tck:clean :micronaut-http-server-tck:compileJava :micronaut-http-server-tck:jar :test-suite-http-server-tck-netty:test --rerun-tasks --tests 'io.micronaut.http.server.tck.netty.tests.NettyHttpServerTestSuite'`

Fixes #11213