### PR TITLE
fix: flush HTTP/2 decompressor when END_STREAM arrives on trailing HEADERS

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
@@ -336,6 +336,7 @@ public final class Http2ServerHandler extends MultiplexedServerHandler implement
         public ConnectionHandler build() {
             connection(new DefaultHttp2Connection(isServer(), maxReservedStreams()));
             Http2FrameListener fl = decompress ? new DelegatingDecompressorFrameListener(connection(), frameListener, false) : frameListener;
+            fl = new Http2TrailerFlushListener(fl, connection());
             if (accessLogManagerFactory != null) {
                 accessLogManager = new Http2AccessLogManager(accessLogManagerFactory, connection());
                 fl = new Http2AccessLogFrameListener(fl, accessLogManager);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2TrailerFlushListener.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2TrailerFlushListener.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.handler;
+
+import io.micronaut.core.annotation.Internal;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2FrameListener;
+import io.netty.handler.codec.http2.Http2FrameListenerDecorator;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2Stream;
+
+/**
+ * {@link Http2FrameListener} decorator that handles END_STREAM on trailing HEADERS frames.
+ *
+ * <p>When HTTP/2 trailing headers carry END_STREAM (common with Envoy, proxies, etc.), the
+ * {@link io.netty.handler.codec.http2.DelegatingDecompressorFrameListener} never receives an
+ * {@code onDataRead(..., endOfStream=true)} call, so it never flushes its decompressor tail.
+ * This decorator intercepts trailing HEADERS with END_STREAM and routes the signal through
+ * {@code onDataRead} on the wrapped listener, ensuring the decompressor is flushed before the
+ * request body is completed.</p>
+ *
+ * @since 4.6.9
+ * @author Micronaut
+ */
+@Internal
+final class Http2TrailerFlushListener extends Http2FrameListenerDecorator {
+    private final Http2FrameListener delegate;
+    private final Http2Connection connection;
+    private final Http2Connection.PropertyKey seenKey;
+
+    Http2TrailerFlushListener(Http2FrameListener listener, Http2Connection connection) {
+        super(listener);
+        this.delegate = listener;
+        this.connection = connection;
+        this.seenKey = connection.newKey();
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding, boolean endStream) throws Http2Exception {
+        if (handleTrailerEndOfStream(ctx, streamId, endStream)) {
+            return;
+        }
+        super.onHeadersRead(ctx, streamId, headers, padding, endStream);
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) throws Http2Exception {
+        if (handleTrailerEndOfStream(ctx, streamId, endStream)) {
+            return;
+        }
+        super.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive, padding, endStream);
+    }
+
+    /**
+     * Detect trailing HEADERS with END_STREAM and route the signal through the data path.
+     *
+     * @return {@code true} if this was a trailing HEADERS frame and has been handled
+     */
+    private boolean handleTrailerEndOfStream(ChannelHandlerContext ctx, int streamId, boolean endStream) throws Http2Exception {
+        Http2Stream stream = connection.stream(streamId);
+        if (stream != null && stream.getProperty(seenKey) != null) {
+            // Trailing headers: route END_STREAM through onDataRead so that
+            // DelegatingDecompressorFrameListener flushes any pending decompressed bytes.
+            if (endStream) {
+                delegate.onDataRead(ctx, streamId, Unpooled.EMPTY_BUFFER, 0, true);
+            }
+            return true;
+        }
+        if (stream != null) {
+            stream.setProperty(seenKey, Boolean.TRUE);
+        }
+        return false;
+    }
+}

--- a/http-server-netty/src/test/java/io/micronaut/http/server/netty/http2/Http2TrailerEndOfStreamTest.java
+++ b/http-server-netty/src/test/java/io/micronaut/http/server/netty/http2/Http2TrailerEndOfStreamTest.java
@@ -1,0 +1,211 @@
+package io.micronaut.http.server.netty.http2;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
+import io.netty.handler.codec.http2.Http2DataFrame;
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.handler.codec.http2.Http2MultiplexHandler;
+import io.netty.handler.codec.http2.Http2ResetFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.handler.codec.http2.Http2StreamChannelBootstrap;
+import io.netty.handler.codec.http2.Http2StreamFrame;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that HTTP/2 requests are handled correctly in the non-legacy multiplex handler path,
+ * covering both normal END_STREAM on DATA and END_STREAM on trailing HEADERS.
+ */
+class Http2TrailerEndOfStreamTest {
+
+    private static final String JSON_PAYLOAD = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_blockNumber\"}";
+
+    @Test
+    void uncompressedBodyWithTrailers() throws Exception {
+        try (EmbeddedServer server = startServer()) {
+            byte[] payload = JSON_PAYLOAD.getBytes(StandardCharsets.UTF_8);
+            H2Response response = sendRequest(server, payload, null, true);
+            assertEquals(200, response.statusCode);
+            assertEquals("{\"method\":\"eth_blockNumber\"}", response.body);
+        }
+    }
+
+    @Test
+    void gzipCompressedBodyWithTrailers() throws Exception {
+        try (EmbeddedServer server = startServer()) {
+            byte[] compressed = gzip(JSON_PAYLOAD.getBytes(StandardCharsets.UTF_8));
+            H2Response response = sendRequest(server, compressed, "gzip", true);
+            assertEquals(200, response.statusCode);
+            assertEquals("{\"method\":\"eth_blockNumber\"}", response.body);
+        }
+    }
+
+    @Test
+    void gzipCompressedBodyWithoutTrailers() throws Exception {
+        try (EmbeddedServer server = startServer()) {
+            byte[] compressed = gzip(JSON_PAYLOAD.getBytes(StandardCharsets.UTF_8));
+            H2Response response = sendRequest(server, compressed, "gzip", false);
+            assertEquals(200, response.statusCode);
+            assertEquals("{\"method\":\"eth_blockNumber\"}", response.body);
+        }
+    }
+
+    private static EmbeddedServer startServer() {
+        return ApplicationContext.run(
+                EmbeddedServer.class,
+                Map.of(
+                        "spec", "Http2TrailerEndOfStreamTest",
+                        "micronaut.server.http-version", "2.0",
+                        "micronaut.server.netty.legacy-multiplex-handlers", false,
+                        "micronaut.server.port", -1
+                )
+        );
+    }
+
+    private static H2Response sendRequest(
+            EmbeddedServer server, byte[] payload, String contentEncoding, boolean useTrailers) throws Exception {
+        NioEventLoopGroup group = new NioEventLoopGroup(1);
+        CompletableFuture<H2Response> responseFuture = new CompletableFuture<>();
+
+        try {
+            Bootstrap bootstrap = new Bootstrap()
+                    .group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel ch) {
+                            ch.pipeline().addLast(Http2FrameCodecBuilder.forClient().build());
+                            ch.pipeline().addLast(new Http2MultiplexHandler(new SimpleChannelInboundHandler<>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                                }
+                            }));
+                        }
+                    });
+
+            Channel parent = bootstrap.connect(server.getHost(), server.getPort()).sync().channel();
+
+            Http2StreamChannel stream = new Http2StreamChannelBootstrap(parent)
+                    .handler(new SimpleChannelInboundHandler<Http2StreamFrame>() {
+                        private final StringBuilder body = new StringBuilder();
+                        private int statusCode = 0;
+
+                        @Override
+                        protected void channelRead0(ChannelHandlerContext ctx, Http2StreamFrame msg) {
+                            if (msg instanceof Http2HeadersFrame headersFrame) {
+                                CharSequence status = headersFrame.headers().status();
+                                if (status != null) {
+                                    statusCode = Integer.parseInt(status.toString());
+                                }
+                                if (headersFrame.isEndStream()) {
+                                    responseFuture.complete(new H2Response(statusCode, body.toString()));
+                                }
+                            } else if (msg instanceof Http2DataFrame dataFrame) {
+                                body.append(dataFrame.content().toString(StandardCharsets.UTF_8));
+                                if (dataFrame.isEndStream()) {
+                                    responseFuture.complete(new H2Response(statusCode, body.toString()));
+                                }
+                            } else if (msg instanceof Http2ResetFrame resetFrame) {
+                                responseFuture.completeExceptionally(
+                                        new IllegalStateException("RST_STREAM: " + resetFrame.errorCode())
+                                );
+                            }
+                        }
+
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            responseFuture.completeExceptionally(cause);
+                        }
+                    })
+                    .open()
+                    .sync()
+                    .getNow();
+
+            Http2Headers headers = new DefaultHttp2Headers()
+                    .method(HttpMethod.POST.asciiName())
+                    .scheme("http")
+                    .authority(server.getHost() + ":" + server.getPort())
+                    .path("/h2-trailer-test/echo")
+                    .add("content-type", MediaType.APPLICATION_JSON);
+
+            if (contentEncoding != null) {
+                headers.add("content-encoding", contentEncoding);
+            }
+
+            stream.write(new DefaultHttp2HeadersFrame(headers, false));
+
+            // Split body across two DATA frames
+            int split = payload.length / 2;
+            ByteBuf first = Unpooled.wrappedBuffer(payload, 0, split);
+            ByteBuf second = Unpooled.wrappedBuffer(payload, split, payload.length - split);
+
+            stream.write(new DefaultHttp2DataFrame(first, false));
+
+            if (useTrailers) {
+                // Last DATA does NOT carry END_STREAM; trailing HEADERS do
+                stream.write(new DefaultHttp2DataFrame(second, false));
+                Http2Headers trailers = new DefaultHttp2Headers()
+                        .add("x-envoy-peer-metadata", "test");
+                stream.writeAndFlush(new DefaultHttp2HeadersFrame(trailers, true)).sync();
+            } else {
+                // Normal case: last DATA carries END_STREAM
+                stream.writeAndFlush(new DefaultHttp2DataFrame(second, true)).sync();
+            }
+
+            return responseFuture.get(5, TimeUnit.SECONDS);
+        } finally {
+            group.shutdownGracefully().sync();
+        }
+    }
+
+    private static byte[] gzip(byte[] data) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+            gzip.write(data);
+        }
+        return baos.toByteArray();
+    }
+
+    record H2Response(int statusCode, String body) {}
+
+    record JsonRpcRequest(String jsonrpc, int id, String method) {}
+
+    @Requires(property = "spec", value = "Http2TrailerEndOfStreamTest")
+    @Controller("/h2-trailer-test")
+    static class EchoController {
+        @Post(value = "/echo", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+        HttpResponse<String> echo(@Body JsonRpcRequest request) {
+            return HttpResponse.ok("{\"method\":\"" + request.method() + "\"}");
+        }
+    }
+}


### PR DESCRIPTION
When an HTTP/2 request ends with trailing HEADERS carrying END_STREAM (e.g. from Envoy decompressor), the DelegatingDecompressorFrameListener never receives onDataRead(..., endOfStream=true) and so never flushes its decompressor tail bytes. This causes requests to either hang (uncompressed) or complete with a truncated body (compressed).

Add Http2TrailerFlushListener, a frame listener decorator that sits between the decompressor and Http2ServerHandler. When it detects trailing HEADERS with END_STREAM, it routes the signal through the onDataRead path, ensuring the decompressor flushes before the request body is completed.