### PR TITLE
Fix bean-backed URI template expansion ordering

### DIFF
--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospectionMap.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospectionMap.java
@@ -17,7 +17,6 @@ package io.micronaut.core.beans;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.ObjectUtils;
 import org.jspecify.annotations.Nullable;
 
@@ -138,7 +137,7 @@ final class BeanIntrospectionMap<T> implements BeanMap<T> {
 
     @Override
     public Set<String> keySet() {
-        return CollectionUtils.setOf(beanIntrospection.getPropertyNames());
+        return new LinkedHashSet<>(Arrays.asList(beanIntrospection.getPropertyNames()));
     }
 
     @Override
@@ -165,6 +164,6 @@ final class BeanIntrospectionMap<T> implements BeanMap<T> {
             public Object setValue(@Nullable Object value) {
                 return put(key, value);
             }
-        }).collect(Collectors.toSet());
+        }).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/http/src/test/groovy/io/micronaut/http/uri/UriTemplateMatcherSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriTemplateMatcherSpec.groovy
@@ -15,6 +15,8 @@
  */
 package io.micronaut.http.uri
 
+import io.micronaut.core.annotation.Introspected
+
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -189,6 +191,16 @@ class UriTemplateMatcherSpec extends Specification {
         "/books{#hashtag}"               | "/books/"             | true    | [:]
     }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11192")
+    void "test matcher expansion preserves property order for exploded query parameters"() {
+        given:
+        UriTemplateMatcher matcher = new UriTemplateMatcher('/foo{?pagination*}')
+        Pagination pagination = new Pagination(0, 10, 'name', 'asc')
+
+        expect:
+        matcher.expand([pagination: pagination]) == '/foo?offset=0&max=10&sort=name&order=asc'
+    }
+
     @Issue("https://github.com/micronaut-projects/micronaut-aws/issues/110")
     @Unroll
     void "Test URI template #template matches uri with encoded characters: #uri"() {
@@ -209,5 +221,21 @@ class UriTemplateMatcherSpec extends Specification {
         "/{+someId}"    | '/username@company.com'       | true      | [someId: 'username@company.com']
         "/{+someId}"    | '/username%2B1@company.com'   | true      | [someId: 'username%2B1@company.com']
         "/{+someId}"    | '/username+1@company.com'     | true      | [someId: 'username+1@company.com']
+    }
+
+
+    @Introspected
+    static class Pagination {
+        int offset
+        int max
+        String sort
+        String order
+
+        Pagination(int offset, int max, String sort, String order) {
+            this.offset = offset
+            this.max = max
+            this.sort = sort
+            this.order = order
+        }
     }
 }

--- a/http/src/test/groovy/io/micronaut/http/uri/UriTemplateSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriTemplateSpec.groovy
@@ -15,6 +15,9 @@
  */
 package io.micronaut.http.uri
 
+import io.micronaut.core.annotation.Introspected
+import spock.lang.Issue
+
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -141,6 +144,18 @@ class UriTemplateSpec extends Specification {
         '/foo'         | '/find{?keys1*}{&keys2*}'      | '/foo/find{?keys1*}{&keys2*}'
 
 
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11192")
+    void "test bean expansion preserves property order for exploded query parameters"() {
+        given:
+        UriTemplate uriTemplate = new UriTemplate('/foo{?offset,max,sort,order}')
+        UriTemplate explodedUriTemplate = new UriTemplate('/foo{?offset,max,sort,order}{&pagination*}')
+        Pagination pagination = new Pagination(0, 10, 'name', 'asc')
+
+        expect:
+        uriTemplate.expand(pagination) == '/foo?offset=0&max=10&sort=name&order=asc'
+        explodedUriTemplate.expand([offset: 0, max: 10, sort: 'name', order: 'asc', pagination: pagination]) == '/foo?offset=0&max=10&sort=name&order=asc'
     }
 
     @Unroll
@@ -608,4 +623,20 @@ class UriTemplateSpec extends Specification {
         'http://example.com:8080/{?keys*}{&keys2*}'   | [keys: [var: null], keys2: [var2: 'bar']]          | 'http://example.com:8080/&var2=bar'
     }
 
+
+
+    @Introspected
+    static class Pagination {
+        int offset
+        int max
+        String sort
+        String order
+
+        Pagination(int offset, int max, String sort, String order) {
+            this.offset = offset
+            this.max = max
+            this.sort = sort
+            this.order = order
+        }
+    }
 }

--- a/http/src/test/groovy/io/micronaut/http/uri/UriTemplateSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriTemplateSpec.groovy
@@ -147,15 +147,13 @@ class UriTemplateSpec extends Specification {
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11192")
-    void "test bean expansion preserves property order for exploded query parameters"() {
+    void "test bean expansion preserves property order for query parameters"() {
         given:
         UriTemplate uriTemplate = new UriTemplate('/foo{?offset,max,sort,order}')
-        UriTemplate explodedUriTemplate = new UriTemplate('/foo{?offset,max,sort,order}{&pagination*}')
         Pagination pagination = new Pagination(0, 10, 'name', 'asc')
 
         expect:
         uriTemplate.expand(pagination) == '/foo?offset=0&max=10&sort=name&order=asc'
-        explodedUriTemplate.expand([offset: 0, max: 10, sort: 'name', order: 'asc', pagination: pagination]) == '/foo?offset=0&max=10&sort=name&order=asc'
     }
 
     @Unroll


### PR DESCRIPTION
## Summary
- preserve bean introspection property order in `BeanIntrospectionMap` key and entry iteration
- add regression coverage for bean-backed query expansion in `UriTemplate` and `UriTemplateMatcher`
- keep the fix scoped to the bean-to-map adapter used by URI expansion

## Verification
- attempted `./gradlew -q :micronaut-http:test --tests 'io.micronaut.http.uri.UriTemplateSpec' --tests 'io.micronaut.http.uri.UriTemplateMatcherSpec'`
- verification is currently blocked in this environment by a pre-existing compile failure in `core/src/main/java/io/micronaut/core/propagation/ScopedValues.java` related to disabled preview `ScopedValue` APIs

Fixes #11192