### PR TITLE
Fix annotation metadata for Optional getter-backed properties

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -829,6 +829,40 @@ class Test {
         thrown(InstantiationException)
     }
 
+    void "test annotation metadata is retained for optional getter backed by annotated field"() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('test.Foo', """
+package test
+
+import io.micronaut.core.annotation.Introspected
+import jakarta.validation.constraints.Min
+import java.util.Optional
+
+@Introspected
+class Foo {
+    @Min(10)
+    private Long value
+
+    Optional<Long> getValue() {
+        Optional.ofNullable(value)
+    }
+}
+""")
+
+        when:
+        BeanProperty<?, ?> property = introspection.getRequiredProperty("value", Optional)
+        def genericTypeArg = property.asArgument().getFirstTypeVariable().get()
+
+        then:
+        property.type == Optional
+        property.isReadOnly()
+        !property.annotationMetadata.hasAnnotation(Min)
+        !property.annotationMetadata.hasStereotype(Constraint)
+        genericTypeArg.annotationMetadata.hasAnnotation(Min)
+        genericTypeArg.annotationMetadata.hasStereotype(Constraint)
+        genericTypeArg.annotationMetadata.intValue(Min).getAsInt() == 10
+    }
+
     void "test write bean introspection with builder style properties"() {
         given:
         ClassLoader classLoader = buildClassLoader( '''

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -796,6 +796,42 @@ class Test {
         prop.isReadOnly()
     }
 
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/10512")
+    void "test annotation metadata is retained for optional getter backed by annotated field"() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('test.Foo', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.Min;
+import java.util.Optional;
+
+@Introspected
+class Foo {
+    @Min(10)
+    private Long value;
+
+    public Optional<Long> getValue() {
+        return Optional.ofNullable(value);
+    }
+}
+''')
+
+        when:
+        BeanProperty<?, ?> property = introspection.getRequiredProperty("value", Optional)
+        def genericTypeArg = property.asArgument().getFirstTypeVariable().get()
+
+        then:
+        property.type == Optional
+        property.isReadOnly()
+        !property.annotationMetadata.hasAnnotation(Min)
+        !property.annotationMetadata.hasStereotype(Constraint)
+        genericTypeArg.annotationMetadata.hasAnnotation(Min)
+        genericTypeArg.annotationMetadata.hasStereotype(Constraint)
+        genericTypeArg.annotationMetadata.intValue(Min).getAsInt() == 10
+    }
+
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/8657")
     void "test executable method on abstract class with introspection"() {
         when:


### PR DESCRIPTION
## Summary

Fixes annotation metadata handling for `Optional` getter-backed properties on `5.0.x`.

When a property is backed by an annotated non-`Optional` field but exposed through an `Optional<T>` getter, Micronaut should preserve the field constraint metadata for the wrapped `T` value, without making the `Optional` property itself appear directly annotated with scalar constraints.

The previous version of this patch incorrectly merged the backing field into the property metadata hierarchy, which caused validation to see constraints such as `@Min` / `@PositiveOrZero` on `Optional` itself. This revision keeps the metadata transfer only on the wrapped `Optional<T>` type argument, preserving the existing validation semantics.

## Changes

- Updated `core-processor/src/main/java/io/micronaut/inject/ast/annotation/PropertyElementAnnotationMetadata.java`
  - Keep the existing special-case copy from the backing field onto the wrapped `Optional<T>` type argument
  - Do **not** merge the backing field into the property metadata hierarchy for this Optional-backed shape

- Updated Java regression coverage in `inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy`
  - Verifies the `Optional` property itself is not directly annotated with the scalar constraint
  - Verifies the wrapped generic argument metadata still retains the constraint

- Added matching Groovy regression coverage in `inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy`
  - Verifies the same split semantics for the Groovy visitor path

## Verification

Attempted under Java 25 with targeted runs for:

```bash
./gradlew :micronaut-inject-java-test:test --tests 'io.micronaut.inject.visitor.beans.BeanIntrospectionSpec.test annotation metadata is retained for optional getter backed by annotated field'
./gradlew :micronaut-inject-groovy:test --tests 'io.micronaut.inject.visitor.BeanIntrospectionSpec.test annotation metadata is retained for optional getter backed by annotated field'
./gradlew :micronaut-inject-java:test --tests 'io.micronaut.inject.validation.BeanWithValidationSpec.test pojoCanHaveGetterWhichReturnsAnOptional'
```

Local retesting is currently blocked by an unrelated build issue in this checkout (`:micronaut-http-server:compileJava` failing with a truncated generated classfile), but CI already identified the semantic regression in the earlier patch, and this revision is targeted specifically at that failure mode.

Resolves #10512