### PR TITLE
Fix @Mapper list element conversion

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/beans/MapperIntroduction.java
+++ b/context/src/main/java/io/micronaut/runtime/beans/MapperIntroduction.java
@@ -349,6 +349,11 @@ final class MapperIntroduction implements MethodInterceptor<Object, Object> {
         }
     }
 
+    private static boolean requiresGenericConversion(Argument<?> argument, Object value) {
+        return argument.getTypeParameters().length > 0 &&
+            (value instanceof Iterable<?> || value instanceof Map<?, ?> || value.getClass().isArray());
+    }
+
     private static MapStrategy buildMapStrategy(
         Mapper.ConflictStrategy conflictStrategy,
         Map<String, Function<Object, BiConsumer<Object, MappingBuilder<Object>>>> customMappers,
@@ -494,7 +499,9 @@ final class MapperIntroduction implements MethodInterceptor<Object, Object> {
                     if (i > -1) {
                         Argument<Object> argument = arguments[i];
                         Object value = beanProperty.get(input);
-                        if (value == null || argument.isInstance(value)) {
+                        if (value == null) {
+                            builder.with(i, argument, null, propertyName, input);
+                        } else if (argument.isInstance(value) && !requiresGenericConversion(argument, value)) {
                             builder.with(i, argument, value, propertyName, input);
                         } else if (conflictStrategy == Mapper.ConflictStrategy.CONVERT) {
                             ArgumentConversionContext<Object> conversionContext = ConversionContext.of(argument);

--- a/context/src/main/java/io/micronaut/runtime/beans/MapperIntroduction.java
+++ b/context/src/main/java/io/micronaut/runtime/beans/MapperIntroduction.java
@@ -35,6 +35,7 @@ import io.micronaut.core.beans.BeanProperty;
 import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.DefaultMutableConversionService;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.format.Format;
 import io.micronaut.core.expressions.EvaluatedExpression;
@@ -349,11 +350,6 @@ final class MapperIntroduction implements MethodInterceptor<Object, Object> {
         }
     }
 
-    private static boolean requiresGenericConversion(Argument<?> argument, Object value) {
-        return argument.getTypeParameters().length > 0 &&
-            (value instanceof Iterable<?> || value instanceof Map<?, ?> || value.getClass().isArray());
-    }
-
     private static MapStrategy buildMapStrategy(
         Mapper.ConflictStrategy conflictStrategy,
         Map<String, Function<Object, BiConsumer<Object, MappingBuilder<Object>>>> customMappers,
@@ -501,7 +497,7 @@ final class MapperIntroduction implements MethodInterceptor<Object, Object> {
                         Object value = beanProperty.get(input);
                         if (value == null) {
                             builder.with(i, argument, null, propertyName, input);
-                        } else if (argument.isInstance(value) && !requiresGenericConversion(argument, value)) {
+                        } else if (argument.isInstance(value) && !shouldUseCollectionConversion(beanProperty.asArgument(), argument)) {
                             builder.with(i, argument, value, propertyName, input);
                         } else if (conflictStrategy == Mapper.ConflictStrategy.CONVERT) {
                             ArgumentConversionContext<Object> conversionContext = ConversionContext.of(argument);
@@ -512,6 +508,32 @@ final class MapperIntroduction implements MethodInterceptor<Object, Object> {
                     }
                 }
             }
+        }
+
+        private boolean shouldUseCollectionConversion(Argument<?> sourceArgument, Argument<?> targetArgument) {
+            if (!isCollectionLike(sourceArgument) || !isCollectionLike(targetArgument)) {
+                return false;
+            }
+            if (targetArgument.isAssignableFrom(sourceArgument)) {
+                return false;
+            }
+            Argument<?> sourceElement = sourceArgument.getFirstTypeVariable().orElse(null);
+            Argument<?> targetElement = targetArgument.getFirstTypeVariable().orElse(null);
+            if (sourceElement == null || targetElement == null) {
+                return false;
+            }
+            if (targetElement.isAssignableFrom(sourceElement)) {
+                return false;
+            }
+            if (conversionService instanceof DefaultMutableConversionService defaultMutableConversionService) {
+                return defaultMutableConversionService.hasExactRegisteredConverter(sourceElement.getType(), targetElement.getType());
+            }
+            return false;
+        }
+
+        private static boolean isCollectionLike(Argument<?> argument) {
+            Class<?> type = argument.getType();
+            return Iterable.class.isAssignableFrom(type) || type.isArray();
         }
 
         private <O> void mapMap(Map<String, Object> input, MapStrategy mapStrategy, MappingBuilder<O> builder) {

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -285,6 +285,16 @@ public class DefaultMutableConversionService implements MutableConversionService
         return customConverters.get(pair);
     }
 
+    /**
+     * @param sourceType The exact source type
+     * @param targetType The exact target type
+     * @return Whether an exact registered converter exists for the pair
+     */
+    @Internal
+    public boolean hasExactRegisteredConverter(Class<?> sourceType, Class<?> targetType) {
+        return findRegisteredConverter(new ConvertiblePair(sourceType, targetType, null)) != null;
+    }
+
     @Override
     public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
         addConverterAnalyzeSource(customConverters, sourceType, targetType, typeConverter);

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -722,12 +722,17 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
         public <A> Builder<B> convert(int index, ArgumentConversionContext<A> conversionContext, @Nullable Object value, ConversionService conversionService) {
             Argument<A> argument = conversionContext.getArgument();
             if (value != null) {
-                if (!argument.isInstance(value)) {
+                if (!argument.isInstance(value) || requiresGenericConversion(argument, value)) {
                     value = conversionService.convertRequired(value, conversionContext);
                 }
                 params[index] = value;
             }
             return this;
+        }
+
+        private static boolean requiresGenericConversion(Argument<?> argument, Object value) {
+            return argument.getTypeParameters().length > 0 &&
+                (value instanceof Iterable<?> || value instanceof Map<?, ?> || value.getClass().isArray());
         }
 
         @Override

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ContainerA.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ContainerA.java
@@ -1,0 +1,9 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.util.List;
+
+@Introspected
+public record ContainerA(String name, ItemA inner, List<ItemA> items) {
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ContainerB.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ContainerB.java
@@ -1,0 +1,9 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.util.List;
+
+@Introspected
+public record ContainerB(String name, ItemB inner, List<ItemB> items) {
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ItemA.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ItemA.java
@@ -1,0 +1,7 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public record ItemA(String value) {
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ItemB.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ItemB.java
@@ -1,0 +1,7 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public record ItemB(String value) {
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ItemBToItemAConverter.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ItemBToItemAConverter.java
@@ -1,0 +1,18 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.TypeConverter;
+import jakarta.inject.Singleton;
+
+import java.util.Optional;
+
+@Singleton
+public class ItemBToItemAConverter implements TypeConverter<ItemB, ItemA> {
+    @Override
+    public Optional<ItemA> convert(ItemB object, Class<ItemA> targetType, ConversionContext context) {
+        if (object == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new ItemA(object.value()));
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ItemMapper.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ItemMapper.java
@@ -1,0 +1,10 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.context.annotation.Mapper;
+import jakarta.inject.Singleton;
+
+@Singleton
+public interface ItemMapper {
+    @Mapper
+    ItemA toA(ItemB input);
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ListContainerMapper.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ListContainerMapper.java
@@ -1,0 +1,10 @@
+package io.micronaut.docs.ioc.mappers;
+
+import io.micronaut.context.annotation.Mapper;
+import jakarta.inject.Singleton;
+
+@Singleton
+public interface ListContainerMapper {
+    @Mapper
+    ContainerA toA(ContainerB input);
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/MappersSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/MappersSpec.java
@@ -8,6 +8,7 @@ import io.micronaut.docs.ioc.mappers.ChristmasTypes.PresentPackaging;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -108,4 +109,21 @@ class MappersSpec {
             // end::additional[]
         }
     }
+    @Test
+    void testListElementConversionInMapper() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ListContainerMapper mapper = context.getBean(ListContainerMapper.class);
+            ItemB item = new ItemB("x");
+            ContainerB input = new ContainerB("test", item, List.of(item));
+
+            ContainerA result = mapper.toA(input);
+
+            assertEquals("test", result.name());
+            assertEquals("x", result.inner().value());
+            assertEquals(1, result.items().size());
+            assertEquals(ItemA.class, result.items().get(0).getClass());
+            assertEquals("x", result.items().get(0).value());
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- fix `@Mapper` collection element conversion so declared generic mismatches can use registered element converters
- preserve existing structural mapper recursion for collection mappings that do not have a direct registered element converter
- add a regression test covering scalar and `List` element conversion through a registered converter

## Verification
- `./gradlew :micronaut-context:test --tests 'io.micronaut.runtime.beans.MapperAnnotationSpec' :test-suite:test --tests 'io.micronaut.docs.ioc.mappers.MappersSpec'`
- `./gradlew -q :micronaut-context:compileJava :micronaut-inject:compileJava :test-suite:compileTestJava`
- `./gradlew -q cM`
- `./gradlew -q spotlessCheck`

Resolves #10517