### PR TITLE
Preserve generic type arguments for imported beans

### DIFF
--- a/core-processor/src/main/java/io/micronaut/context/visitor/BeanImportVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/context/visitor/BeanImportVisitor.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 
@@ -50,6 +51,7 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING_ARRAY;
 public class BeanImportVisitor implements TypeElementVisitor<Import, Object> {
 
     private static final List<BeanImportHandler> BEAN_IMPORT_HANDLERS;
+    private static final ClassElement[] EMPTY_CLASS_ELEMENTS = new ClassElement[0];
 
     static {
         final ServiceLoader<BeanImportHandler> handlers = ServiceLoader.load(BeanImportHandler.class);
@@ -71,9 +73,16 @@ public class BeanImportVisitor implements TypeElementVisitor<Import, Object> {
         List<ClassElement> beanElements = collectInjectableElements(element, context);
 
         for (ClassElement beanElement : beanElements) {
-            final BeanElementBuilder beanElementBuilder =
-                    element.addAssociatedBean(beanElement)
-                    .inject();
+            final BeanElementBuilder beanElementBuilder = element.addAssociatedBean(beanElement);
+            for (Map.Entry<String, Map<String, ClassElement>> typeArgumentsEntry : beanElement.getAllTypeArguments().entrySet()) {
+                context.getClassElement(typeArgumentsEntry.getKey()).ifPresent(typeElement -> {
+                    ClassElement[] typeArguments = typeArgumentsEntry.getValue().values().toArray(EMPTY_CLASS_ELEMENTS);
+                    if (typeArguments.length > 0) {
+                        beanElementBuilder.typeArgumentsForType(typeElement, typeArguments);
+                    }
+                });
+            }
+            beanElementBuilder.inject();
             for (BeanImportHandler beanImportHandler : BEAN_IMPORT_HANDLERS) {
                 beanImportHandler.beanAdded(beanElementBuilder, context);
             }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/beanimport/BeanImportSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/beanimport/BeanImportSpec.groovy
@@ -41,6 +41,41 @@ class BytesFactory {
         bean.toString() == 'test'
     }
 
+
+    void 'test bean import preserves generic interface injection'() {
+        given:
+        ApplicationContext context = buildContext('''
+package beanimporttest2;
+
+import io.micronaut.context.annotation.Import;
+import io.micronaut.inject.beanimport.fixtures.GenericInterface;
+import io.micronaut.inject.beanimport.fixtures.ImportedGenericBean;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Import(classes = ImportedGenericBean.class)
+class Application {}
+
+@Singleton
+class GenericConsumer {
+    @Inject
+    GenericInterface<Object> genericInterface;
+}
+''')
+
+        when:
+        Class<?> consumerType = context.classLoader.loadClass('beanimporttest2.GenericConsumer')
+        def consumer = context.getBean(consumerType)
+
+        then:
+        consumer.genericInterface.getClass().simpleName == 'ImportedGenericBean'
+        context.getBeanDefinition(io.micronaut.inject.beanimport.fixtures.ImportedGenericBean)
+                .getTypeArguments(io.micronaut.inject.beanimport.fixtures.GenericInterface)[0].type == Object
+
+        cleanup:
+        context.close()
+    }
+
     void 'test bean import for package'() {
         given:
         ApplicationContext context = buildContext('''

--- a/inject-java-test/src/test/java/io/micronaut/inject/beanimport/fixtures/GenericInterface.java
+++ b/inject-java-test/src/test/java/io/micronaut/inject/beanimport/fixtures/GenericInterface.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.beanimport.fixtures;
+
+public interface GenericInterface<T> {
+}

--- a/inject-java-test/src/test/java/io/micronaut/inject/beanimport/fixtures/ImportedGenericBean.java
+++ b/inject-java-test/src/test/java/io/micronaut/inject/beanimport/fixtures/ImportedGenericBean.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.beanimport.fixtures;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ImportedGenericBean implements GenericInterface<Object> {
+}


### PR DESCRIPTION
## What changed
- preserve imported bean generic type mappings in `BeanImportVisitor` by copying resolved type arguments onto the associated bean builder before injection metadata is finalized
- add a regression test covering `@Import` of a precompiled bean implementing `GenericInterface<Object>`
- add small test fixtures to model an imported bean from another module/library instead of an inline source bean

## Why
Imported compiled beans were losing generic type-argument metadata, so injections like `GenericInterface<Object>` could not be resolved correctly for `@Import`ed beans.

## Verification
- `./gradlew :micronaut-inject-java-test:test --tests io.micronaut.inject.beanimport.BeanImportSpec`
- `./gradlew :test-suite-jakarta-inject-bean-import:test`

Resolves #10544