### PR TITLE
Preserve HEAD content-length for proxied multiplexed responses

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
@@ -387,6 +387,9 @@ abstract class MultiplexedServerHandler {
         @Override
         public void writeHeadResponse(HttpResponse response) {
             response.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
+            if (!PipeliningServerHandler.canHaveBody(response.status())) {
+                response.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
+            }
             writeFull(response, Unpooled.EMPTY_BUFFER);
         }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/FilterProxyTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/FilterProxyTest.java
@@ -64,6 +64,21 @@ public class FilterProxyTest {
         }
     }
 
+    @Test
+    void testHeadProxyPreservesContentLength() throws IOException {
+        Map<String, Object> configuration = Map.of(
+            PROP_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE
+        );
+        try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME, configuration)) {
+            HttpRequest<?> request = HttpRequest.HEAD("/filter-test/redirection");
+            AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.OK)
+                .header("X-Test-Filter", StringUtils.TRUE)
+                .header("Content-Length", "2")
+                .build());
+        }
+    }
+
     @Controller("/ok")
     @Requires(property = "spec.name", value = SPEC_NAME)
     static class TestController {


### PR DESCRIPTION
## Summary
- preserve an existing `Content-Length` when writing `HEAD` responses through the multiplexed server handler
- keep removing `Transfer-Encoding`, and still remove `Content-Length` for statuses that cannot have a body
- add a shared TCK regression covering proxied `HEAD` responses through `FilterProxyTest`

## Verification
- `./gradlew :micronaut-http-server-netty:compileJava :micronaut-http-server-netty:testClasses`
- `./gradlew :micronaut-context-propagation:test --tests "io.micronaut.context.propagation.MDCRxJava3Spec" --tests "io.micronaut.context.propagation.ReactorRxJavaSpec"`
- attempted `./gradlew test`, but the full suite is flaky in this environment due to `:micronaut-context-propagation:test` timing out intermittently (`MDCRxJava3Spec`), unrelated to the touched module

Resolves #10433