### PR TITLE
ensure consistent use of context class loader

### DIFF
--- a/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
+++ b/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
@@ -49,11 +49,11 @@ class DefaultBeanIntrospector implements BeanIntrospector {
     private final ClassLoader classLoader;
 
     DefaultBeanIntrospector() {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        if (cl == null) {
-            cl = DefaultBeanIntrospector.class.getClassLoader();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = DefaultBeanIntrospector.class.getClassLoader();
         }
-        this.classLoader = cl;
+        this.classLoader = classLoader;
     }
 
     DefaultBeanIntrospector(ClassLoader classLoader) {

--- a/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
+++ b/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
@@ -49,7 +49,11 @@ class DefaultBeanIntrospector implements BeanIntrospector {
     private final ClassLoader classLoader;
 
     DefaultBeanIntrospector() {
-        this.classLoader = DefaultBeanIntrospector.class.getClassLoader();
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = DefaultBeanIntrospector.class.getClassLoader();
+        }
+        this.classLoader = cl;
     }
 
     DefaultBeanIntrospector(ClassLoader classLoader) {

--- a/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
+++ b/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
@@ -49,11 +49,7 @@ class DefaultBeanIntrospector implements BeanIntrospector {
     private final ClassLoader classLoader;
 
     DefaultBeanIntrospector() {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        if (cl == null) {
-            cl = DefaultBeanIntrospector.class.getClassLoader();
-        }
-        this.classLoader = cl;
+        this.classLoader = DefaultBeanIntrospector.class.getClassLoader();
     }
 
     DefaultBeanIntrospector(ClassLoader classLoader) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParser.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParser.java
@@ -95,11 +95,11 @@ public class AccessLogFormatParser {
     private String[] elements;
 
     static {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        if (cl == null) {
-            cl = LogElementBuilder.class.getClassLoader();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = LogElementBuilder.class.getClassLoader();
         }
-        SoftServiceLoader<LogElementBuilder> builders = SoftServiceLoader.load(LogElementBuilder.class, cl)
+        SoftServiceLoader<LogElementBuilder> builders = SoftServiceLoader.load(LogElementBuilder.class, classLoader)
             .disableFork();
         LOG_ELEMENT_BUILDERS = new ArrayList<>();
         builders.collectAll(LOG_ELEMENT_BUILDERS);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParser.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParser.java
@@ -95,7 +95,11 @@ public class AccessLogFormatParser {
     private String[] elements;
 
     static {
-        SoftServiceLoader<LogElementBuilder> builders = SoftServiceLoader.load(LogElementBuilder.class, LogElementBuilder.class.getClassLoader())
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = LogElementBuilder.class.getClassLoader();
+        }
+        SoftServiceLoader<LogElementBuilder> builders = SoftServiceLoader.load(LogElementBuilder.class, cl)
             .disableFork();
         LOG_ELEMENT_BUILDERS = new ArrayList<>();
         builders.collectAll(LOG_ELEMENT_BUILDERS);

--- a/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
@@ -79,13 +79,21 @@ public class DefaultPropertyPlaceholderResolver implements PropertyPlaceholderRe
                 exResolvers = this.expressionResolvers;
                 if (exResolvers == null) {
                     exResolvers = new ArrayList<>(DEFAULT_EXPRESSION_RESOLVERS);
-                    ClassLoader classLoader = (environment instanceof Environment e) ? e.getClassLoader() : environment.getClass().getClassLoader();
+                    ClassLoader classLoader = (environment instanceof Environment e) ? e.getClassLoader() : fallbackClassLoader();
                     SoftServiceLoader.load(PropertyExpressionResolver.class, classLoader).collectAll(exResolvers);
                     this.expressionResolvers = exResolvers;
                 }
             }
         }
         return exResolvers;
+    }
+
+    private ClassLoader fallbackClassLoader() {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        if (contextClassLoader != null) {
+            return contextClassLoader;
+        }
+        return environment.getClass().getClassLoader();
     }
 
     @Override


### PR DESCRIPTION
If an application is loaded with the alternative context loader there are cases where this context loader is not used. This addresses those cases.