### PR TITLE
Preserve @Named BeanRegistration identifiers across singleton reuse

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2810,7 +2810,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 if (dependentFactoryBean != null) {
                     destroyBean(dependentFactoryBean);
                 }
-                BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);
+                Qualifier<T> registrationQualifier = qualifier;
+                if (registrationQualifier == null) {
+                    registrationQualifier = definition.getDeclaredQualifier();
+                }
+                BeanKey<T> beanKey = new BeanKey<>(beanType, registrationQualifier);
                 List<BeanRegistration<?>> dependentBeans = context.getAndResetDependentBeans();
                 BeanRegistration<T> beanRegistration = BeanRegistration.of(this, beanKey, definition, bean, dependentBeans);
                 context.pushDependentBeans(parentDependentBeans);

--- a/inject/src/test/groovy/io/micronaut/context/BeanRegistrationCollectionSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/BeanRegistrationCollectionSpec.groovy
@@ -18,6 +18,18 @@ class BeanRegistrationCollectionSpec extends Specification {
         service.beans*.identifier*.name.sort() == ['first-bean', 'second-bean']
     }
 
+    void "test beanregistration identifiers are returned regardless of prior direct bean lookup"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(["spec.name": getClass().simpleName])
+
+        when:
+        ctx.getBean(FirstBean)
+        def service = ctx.getBean(MyService)
+
+        then:
+        service.beans*.identifier*.name.sort() == ['first-bean', 'second-bean']
+    }
+
     static interface BaseBean {
     }
 


### PR DESCRIPTION
## Summary
- add a regression test for `BeanRegistration` identifiers after a prior direct singleton lookup
- preserve the bean definition's declared qualifier when creating a cached `BeanRegistration` without an explicit lookup qualifier
- keep reused singleton registrations aligned with their declared `@Named` identifiers instead of falling back to `Primary`

## Verification
- `./gradlew :micronaut-inject:test --tests 'io.micronaut.context.BeanRegistrationCollectionSpec'`

Resolves #10327