### PR TITLE
Preserve empty string elements when binding string query lists

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -532,6 +532,9 @@ public class DefaultMutableConversionService implements MutableConversionService
             }
         });
 
+        // CharSequence -> String
+        addInternalConverter(CharSequence.class, String.class, (object, targetType, context) -> Optional.of(object.toString()));
+
         // String -> File
         addInternalConverter(CharSequence.class, File.class, (object, targetType, context) -> {
             if (StringUtils.isEmpty(object)) {

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -983,7 +983,7 @@ public class DefaultMutableConversionService implements MutableConversionService
             ConversionContext newContext = context.with(componentType);
 
             Class<?> targetComponentType = ReflectionUtils.getWrapperType(componentType.getType());
-            String[] strings = object.toString().split(",");
+            String[] strings = object.toString().split(",", -1);
             List<Object> list = new ArrayList<>();
             for (String string : strings) {
                 Optional<?> converted = convert(string, targetComponentType, newContext);

--- a/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
@@ -119,4 +119,27 @@ class DefaultConversionServiceSpec extends Specification {
         "1"          | Optional   | [T: Argument.of(Long, 'T')]    | Optional.of(1L)
 
     }
+
+    void "test conversion service preserves empty string elements for string iterables"() {
+        given:
+        ConversionService conversionService = new DefaultMutableConversionService()
+
+        expect:
+        conversionService.convert(sourceObject, List, ConversionContext.of([E: Argument.of(String, 'E')])).get() == result
+
+        where:
+        sourceObject | result
+        ""           | [""]
+        ","          | ["", ""]
+        "a,,b"       | ["a", "", "b"]
+    }
+
+    void "test conversion service converts char sequence to string"() {
+        given:
+        ConversionService conversionService = new DefaultMutableConversionService()
+
+        expect:
+        conversionService.convert(new StringBuilder("value"), String).get() == "value"
+        conversionService.convert(new StringBuilder(""), String).get() == ""
+    }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
@@ -70,6 +70,8 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
         HttpMethod.GET  | '/parameter/set?values=10,20'                   | "Parameter Value: [10, 20]" | HttpStatus.OK
         HttpMethod.GET  | '/parameter/list?values=10,20'                  | "Parameter Value: [10, 20]" | HttpStatus.OK
         HttpMethod.GET  | '/parameter/list?values=10&values=20'           | "Parameter Value: [10, 20]" | HttpStatus.OK
+        HttpMethod.GET  | '/parameter/string-list?values='                | "Parameter Value: ['']"     | HttpStatus.OK
+        HttpMethod.GET  | '/parameter/string-list?values=,'               | "Parameter Value: ['', '']" | HttpStatus.OK
         HttpMethod.GET  | '/parameter/set?values=10&values=20'            | "Parameter Value: [10, 20]" | HttpStatus.OK
         HttpMethod.GET  | '/parameter/optional-list?values=10&values=20'  | "Parameter Value: [10, 20]" | HttpStatus.OK
         HttpMethod.GET  | '/parameter/optional-date?date=1941-01-05'      | "Parameter Value: 1941"     | HttpStatus.OK
@@ -251,6 +253,12 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
         @Get("/list")
         String list(List<Integer> values) {
             assert values.every() { it instanceof Integer }
+            "Parameter Value: ${values.inspect()}"
+        }
+
+        @Get("/string-list")
+        String stringList(List<String> values) {
+            assert values.every() { it instanceof String }
             "Parameter Value: ${values.inspect()}"
         }
 


### PR DESCRIPTION
## Summary
- add a shared `CharSequence -> String` converter so present empty string values are preserved through normal conversion
- add conversion-layer regression coverage for empty string string iterables and direct `CharSequence -> String` conversion
- add HTTP binding regression coverage for `List<String>` query parameters with `?values=` and `?values=,`

## Rationale
The original local fix in iterable conversion was too hacky because it special-cased `String` inside list binding. This version moves the behavior into the central conversion service so iterable binding can keep using the normal `convert(...)` flow.

## Verification
- added `DefaultConversionServiceSpec` coverage for:
  - `"" -> [""]`
  - `"," -> ["", ""]`
  - `"a,,b" -> ["a", "", "b"]`
  - `new StringBuilder("value") -> "value"`
  - `new StringBuilder("") -> ""`
- added `ParameterBindingSpec` coverage for:
  - `/parameter/string-list?values=`
  - `/parameter/string-list?values=,`

## Notes
I was not able to complete a clean local Gradle verification in this environment because the repository currently fails earlier on an unrelated preview-API/toolchain compile issue in `core/src/main/java/io/micronaut/core/propagation/ScopedValues.java`.

Fixes #10804 