### PR TITLE
Fix constructor-order check for proxied factory beans

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/FactoryBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/FactoryBeanElementCreator.java
@@ -212,14 +212,19 @@ final class FactoryBeanElementCreator extends DeclaredBeanElementCreator {
             }
 
             MethodElement constructorElement = producedType.getPrimaryConstructor().orElse(null);
-            if (!producedType.isInterface() && constructorElement != null && constructorElement.getParameters().length > 0) {
+            MethodElement defaultConstructor = producedType.getDefaultConstructor().orElse(null);
+            if (!producedType.isInterface() && defaultConstructor == null) {
                 final String proxyTargetMode = producedAnnotationMetadata.stringValue(AnnotationUtil.ANN_AROUND, "proxyTargetMode").orElse("ERROR");
                 switch (proxyTargetMode) {
                     case "ALLOW":
-                        allowProxyConstruction(constructorElement);
+                        if (constructorElement != null) {
+                            allowProxyConstruction(constructorElement);
+                        }
                         break;
                     case "WARN":
-                        allowProxyConstruction(constructorElement);
+                        if (constructorElement != null) {
+                            allowProxyConstruction(constructorElement);
+                        }
                         visitorContext.warn("The produced type of a @Factory method has constructor arguments and is proxied. " +
                             "This can lead to unexpected behaviour. See the javadoc for Around.ProxyTargetConstructorMode for more information: " + producingElement.getName(), producingElement);
                         break;

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
@@ -117,4 +117,30 @@ class Test {
         def e = thrown(RuntimeException)
         e.message.contains("The produced type from a factory which has AOP proxy advice specified must define an accessible no arguments constructor")
     }
+
+    void "test that a factory that returns a class with reordered constructors and an accessible no args constructor compiles"() {
+        expect:
+        buildBeanDefinition('factproxyreordered.TestFactory', '''
+package factproxyreordered;
+
+import io.micronaut.context.annotation.*;
+
+@Factory
+class TestFactory {
+
+    @Bean
+    @io.micronaut.runtime.context.scope.ThreadLocal
+    Test test() {
+        return new Test();
+    }
+}
+
+class Test {
+    Test(String name) {}
+    Test() {
+        this("foo")
+    }
+}
+''')
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
@@ -33,6 +33,32 @@ class Test {
         e.message.contains("The produced type from a factory which has AOP proxy advice specified must define an accessible no arguments constructor")
     }
 
+    void "test that a factory that returns a class with reordered constructors and an accessible no args constructor compiles"() {
+        expect:
+        buildBeanDefinition('factproxyreordered.TestFactory', '''
+package factproxyreordered;
+
+import io.micronaut.context.annotation.*;
+
+@Factory
+class TestFactory {
+
+    @Bean
+    @io.micronaut.runtime.context.scope.ThreadLocal
+    Test test() {
+        return new Test();
+    }
+}
+
+class Test {
+    Test(String name) {}
+    Test() {
+        this("foo")
+    }
+}
+''')
+    }
+
 
     void "test mock bean compiles"() {
         expect:"mock bean to compile"

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
@@ -53,7 +53,7 @@ class TestFactory {
 class Test {
     Test(String name) {}
     Test() {
-        this("foo")
+        this("foo");
     }
 }
 ''')


### PR DESCRIPTION
## Summary
- validate proxied factory-produced beans against the presence of an accessible default constructor instead of the selected primary constructor
- add Java and Groovy regression coverage for classes that declare a parameterized constructor before an accessible no-arg constructor
- preserve the existing proxy writer constructor visitation path while removing the false constructor-order dependency

## Verification
- attempted targeted runs for `FactoryWithScopedProxySpec` in `micronaut-inject-java` and `micronaut-inject-groovy`
- verification in this environment is blocked by a pre-existing unrelated compile failure in `core/src/main/java/io/micronaut/core/propagation/ScopedValues.java` (`ScopedValue` preview/toolchain issue), so those targeted tests could not be executed to completion here

Resolves #10834