### PR TITLE
Preserve raw map targets in bean property binder

### DIFF
--- a/jackson-databind/src/test/groovy/io/micronaut/json/bind/JsonBeanPropertyBinderSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/json/bind/JsonBeanPropertyBinderSpec.groovy
@@ -16,7 +16,6 @@
 package io.micronaut.json.bind
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
@@ -24,15 +23,12 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.convert.ConversionService
 import io.micronaut.core.convert.exceptions.ConversionErrorException
+import io.micronaut.core.type.Argument
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
-/**
- * @author Graeme Rocher
- * @since 1.0
- */
 class JsonBeanPropertyBinderSpec extends Specification {
 
     @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
@@ -58,7 +54,18 @@ class JsonBeanPropertyBinderSpec extends Specification {
                   'authors[1].name': 'JRR Tolkien', 'authors[1].age': 110]                                      | new Book(authors: [new Author(name: "Stephen King", age: 60), new Author(name: "JRR Tolkien", age: 110)])
         Book   | ['authorsByInitials[SK].name' : 'Stephen King', 'authorsByInitials[SK].age': 60,
                   'authorsByInitials[JRR].name': 'JRR Tolkien', 'authorsByInitials[JRR].age': 110]              | new Book(authorsByInitials: [SK: new Author(name: "Stephen King", age: 60), JRR: new Author(name: "JRR Tolkien", age: 110)])
+    }
 
+    void 'test bind raw map target preserves nested uppercase keys'() {
+        given:
+        JsonBeanPropertyBinder binder = context.getBean(JsonBeanPropertyBinder)
+
+        when:
+        Map result = binder.bind(io.micronaut.core.convert.ConversionContext.of(Argument.of(Map)), [props: ['AB_VALUE': 'value']]).getValue().get()
+
+        then:
+        result.props.AB_VALUE == 'value'
+        !result.props.containsKey('aB_VALUE')
     }
 
     void "test convert map to immutable object"() {
@@ -87,7 +94,6 @@ class JsonBeanPropertyBinderSpec extends Specification {
     static class Author {
         String name
         Integer age
-
         Publisher publisher
     }
 
@@ -97,10 +103,8 @@ class JsonBeanPropertyBinderSpec extends Specification {
         String name
     }
 
-
     @Introspected
     static class ImmutablePerson {
-
         @JsonProperty("first_name")
         private String firstName
 

--- a/json-core/src/main/java/io/micronaut/json/bind/JsonBeanPropertyBinder.java
+++ b/json-core/src/main/java/io/micronaut/json/bind/JsonBeanPropertyBinder.java
@@ -70,7 +70,9 @@ final class JsonBeanPropertyBinder implements BeanPropertyBinder {
     @Override
     public BindingResult<Object> bind(ArgumentConversionContext<Object> context, Map<CharSequence, ? super Object> source) {
         try {
-            JsonNode objectNode = buildSourceObjectNode(source.entrySet());
+            JsonNode objectNode = Map.class.isAssignableFrom(context.getArgument().getType())
+                ? jsonMapper.writeValueToTree(source)
+                : buildSourceObjectNode(source.entrySet());
             Object result = jsonMapper.readValueFromTree(objectNode, context.getArgument());
             return () -> Optional.ofNullable(result);
         } catch (Exception e) {


### PR DESCRIPTION
## What
- preserve raw `Map` targets in `JsonBeanPropertyBinder` by bypassing property-path expansion
- add a binder regression proving nested uppercase keys like `AB_VALUE` remain intact for real `Map` targets

## Why
The original approach adjusted `JsonConverterRegistrar.correctKeys`, but that change was too broad and risked altering nested binding semantics. The validated fix is narrower: when the binder is asked to bind to an actual `Map` target, it should treat the source as raw map data instead of expanding keys as bean-property paths.

## Verification
- `./gradlew :micronaut-jackson-databind:test --tests 'io.micronaut.json.bind.JsonBeanPropertyBinderSpec'`
- `./gradlew :micronaut-jackson-databind:test --tests 'io.micronaut.jackson.convert.JsonConverterRegistrarSpec'`

Note: a broader `:test-suite:test --tests ...` run hit an unrelated pre-existing test discovery/compile issue in this checkout; it is not caused by this change.

Resolves #10587