### PR TITLE
Clarify MutableHttpMessage header semantics

### DIFF
--- a/http/src/main/java/io/micronaut/http/MutableHttpMessage.java
+++ b/http/src/main/java/io/micronaut/http/MutableHttpMessage.java
@@ -68,11 +68,14 @@ public interface MutableHttpMessage<B> extends HttpMessage<B> {
     }
 
     /**
-     * Set a response header.
+     * Adds a header value to this message.
+     * <p>
+     * To replace any existing value for the same header, use {@link #getHeaders()} and
+     * {@link MutableHttpHeaders#set(CharSequence, CharSequence)} instead.
      *
      * @param name  The name of the header
      * @param value The value of the header
-     * @return This response
+     * @return This message
      */
     default MutableHttpMessage<B> header(CharSequence name, CharSequence value) {
         getHeaders().add(name, value);


### PR DESCRIPTION
## Summary
- clarify that `MutableHttpMessage.header(...)` adds a header value instead of replacing existing values
- point users to `MutableHttpHeaders.set(...)` when overwrite semantics are required
- align the method Javadoc with the current implementation without changing runtime behavior

## Verification
- ran `./gradlew :micronaut-http:compileJava -q`

Resolves #10362