### PR TITLE
Clarify bootstrap requirements for custom distributed configuration

### DIFF
--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfiguration.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfiguration.adoc
@@ -9,3 +9,5 @@ The `getPropertySources` returns a rs:Publisher[] that emits zero or many api:co
 The default implementation is api:discovery.config.DefaultCompositeConfigurationClient[] which merges all registered `ConfigurationClient` beans into a single bean.
 
 You can either implement your own api:discovery.config.ConfigurationClient[] or use the implementations provided by Micronaut. The following sections cover those.
+
+NOTE: When implementing custom distributed configuration that is loaded during bootstrap, implementing api:discovery.config.ConfigurationClient[] alone is not enough. The application also needs the discovery client infrastructure, which normally comes from the `io.micronaut.discovery:micronaut-discovery-client` dependency, and any beans involved in resolving that configuration must still be bootstrap-compatible.

--- a/src/main/docs/guide/config/bootstrap.adoc
+++ b/src/main/docs/guide/config/bootstrap.adoc
@@ -6,7 +6,7 @@ The bootstrap context is enabled depending on the following conditions. The cond
 
 - If The api:context.env.Environment#BOOTSTRAP_CONTEXT_PROPERTY[micronaut.bootstrap.context] system property is set, that value determines if the bootstrap context is enabled.
 - If The application context builder option api:context.ApplicationContextBuilder#bootstrapEnvironment[bootstrapEnvironment] is set, that value determines if the bootstrap context is enabled.
-- If a api:context.env.BootstrapPropertySourceLocator[] bean is present the bootstrap context is enabled. Normally this comes from the `micronaut-discovery-client` dependency.
+- If a api:context.env.BootstrapPropertySourceLocator[] bean is present the bootstrap context is enabled. Normally this comes from the `micronaut-discovery-client` dependency. If you provide a custom api:discovery.config.ConfigurationClient[] for distributed configuration, make sure that dependency is present so the bootstrap/distributed configuration infrastructure is loaded.
 
 Configuration properties that must be present before application context configuration properties are resolved, for example when using distributed configuration, are stored in a bootstrap configuration file. Once it is determined the bootstrap context is enabled (as described above), the bootstrap configuration files are read using the same rules as regular application configuration.
 See the <<propertySource, property source>> documentation for the details. The only difference is the prefix (`bootstrap` instead of `application`).
@@ -22,3 +22,5 @@ See the <<distributedConfiguration, distributed configuration>> section of the d
 === Bootstrap Context Beans
 
 In order for a bean to be resolvable in the bootstrap context it must be annotated with ann:context.annotation.BootstrapContextCompatible[]. If any given bean is not annotated then it will not be able to be resolved in the bootstrap context. Typically, any bean that is participating in the process of retrieving distributed configuration needs to be annotated.
+
+For example, if you implement custom distributed configuration that is resolved during bootstrap, any supporting beans it depends on must be bootstrap-compatible, and the application must include the discovery client infrastructure, typically by adding the `io.micronaut.discovery:micronaut-discovery-client` dependency.


### PR DESCRIPTION
## Summary
- clarify that implementing `ConfigurationClient` alone is not enough when custom distributed configuration is loaded during bootstrap
- document that the discovery client infrastructure typically comes from `io.micronaut.discovery:micronaut-discovery-client`
- remind readers that beans involved in bootstrap configuration resolution must be bootstrap-compatible

## Validation
- verified the edited docs source directly
- attempted `./gradlew validateAssembleDocs -q` with a writable `GRADLE_USER_HOME`
- build is currently blocked by a pre-existing repository/JDK issue in `core/src/main/java/io/micronaut/core/propagation/ScopedValues.java`, unrelated to this docs-only change

Fixes #10994