### PR TITLE
Fix bean introspection for Kotlin extension methods

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -390,7 +390,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, ClassOutputW
             int dispatchIndex = dispatchWriter.addMethod(beanClassElement, element);
             beanMethods.add(new BeanMethodData(element, dispatchIndex));
             this.evaluatedExpressionProcessor.processEvaluatedExpressions(element.getAnnotationMetadata(), beanClassElement);
-            for (ParameterElement parameter : element.getParameters()) {
+            for (ParameterElement parameter : element.getSuspendParameters()) {
                 this.evaluatedExpressionProcessor.processEvaluatedExpressions(parameter.getAnnotationMetadata(), beanClassElement);
             }
         }
@@ -507,11 +507,11 @@ final class BeanIntrospectionWriter implements OriginatingElements, ClassOutputW
                 // 3: annotation metadata
                 getAnnotationMetadataExpression(beanMethodData.methodElement.getAnnotationMetadata(), loadClassValueExpressionFn),
                 // 4: arguments
-                beanMethodData.methodElement.getParameters().length == 0 ? ExpressionDef.nullValue() : ArgumentExpUtils.pushBuildArgumentsForMethod(
+                beanMethodData.methodElement.getSuspendParameters().length == 0 ? ExpressionDef.nullValue() : ArgumentExpUtils.pushBuildArgumentsForMethod(
                     annotationMetadata,
                     beanClassElement,
                     introspectionTypeDef,
-                    Arrays.asList(beanMethodData.methodElement.getParameters()),
+                    Arrays.asList(beanMethodData.methodElement.getSuspendParameters()),
                     loadClassValueExpressionFn
                 ),
                 // 5: method index

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinMethodElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinMethodElement.kt
@@ -61,14 +61,24 @@ internal open class KotlinMethodElement(
 
     override val resolvedParameters: List<ParameterElement> by lazy {
         presetParameters
-            ?: declaration.parameters.map {
-                KotlinParameterElement(
-                    null,
-                    this,
-                    it,
-                    elementAnnotationMetadataFactory,
-                    visitorContext
-                )
+            ?: buildList {
+                declaration.extensionReceiver?.let { extensionReceiver ->
+                    add(
+                        ParameterElement.of(
+                            newClassElement(nativeType, extensionReceiver.resolve(), emptyMap()),
+                            "\$this"
+                        )
+                    )
+                }
+                addAll(declaration.parameters.map {
+                    KotlinParameterElement(
+                        null,
+                        this@KotlinMethodElement,
+                        it,
+                        elementAnnotationMetadataFactory,
+                        visitorContext
+                    )
+                })
             }
     }
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -452,6 +452,34 @@ interface SomeInt {
         itfeMethod.invoke(bean) == true
     }
 
+    void "test generate bean method for kotlin extension function"() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('test.ExtensionMethodTest', '''
+package test
+
+import io.micronaut.context.annotation.Executable
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class ExtensionMethodTest {
+    @Executable
+    fun Int.addOne(): Int {
+        return this + 1
+    }
+}
+''')
+
+        when:
+        Collection<BeanMethod> beanMethods = introspection.getBeanMethods()
+        def addOne = beanMethods.find { it.name == 'addOne' }
+        def bean = introspection.instantiate()
+
+        then:
+        beanMethods*.name.contains('addOne')
+        addOne instanceof ExecutableMethod
+        addOne.invoke(bean, 1) == 2
+    }
+
     void "test custom with prefix"() {
         given:
         BeanIntrospection introspection = buildBeanIntrospection('customwith.CopyMe', '''\


### PR DESCRIPTION
## Summary
- model Kotlin extension receivers as method parameters in `KotlinMethodElement`
- use the same parameter view when generating bean method metadata for introspections
- add a regression test for invoking an `@Executable` Kotlin extension method through `BeanIntrospection`

## Problem
`BeanIntrospection` bean methods for Kotlin extension functions were generated without the extension receiver in the method signature. That made invocations like `addOne.invoke(bean, 1)` resolve to a zero-argument JVM method and fail with `NoSuchMethodError`.

## Verification
- ran `:micronaut-inject-kotlin:test --tests 'io.micronaut.kotlin.processing.visitor.BeanIntrospectionSpec.test generate bean method for kotlin extension function'`
- verified the targeted regression passes under Java 25 (`JAVA_HOME=/usr/lib/jvm/java-25-openjdk`)

Resolves #10669