### PR TITLE
Add regression test for declarative Mono<Void> no-content response

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
@@ -631,6 +631,16 @@ class HttpGetSpec extends Specification {
         Mono.from(publisher).block() == null
     }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/10810")
+    void "test a declarative client that returns Mono<Void> for no content response"() {
+        when:
+        def mono = myGetClient.noContentMonoVoid()
+
+        then:
+        mono != null
+        mono.block() == null
+    }
+
     @Requires(property = 'spec.name', value = 'HttpGetSpec')
     @Controller("/get")
     static class GetController {
@@ -956,6 +966,9 @@ class HttpGetSpec extends Specification {
 
         @Get(value = "/noContentPublisher")
         Publisher<String> noContentPublisher()
+
+        @Get(value = "/noContentPublisher")
+        Mono<Void> noContentMonoVoid()
     }
 
     @Requires(property = 'spec.name', value = 'HttpGetSpec')


### PR DESCRIPTION
## Summary
- add an explicit `Mono<Void>` declarative client regression test for `204 No Content`
- reuse the existing no-content endpoint in `HttpGetSpec`
- document the `#10810` reactive empty-completion scenario on `5.0.x`

## Context
`5.0.x` already contains the runtime behavior for declarative `Void` / `void` no-content handling, but `HttpGetSpec` only covered the related `Publisher<String>` no-content case. This adds direct regression coverage for the `Mono<Void>` path discussed in #10810.

## Verification
- `./gradlew :micronaut-http-client:test --tests 'io.micronaut.http.client.HttpGetSpec' --console=plain`

Resolves #10810