### PR TITLE
Rename field to prevent any missunderstanding clash

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/graceful/GracefulShutdownConfiguration.java
+++ b/context/src/main/java/io/micronaut/runtime/graceful/GracefulShutdownConfiguration.java
@@ -30,10 +30,10 @@ import java.time.Duration;
  * @author Jonas Konrad
  */
 @ConfigurationProperties(GracefulShutdownConfiguration.PREFIX)
-@Requires(property = GracefulShutdownConfiguration.ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
+@Requires(property = GracefulShutdownConfiguration.MICRONAUT_LIFECYCLE_GRACEFUL_SHUTDOWN_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
 public final class GracefulShutdownConfiguration implements Toggleable {
     public static final String PREFIX = "micronaut.lifecycle.graceful-shutdown";
-    public static final String ENABLED = PREFIX + ".enabled";
+    public static final String MICRONAUT_LIFECYCLE_GRACEFUL_SHUTDOWN_ENABLED = PREFIX + ".enabled";
 
     private boolean enabled;
     private Duration gracePeriod = Duration.ofSeconds(15);

--- a/context/src/main/java/io/micronaut/runtime/graceful/GracefulShutdownListener.java
+++ b/context/src/main/java/io/micronaut/runtime/graceful/GracefulShutdownListener.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeoutException;
  */
 @Singleton
 @Requires(bean = GracefulShutdownManager.class)
-@Requires(property = GracefulShutdownConfiguration.ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
+@Requires(property = GracefulShutdownConfiguration.MICRONAUT_LIFECYCLE_GRACEFUL_SHUTDOWN_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
 @Experimental
 public final class GracefulShutdownListener implements ApplicationEventListener<ShutdownEvent>, Ordered {
     private static final Logger LOG = LoggerFactory.getLogger(GracefulShutdownListener.class);

--- a/core/src/main/java/io/micronaut/core/bind/ArgumentBinder.java
+++ b/core/src/main/java/io/micronaut/core/bind/ArgumentBinder.java
@@ -82,7 +82,7 @@ public interface ArgumentBinder<T, S> {
         /**
          * An empty but unsatisfied result.
          */
-        BindingResult UNSATISFIED = new BindingResult() {
+        BindingResult BINDING_RESULT_UNSATISFIED = new BindingResult() {
             @Override
             public Optional getValue() {
                 return Optional.empty();
@@ -163,7 +163,7 @@ public interface ArgumentBinder<T, S> {
          * @since 4.0.0
          */
         static <R> BindingResult<R> unsatisfied() {
-            return UNSATISFIED;
+            return BINDING_RESULT_UNSATISFIED;
         }
     }
 }

--- a/core/src/main/java/io/micronaut/core/bind/ArgumentBinder.java
+++ b/core/src/main/java/io/micronaut/core/bind/ArgumentBinder.java
@@ -77,7 +77,7 @@ public interface ArgumentBinder<T, S> {
         /**
          * An empty but satisfied result.
          */
-        BindingResult EMPTY = Optional::empty;
+        BindingResult BINDING_RESULT_EMPTY = Optional::empty;
 
         /**
          * An empty but unsatisfied result.
@@ -154,7 +154,7 @@ public interface ArgumentBinder<T, S> {
          * @since 4.0.0
          */
         static <R> BindingResult<R> empty() {
-            return BindingResult.EMPTY;
+            return BindingResult.BINDING_RESULT_EMPTY;
         }
 
         /**

--- a/core/src/test/groovy/io/micronaut/core/bind/ExecutableBinderSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/bind/ExecutableBinderSpec.groovy
@@ -100,7 +100,7 @@ class ExecutableBinderSpec extends Specification {
         ArgumentBinder argumentBinder = Mock(ArgumentBinder)
 
         argumentBinder.bind(_, _) >> ({ args ->
-            return ArgumentBinder.BindingResult.UNSATISFIED
+            return ArgumentBinder.BindingResult.BINDING_RESULT_UNSATISFIED
         } )
 
         registry.findArgumentBinder(_) >> Optional.of( argumentBinder)
@@ -138,7 +138,7 @@ class ExecutableBinderSpec extends Specification {
         ArgumentBinder argumentBinder = Mock(ArgumentBinder)
 
         argumentBinder.bind(_, _) >> ({ args ->
-            return ArgumentBinder.BindingResult.UNSATISFIED
+            return ArgumentBinder.BindingResult.BINDING_RESULT_UNSATISFIED
         } )
 
         registry.findArgumentBinder(_) >> Optional.of( argumentBinder)

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyRequestArgumentBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyRequestArgumentBinder.java
@@ -38,7 +38,7 @@ public sealed interface NettyRequestArgumentBinder<T> extends RequestArgumentBin
         if (source instanceof NettyHttpRequest<?> nettyHttpRequest) {
             return bindForNettyRequest(context, nettyHttpRequest);
         }
-        return BindingResult.EMPTY;
+        return BindingResult.BINDING_RESULT_EMPTY;
     }
 
     /**

--- a/http-server/src/main/java/io/micronaut/http/server/binding/BasicAuthArgumentBinder.java
+++ b/http-server/src/main/java/io/micronaut/http/server/binding/BasicAuthArgumentBinder.java
@@ -56,6 +56,6 @@ public class BasicAuthArgumentBinder implements TypedRequestArgumentBinder<Basic
                 return () -> Optional.of(new BasicAuth(values[0], values[1]));
             }
         }
-        return BindingResult.EMPTY;
+        return BindingResult.BINDING_RESULT_EMPTY;
     }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/binding/LocaleArgumentBinder.java
+++ b/http-server/src/main/java/io/micronaut/http/server/binding/LocaleArgumentBinder.java
@@ -55,7 +55,7 @@ public class LocaleArgumentBinder implements TypedRequestArgumentBinder<Locale> 
         if (locale.isPresent()) {
             return () -> locale;
         } else {
-            return BindingResult.UNSATISFIED;
+            return BindingResult.BINDING_RESULT_UNSATISFIED;
         }
     }
 }

--- a/http/src/main/java/io/micronaut/http/bind/binders/DefaultUnmatchedRequestArgumentBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/DefaultUnmatchedRequestArgumentBinder.java
@@ -87,7 +87,7 @@ public final class DefaultUnmatchedRequestArgumentBinder<T> implements Postponed
                 pending.add(pendingRequestBindingResult);
                 allUnsatisfied = false;
             } else {
-                if (result != BindingResult.UNSATISFIED) {
+                if (result != BindingResult.BINDING_RESULT_UNSATISFIED) {
                     errors.addAll(result.getConversionErrors());
                     allUnsatisfied = false;
                 }

--- a/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
@@ -105,7 +105,7 @@ public class RequestBeanAnnotationBinder<T> implements AnnotatedRequestArgumentB
             }
         } else {
             //noinspection unchecked
-            return BindingResult.EMPTY;
+            return BindingResult.BINDING_RESULT_EMPTY;
         }
     }
 

--- a/management/src/test/groovy/io/micronaut/management/health/indicator/GracefulShutdownContextSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/health/indicator/GracefulShutdownContextSpec.groovy
@@ -20,12 +20,12 @@ class GracefulShutdownContextSpec extends Specification {
         given:
         def mgmtPort = SocketUtils.findAvailableTcpPort()
         def ctx = ApplicationContext.run([
-                (GracefulShutdownConfiguration.ENABLED): true,
-                'micronaut.application.name': 'foo',
-                "spec.name": "GracefulShutdownContextSpec",
-                'endpoints.health.sensitive': false,
-                'endpoints.all.port': mgmtPort,
-                'micronaut.http.client.exception-on-error-status': false
+                (GracefulShutdownConfiguration.MICRONAUT_LIFECYCLE_GRACEFUL_SHUTDOWN_ENABLED): true,
+                'micronaut.application.name'                                                 : 'foo',
+                "spec.name"                                                                  : "GracefulShutdownContextSpec",
+                'endpoints.health.sensitive'                                                 : false,
+                'endpoints.all.port'                                                         : mgmtPort,
+                'micronaut.http.client.exception-on-error-status'                            : false
         ])
         def server = ctx.getBean(EmbeddedServer)
         server.start()

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.groovy
@@ -43,7 +43,7 @@ class ShoppingCartRequestArgumentBinder
 
         Cookie cookie = source.cookies.get("shoppingCart")
         if (!cookie) {
-            return BindingResult.EMPTY
+            return BindingResult.BINDING_RESULT_EMPTY
         }
 
         Optional<Map<String, Object>> cookieValue = objectSerializer.deserialize(

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/bind/type/ShoppingCartRequestArgumentBinder.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/bind/type/ShoppingCartRequestArgumentBinder.groovy
@@ -26,7 +26,7 @@ class ShoppingCartRequestArgumentBinder
 
         Cookie cookie = source.cookies.get("shoppingCart")
         if (!cookie) {
-            return BindingResult.EMPTY
+            return BindingResult.BINDING_RESULT_EMPTY
         }
 
         return () -> objectSerializer.deserialize( //<2>

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.kt
@@ -28,7 +28,7 @@ class ShoppingCartRequestArgumentBinder(
             .stringValue(ShoppingCart::class.java)
             .orElse(context.argument.name)
 
-        val cookie = source.cookies.get("shoppingCart") ?: return BindingResult.EMPTY
+        val cookie = source.cookies.get("shoppingCart") ?: return BindingResult.BINDING_RESULT_EMPTY
 
         val cookieValue: Optional<Map<String, Any>> = objectSerializer.deserialize(
                 cookie.value.toByteArray(),

--- a/test-suite/src/test/groovy/io/micronaut/upload/PrincipalBinder.java
+++ b/test-suite/src/test/groovy/io/micronaut/upload/PrincipalBinder.java
@@ -23,7 +23,7 @@ public class PrincipalBinder implements TypedRequestArgumentBinder<Principal> {
         if (existing.isPresent()) {
             return () -> existing;
         } else {
-            return BindingResult.EMPTY;
+            return BindingResult.BINDING_RESULT_EMPTY;
         }
     }
 }

--- a/test-suite/src/test/java/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.java
@@ -42,7 +42,7 @@ public class ShoppingCartRequestArgumentBinder
 
         Cookie cookie = source.getCookies().get("shoppingCart");
         if (cookie == null) {
-            return BindingResult.EMPTY;
+            return BindingResult.BINDING_RESULT_EMPTY;
         }
 
         Optional<Map<String, Object>> cookieValue = objectSerializer.deserialize(

--- a/websocket/src/main/java/io/micronaut/websocket/bind/WebSocketStateBinderRegistry.java
+++ b/websocket/src/main/java/io/micronaut/websocket/bind/WebSocketStateBinderRegistry.java
@@ -79,7 +79,7 @@ public class WebSocketStateBinderRegistry implements ArgumentBinderRegistry<WebS
             ConvertibleValues<Object> uriVariables = source.getSession().getUriVariables();
             if (uriVariables.contains(argument.getName())) {
                 Optional<T> val = uriVariables.get(argument.getName(), argument);
-                return val.isEmpty() ? ArgumentBinder.BindingResult.UNSATISFIED : () -> val;
+                return val.isEmpty() ? ArgumentBinder.BindingResult.BINDING_RESULT_UNSATISFIED : () -> val;
             }
             return (ArgumentBinder.BindingResult<T>) queryValueArgumentBinder.bind((ArgumentConversionContext<Object>) context, source.getOriginatingRequest());
         });


### PR DESCRIPTION
I am not sure I like this change, but it satisfies Sonar's complaints about name clashes.