### PR TITLE
Add programmatic retry and circuit breaker APIs

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/retry/HttpClientWithCircuitBreakerSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/retry/HttpClientWithCircuitBreakerSpec.groovy
@@ -71,8 +71,8 @@ class HttpClientWithCircuitBreakerSpec extends Specification {
         then:"The original exception is thrown"
         HttpClientResponseException e = thrown()
         e.response.getBody(Map).get()._embedded.errors[0].message == "Internal Server Error: Bad count"
-        controller.countValue == 6
-        countFilter.requests.size() == 6
+        controller.countValue == 4
+        countFilter.requests.size() == 4
 
         when:"the method is called again"
         countClient.getCount()
@@ -80,8 +80,8 @@ class HttpClientWithCircuitBreakerSpec extends Specification {
         then:"The value is not incremented because the circuit is open"
         e = thrown(HttpClientResponseException)
         e.response.getBody(Map).get()._embedded.errors[0].message == "Internal Server Error: Bad count"
-        controller.countValue == 6
-        countFilter.requests.size() == 6
+        controller.countValue == 4
+        countFilter.requests.size() == 4
     }
 
     void "test simply retry with reactive publisher"() {
@@ -138,7 +138,7 @@ class HttpClientWithCircuitBreakerSpec extends Specification {
 
     @Requires(property = 'spec.name', value = 'HttpClientWithCircuitBreakerSpec')
     @Client("/circuit-breaker-test")
-    @CircuitBreaker(attempts = '5', delay = '5ms')
+    @CircuitBreaker(attempts = '3', delay = '5ms')
     static interface CountClient extends CountService {
 
     }

--- a/http-client/src/test/groovy/io/micronaut/http/client/retry/HttpClientWithCircuitBreakerSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/retry/HttpClientWithCircuitBreakerSpec.groovy
@@ -110,8 +110,8 @@ class HttpClientWithCircuitBreakerSpec extends Specification {
         then:"The original exception is thrown"
         HttpClientResponseException e = thrown()
         e.response.getBody(Map).get()._embedded.errors[0].message == "Internal Server Error: Bad count"
-        controller.countRx == 6
-        countFilter.requests.size() == 6
+        controller.countRx == 4
+        countFilter.requests.size() == 4
 
         when:"The method is called again"
         single = countClient.getCountSingle()
@@ -120,8 +120,8 @@ class HttpClientWithCircuitBreakerSpec extends Specification {
         then:"The value is not incremented because the circuit is open"
         e = thrown()
         e.response.getBody(Map).get()._embedded.errors[0].message == "Internal Server Error: Bad count"
-        controller.countRx == 6
-        countFilter.requests.size() == 6
+        controller.countRx == 4
+        countFilter.requests.size() == 4
     }
 
     @Requires(property = 'spec.name', value = 'HttpClientWithCircuitBreakerSpec')

--- a/retry/src/main/java/io/micronaut/retry/CircuitBreakerOperations.java
+++ b/retry/src/main/java/io/micronaut/retry/CircuitBreakerOperations.java
@@ -13,24 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.retry.intercept;
-
-import io.micronaut.core.annotation.Internal;
-import io.micronaut.retry.RetryState;
+package io.micronaut.retry;
 
 /**
- * Mutable retry state that can calculate the next retry delay.
+ * Programmatic circuit breaker operations.
  *
  * @author graemerocher
- * @since 1.0
+ * @since 5.0.0
  */
-@Internal
-public interface MutableRetryState extends RetryState {
+public interface CircuitBreakerOperations extends RetryOperations {
 
     /**
-     * Returns the millisecond value for the next delay.
+     * Returns the current circuit state for this operations instance.
      *
-     * @return The next delay in milliseconds
+     * @return The current circuit state
      */
-    long nextDelay();
+    CircuitState currentState();
 }

--- a/retry/src/main/java/io/micronaut/retry/CircuitBreakerOperationsFactory.java
+++ b/retry/src/main/java/io/micronaut/retry/CircuitBreakerOperationsFactory.java
@@ -13,24 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.retry.intercept;
-
-import io.micronaut.core.annotation.Internal;
-import io.micronaut.retry.RetryState;
+package io.micronaut.retry;
 
 /**
- * Mutable retry state that can calculate the next retry delay.
+ * Factory for programmatic circuit breaker operations.
  *
  * @author graemerocher
- * @since 1.0
+ * @since 5.0.0
  */
-@Internal
-public interface MutableRetryState extends RetryState {
+public interface CircuitBreakerOperationsFactory {
 
     /**
-     * Returns the millisecond value for the next delay.
+     * Creates reusable circuit breaker operations for the given policy.
      *
-     * @return The next delay in milliseconds
+     * @param circuitBreakerPolicy The circuit breaker policy to apply
+     * @return Reusable circuit breaker operations
      */
-    long nextDelay();
+    CircuitBreakerOperations createCircuitBreakerOperations(CircuitBreakerPolicy circuitBreakerPolicy);
 }

--- a/retry/src/main/java/io/micronaut/retry/CircuitBreakerPolicy.java
+++ b/retry/src/main/java/io/micronaut/retry/CircuitBreakerPolicy.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.retry;
 
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.retry.annotation.RetryPredicate;
 
 import java.time.Duration;
@@ -29,9 +28,14 @@ import java.util.Optional;
  * @author graemerocher
  * @since 5.0.0
  */
-public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
-                                   @NonNull Duration resetTimeout,
+public record CircuitBreakerPolicy(RetryPolicy retryPolicy,
+                                   Duration resetTimeout,
                                    boolean throwWrappedException) {
+
+    public static final Duration DEFAULT_DELAY = Duration.ofMillis(500);
+    public static final Duration DEFAULT_MAX_DELAY = Duration.ofSeconds(5);
+    public static final double DEFAULT_MULTIPLIER = 0.0d;
+    public static final Duration DEFAULT_RESET_TIMEOUT = Duration.ofSeconds(20);
 
     public CircuitBreakerPolicy {
         Objects.requireNonNull(retryPolicy, "retryPolicy");
@@ -46,7 +50,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      *
      * @return A circuit breaker policy builder
      */
-    public static @NonNull Builder builder() {
+    public static Builder builder() {
         return new Builder();
     }
 
@@ -64,7 +68,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      *
      * @return The delay between retry attempts
      */
-    public @NonNull Duration getDelay() {
+    public Duration getDelay() {
         return retryPolicy.delay();
     }
 
@@ -73,7 +77,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      *
      * @return The maximum overall delay if configured
      */
-    public @NonNull Optional<Duration> getMaxDelay() {
+    public Optional<Duration> getMaxDelay() {
         return retryPolicy.getMaxDelay();
     }
 
@@ -100,7 +104,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      *
      * @return The retry predicate
      */
-    public @NonNull RetryPredicate getPredicate() {
+    public RetryPredicate getPredicate() {
         return retryPolicy.predicate();
     }
 
@@ -109,7 +113,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      *
      * @return The captured exception type
      */
-    public @NonNull Class<? extends Throwable> getCapturedException() {
+    public Class<? extends Throwable> getCapturedException() {
         return retryPolicy.capturedException();
     }
 
@@ -118,7 +122,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      *
      * @return The included exception types
      */
-    public @NonNull List<Class<? extends Throwable>> getIncludes() {
+    public List<Class<? extends Throwable>> getIncludes() {
         return retryPolicy.includes();
     }
 
@@ -127,7 +131,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      *
      * @return The excluded exception types
      */
-    public @NonNull List<Class<? extends Throwable>> getExcludes() {
+    public List<Class<? extends Throwable>> getExcludes() {
         return retryPolicy.excludes();
     }
 
@@ -136,7 +140,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      *
      * @return The circuit reset timeout
      */
-    public @NonNull Duration getResetTimeout() {
+    public Duration getResetTimeout() {
         return resetTimeout;
     }
 
@@ -154,7 +158,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      *
      * @return The retry policy view
      */
-    public @NonNull RetryPolicy asRetryPolicy() {
+    public RetryPolicy asRetryPolicy() {
         return retryPolicy;
     }
 
@@ -163,10 +167,10 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
      */
     public static final class Builder {
         private final RetryPolicy.Builder retryPolicyBuilder = RetryPolicy.builder()
-            .delay(Duration.ofMillis(500))
-            .multiplier(0.0d)
-            .maxDelay(Duration.ofSeconds(5));
-        private Duration resetTimeout = Duration.ofSeconds(20);
+            .delay(DEFAULT_DELAY)
+            .multiplier(DEFAULT_MULTIPLIER)
+            .maxDelay(DEFAULT_MAX_DELAY);
+        private Duration resetTimeout = DEFAULT_RESET_TIMEOUT;
         private boolean throwWrappedException;
 
         private Builder() {
@@ -178,7 +182,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @param maxAttempts The maximum number of attempts
          * @return This builder
          */
-        public @NonNull Builder maxAttempts(int maxAttempts) {
+        public Builder maxAttempts(int maxAttempts) {
             retryPolicyBuilder.maxAttempts(maxAttempts);
             return this;
         }
@@ -189,7 +193,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @param delay The delay between retry attempts
          * @return This builder
          */
-        public @NonNull Builder delay(@NonNull Duration delay) {
+        public Builder delay(Duration delay) {
             retryPolicyBuilder.delay(delay);
             return this;
         }
@@ -200,7 +204,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @param maxDelay The maximum overall delay
          * @return This builder
          */
-        public @NonNull Builder maxDelay(Duration maxDelay) {
+        public Builder maxDelay(Duration maxDelay) {
             retryPolicyBuilder.maxDelay(maxDelay);
             return this;
         }
@@ -211,7 +215,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @param multiplier The delay multiplier
          * @return This builder
          */
-        public @NonNull Builder multiplier(double multiplier) {
+        public Builder multiplier(double multiplier) {
             retryPolicyBuilder.multiplier(multiplier);
             return this;
         }
@@ -222,7 +226,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @param jitter The jitter factor
          * @return This builder
          */
-        public @NonNull Builder jitter(double jitter) {
+        public Builder jitter(double jitter) {
             retryPolicyBuilder.jitter(jitter);
             return this;
         }
@@ -233,7 +237,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @param predicate The retry predicate
          * @return This builder
          */
-        public @NonNull Builder predicate(@NonNull RetryPredicate predicate) {
+        public Builder predicate(RetryPredicate predicate) {
             retryPolicyBuilder.predicate(predicate);
             return this;
         }
@@ -244,7 +248,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @param capturedException The captured exception type
          * @return This builder
          */
-        public @NonNull Builder capturedException(@NonNull Class<? extends Throwable> capturedException) {
+        public Builder capturedException(Class<? extends Throwable> capturedException) {
             retryPolicyBuilder.capturedException(capturedException);
             return this;
         }
@@ -256,7 +260,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @return This builder
          */
         @SafeVarargs
-        public final @NonNull Builder includes(@NonNull Class<? extends Throwable>... includes) {
+        public final Builder includes(Class<? extends Throwable>... includes) {
             retryPolicyBuilder.includes(includes);
             return this;
         }
@@ -268,7 +272,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @return This builder
          */
         @SafeVarargs
-        public final @NonNull Builder excludes(@NonNull Class<? extends Throwable>... excludes) {
+        public final Builder excludes(Class<? extends Throwable>... excludes) {
             retryPolicyBuilder.excludes(excludes);
             return this;
         }
@@ -279,7 +283,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @param resetTimeout The circuit reset timeout
          * @return This builder
          */
-        public @NonNull Builder resetTimeout(@NonNull Duration resetTimeout) {
+        public Builder resetTimeout(Duration resetTimeout) {
             this.resetTimeout = resetTimeout;
             return this;
         }
@@ -290,7 +294,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          * @param throwWrappedException Whether open-circuit exceptions should be wrapped
          * @return This builder
          */
-        public @NonNull Builder throwWrappedException(boolean throwWrappedException) {
+        public Builder throwWrappedException(boolean throwWrappedException) {
             this.throwWrappedException = throwWrappedException;
             return this;
         }
@@ -300,7 +304,7 @@ public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
          *
          * @return The circuit breaker policy
          */
-        public @NonNull CircuitBreakerPolicy build() {
+        public CircuitBreakerPolicy build() {
             return new CircuitBreakerPolicy(retryPolicyBuilder.build(), resetTimeout, throwWrappedException);
         }
     }

--- a/retry/src/main/java/io/micronaut/retry/CircuitBreakerPolicy.java
+++ b/retry/src/main/java/io/micronaut/retry/CircuitBreakerPolicy.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.retry.annotation.RetryPredicate;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Typed circuit breaker policy for programmatic execution.
+ *
+ * @author graemerocher
+ * @since 5.0.0
+ */
+public record CircuitBreakerPolicy(@NonNull RetryPolicy retryPolicy,
+                                   @NonNull Duration resetTimeout,
+                                   boolean throwWrappedException) {
+
+    public CircuitBreakerPolicy {
+        Objects.requireNonNull(retryPolicy, "retryPolicy");
+        Objects.requireNonNull(resetTimeout, "resetTimeout");
+        if (resetTimeout.isZero() || resetTimeout.isNegative()) {
+            throw new IllegalArgumentException("resetTimeout must be greater than 0");
+        }
+    }
+
+    /**
+     * Creates a circuit breaker policy builder.
+     *
+     * @return A circuit breaker policy builder
+     */
+    public static @NonNull Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns the maximum number of attempts.
+     *
+     * @return The maximum number of attempts
+     */
+    public int getMaxAttempts() {
+        return retryPolicy.maxAttempts();
+    }
+
+    /**
+     * Returns the delay between retry attempts.
+     *
+     * @return The delay between retry attempts
+     */
+    public @NonNull Duration getDelay() {
+        return retryPolicy.delay();
+    }
+
+    /**
+     * Returns the maximum overall delay.
+     *
+     * @return The maximum overall delay if configured
+     */
+    public @NonNull Optional<Duration> getMaxDelay() {
+        return retryPolicy.getMaxDelay();
+    }
+
+    /**
+     * Returns the delay multiplier.
+     *
+     * @return The delay multiplier
+     */
+    public double getMultiplier() {
+        return retryPolicy.multiplier();
+    }
+
+    /**
+     * Returns the retry jitter factor.
+     *
+     * @return The retry jitter factor
+     */
+    public double getJitter() {
+        return retryPolicy.jitter();
+    }
+
+    /**
+     * Returns the retry predicate.
+     *
+     * @return The retry predicate
+     */
+    public @NonNull RetryPredicate getPredicate() {
+        return retryPolicy.predicate();
+    }
+
+    /**
+     * Returns the captured exception type.
+     *
+     * @return The captured exception type
+     */
+    public @NonNull Class<? extends Throwable> getCapturedException() {
+        return retryPolicy.capturedException();
+    }
+
+    /**
+     * Returns the included exception types.
+     *
+     * @return The included exception types
+     */
+    public @NonNull List<Class<? extends Throwable>> getIncludes() {
+        return retryPolicy.includes();
+    }
+
+    /**
+     * Returns the excluded exception types.
+     *
+     * @return The excluded exception types
+     */
+    public @NonNull List<Class<? extends Throwable>> getExcludes() {
+        return retryPolicy.excludes();
+    }
+
+    /**
+     * Returns the circuit reset timeout.
+     *
+     * @return The circuit reset timeout
+     */
+    public @NonNull Duration getResetTimeout() {
+        return resetTimeout;
+    }
+
+    /**
+     * Returns whether open-circuit exceptions should be wrapped.
+     *
+     * @return Whether open-circuit exceptions should be wrapped
+     */
+    public boolean isThrowWrappedException() {
+        return throwWrappedException;
+    }
+
+    /**
+     * Returns the retry policy view of this circuit breaker policy.
+     *
+     * @return The retry policy view
+     */
+    public @NonNull RetryPolicy asRetryPolicy() {
+        return retryPolicy;
+    }
+
+    /**
+     * Builder for {@link CircuitBreakerPolicy}.
+     */
+    public static final class Builder {
+        private final RetryPolicy.Builder retryPolicyBuilder = RetryPolicy.builder()
+            .delay(Duration.ofMillis(500))
+            .multiplier(0.0d)
+            .maxDelay(Duration.ofSeconds(5));
+        private Duration resetTimeout = Duration.ofSeconds(20);
+        private boolean throwWrappedException;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the maximum number of attempts.
+         *
+         * @param maxAttempts The maximum number of attempts
+         * @return This builder
+         */
+        public @NonNull Builder maxAttempts(int maxAttempts) {
+            retryPolicyBuilder.maxAttempts(maxAttempts);
+            return this;
+        }
+
+        /**
+         * Sets the delay between retry attempts.
+         *
+         * @param delay The delay between retry attempts
+         * @return This builder
+         */
+        public @NonNull Builder delay(@NonNull Duration delay) {
+            retryPolicyBuilder.delay(delay);
+            return this;
+        }
+
+        /**
+         * Sets the maximum overall delay.
+         *
+         * @param maxDelay The maximum overall delay
+         * @return This builder
+         */
+        public @NonNull Builder maxDelay(Duration maxDelay) {
+            retryPolicyBuilder.maxDelay(maxDelay);
+            return this;
+        }
+
+        /**
+         * Sets the delay multiplier.
+         *
+         * @param multiplier The delay multiplier
+         * @return This builder
+         */
+        public @NonNull Builder multiplier(double multiplier) {
+            retryPolicyBuilder.multiplier(multiplier);
+            return this;
+        }
+
+        /**
+         * Sets the jitter factor.
+         *
+         * @param jitter The jitter factor
+         * @return This builder
+         */
+        public @NonNull Builder jitter(double jitter) {
+            retryPolicyBuilder.jitter(jitter);
+            return this;
+        }
+
+        /**
+         * Sets the retry predicate.
+         *
+         * @param predicate The retry predicate
+         * @return This builder
+         */
+        public @NonNull Builder predicate(@NonNull RetryPredicate predicate) {
+            retryPolicyBuilder.predicate(predicate);
+            return this;
+        }
+
+        /**
+         * Sets the captured exception type.
+         *
+         * @param capturedException The captured exception type
+         * @return This builder
+         */
+        public @NonNull Builder capturedException(@NonNull Class<? extends Throwable> capturedException) {
+            retryPolicyBuilder.capturedException(capturedException);
+            return this;
+        }
+
+        /**
+         * Adds included exception types.
+         *
+         * @param includes The included exception types
+         * @return This builder
+         */
+        @SafeVarargs
+        public final @NonNull Builder includes(@NonNull Class<? extends Throwable>... includes) {
+            retryPolicyBuilder.includes(includes);
+            return this;
+        }
+
+        /**
+         * Adds excluded exception types.
+         *
+         * @param excludes The excluded exception types
+         * @return This builder
+         */
+        @SafeVarargs
+        public final @NonNull Builder excludes(@NonNull Class<? extends Throwable>... excludes) {
+            retryPolicyBuilder.excludes(excludes);
+            return this;
+        }
+
+        /**
+         * Sets the circuit reset timeout.
+         *
+         * @param resetTimeout The circuit reset timeout
+         * @return This builder
+         */
+        public @NonNull Builder resetTimeout(@NonNull Duration resetTimeout) {
+            this.resetTimeout = resetTimeout;
+            return this;
+        }
+
+        /**
+         * Sets whether open-circuit exceptions should be wrapped.
+         *
+         * @param throwWrappedException Whether open-circuit exceptions should be wrapped
+         * @return This builder
+         */
+        public @NonNull Builder throwWrappedException(boolean throwWrappedException) {
+            this.throwWrappedException = throwWrappedException;
+            return this;
+        }
+
+        /**
+         * Builds the circuit breaker policy.
+         *
+         * @return The circuit breaker policy
+         */
+        public @NonNull CircuitBreakerPolicy build() {
+            return new CircuitBreakerPolicy(retryPolicyBuilder.build(), resetTimeout, throwWrappedException);
+        }
+    }
+}

--- a/retry/src/main/java/io/micronaut/retry/CircuitBreakerPolicy.java
+++ b/retry/src/main/java/io/micronaut/retry/CircuitBreakerPolicy.java
@@ -25,6 +25,9 @@ import java.util.Optional;
 /**
  * Typed circuit breaker policy for programmatic execution.
  *
+ * @param retryPolicy The retry policy used by the circuit breaker
+ * @param resetTimeout The timeout before the circuit transitions to half open
+ * @param throwWrappedException Whether open-circuit exceptions should be wrapped
  * @author graemerocher
  * @since 5.0.0
  */

--- a/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperations.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperations.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry;
+
+import io.micronaut.retry.intercept.CircuitBreakerRetry;
+import io.micronaut.retry.intercept.DefaultRetryRunner;
+import io.micronaut.retry.intercept.PolicyRetryStateBuilder;
+import io.micronaut.retry.intercept.RetryEventEmitter;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ReturnType;
+import io.micronaut.inject.ExecutableMethod;
+import org.jspecify.annotations.Nullable;
+import org.reactivestreams.Publisher;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Internal implementation of {@link CircuitBreakerOperations} that owns a shared circuit state for the created
+ * operations instance while delegating execution to the shared retry runner.
+ */
+final class DefaultCircuitBreakerOperations implements CircuitBreakerOperations {
+
+    private final DefaultRetryRunner retryRunner;
+    private final CircuitBreakerRetry retryState;
+    private final RetryEventEmitter retryEventEmitter;
+    private final ExecutableMethod<Object, Object> executableMethod = new ProgrammaticExecutableMethod();
+
+    DefaultCircuitBreakerOperations(CircuitBreakerPolicy circuitBreakerPolicy,
+                                    DefaultRetryRunner retryRunner,
+                                    RetryEventEmitter retryEventEmitter) {
+        this.retryRunner = retryRunner;
+        this.retryEventEmitter = retryEventEmitter;
+        this.retryState = new CircuitBreakerRetry(
+            circuitBreakerPolicy.getResetTimeout().toMillis(),
+            new PolicyRetryStateBuilder(circuitBreakerPolicy.asRetryPolicy()),
+            executableMethod,
+            null,
+            circuitBreakerPolicy.isThrowWrappedException()
+        );
+    }
+
+    @Override
+    public <T> T execute(Supplier<T> supplier) {
+        retryState.open();
+        return retryRunner.executeSync(supplier, retryState, DefaultCircuitBreakerOperations.class.getSimpleName(), retryEventEmitter);
+    }
+
+    @Override
+    public <T> CompletionStage<T> executeCompletionStage(Supplier<? extends CompletionStage<T>> supplier) {
+        retryState.open();
+        return retryRunner.executeCompletionStage(supplier, retryState, DefaultCircuitBreakerOperations.class.getSimpleName(), retryEventEmitter);
+    }
+
+    @Override
+    public <T> Publisher<T> executePublisher(Supplier<? extends Publisher<T>> supplier) {
+        retryState.open();
+        return retryRunner.executePublisher(supplier, retryState, DefaultCircuitBreakerOperations.class.getSimpleName(), retryEventEmitter);
+    }
+
+    @Override
+    public CircuitState currentState() {
+        @Nullable CircuitState circuitState = retryState.currentState();
+        return circuitState == null ? CircuitState.CLOSED : circuitState;
+    }
+
+    private static final class ProgrammaticExecutableMethod implements ExecutableMethod<Object, Object> {
+
+        @Override
+        public Class<Object> getDeclaringType() {
+            return Object.class;
+        }
+
+        @Override
+        public String getMethodName() {
+            return "programmaticCircuitBreaker";
+        }
+
+        @Override
+        public Argument<?>[] getArguments() {
+            return Argument.ZERO_ARGUMENTS;
+        }
+
+        @Override
+        public Method getTargetMethod() {
+            throw new UnsupportedOperationException("No target method for programmatic circuit breaker executable method");
+        }
+
+        @Override
+        public ReturnType<Object> getReturnType() {
+            return ReturnType.of(Object.class);
+        }
+
+        @Override
+        public Object invoke(@Nullable Object instance, Object... arguments) {
+            throw new UnsupportedOperationException("No direct invocation for programmatic circuit breaker executable method");
+        }
+    }
+}

--- a/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperations.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperations.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.retry;
 
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.async.publisher.Publishers;
+import reactor.core.publisher.Flux;
 import io.micronaut.retry.intercept.CircuitBreakerRetry;
 import io.micronaut.retry.intercept.DefaultRetryRunner;
 import io.micronaut.retry.intercept.PolicyRetryStateBuilder;
@@ -33,6 +36,7 @@ import java.util.function.Supplier;
  * Internal implementation of {@link CircuitBreakerOperations} that owns a shared circuit state for the created
  * operations instance while delegating execution to the shared retry runner.
  */
+@Internal
 final class DefaultCircuitBreakerOperations implements CircuitBreakerOperations {
 
     private final DefaultRetryRunner retryRunner;
@@ -68,8 +72,10 @@ final class DefaultCircuitBreakerOperations implements CircuitBreakerOperations 
 
     @Override
     public <T> Publisher<T> executePublisher(Supplier<? extends Publisher<T>> supplier) {
-        retryState.open();
-        return retryRunner.executePublisher(supplier, retryState, DefaultCircuitBreakerOperations.class.getSimpleName(), retryEventEmitter);
+        return Flux.defer(() -> {
+            retryState.open();
+            return Flux.from(retryRunner.executePublisher(supplier, retryState, DefaultCircuitBreakerOperations.class.getSimpleName(), retryEventEmitter));
+        });
     }
 
     @Override

--- a/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperations.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperations.java
@@ -16,7 +16,6 @@
 package io.micronaut.retry;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.async.publisher.Publishers;
 import reactor.core.publisher.Flux;
 import io.micronaut.retry.intercept.CircuitBreakerRetry;
 import io.micronaut.retry.intercept.DefaultRetryRunner;

--- a/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperationsFactory.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperationsFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry;
+
+import io.micronaut.retry.intercept.DefaultRetryRunner;
+import io.micronaut.retry.intercept.RetryEventEmitter;
+import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Internal factory that creates reusable programmatic circuit breaker operations backed by Micronaut scheduler infrastructure.
+ */
+@Singleton
+final class DefaultCircuitBreakerOperationsFactory implements CircuitBreakerOperationsFactory {
+
+    private static final RetryEventEmitter NO_OP_EVENT_EMITTER = (retryState, exception) -> { };
+
+    private final ScheduledExecutorService executorService;
+
+    DefaultCircuitBreakerOperationsFactory(@Named(TaskExecutors.SCHEDULED) ExecutorService executorService) {
+        this.executorService = (ScheduledExecutorService) executorService;
+    }
+
+    @Override
+    public CircuitBreakerOperations createCircuitBreakerOperations(CircuitBreakerPolicy circuitBreakerPolicy) {
+        return new DefaultCircuitBreakerOperations(circuitBreakerPolicy, new DefaultRetryRunner(executorService, NO_OP_EVENT_EMITTER), NO_OP_EVENT_EMITTER);
+    }
+}

--- a/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperationsFactory.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperationsFactory.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.retry;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.retry.intercept.DefaultRetryRunner;
 import io.micronaut.retry.intercept.RetryEventEmitter;
 import io.micronaut.scheduling.TaskExecutors;
@@ -27,6 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * Internal factory that creates reusable programmatic circuit breaker operations backed by Micronaut scheduler infrastructure.
  */
+@Internal
 @Singleton
 final class DefaultCircuitBreakerOperationsFactory implements CircuitBreakerOperationsFactory {
 

--- a/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperationsFactory.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultCircuitBreakerOperationsFactory.java
@@ -42,6 +42,6 @@ final class DefaultCircuitBreakerOperationsFactory implements CircuitBreakerOper
 
     @Override
     public CircuitBreakerOperations createCircuitBreakerOperations(CircuitBreakerPolicy circuitBreakerPolicy) {
-        return new DefaultCircuitBreakerOperations(circuitBreakerPolicy, new DefaultRetryRunner(executorService, NO_OP_EVENT_EMITTER), NO_OP_EVENT_EMITTER);
+        return new DefaultCircuitBreakerOperations(circuitBreakerPolicy, new DefaultRetryRunner(executorService, Thread::sleep), NO_OP_EVENT_EMITTER);
     }
 }

--- a/retry/src/main/java/io/micronaut/retry/DefaultRetryOperations.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultRetryOperations.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry;
+
+import io.micronaut.retry.intercept.DefaultRetryRunner;
+import io.micronaut.retry.intercept.MutableRetryState;
+import io.micronaut.retry.intercept.PolicyRetryStateBuilder;
+import io.micronaut.retry.intercept.RetryEventEmitter;
+import org.reactivestreams.Publisher;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Internal implementation of {@link RetryOperations} that creates a fresh retry state per execution while
+ * reusing the shared retry runner infrastructure.
+ */
+final class DefaultRetryOperations implements RetryOperations {
+
+    private final RetryPolicy retryPolicy;
+    private final DefaultRetryRunner retryRunner;
+    private final RetryEventEmitter retryEventEmitter;
+
+    DefaultRetryOperations(RetryPolicy retryPolicy,
+                           DefaultRetryRunner retryRunner,
+                           RetryEventEmitter retryEventEmitter) {
+        this.retryPolicy = retryPolicy;
+        this.retryRunner = retryRunner;
+        this.retryEventEmitter = retryEventEmitter;
+    }
+
+    @Override
+    public <T> T execute(Supplier<T> supplier) {
+        return retryRunner.executeSync(supplier, newRetryState(), DefaultRetryOperations.class.getSimpleName(), retryEventEmitter);
+    }
+
+    @Override
+    public <T> CompletionStage<T> executeCompletionStage(Supplier<? extends CompletionStage<T>> supplier) {
+        return retryRunner.executeCompletionStage(supplier, newRetryState(), DefaultRetryOperations.class.getSimpleName(), retryEventEmitter);
+    }
+
+    @Override
+    public <T> Publisher<T> executePublisher(Supplier<? extends Publisher<T>> supplier) {
+        return retryRunner.executePublisher(supplier, newRetryState(), DefaultRetryOperations.class.getSimpleName(), retryEventEmitter);
+    }
+
+    private MutableRetryState newRetryState() {
+        return (MutableRetryState) new PolicyRetryStateBuilder(retryPolicy).build();
+    }
+}

--- a/retry/src/main/java/io/micronaut/retry/DefaultRetryOperations.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultRetryOperations.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.retry;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.retry.intercept.DefaultRetryRunner;
 import io.micronaut.retry.intercept.MutableRetryState;
 import io.micronaut.retry.intercept.PolicyRetryStateBuilder;
@@ -28,6 +29,7 @@ import java.util.function.Supplier;
  * Internal implementation of {@link RetryOperations} that creates a fresh retry state per execution while
  * reusing the shared retry runner infrastructure.
  */
+@Internal
 final class DefaultRetryOperations implements RetryOperations {
 
     private final RetryPolicy retryPolicy;

--- a/retry/src/main/java/io/micronaut/retry/DefaultRetryOperationsFactory.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultRetryOperationsFactory.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.retry;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.retry.intercept.DefaultRetryRunner;
 import io.micronaut.retry.intercept.RetryEventEmitter;
 import io.micronaut.scheduling.TaskExecutors;
@@ -27,6 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * Internal factory that adapts Micronaut-managed scheduler infrastructure into reusable programmatic retry operations.
  */
+@Internal
 @Singleton
 final class DefaultRetryOperationsFactory implements RetryOperationsFactory {
 

--- a/retry/src/main/java/io/micronaut/retry/DefaultRetryOperationsFactory.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultRetryOperationsFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry;
+
+import io.micronaut.retry.intercept.DefaultRetryRunner;
+import io.micronaut.retry.intercept.RetryEventEmitter;
+import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Internal factory that adapts Micronaut-managed scheduler infrastructure into reusable programmatic retry operations.
+ */
+@Singleton
+final class DefaultRetryOperationsFactory implements RetryOperationsFactory {
+
+    private static final RetryEventEmitter NO_OP_EVENT_EMITTER = (retryState, exception) -> { };
+
+    private final ScheduledExecutorService executorService;
+
+    DefaultRetryOperationsFactory(@Named(TaskExecutors.SCHEDULED) ExecutorService executorService) {
+        this.executorService = (ScheduledExecutorService) executorService;
+    }
+
+    @Override
+    public RetryOperations createRetryOperations(RetryPolicy retryPolicy) {
+        return new DefaultRetryOperations(retryPolicy, new DefaultRetryRunner(executorService, NO_OP_EVENT_EMITTER), NO_OP_EVENT_EMITTER);
+    }
+}

--- a/retry/src/main/java/io/micronaut/retry/DefaultRetryOperationsFactory.java
+++ b/retry/src/main/java/io/micronaut/retry/DefaultRetryOperationsFactory.java
@@ -42,6 +42,6 @@ final class DefaultRetryOperationsFactory implements RetryOperationsFactory {
 
     @Override
     public RetryOperations createRetryOperations(RetryPolicy retryPolicy) {
-        return new DefaultRetryOperations(retryPolicy, new DefaultRetryRunner(executorService, NO_OP_EVENT_EMITTER), NO_OP_EVENT_EMITTER);
+        return new DefaultRetryOperations(retryPolicy, new DefaultRetryRunner(executorService, Thread::sleep), NO_OP_EVENT_EMITTER);
     }
 }

--- a/retry/src/main/java/io/micronaut/retry/RetryOperations.java
+++ b/retry/src/main/java/io/micronaut/retry/RetryOperations.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry;
+
+import org.reactivestreams.Publisher;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Programmatic retry operations.
+ *
+ * @author graemerocher
+ * @since 5.0.0
+ */
+public interface RetryOperations {
+
+    /**
+     * Executes synchronous work with retry.
+     *
+     * @param supplier The supplier to invoke for each attempt
+     * @param <T> The result type
+     * @return The computed result
+     */
+    <T> T execute(Supplier<T> supplier);
+
+    /**
+     * Executes asynchronous work backed by a completion stage with retry.
+     *
+     * @param supplier The supplier that creates a new completion stage for each attempt
+     * @param <T> The result type
+     * @return A completion stage representing the retried execution
+     */
+    <T> CompletionStage<T> executeCompletionStage(Supplier<? extends CompletionStage<T>> supplier);
+
+    /**
+     * Executes reactive work backed by a publisher with retry.
+     *
+     * @param supplier The supplier that creates a new publisher for each attempt
+     * @param <T> The emitted type
+     * @return A publisher representing the retried execution
+     */
+    <T> Publisher<T> executePublisher(Supplier<? extends Publisher<T>> supplier);
+}

--- a/retry/src/main/java/io/micronaut/retry/RetryOperationsFactory.java
+++ b/retry/src/main/java/io/micronaut/retry/RetryOperationsFactory.java
@@ -13,24 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.retry.intercept;
-
-import io.micronaut.core.annotation.Internal;
-import io.micronaut.retry.RetryState;
+package io.micronaut.retry;
 
 /**
- * Mutable retry state that can calculate the next retry delay.
+ * Factory for programmatic retry operations.
  *
  * @author graemerocher
- * @since 1.0
+ * @since 5.0.0
  */
-@Internal
-public interface MutableRetryState extends RetryState {
+public interface RetryOperationsFactory {
 
     /**
-     * Returns the millisecond value for the next delay.
+     * Creates reusable retry operations for the given policy.
      *
-     * @return The next delay in milliseconds
+     * @param retryPolicy The retry policy to apply
+     * @return Reusable retry operations
      */
-    long nextDelay();
+    RetryOperations createRetryOperations(RetryPolicy retryPolicy);
 }

--- a/retry/src/main/java/io/micronaut/retry/RetryPolicy.java
+++ b/retry/src/main/java/io/micronaut/retry/RetryPolicy.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.retry.annotation.DefaultRetryPredicate;
+import io.micronaut.retry.annotation.RetryPredicate;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Typed retry policy for programmatic retry execution.
+ *
+ * @author graemerocher
+ * @since 5.0.0
+ */
+public record RetryPolicy(int maxAttempts,
+                          @NonNull Duration delay,
+                          @Nullable Duration maxDelay,
+                          double multiplier,
+                          double jitter,
+                          @NonNull RetryPredicate predicate,
+                          @NonNull Class<? extends Throwable> capturedException,
+                          @NonNull List<Class<? extends Throwable>> includes,
+                          @NonNull List<Class<? extends Throwable>> excludes) {
+
+    public RetryPolicy {
+        if (maxAttempts < 1) {
+            throw new IllegalArgumentException("maxAttempts must be greater than or equal to 1");
+        }
+        Objects.requireNonNull(delay, "delay");
+        if (delay.isNegative()) {
+            throw new IllegalArgumentException("delay must be greater than or equal to 0");
+        }
+        if (maxDelay != null && maxDelay.isNegative()) {
+            throw new IllegalArgumentException("maxDelay must be greater than or equal to 0");
+        }
+        if (multiplier < 0) {
+            throw new IllegalArgumentException("multiplier must be greater than or equal to 0");
+        }
+        if (jitter < 0 || jitter > 1) {
+            throw new IllegalArgumentException("jitter must be between 0 and 1");
+        }
+        Objects.requireNonNull(predicate, "predicate");
+        Objects.requireNonNull(capturedException, "capturedException");
+        includes = List.copyOf(Objects.requireNonNull(includes, "includes"));
+        excludes = List.copyOf(Objects.requireNonNull(excludes, "excludes"));
+    }
+
+    /**
+     * Creates a retry policy builder.
+     *
+     * @return A retry policy builder
+     */
+    public static @NonNull Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns the maximum overall delay.
+     *
+     * @return The maximum overall delay if configured
+     */
+    public @NonNull Optional<Duration> getMaxDelay() {
+        return Optional.ofNullable(maxDelay);
+    }
+
+    /**
+     * Builder for {@link RetryPolicy}.
+     */
+    public static final class Builder {
+        private int maxAttempts = 3;
+        private Duration delay = Duration.ofSeconds(1);
+        @Nullable
+        private Duration maxDelay;
+        private double multiplier = 1.0d;
+        private double jitter;
+        private RetryPredicate predicate = new DefaultRetryPredicate();
+        private Class<? extends Throwable> capturedException = RuntimeException.class;
+        private final List<Class<? extends Throwable>> includes = new ArrayList<>();
+        private final List<Class<? extends Throwable>> excludes = new ArrayList<>();
+        private boolean explicitPredicate;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the maximum number of attempts.
+         *
+         * @param maxAttempts The maximum number of attempts
+         * @return This builder
+         */
+        public @NonNull Builder maxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        /**
+         * Sets the delay between retry attempts.
+         *
+         * @param delay The delay between retry attempts
+         * @return This builder
+         */
+        public @NonNull Builder delay(@NonNull Duration delay) {
+            this.delay = delay;
+            return this;
+        }
+
+        /**
+         * Sets the maximum overall delay.
+         *
+         * @param maxDelay The maximum overall delay
+         * @return This builder
+         */
+        public @NonNull Builder maxDelay(@Nullable Duration maxDelay) {
+            this.maxDelay = maxDelay;
+            return this;
+        }
+
+        /**
+         * Sets the delay multiplier.
+         *
+         * @param multiplier The delay multiplier
+         * @return This builder
+         */
+        public @NonNull Builder multiplier(double multiplier) {
+            this.multiplier = multiplier;
+            return this;
+        }
+
+        /**
+         * Sets the jitter factor.
+         *
+         * @param jitter The jitter factor
+         * @return This builder
+         */
+        public @NonNull Builder jitter(double jitter) {
+            this.jitter = jitter;
+            return this;
+        }
+
+        /**
+         * Sets the retry predicate.
+         *
+         * @param predicate The retry predicate
+         * @return This builder
+         */
+        public @NonNull Builder predicate(@NonNull RetryPredicate predicate) {
+            this.predicate = Objects.requireNonNull(predicate, "predicate");
+            explicitPredicate = true;
+            return this;
+        }
+
+        /**
+         * Sets the captured exception type.
+         *
+         * @param capturedException The captured exception type
+         * @return This builder
+         */
+        public @NonNull Builder capturedException(@NonNull Class<? extends Throwable> capturedException) {
+            this.capturedException = Objects.requireNonNull(capturedException, "capturedException");
+            return this;
+        }
+
+        /**
+         * Adds included exception types.
+         *
+         * @param includes The included exception types
+         * @return This builder
+         */
+        @SafeVarargs
+        public final @NonNull Builder includes(@NonNull Class<? extends Throwable>... includes) {
+            Collections.addAll(this.includes, Objects.requireNonNull(includes, "includes"));
+            return this;
+        }
+
+        /**
+         * Adds excluded exception types.
+         *
+         * @param excludes The excluded exception types
+         * @return This builder
+         */
+        @SafeVarargs
+        public final @NonNull Builder excludes(@NonNull Class<? extends Throwable>... excludes) {
+            Collections.addAll(this.excludes, Objects.requireNonNull(excludes, "excludes"));
+            return this;
+        }
+
+        /**
+         * Builds the retry policy.
+         *
+         * @return The retry policy
+         */
+        public @NonNull RetryPolicy build() {
+            RetryPredicate resolvedPredicate = explicitPredicate
+                ? predicate
+                : new DefaultRetryPredicate(List.copyOf(includes), List.copyOf(excludes));
+            return new RetryPolicy(
+                maxAttempts,
+                delay,
+                maxDelay,
+                multiplier,
+                jitter,
+                resolvedPredicate,
+                capturedException,
+                includes,
+                excludes
+            );
+        }
+    }
+}

--- a/retry/src/main/java/io/micronaut/retry/RetryPolicy.java
+++ b/retry/src/main/java/io/micronaut/retry/RetryPolicy.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.retry;
 
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.retry.annotation.DefaultRetryPredicate;
 import io.micronaut.retry.annotation.RetryPredicate;
 import org.jspecify.annotations.Nullable;
@@ -34,14 +33,20 @@ import java.util.Optional;
  * @since 5.0.0
  */
 public record RetryPolicy(int maxAttempts,
-                          @NonNull Duration delay,
+                          Duration delay,
                           @Nullable Duration maxDelay,
                           double multiplier,
                           double jitter,
-                          @NonNull RetryPredicate predicate,
-                          @NonNull Class<? extends Throwable> capturedException,
-                          @NonNull List<Class<? extends Throwable>> includes,
-                          @NonNull List<Class<? extends Throwable>> excludes) {
+                          RetryPredicate predicate,
+                          Class<? extends Throwable> capturedException,
+                          List<Class<? extends Throwable>> includes,
+                          List<Class<? extends Throwable>> excludes) {
+
+    public static final int DEFAULT_MAX_ATTEMPTS = 3;
+    public static final Duration DEFAULT_DELAY = Duration.ofSeconds(1);
+    public static final double DEFAULT_MULTIPLIER = 1.0d;
+    public static final double DEFAULT_JITTER = 0.0d;
+    public static final Class<? extends Throwable> DEFAULT_CAPTURED_EXCEPTION = RuntimeException.class;
 
     public RetryPolicy {
         if (maxAttempts < 1) {
@@ -71,7 +76,7 @@ public record RetryPolicy(int maxAttempts,
      *
      * @return A retry policy builder
      */
-    public static @NonNull Builder builder() {
+    public static Builder builder() {
         return new Builder();
     }
 
@@ -80,7 +85,7 @@ public record RetryPolicy(int maxAttempts,
      *
      * @return The maximum overall delay if configured
      */
-    public @NonNull Optional<Duration> getMaxDelay() {
+    public Optional<Duration> getMaxDelay() {
         return Optional.ofNullable(maxDelay);
     }
 
@@ -88,14 +93,14 @@ public record RetryPolicy(int maxAttempts,
      * Builder for {@link RetryPolicy}.
      */
     public static final class Builder {
-        private int maxAttempts = 3;
-        private Duration delay = Duration.ofSeconds(1);
+        private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+        private Duration delay = DEFAULT_DELAY;
         @Nullable
         private Duration maxDelay;
-        private double multiplier = 1.0d;
-        private double jitter;
+        private double multiplier = DEFAULT_MULTIPLIER;
+        private double jitter = DEFAULT_JITTER;
         private RetryPredicate predicate = new DefaultRetryPredicate();
-        private Class<? extends Throwable> capturedException = RuntimeException.class;
+        private Class<? extends Throwable> capturedException = DEFAULT_CAPTURED_EXCEPTION;
         private final List<Class<? extends Throwable>> includes = new ArrayList<>();
         private final List<Class<? extends Throwable>> excludes = new ArrayList<>();
         private boolean explicitPredicate;
@@ -109,7 +114,7 @@ public record RetryPolicy(int maxAttempts,
          * @param maxAttempts The maximum number of attempts
          * @return This builder
          */
-        public @NonNull Builder maxAttempts(int maxAttempts) {
+        public Builder maxAttempts(int maxAttempts) {
             this.maxAttempts = maxAttempts;
             return this;
         }
@@ -120,7 +125,7 @@ public record RetryPolicy(int maxAttempts,
          * @param delay The delay between retry attempts
          * @return This builder
          */
-        public @NonNull Builder delay(@NonNull Duration delay) {
+        public Builder delay(Duration delay) {
             this.delay = delay;
             return this;
         }
@@ -131,7 +136,7 @@ public record RetryPolicy(int maxAttempts,
          * @param maxDelay The maximum overall delay
          * @return This builder
          */
-        public @NonNull Builder maxDelay(@Nullable Duration maxDelay) {
+        public Builder maxDelay(@Nullable Duration maxDelay) {
             this.maxDelay = maxDelay;
             return this;
         }
@@ -142,7 +147,7 @@ public record RetryPolicy(int maxAttempts,
          * @param multiplier The delay multiplier
          * @return This builder
          */
-        public @NonNull Builder multiplier(double multiplier) {
+        public Builder multiplier(double multiplier) {
             this.multiplier = multiplier;
             return this;
         }
@@ -153,7 +158,7 @@ public record RetryPolicy(int maxAttempts,
          * @param jitter The jitter factor
          * @return This builder
          */
-        public @NonNull Builder jitter(double jitter) {
+        public Builder jitter(double jitter) {
             this.jitter = jitter;
             return this;
         }
@@ -164,7 +169,7 @@ public record RetryPolicy(int maxAttempts,
          * @param predicate The retry predicate
          * @return This builder
          */
-        public @NonNull Builder predicate(@NonNull RetryPredicate predicate) {
+        public Builder predicate(RetryPredicate predicate) {
             this.predicate = Objects.requireNonNull(predicate, "predicate");
             explicitPredicate = true;
             return this;
@@ -176,7 +181,7 @@ public record RetryPolicy(int maxAttempts,
          * @param capturedException The captured exception type
          * @return This builder
          */
-        public @NonNull Builder capturedException(@NonNull Class<? extends Throwable> capturedException) {
+        public Builder capturedException(Class<? extends Throwable> capturedException) {
             this.capturedException = Objects.requireNonNull(capturedException, "capturedException");
             return this;
         }
@@ -188,7 +193,7 @@ public record RetryPolicy(int maxAttempts,
          * @return This builder
          */
         @SafeVarargs
-        public final @NonNull Builder includes(@NonNull Class<? extends Throwable>... includes) {
+        public final Builder includes(Class<? extends Throwable>... includes) {
             Collections.addAll(this.includes, Objects.requireNonNull(includes, "includes"));
             return this;
         }
@@ -200,7 +205,7 @@ public record RetryPolicy(int maxAttempts,
          * @return This builder
          */
         @SafeVarargs
-        public final @NonNull Builder excludes(@NonNull Class<? extends Throwable>... excludes) {
+        public final Builder excludes(Class<? extends Throwable>... excludes) {
             Collections.addAll(this.excludes, Objects.requireNonNull(excludes, "excludes"));
             return this;
         }
@@ -210,7 +215,7 @@ public record RetryPolicy(int maxAttempts,
          *
          * @return The retry policy
          */
-        public @NonNull RetryPolicy build() {
+        public RetryPolicy build() {
             RetryPredicate resolvedPredicate = explicitPredicate
                 ? predicate
                 : new DefaultRetryPredicate(List.copyOf(includes), List.copyOf(excludes));

--- a/retry/src/main/java/io/micronaut/retry/RetryPolicy.java
+++ b/retry/src/main/java/io/micronaut/retry/RetryPolicy.java
@@ -29,6 +29,15 @@ import java.util.Optional;
 /**
  * Typed retry policy for programmatic retry execution.
  *
+ * @param maxAttempts The maximum number of attempts
+ * @param delay The delay between retry attempts
+ * @param maxDelay The maximum overall delay
+ * @param multiplier The delay multiplier
+ * @param jitter The retry jitter factor
+ * @param predicate The retry predicate
+ * @param capturedException The captured exception type
+ * @param includes The included exception types
+ * @param excludes The excluded exception types
  * @author graemerocher
  * @since 5.0.0
  */

--- a/retry/src/main/java/io/micronaut/retry/RetryState.java
+++ b/retry/src/main/java/io/micronaut/retry/RetryState.java
@@ -39,36 +39,50 @@ public interface RetryState {
     boolean canRetry(Throwable exception);
 
     /**
+     * Returns the maximum number of attempts.
+     *
      * @return The maximum number of attempts
      */
     int getMaxAttempts();
 
     /**
+     * Returns the number of the current attempt.
+     *
      * @return The number of the current attempt
      */
     int currentAttempt();
 
     /**
+     * Returns the multiplier to use between delays.
+     *
      * @return The multiplier to use between delays
      */
     OptionalDouble getMultiplier();
 
     /**
+     * Returns the delay between attempts.
+     *
      * @return The delay between attempts
      */
     Duration getDelay();
 
     /**
+     * Returns the overall delay so far.
+     *
      * @return The overall delay so far
      */
     Duration getOverallDelay();
 
     /**
+     * Returns the maximum overall delay.
+     *
      * @return The maximum overall delay
      */
     Optional<Duration> getMaxDelay();
 
     /**
+     * Returns the jitter factor used to apply random deviation to retry delays.
+     *
      * @return The jitter factor used to apply random deviation to retry delays
      */
     default OptionalDouble getJitter() {
@@ -76,14 +90,18 @@ public interface RetryState {
     }
 
     /**
-     * @return The retry predicate checking for includes/excludes throwable classes
+     * Returns the retry predicate checking for includes and excludes throwable classes.
+     *
+     * @return The retry predicate checking for includes and excludes throwable classes
      */
     default RetryPredicate getRetryPredicate() {
         throw new UnsupportedOperationException("Retry predicate not supported on this type");
     }
 
     /**
-     * @return The captured exception type (default to {@link RuntimeException}
+     * Returns the captured exception type, which defaults to {@link RuntimeException}.
+     *
+     * @return The captured exception type
      */
     @Nullable
     Class<? extends Throwable> getCapturedException();

--- a/retry/src/main/java/io/micronaut/retry/RetryStateBuilder.java
+++ b/retry/src/main/java/io/micronaut/retry/RetryStateBuilder.java
@@ -25,7 +25,9 @@ package io.micronaut.retry;
 public interface RetryStateBuilder {
 
     /**
-     * @return Builds retry state
+     * Builds retry state.
+     *
+     * @return The retry state
      */
     RetryState build();
 }

--- a/retry/src/main/java/io/micronaut/retry/annotation/CircuitBreaker.java
+++ b/retry/src/main/java/io/micronaut/retry/annotation/CircuitBreaker.java
@@ -38,21 +38,30 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retryable
 public @interface CircuitBreaker {
 
+    /**
+     * The maximum integral digits for circuit breaker attempts validation.
+     */
     int MAX_RETRY_ATTEMPTS = 4;
 
     /**
+     * Returns the exception types to include, which defaults to all.
+     *
      * @return The exception types to include (defaults to all)
      */
     @AliasFor(annotation = Retryable.class, member = "includes")
     Class<? extends Throwable>[] includes() default {};
 
     /**
+     * Returns the exception types to exclude, which defaults to none.
+     *
      * @return The exception types to exclude (defaults to none)
      */
     @AliasFor(annotation = Retryable.class, member = "excludes")
     Class<? extends Throwable>[] excludes() default {};
 
     /**
+     * Returns the maximum number of retry attempts.
+     *
      * @return The maximum number of retry attempts
      */
     @Digits(integer = MAX_RETRY_ATTEMPTS, fraction = 0)
@@ -60,12 +69,16 @@ public @interface CircuitBreaker {
     String attempts() default "3";
 
     /**
+     * Returns the delay between retry attempts.
+     *
      * @return The delay between retry attempts
      */
     @AliasFor(annotation = Retryable.class, member = "delay")
     String delay() default "500ms";
 
     /**
+     * Returns the multiplier to use to calculate the delay between retries.
+     *
      * @return The multiplier to use to calculate the delay between retries.
      */
     @Digits(integer = 2, fraction = 2)
@@ -90,6 +103,8 @@ public @interface CircuitBreaker {
     String reset() default "20s";
 
     /**
+     * Returns the retry predicate class to use instead of {@link Retryable#includes} and {@link Retryable#excludes}.
+     *
      * @return The retry predicate class to use instead of {@link Retryable#includes} and {@link Retryable#excludes}
      * (defaults to none)
      */

--- a/retry/src/main/java/io/micronaut/retry/annotation/DefaultRetryPredicate.java
+++ b/retry/src/main/java/io/micronaut/retry/annotation/DefaultRetryPredicate.java
@@ -35,6 +35,8 @@ public class DefaultRetryPredicate implements RetryPredicate {
     private final boolean hasExcludes;
 
     /**
+     * Creates a retry predicate with explicit include and exclude rules.
+     *
      * @param includes Classes to include for retry
      * @param excludes Classes to exclude for retry
      */

--- a/retry/src/main/java/io/micronaut/retry/annotation/Fallback.java
+++ b/retry/src/main/java/io/micronaut/retry/annotation/Fallback.java
@@ -36,11 +36,15 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Fallback {
 
     /**
+     * Returns the exception types to include, which defaults to all.
+     *
      * @return The exception types to include (defaults to all)
      */
     Class<? extends Throwable>[] includes() default {};
 
     /**
+     * Returns the exception types to exclude, which defaults to none.
+     *
      * @return The exception types to exclude (defaults to none)
      */
     Class<? extends Throwable>[] excludes() default {};

--- a/retry/src/main/java/io/micronaut/retry/annotation/Retryable.java
+++ b/retry/src/main/java/io/micronaut/retry/annotation/Retryable.java
@@ -41,53 +41,74 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Type(DefaultRetryInterceptor.class)
 public @interface Retryable {
 
+    /**
+     * The maximum integral digits for retry attempts validation.
+     */
     int MAX_INTEGRAL_DIGITS = 4;
 
     /**
+     * Returns the exception types to include, which defaults to all.
+     *
      * @return The exception types to include (defaults to all)
      */
     @AliasFor(member = "includes")
     Class<? extends Throwable>[] value() default {};
 
     /**
+     * Returns the exception types to include, which defaults to all.
+     *
      * @return The exception types to include (defaults to all)
      */
     Class<? extends Throwable>[] includes() default {};
 
     /**
+     * Returns the exception types to exclude, which defaults to none.
+     *
      * @return The exception types to exclude (defaults to none)
      */
     Class<? extends Throwable>[] excludes() default {};
 
     /**
+     * Returns the maximum number of retry attempts.
+     *
      * @return The maximum number of retry attempts
      */
     @Digits(integer = MAX_INTEGRAL_DIGITS, fraction = 0)
     String attempts() default "3";
 
     /**
+     * Returns the delay between retry attempts.
+     *
      * @return The delay between retry attempts
      */
     String delay() default "1s";
 
     /**
+     * Returns the maximum overall delay.
+     *
      * @return The maximum overall delay
      */
     String maxDelay() default "";
 
     /**
+     * Returns the multiplier to use to calculate the delay.
+     *
      * @return The multiplier to use to calculate the delay
      */
     @Digits(integer = 2, fraction = 2)
     String multiplier() default "1.0";
 
     /**
+     * Returns the retry predicate class to use instead of {@link Retryable#includes} and {@link Retryable#excludes}.
+     *
      * @return The retry predicate class to use instead of {@link Retryable#includes} and {@link Retryable#excludes}
      * (defaults to none)
      */
     Class<? extends RetryPredicate> predicate() default DefaultRetryPredicate.class;
 
     /**
+     * Returns the exception type that should be intercepted for retry handling.
+     *
      * @return The exception type that should be intercepted for retry handling. Once an exception is captured,
      * it is still evaluated by {@link Retryable#includes}, {@link Retryable#excludes}, or
      * {@link Retryable#predicate()} to decide whether to retry. Defaults to {@link RuntimeException}.
@@ -95,6 +116,8 @@ public @interface Retryable {
     Class<? extends Throwable> capturedException() default RuntimeException.class;
 
     /**
+     * Returns the jitter factor used to apply random deviation to retry delays.
+     *
      * @return The jitter factor used to apply random deviation to retry delays
      */
     @Digits(integer = 1, fraction = 2)

--- a/retry/src/main/java/io/micronaut/retry/event/CircuitOpenEvent.java
+++ b/retry/src/main/java/io/micronaut/retry/event/CircuitOpenEvent.java
@@ -28,10 +28,19 @@ import io.micronaut.retry.RetryState;
  */
 public class CircuitOpenEvent extends ApplicationEvent {
 
+    /**
+     * The retry state at the time the circuit was opened.
+     */
     private final RetryState retryState;
+
+    /**
+     * The triggering throwable.
+     */
     private final Throwable throwable;
 
     /**
+     * Creates a circuit open event.
+     *
      * @param source A compile time produced invocation of a method call
      * @param retryState Encapsulate the current state of {@link io.micronaut.retry.annotation.Retryable} operation.
      * @param throwable The cause
@@ -47,6 +56,8 @@ public class CircuitOpenEvent extends ApplicationEvent {
     }
 
     /**
+     * Returns the retry context.
+     *
      * @return The retry context
      */
     public RetryState getRetryState() {
@@ -54,6 +65,8 @@ public class CircuitOpenEvent extends ApplicationEvent {
     }
 
     /**
+     * Returns the original exception that will be rethrown to the user.
+     *
      * @return The original exception that will be rethrown to the user
      */
     public Throwable getThrowable() {

--- a/retry/src/main/java/io/micronaut/retry/event/RetryEvent.java
+++ b/retry/src/main/java/io/micronaut/retry/event/RetryEvent.java
@@ -27,10 +27,19 @@ import io.micronaut.retry.RetryState;
  */
 public class RetryEvent extends ApplicationEvent {
 
+    /**
+     * The retry state for the current attempt.
+     */
     private final RetryState retryState;
+
+    /**
+     * The throwable that triggered the retry.
+     */
     private final Throwable throwable;
 
     /**
+     * Creates a retry event.
+     *
      * @param source The source method invocation context for intercepting method call
      * @param retryState To encapsulate current state into {@link io.micronaut.retry.annotation.Retryable}
      * @param throwable The error
@@ -42,6 +51,8 @@ public class RetryEvent extends ApplicationEvent {
     }
 
     /**
+     * Returns the retry context.
+     *
      * @return The retry context
      */
     public RetryState getRetryState() {
@@ -49,6 +60,8 @@ public class RetryEvent extends ApplicationEvent {
     }
 
     /**
+     * Returns the exception that caused the retry.
+     *
      * @return The exception that caused the retry
      */
     public Throwable getThrowable() {

--- a/retry/src/main/java/io/micronaut/retry/intercept/AnnotationRetryStateBuilder.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/AnnotationRetryStateBuilder.java
@@ -18,9 +18,12 @@ package io.micronaut.retry.intercept;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.reflect.InstantiationUtils;
+import io.micronaut.retry.CircuitBreakerPolicy;
+import io.micronaut.retry.RetryPolicy;
 import io.micronaut.retry.RetryState;
 import io.micronaut.retry.RetryStateBuilder;
 import io.micronaut.retry.annotation.DefaultRetryPredicate;
+import io.micronaut.retry.annotation.CircuitBreaker;
 import io.micronaut.retry.annotation.RetryPredicate;
 import io.micronaut.retry.annotation.Retryable;
 
@@ -44,6 +47,8 @@ class AnnotationRetryStateBuilder implements RetryStateBuilder {
     private static final String PREDICATE = "predicate";
     private static final String CAPTURED_EXCEPTION = "capturedException";
     private static final String JITTER = "jitter";
+    private static final String RESET = "reset";
+    private static final String THROW_WRAPPED_EXCEPTION = "throwWrappedException";
     private static final int DEFAULT_RETRY_ATTEMPTS = 3;
 
     private final AnnotationMetadata annotationMetadata;
@@ -59,27 +64,46 @@ class AnnotationRetryStateBuilder implements RetryStateBuilder {
 
     @Override
     public RetryState build() {
+        return new PolicyRetryStateBuilder(retryPolicy()).build();
+    }
+
+    RetryPolicy retryPolicy() {
         AnnotationValue<Retryable> retry = annotationMetadata.findAnnotation(Retryable.class)
             .orElseThrow(() -> new IllegalStateException("Missing @Retryable annotation"));
-        int attempts = retry.intValue(ATTEMPTS).orElse(DEFAULT_RETRY_ATTEMPTS);
-        Duration delay = retry.get(DELAY, Duration.class).orElse(Duration.ofSeconds(1));
+        Duration maxDelay = retry.get(MAX_DELAY, Duration.class).orElse(null);
+        RetryPolicy.Builder builder = RetryPolicy.builder()
+            .maxAttempts(retry.intValue(ATTEMPTS).orElse(DEFAULT_RETRY_ATTEMPTS))
+            .delay(retry.get(DELAY, Duration.class).orElse(Duration.ofSeconds(1)))
+            .multiplier(retry.get(MULTIPLIER, Double.class).orElse(0d))
+            .capturedException(retry.classValue(CAPTURED_EXCEPTION, Throwable.class).orElse(RuntimeException.class))
+            .jitter(retry.get(JITTER, Double.class).orElse(0d));
+        if (maxDelay != null) {
+            builder.maxDelay(maxDelay);
+        }
+
         @SuppressWarnings("unchecked")
         Class<? extends RetryPredicate> predicateClass = (Class<? extends RetryPredicate>) retry.classValue(PREDICATE).orElse(DefaultRetryPredicate.class);
-        RetryPredicate predicate = createPredicate(predicateClass, retry);
-        @SuppressWarnings("unchecked")
-        Class<? extends RuntimeException> capturedException = (Class<? extends RuntimeException>) retry
-            .classValue(CAPTURED_EXCEPTION)
-            .orElse(RuntimeException.class);
+        builder.includes(toThrowableClasses(retry.classValues(INCLUDES)));
+        builder.excludes(toThrowableClasses(retry.classValues(EXCLUDES)));
+        builder.predicate(createPredicate(predicateClass, retry));
+        return builder.build();
+    }
 
-        return new SimpleRetry(
-            attempts,
-            retry.get(MULTIPLIER, Double.class).orElse(0d),
-            delay,
-            retry.get(MAX_DELAY, Duration.class).orElse(null),
-            predicate,
-            capturedException,
-            retry.get(JITTER, Double.class).orElse(0d)
-        );
+    CircuitBreakerPolicy circuitBreakerPolicy() {
+        AnnotationValue<CircuitBreaker> circuitBreaker = annotationMetadata.findAnnotation(CircuitBreaker.class)
+            .orElseThrow(() -> new IllegalStateException("Missing @CircuitBreaker annotation"));
+        RetryPolicy retryPolicy = retryPolicy();
+        CircuitBreakerPolicy.Builder builder = CircuitBreakerPolicy.builder()
+            .maxAttempts(retryPolicy.maxAttempts())
+            .delay(retryPolicy.delay())
+            .multiplier(retryPolicy.multiplier())
+            .jitter(retryPolicy.jitter())
+            .capturedException(retryPolicy.capturedException())
+            .predicate(retryPolicy.predicate())
+            .resetTimeout(circuitBreaker.get(RESET, Duration.class).orElse(Duration.ofSeconds(20)))
+            .throwWrappedException(circuitBreaker.booleanValue(THROW_WRAPPED_EXCEPTION).orElse(false));
+        retryPolicy.getMaxDelay().ifPresent(builder::maxDelay);
+        return builder.build();
     }
 
     private static RetryPredicate createPredicate(Class<? extends RetryPredicate> predicateClass, AnnotationValue<Retryable> retry) {
@@ -96,5 +120,14 @@ class AnnotationRetryStateBuilder implements RetryStateBuilder {
     private static List<Class<? extends Throwable>> resolveIncludes(AnnotationValue<Retryable> retry, String includes) {
         Class<?>[] values = retry.classValues(includes);
         return (List) List.of(values);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends Throwable>[] toThrowableClasses(Class<?>[] values) {
+        Class<? extends Throwable>[] converted = new Class[values.length];
+        for (int i = 0; i < values.length; i++) {
+            converted[i] = (Class<? extends Throwable>) values[i];
+        }
+        return converted;
     }
 }

--- a/retry/src/main/java/io/micronaut/retry/intercept/CircuitBreakerRetry.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/CircuitBreakerRetry.java
@@ -16,6 +16,7 @@
 package io.micronaut.retry.intercept;
 
 import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.retry.CircuitState;
@@ -38,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class CircuitBreakerRetry implements MutableRetryState {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultRetryInterceptor.class);

--- a/retry/src/main/java/io/micronaut/retry/intercept/CircuitBreakerRetry.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/CircuitBreakerRetry.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author graemerocher
  * @since 1.0
  */
-class CircuitBreakerRetry implements MutableRetryState {
+public class CircuitBreakerRetry implements MutableRetryState {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultRetryInterceptor.class);
 
@@ -55,17 +55,19 @@ class CircuitBreakerRetry implements MutableRetryState {
     private volatile MutableRetryState childState;
 
     /**
+     * Creates a circuit breaker retry state.
+     *
      * @param openTimeout The circuit open timeout in millis
      * @param childStateBuilder The retry state builder
      * @param method A compile time produced invocation of a method call
      * @param eventPublisher To publish circuit events
      * @param throwWrappedException If {@code true}, the original exception will be wrapped in {@link CircuitOpenException}
      */
-    CircuitBreakerRetry(long openTimeout,
-                        RetryStateBuilder childStateBuilder,
-                        ExecutableMethod<?, ?> method,
-                        @Nullable ApplicationEventPublisher eventPublisher,
-                        boolean throwWrappedException) {
+    public CircuitBreakerRetry(long openTimeout,
+                               RetryStateBuilder childStateBuilder,
+                               ExecutableMethod<?, ?> method,
+                               @Nullable ApplicationEventPublisher eventPublisher,
+                               boolean throwWrappedException) {
 
         this.retryStateBuilder = childStateBuilder;
         this.openTimeout = openTimeout;
@@ -171,10 +173,12 @@ class CircuitBreakerRetry implements MutableRetryState {
     }
 
     /**
+     * Returns the current circuit state.
+     *
      * @return The current state
      */
     @Nullable
-    CircuitState currentState() {
+    public CircuitState currentState() {
         if (state.get() == CircuitState.OPEN) {
             long now = System.currentTimeMillis();
             long timeout = time + openTimeout;

--- a/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryInterceptor.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryInterceptor.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.retry.CircuitBreakerPolicy;
 import io.micronaut.retry.RetryState;
 import io.micronaut.retry.annotation.CircuitBreaker;
 import io.micronaut.retry.annotation.Retryable;
@@ -35,22 +36,12 @@ import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A {@link MethodInterceptor} that retries an operation according to the specified
@@ -63,13 +54,12 @@ import java.util.function.Supplier;
 public class DefaultRetryInterceptor implements MethodInterceptor<Object, Object> {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultRetryInterceptor.class);
-    private static final int DEFAULT_CIRCUIT_BREAKER_TIMEOUT_IN_MILLIS = 20;
-
     private final ConversionService conversionService;
     @Nullable
     private final ApplicationEventPublisher eventPublisher;
     private final ScheduledExecutorService executorService;
     private final Map<ExecutableMethod, CircuitBreakerRetry> circuitContexts = new ConcurrentHashMap<>();
+    private final DefaultRetryRunner retryRunner;
 
     /**
      * Construct a default retry method interceptor with the event publisher.
@@ -85,6 +75,7 @@ public class DefaultRetryInterceptor implements MethodInterceptor<Object, Object
         this.conversionService = conversionService;
         this.eventPublisher = eventPublisher;
         this.executorService = (ScheduledExecutorService) executorService;
+        this.retryRunner = new DefaultRetryRunner(this.executorService, (retryState, exception) -> { });
     }
 
     @Override
@@ -103,23 +94,21 @@ public class DefaultRetryInterceptor implements MethodInterceptor<Object, Object
         AnnotationValue<Retryable> retry = opt.get();
         boolean isCircuitBreaker = context.hasStereotype(CircuitBreaker.class);
         MutableRetryState retryState;
-        AnnotationRetryStateBuilder retryStateBuilder = new AnnotationRetryStateBuilder(
+        AnnotationRetryStateBuilder annotationRetryStateBuilder = new AnnotationRetryStateBuilder(
             context
         );
 
         if (isCircuitBreaker) {
-            long timeout = context
-                .getValue(CircuitBreaker.class, "reset", Duration.class)
-                .map(Duration::toMillis).orElse(Duration.ofSeconds(DEFAULT_CIRCUIT_BREAKER_TIMEOUT_IN_MILLIS).toMillis());
-            boolean wrapException = context
-                .getValue(CircuitBreaker.class, "throwWrappedException", Boolean.class)
-                .orElse(false);
+            CircuitBreakerPolicy circuitBreakerPolicy = annotationRetryStateBuilder.circuitBreakerPolicy();
+            long timeout = circuitBreakerPolicy.getResetTimeout().toMillis();
+            boolean wrapException = circuitBreakerPolicy.isThrowWrappedException();
+            PolicyRetryStateBuilder retryStateBuilder = new PolicyRetryStateBuilder(circuitBreakerPolicy.asRetryPolicy());
             retryState = circuitContexts.computeIfAbsent(
                 context.getExecutableMethod(),
                 method -> new CircuitBreakerRetry(timeout, retryStateBuilder, context, eventPublisher, wrapException)
             );
         } else {
-            retryState = (MutableRetryState) retryStateBuilder.build();
+            retryState = (MutableRetryState) annotationRetryStateBuilder.build();
         }
 
         MutableConvertibleValues<Object> attrs = context.getAttributes();
@@ -128,26 +117,33 @@ public class DefaultRetryInterceptor implements MethodInterceptor<Object, Object
         InterceptedMethod interceptedMethod = InterceptedMethod.of(context, conversionService);
         try {
             retryState.open();
-            // Retry method call before we have actual Publisher/CompletionStage result
-            Object result = retrySync(context, retryState, interceptedMethod);
             switch (interceptedMethod.resultType()) {
                 case PUBLISHER -> {
-                    Flux<Object> reactiveSequence = Flux.from((Publisher<?>) result);
-                    return interceptedMethod.handleResult(
-                        reactiveSequence.onErrorResume(retryFlowable(context, retryState, reactiveSequence))
-                            .doOnNext(o -> retryState.close(null))
+                    Publisher<Object> publisher = retryRunner.executePublisher(
+                        () -> (Publisher<Object>) interceptedMethod.interceptResult(this),
+                        retryState,
+                        context.toString(),
+                        (state, exception) -> publishRetryEvent(context, state, exception)
                     );
+                    return interceptedMethod.handleResult(publisher);
                 }
                 case COMPLETION_STAGE -> {
-                    CompletableFuture<Object> newFuture = new CompletableFuture<>();
-                    Supplier<CompletionStage<?>> retrySupplier = () -> interceptedMethod.interceptResultAsCompletionStage(this);
-                    Objects.requireNonNull(result);
-                    ((CompletionStage<?>) result).whenComplete(retryCompletable(context, retryState, newFuture, retrySupplier));
-                    return interceptedMethod.handleResult(newFuture);
+                    return interceptedMethod.handleResult(
+                        retryRunner.executeCompletionStage(
+                            () -> interceptedMethod.interceptResultAsCompletionStage(this),
+                            retryState,
+                            context.toString(),
+                            (state, exception) -> publishRetryEvent(context, state, exception)
+                        )
+                    );
                 }
                 case SYNCHRONOUS -> {
-                    retryState.close(null);
-                    return result;
+                    return retryRunner.executeSync(
+                        () -> (Object) interceptedMethod.interceptResult(this),
+                        retryState,
+                        context.toString(),
+                        (state, exception) -> publishRetryEvent(context, state, exception)
+                    );
                 }
                 default -> {
                     return interceptedMethod.unsupported();
@@ -158,121 +154,15 @@ public class DefaultRetryInterceptor implements MethodInterceptor<Object, Object
         }
     }
 
-    private BiConsumer<Object, ? super Throwable> retryCompletable(MethodInvocationContext<Object, Object> context,
-                                                                   MutableRetryState retryState,
-                                                                   CompletableFuture<Object> newFuture,
-                                                                   Supplier<CompletionStage<?>> retryResultSupplier) {
-        return (Object value, Throwable exception) -> {
-            if (exception == null) {
-                retryState.close(null);
-                newFuture.complete(value);
-                return;
-            }
-            if (retryState.canRetry(exception)) {
-                long delay = retryState.nextDelay();
-                if (eventPublisher != null) {
-                    try {
-                        eventPublisher.publishEvent(new RetryEvent(context, retryState, exception));
-                    } catch (Exception e) {
-                        LOG.error("Error occurred publishing RetryEvent: {}", e.getMessage(), e);
-                    }
-                }
-                executorService.schedule(() -> {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Retrying execution for method [{}] after delay of {}ms for exception: {}", context, delay, exception.getMessage(), exception);
-                    }
-                    retryResultSupplier.get().whenComplete(retryCompletable(context, retryState, newFuture, retryResultSupplier));
-
-                }, delay, TimeUnit.MILLISECONDS);
-            } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Cannot retry anymore. Rethrowing original exception for method: {}", context);
-                }
-                retryState.close(exception);
-                newFuture.completeExceptionally(exception);
-            }
-        };
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> Function<? super Throwable, ? extends Publisher<? extends T>> retryFlowable(MethodInvocationContext<Object, Object> context, MutableRetryState retryState, Flux<Object> observable) {
-        return exception -> {
-            if (retryState.canRetry(exception)) {
-                Flux retryObservable = observable.onErrorResume(retryFlowable(context, retryState, observable));
-                long delay = retryState.nextDelay();
-                if (eventPublisher != null) {
-                    try {
-                        eventPublisher.publishEvent(new RetryEvent(context, retryState, exception));
-                    } catch (Exception e1) {
-                        LOG.error("Error occurred publishing RetryEvent: {}", e1.getMessage(), e1);
-                    }
-                }
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Retrying execution for method [{}] after delay of {}ms for exception: {}", context, delay, exception.getMessage(), exception);
-                }
-                return retryObservable.delaySubscription(Duration.of(delay, ChronoUnit.MILLIS));
-            } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Cannot retry anymore. Rethrowing original exception for method: {}", context);
-                }
-                retryState.close(exception);
-                return Flux.error(exception);
-            }
-        };
-    }
-
-    @Nullable
-    private Object retrySync(MethodInvocationContext<Object, Object> context, MutableRetryState retryState, InterceptedMethod interceptedMethod) {
-        boolean firstCall = true;
-        while (true) {
+    private void publishRetryEvent(MethodInvocationContext<Object, Object> context,
+                                   MutableRetryState retryState,
+                                   Throwable exception) {
+        if (eventPublisher != null) {
             try {
-                if (firstCall) {
-                    firstCall = false;
-                    return interceptedMethod.interceptResult();
-                }
-                return interceptedMethod.interceptResult(this);
-            } catch (Throwable e) {
-                if (retryState.getCapturedException() != null && !retryState.getCapturedException().isAssignableFrom(e.getClass())) {
-                    throw e;
-                }
-
-                if (!retryState.canRetry(e)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Cannot retry anymore. Rethrowing original exception for method: {}", context);
-                    }
-                    retryState.close(e);
-                    throw e;
-                } else {
-                    long delayMillis = retryState.nextDelay();
-                    try {
-                        if (eventPublisher != null) {
-                            try {
-                                eventPublisher.publishEvent(new RetryEvent(context, retryState, e));
-                            } catch (Exception e1) {
-                                LOG.error("Error occurred publishing RetryEvent: {}", e1.getMessage(), e1);
-                            }
-                        }
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Retrying execution for method [{}] after delay of {}ms for exception: {}", context, delayMillis, e.getMessage());
-                        }
-                        sleep(delayMillis);
-                    } catch (InterruptedException e1) {
-                        Thread.currentThread().interrupt();
-                        throw e;
-                    }
-                }
+                eventPublisher.publishEvent(new RetryEvent(context, retryState, exception));
+            } catch (Exception eventException) {
+                LOG.error("Error occurred publishing RetryEvent: {}", eventException.getMessage(), eventException);
             }
         }
-    }
-
-    /**
-     * Performs the sleep between retries, can be overridden to customize the sleep behavior.
-     * The default implementation just calls {@link Thread#sleep(long)}.
-     *
-     * @param delayMillis the delay in milliseconds
-     * @throws InterruptedException if the thread is interrupted during sleep
-     */
-    protected void sleep(long delayMillis) throws InterruptedException {
-        Thread.sleep(delayMillis);
     }
 }

--- a/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryInterceptor.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryInterceptor.java
@@ -75,7 +75,7 @@ public class DefaultRetryInterceptor implements MethodInterceptor<Object, Object
         this.conversionService = conversionService;
         this.eventPublisher = eventPublisher;
         this.executorService = (ScheduledExecutorService) executorService;
-        this.retryRunner = new DefaultRetryRunner(this.executorService, (retryState, exception) -> { });
+        this.retryRunner = new DefaultRetryRunner(this.executorService, this::sleep);
     }
 
     @Override
@@ -164,5 +164,15 @@ public class DefaultRetryInterceptor implements MethodInterceptor<Object, Object
                 LOG.error("Error occurred publishing RetryEvent: {}", eventException.getMessage(), eventException);
             }
         }
+    }
+
+    /**
+     * Performs the sleep between retries and can be overridden to customize sleep behavior.
+     *
+     * @param delayMillis The delay in milliseconds
+     * @throws InterruptedException If the thread is interrupted during sleep
+     */
+    protected void sleep(long delayMillis) throws InterruptedException {
+        Thread.sleep(delayMillis);
     }
 }

--- a/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry.intercept;
+
+import org.jspecify.annotations.Nullable;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Shared retry execution engine for synchronous, reactive, and asynchronous flows.
+ *
+ * @author graemerocher
+ * @since 4.9.0
+ */
+public final class DefaultRetryRunner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultRetryRunner.class);
+
+    private final ScheduledExecutorService executorService;
+
+    /**
+     * Creates a shared retry runner.
+     *
+     * @param executorService The scheduler used for delayed retries
+     * @param retryEventEmitter The emitter used for retry notifications
+     */
+    public DefaultRetryRunner(ScheduledExecutorService executorService, RetryEventEmitter retryEventEmitter) {
+        this.executorService = executorService;
+    }
+
+    /**
+     * Executes synchronous work with retry.
+     *
+     * @param supplier The supplier to invoke for each attempt
+     * @param retryState The retry state
+     * @param logContext The log context
+     * @param retryEventEmitter The retry event emitter
+     * @param <T> The result type
+     * @return The computed result
+     */
+    public <T> T executeSync(Supplier<T> supplier,
+                             MutableRetryState retryState,
+                             String logContext,
+                             RetryEventEmitter retryEventEmitter) {
+        while (true) {
+            try {
+                T value = supplier.get();
+                retryState.close(null);
+                return value;
+            } catch (Throwable exception) {
+                if (!isCaptured(retryState, exception)) {
+                    throw exception;
+                }
+                if (!retryState.canRetry(exception)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Cannot retry anymore. Rethrowing original exception for {}", logContext);
+                    }
+                    retryState.close(exception);
+                    throw exception;
+                }
+                long delayMillis = retryState.nextDelay();
+                retryEventEmitter.onRetry(retryState, exception);
+                try {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Retrying execution for [{}] after delay of {}ms for exception: {}", logContext, delayMillis, exception.getMessage());
+                    }
+                    sleep(delayMillis);
+                } catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw exception;
+                }
+            }
+        }
+    }
+
+    /**
+     * Executes completion stage work with retry.
+     *
+     * @param supplier The supplier that creates a new completion stage for each attempt
+     * @param retryState The retry state
+     * @param logContext The log context
+     * @param retryEventEmitter The retry event emitter
+     * @param <T> The result type
+     * @return A completion stage representing the retried execution
+     */
+    public <T> CompletionStage<T> executeCompletionStage(Supplier<? extends CompletionStage<T>> supplier,
+                                                         MutableRetryState retryState,
+                                                         String logContext,
+                                                         RetryEventEmitter retryEventEmitter) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        try {
+            CompletionStage<T> initialStage = Objects.requireNonNull(supplier.get(), "supplier returned null completion stage");
+            initialStage.whenComplete(retryCompletionStage(future, supplier, retryState, logContext, retryEventEmitter));
+        } catch (Throwable exception) {
+            if (!isCaptured(retryState, exception)) {
+                future.completeExceptionally(exception);
+                return future;
+            }
+            if (!retryState.canRetry(exception)) {
+                retryState.close(exception);
+                future.completeExceptionally(exception);
+                return future;
+            }
+            long delayMillis = retryState.nextDelay();
+            retryEventEmitter.onRetry(retryState, exception);
+            var unused = executorService.schedule(() ->
+                executeScheduledCompletionStage(future, supplier, retryState, logContext, retryEventEmitter), delayMillis, TimeUnit.MILLISECONDS);
+        }
+        return future;
+    }
+
+    /**
+     * Executes publisher work with retry.
+     *
+     * @param supplier The supplier that creates a new publisher for each attempt
+     * @param retryState The retry state
+     * @param logContext The log context
+     * @param retryEventEmitter The retry event emitter
+     * @param <T> The emitted type
+     * @return A publisher representing the retried execution
+     */
+    public <T> Publisher<T> executePublisher(Supplier<? extends Publisher<T>> supplier,
+                                             MutableRetryState retryState,
+                                             String logContext,
+                                             RetryEventEmitter retryEventEmitter) {
+        return Flux.defer(() -> {
+            try {
+                return Flux.from(Objects.requireNonNull(supplier.get(), "supplier returned null publisher"));
+            } catch (Throwable exception) {
+                return Flux.error(exception);
+            }
+        }).onErrorResume(retryPublisher(supplier, retryState, logContext, retryEventEmitter))
+            .doOnComplete(() -> retryState.close(null));
+    }
+
+    private void sleep(long delayMillis) throws InterruptedException {
+        Thread.sleep(delayMillis);
+    }
+
+    private <T> void executeScheduledCompletionStage(CompletableFuture<T> future,
+                                                     Supplier<? extends CompletionStage<T>> supplier,
+                                                     MutableRetryState retryState,
+                                                     String logContext,
+                                                     RetryEventEmitter retryEventEmitter) {
+        try {
+            CompletionStage<T> nextStage = Objects.requireNonNull(supplier.get(), "supplier returned null completion stage");
+            nextStage.whenComplete(retryCompletionStage(future, supplier, retryState, logContext, retryEventEmitter));
+        } catch (Throwable exception) {
+            retryCompletionStage(future, supplier, retryState, logContext, retryEventEmitter).accept(null, exception);
+        }
+    }
+
+    private <T> BiConsumer<T, ? super Throwable> retryCompletionStage(CompletableFuture<T> future,
+                                                                      Supplier<? extends CompletionStage<T>> supplier,
+                                                                      MutableRetryState retryState,
+                                                                      String logContext,
+                                                                      RetryEventEmitter retryEventEmitter) {
+        return (value, exception) -> {
+            if (exception == null) {
+                retryState.close(null);
+                future.complete(value);
+                return;
+            }
+            if (!retryState.canRetry(exception)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Cannot retry anymore. Rethrowing original exception for {}", logContext);
+                }
+                retryState.close(exception);
+                future.completeExceptionally(exception);
+                return;
+            }
+            long delayMillis = retryState.nextDelay();
+            retryEventEmitter.onRetry(retryState, exception);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Retrying execution for [{}] after delay of {}ms for exception: {}", logContext, delayMillis, exception.getMessage(), exception);
+            }
+            var unused = executorService.schedule(() -> executeScheduledCompletionStage(future, supplier, retryState, logContext, retryEventEmitter), delayMillis, TimeUnit.MILLISECONDS);
+        };
+    }
+
+    private <T> Function<? super Throwable, ? extends Publisher<? extends T>> retryPublisher(Supplier<? extends Publisher<T>> supplier,
+                                                                                               MutableRetryState retryState,
+                                                                                               String logContext,
+                                                                                               RetryEventEmitter retryEventEmitter) {
+        return exception -> {
+            if (!retryState.canRetry(exception)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Cannot retry anymore. Rethrowing original exception for {}", logContext);
+                }
+                retryState.close(exception);
+                return Flux.error(exception);
+            }
+            long delayMillis = retryState.nextDelay();
+            retryEventEmitter.onRetry(retryState, exception);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Retrying execution for [{}] after delay of {}ms for exception: {}", logContext, delayMillis, exception.getMessage(), exception);
+            }
+            return Flux.defer(() -> executePublisher(supplier, retryState, logContext, retryEventEmitter))
+                .delaySubscription(Duration.of(delayMillis, ChronoUnit.MILLIS));
+        };
+    }
+
+    private static boolean isCaptured(MutableRetryState retryState, Throwable exception) {
+        @Nullable Class<? extends Throwable> capturedException = retryState.getCapturedException();
+        return capturedException == null || capturedException.isAssignableFrom(exception.getClass());
+    }
+}

--- a/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
@@ -21,12 +21,15 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.SignalType;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -123,18 +126,19 @@ public final class DefaultRetryRunner {
         try {
             CompletionStage<T> initialStage = Objects.requireNonNull(supplier.get(), "supplier returned null completion stage");
             initialStage.whenComplete(retryCompletionStage(future, supplier, retryState, logContext, retryEventEmitter));
-        } catch (Exception exception) {
-            if (!isCaptured(retryState, exception)) {
-                future.completeExceptionally(exception);
+        } catch (Throwable exception) {
+            Throwable cause = unwrapCompletionException(exception);
+            if (!isCaptured(retryState, cause)) {
+                future.completeExceptionally(cause);
                 return future;
             }
-            if (!retryState.canRetry(exception)) {
-                retryState.close(exception);
-                future.completeExceptionally(exception);
+            if (!retryState.canRetry(cause)) {
+                retryState.close(cause);
+                future.completeExceptionally(cause);
                 return future;
             }
             long delayMillis = retryState.nextDelay();
-            retryEventEmitter.onRetry(retryState, exception);
+            retryEventEmitter.onRetry(retryState, cause);
             executorService.schedule(() ->
                 executeScheduledCompletionStage(future, supplier, retryState, logContext, retryEventEmitter), delayMillis, TimeUnit.MILLISECONDS);
         }
@@ -162,7 +166,12 @@ public final class DefaultRetryRunner {
                 return Flux.error(exception);
             }
         }).onErrorResume(retryPublisher(supplier, retryState, logContext, retryEventEmitter))
-            .doOnComplete(() -> retryState.close(null));
+            .doFinally(signalType -> {
+                // ON_ERROR: retryPublisher already calls retryState.close(exception) when retries are exhausted
+                if (signalType != SignalType.ON_ERROR) {
+                    retryState.close(null);
+                }
+            });
     }
 
     private <T> void executeScheduledCompletionStage(CompletableFuture<T> future,
@@ -173,7 +182,7 @@ public final class DefaultRetryRunner {
         try {
             CompletionStage<T> nextStage = Objects.requireNonNull(supplier.get(), "supplier returned null completion stage");
             nextStage.whenComplete(retryCompletionStage(future, supplier, retryState, logContext, retryEventEmitter));
-        } catch (Exception exception) {
+        } catch (Throwable exception) {
             retryCompletionStage(future, supplier, retryState, logContext, retryEventEmitter).accept(null, exception);
         }
     }
@@ -189,22 +198,23 @@ public final class DefaultRetryRunner {
                 future.complete(value);
                 return;
             }
-            if (!isCaptured(retryState, exception)) {
-                future.completeExceptionally(exception);
+            Throwable cause = unwrapCompletionException(exception);
+            if (!isCaptured(retryState, cause)) {
+                future.completeExceptionally(cause);
                 return;
             }
-            if (!retryState.canRetry(exception)) {
+            if (!retryState.canRetry(cause)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(CANNOT_RETRY_MESSAGE, logContext);
                 }
-                retryState.close(exception);
-                future.completeExceptionally(exception);
+                retryState.close(cause);
+                future.completeExceptionally(cause);
                 return;
             }
             long delayMillis = retryState.nextDelay();
-            retryEventEmitter.onRetry(retryState, exception);
+            retryEventEmitter.onRetry(retryState, cause);
             if (LOG.isDebugEnabled()) {
-                LOG.debug(RETRYING_MESSAGE, logContext, delayMillis, exception.getMessage(), exception);
+                LOG.debug(RETRYING_MESSAGE, logContext, delayMillis, cause.getMessage(), cause);
             }
             executorService.schedule(() -> executeScheduledCompletionStage(future, supplier, retryState, logContext, retryEventEmitter), delayMillis, TimeUnit.MILLISECONDS);
         };
@@ -238,5 +248,15 @@ public final class DefaultRetryRunner {
     private static boolean isCaptured(MutableRetryState retryState, Throwable exception) {
         @Nullable Class<? extends Throwable> capturedException = retryState.getCapturedException();
         return capturedException == null || capturedException.isAssignableFrom(exception.getClass());
+    }
+
+    private static Throwable unwrapCompletionException(Throwable exception) {
+        if (exception instanceof CompletionException || exception instanceof ExecutionException) {
+            Throwable cause = exception.getCause();
+            if (cause != null) {
+                return cause;
+            }
+        }
+        return exception;
     }
 }

--- a/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
@@ -43,6 +43,8 @@ import java.util.function.Supplier;
 public final class DefaultRetryRunner {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultRetryRunner.class);
+    private static final String CANNOT_RETRY_MESSAGE = "Cannot retry anymore. Rethrowing original exception for {}";
+    private static final String RETRYING_MESSAGE = "Retrying execution for [{}] after delay of {}ms for exception: {}";
 
     private final ScheduledExecutorService executorService;
     private final RetrySleeper retrySleeper;
@@ -83,7 +85,7 @@ public final class DefaultRetryRunner {
                 }
                 if (!retryState.canRetry(exception)) {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Cannot retry anymore. Rethrowing original exception for {}", logContext);
+                        LOG.debug(CANNOT_RETRY_MESSAGE, logContext);
                     }
                     retryState.close(exception);
                     throw exception;
@@ -92,7 +94,7 @@ public final class DefaultRetryRunner {
                 retryEventEmitter.onRetry(retryState, exception);
                 try {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Retrying execution for [{}] after delay of {}ms for exception: {}", logContext, delayMillis, exception.getMessage());
+                        LOG.debug(RETRYING_MESSAGE, logContext, delayMillis, exception.getMessage());
                     }
                     retrySleeper.sleep(delayMillis);
                 } catch (InterruptedException interruptedException) {
@@ -121,7 +123,7 @@ public final class DefaultRetryRunner {
         try {
             CompletionStage<T> initialStage = Objects.requireNonNull(supplier.get(), "supplier returned null completion stage");
             initialStage.whenComplete(retryCompletionStage(future, supplier, retryState, logContext, retryEventEmitter));
-        } catch (Throwable exception) {
+        } catch (Exception exception) {
             if (!isCaptured(retryState, exception)) {
                 future.completeExceptionally(exception);
                 return future;
@@ -133,7 +135,7 @@ public final class DefaultRetryRunner {
             }
             long delayMillis = retryState.nextDelay();
             retryEventEmitter.onRetry(retryState, exception);
-            var unused = executorService.schedule(() ->
+            executorService.schedule(() ->
                 executeScheduledCompletionStage(future, supplier, retryState, logContext, retryEventEmitter), delayMillis, TimeUnit.MILLISECONDS);
         }
         return future;
@@ -156,7 +158,7 @@ public final class DefaultRetryRunner {
         return Flux.defer(() -> {
             try {
                 return Flux.from(Objects.requireNonNull(supplier.get(), "supplier returned null publisher"));
-            } catch (Throwable exception) {
+            } catch (Exception exception) {
                 return Flux.error(exception);
             }
         }).onErrorResume(retryPublisher(supplier, retryState, logContext, retryEventEmitter))
@@ -171,7 +173,7 @@ public final class DefaultRetryRunner {
         try {
             CompletionStage<T> nextStage = Objects.requireNonNull(supplier.get(), "supplier returned null completion stage");
             nextStage.whenComplete(retryCompletionStage(future, supplier, retryState, logContext, retryEventEmitter));
-        } catch (Throwable exception) {
+        } catch (Exception exception) {
             retryCompletionStage(future, supplier, retryState, logContext, retryEventEmitter).accept(null, exception);
         }
     }
@@ -189,7 +191,7 @@ public final class DefaultRetryRunner {
             }
             if (!retryState.canRetry(exception)) {
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Cannot retry anymore. Rethrowing original exception for {}", logContext);
+                    LOG.debug(CANNOT_RETRY_MESSAGE, logContext);
                 }
                 retryState.close(exception);
                 future.completeExceptionally(exception);
@@ -198,9 +200,9 @@ public final class DefaultRetryRunner {
             long delayMillis = retryState.nextDelay();
             retryEventEmitter.onRetry(retryState, exception);
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Retrying execution for [{}] after delay of {}ms for exception: {}", logContext, delayMillis, exception.getMessage(), exception);
+                LOG.debug(RETRYING_MESSAGE, logContext, delayMillis, exception.getMessage(), exception);
             }
-            var unused = executorService.schedule(() -> executeScheduledCompletionStage(future, supplier, retryState, logContext, retryEventEmitter), delayMillis, TimeUnit.MILLISECONDS);
+            executorService.schedule(() -> executeScheduledCompletionStage(future, supplier, retryState, logContext, retryEventEmitter), delayMillis, TimeUnit.MILLISECONDS);
         };
     }
 
@@ -211,7 +213,7 @@ public final class DefaultRetryRunner {
         return exception -> {
             if (!retryState.canRetry(exception)) {
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Cannot retry anymore. Rethrowing original exception for {}", logContext);
+                    LOG.debug(CANNOT_RETRY_MESSAGE, logContext);
                 }
                 retryState.close(exception);
                 return Flux.error(exception);
@@ -219,7 +221,7 @@ public final class DefaultRetryRunner {
             long delayMillis = retryState.nextDelay();
             retryEventEmitter.onRetry(retryState, exception);
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Retrying execution for [{}] after delay of {}ms for exception: {}", logContext, delayMillis, exception.getMessage(), exception);
+                LOG.debug(RETRYING_MESSAGE, logContext, delayMillis, exception.getMessage(), exception);
             }
             return Flux.defer(() -> executePublisher(supplier, retryState, logContext, retryEventEmitter))
                 .delaySubscription(Duration.of(delayMillis, ChronoUnit.MILLIS));

--- a/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.retry.intercept;
 
+import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -36,22 +37,25 @@ import java.util.function.Supplier;
  * Shared retry execution engine for synchronous, reactive, and asynchronous flows.
  *
  * @author graemerocher
- * @since 4.9.0
+ * @since 5.0.0
  */
+@Internal
 public final class DefaultRetryRunner {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultRetryRunner.class);
 
     private final ScheduledExecutorService executorService;
+    private final RetrySleeper retrySleeper;
 
     /**
      * Creates a shared retry runner.
      *
      * @param executorService The scheduler used for delayed retries
-     * @param retryEventEmitter The emitter used for retry notifications
+     * @param retrySleeper The strategy used to sleep between retries
      */
-    public DefaultRetryRunner(ScheduledExecutorService executorService, RetryEventEmitter retryEventEmitter) {
+    public DefaultRetryRunner(ScheduledExecutorService executorService, RetrySleeper retrySleeper) {
         this.executorService = executorService;
+        this.retrySleeper = retrySleeper;
     }
 
     /**
@@ -90,7 +94,7 @@ public final class DefaultRetryRunner {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Retrying execution for [{}] after delay of {}ms for exception: {}", logContext, delayMillis, exception.getMessage());
                     }
-                    sleep(delayMillis);
+                    retrySleeper.sleep(delayMillis);
                 } catch (InterruptedException interruptedException) {
                     Thread.currentThread().interrupt();
                     throw exception;
@@ -157,10 +161,6 @@ public final class DefaultRetryRunner {
             }
         }).onErrorResume(retryPublisher(supplier, retryState, logContext, retryEventEmitter))
             .doOnComplete(() -> retryState.close(null));
-    }
-
-    private void sleep(long delayMillis) throws InterruptedException {
-        Thread.sleep(delayMillis);
     }
 
     private <T> void executeScheduledCompletionStage(CompletableFuture<T> future,

--- a/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/DefaultRetryRunner.java
@@ -189,6 +189,10 @@ public final class DefaultRetryRunner {
                 future.complete(value);
                 return;
             }
+            if (!isCaptured(retryState, exception)) {
+                future.completeExceptionally(exception);
+                return;
+            }
             if (!retryState.canRetry(exception)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(CANNOT_RETRY_MESSAGE, logContext);
@@ -211,6 +215,9 @@ public final class DefaultRetryRunner {
                                                                                                String logContext,
                                                                                                RetryEventEmitter retryEventEmitter) {
         return exception -> {
+            if (!isCaptured(retryState, exception)) {
+                return Flux.error(exception);
+            }
             if (!retryState.canRetry(exception)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(CANNOT_RETRY_MESSAGE, logContext);

--- a/retry/src/main/java/io/micronaut/retry/intercept/PolicyRetryStateBuilder.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/PolicyRetryStateBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry.intercept;
+
+import io.micronaut.retry.RetryPolicy;
+import io.micronaut.retry.RetryState;
+import io.micronaut.retry.RetryStateBuilder;
+
+/**
+ * Builds retry state from a typed retry policy.
+ *
+ * @author graemerocher
+ * @since 4.9.0
+ */
+public final class PolicyRetryStateBuilder implements RetryStateBuilder {
+
+    private final RetryPolicy retryPolicy;
+
+    /**
+     * Creates a retry state builder from a typed retry policy.
+     *
+     * @param retryPolicy The retry policy
+     */
+    public PolicyRetryStateBuilder(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+    }
+
+    /**
+     * Builds retry state from the configured retry policy.
+     *
+     * @return The retry state
+     */
+    @Override
+    public RetryState build() {
+        return new SimpleRetry(
+            retryPolicy.maxAttempts(),
+            retryPolicy.multiplier(),
+            retryPolicy.delay(),
+            retryPolicy.getMaxDelay().orElse(null),
+            retryPolicy.predicate(),
+            retryPolicy.capturedException(),
+            retryPolicy.jitter()
+        );
+    }
+}

--- a/retry/src/main/java/io/micronaut/retry/intercept/PolicyRetryStateBuilder.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/PolicyRetryStateBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.retry.intercept;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.retry.RetryPolicy;
 import io.micronaut.retry.RetryState;
 import io.micronaut.retry.RetryStateBuilder;
@@ -23,8 +24,9 @@ import io.micronaut.retry.RetryStateBuilder;
  * Builds retry state from a typed retry policy.
  *
  * @author graemerocher
- * @since 4.9.0
+ * @since 5.0.0
  */
+@Internal
 public final class PolicyRetryStateBuilder implements RetryStateBuilder {
 
     private final RetryPolicy retryPolicy;

--- a/retry/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
@@ -59,6 +59,8 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
     private final BeanContext beanContext;
 
     /**
+     * Creates a recovery interceptor.
+     *
      * @param beanContext The bean context to allow for DI of class annotated with {@link jakarta.inject.Inject}.
      */
     public RecoveryInterceptor(BeanContext beanContext) {

--- a/retry/src/main/java/io/micronaut/retry/intercept/RetryEventEmitter.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/RetryEventEmitter.java
@@ -15,22 +15,20 @@
  */
 package io.micronaut.retry.intercept;
 
-import io.micronaut.core.annotation.Internal;
-import io.micronaut.retry.RetryState;
-
 /**
- * Mutable retry state that can calculate the next retry delay.
+ * Emits retry attempt notifications for the shared retry runner.
  *
  * @author graemerocher
- * @since 1.0
+ * @since 4.9.0
  */
-@Internal
-public interface MutableRetryState extends RetryState {
+@FunctionalInterface
+public interface RetryEventEmitter {
 
     /**
-     * Returns the millisecond value for the next delay.
+     * Emits a retry notification.
      *
-     * @return The next delay in milliseconds
+     * @param retryState The retry state
+     * @param exception The exception that triggered the retry
      */
-    long nextDelay();
+    void onRetry(MutableRetryState retryState, Throwable exception);
 }

--- a/retry/src/main/java/io/micronaut/retry/intercept/RetrySleeper.java
+++ b/retry/src/main/java/io/micronaut/retry/intercept/RetrySleeper.java
@@ -18,20 +18,14 @@ package io.micronaut.retry.intercept;
 import io.micronaut.core.annotation.Internal;
 
 /**
- * Emits retry attempt notifications for the shared retry runner.
+ * Internal abstraction for sleeping between retry attempts.
  *
  * @author graemerocher
  * @since 5.0.0
  */
 @Internal
 @FunctionalInterface
-public interface RetryEventEmitter {
+public interface RetrySleeper {
 
-    /**
-     * Emits a retry notification.
-     *
-     * @param retryState The retry state
-     * @param exception The exception that triggered the retry
-     */
-    void onRetry(MutableRetryState retryState, Throwable exception);
+    void sleep(long delayMillis) throws InterruptedException;
 }

--- a/retry/src/test/groovy/io/micronaut/retry/ProgrammaticCircuitBreakerSpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/ProgrammaticCircuitBreakerSpec.groovy
@@ -22,6 +22,7 @@ import reactor.core.publisher.Mono
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicInteger

--- a/retry/src/test/groovy/io/micronaut/retry/ProgrammaticCircuitBreakerSpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/ProgrammaticCircuitBreakerSpec.groovy
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.retry.annotation.RetryPredicate
+import io.micronaut.retry.exception.CircuitOpenException
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.atomic.AtomicInteger
+
+class ProgrammaticCircuitBreakerSpec extends Specification {
+
+    void "programmatic circuit breaker shares state across invocations"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        CircuitBreakerOperationsFactory factory = context.getBean(CircuitBreakerOperationsFactory)
+        CircuitBreakerOperations operations = factory.createCircuitBreakerOperations(
+            CircuitBreakerPolicy.builder().maxAttempts(2).delay(Duration.ofMillis(5)).resetTimeout(Duration.ofMillis(100)).build()
+        )
+        AtomicInteger counter = new AtomicInteger()
+
+        when:
+        operations.execute {
+            counter.incrementAndGet()
+            throw new IllegalStateException('boom')
+        }
+
+        then:
+        thrown(IllegalStateException)
+        operations.currentState() == CircuitState.OPEN
+        counter.get() == 3
+
+        when:
+        operations.execute {
+            counter.incrementAndGet()
+            return counter.get()
+        }
+
+        then:
+        thrown(IllegalStateException)
+        counter.get() == 3
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic circuit breaker transitions from open to half open to closed"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        CircuitBreakerOperationsFactory factory = context.getBean(CircuitBreakerOperationsFactory)
+        CircuitBreakerOperations operations = factory.createCircuitBreakerOperations(
+            CircuitBreakerPolicy.builder().maxAttempts(2).delay(Duration.ofMillis(5)).resetTimeout(Duration.ofMillis(100)).build()
+        )
+        AtomicInteger counter = new AtomicInteger()
+        PollingConditions conditions = new PollingConditions(timeout: 3)
+
+        when:
+        operations.execute {
+            counter.incrementAndGet()
+            throw new IllegalStateException('boom')
+        }
+
+        then:
+        thrown(IllegalStateException)
+        operations.currentState() == CircuitState.OPEN
+
+        when:
+        conditions.eventually {
+            operations.currentState() == CircuitState.HALF_OPEN
+        }
+        int result = operations.execute {
+            counter.incrementAndGet()
+            return counter.get()
+        }
+
+        then:
+        result == 4
+        operations.currentState() == CircuitState.CLOSED
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic circuit breaker supports publisher and completion stage flows"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        CircuitBreakerOperationsFactory factory = context.getBean(CircuitBreakerOperationsFactory)
+        CircuitBreakerOperations publisherOperations = factory.createCircuitBreakerOperations(
+            CircuitBreakerPolicy.builder().maxAttempts(3).delay(Duration.ofMillis(5)).resetTimeout(Duration.ofMillis(100)).build()
+        )
+        CircuitBreakerOperations completionStageOperations = factory.createCircuitBreakerOperations(
+            CircuitBreakerPolicy.builder().maxAttempts(3).delay(Duration.ofMillis(5)).resetTimeout(Duration.ofMillis(100)).build()
+        )
+        AtomicInteger publisherCounter = new AtomicInteger()
+        AtomicInteger stageCounter = new AtomicInteger()
+
+        when:
+        int publisherResult = Mono.from(publisherOperations.executePublisher {
+            Mono.fromCallable {
+                int current = publisherCounter.incrementAndGet()
+                if (current < 3) {
+                    throw new IllegalStateException('bad publisher')
+                }
+                return current
+            }
+        }).block()
+        int stageResult = completionStageOperations.executeCompletionStage {
+            CompletableFuture.supplyAsync {
+                int current = stageCounter.incrementAndGet()
+                if (current < 3) {
+                    throw new IllegalStateException('bad stage')
+                }
+                return current
+            }
+        }.toCompletableFuture().get()
+
+        then:
+        publisherResult == 3
+        stageResult == 3
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic circuit breaker can throw wrapped exceptions"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        CircuitBreakerOperationsFactory factory = context.getBean(CircuitBreakerOperationsFactory)
+        CircuitBreakerOperations operations = factory.createCircuitBreakerOperations(
+            CircuitBreakerPolicy.builder()
+                .maxAttempts(2)
+                .delay(Duration.ofMillis(5))
+                .resetTimeout(Duration.ofMillis(100))
+                .throwWrappedException(true)
+                .build()
+        )
+
+        when:
+        operations.execute {
+            throw new IllegalStateException('boom')
+        }
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        operations.execute {
+            1
+        }
+
+        then:
+        CircuitOpenException exception = thrown()
+        exception.cause instanceof IllegalStateException
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic circuit breaker honors predicate and excludes"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        CircuitBreakerOperationsFactory factory = context.getBean(CircuitBreakerOperationsFactory)
+        RetryPredicate predicate = { failure -> failure instanceof MyProgrammaticException } as RetryPredicate
+        CircuitBreakerOperations predicateOperations = factory.createCircuitBreakerOperations(
+            CircuitBreakerPolicy.builder().maxAttempts(2).delay(Duration.ofMillis(5)).predicate(predicate).build()
+        )
+        CircuitBreakerOperations excludeOperations = factory.createCircuitBreakerOperations(
+            CircuitBreakerPolicy.builder().maxAttempts(2).delay(Duration.ofMillis(5)).excludes(MyProgrammaticException).build()
+        )
+
+        when:
+        predicateOperations.execute {
+            throw new IllegalStateException('boom')
+        }
+
+        then:
+        thrown(IllegalStateException)
+        predicateOperations.currentState() == CircuitState.CLOSED
+
+        when:
+        excludeOperations.execute {
+            throw new MyProgrammaticException('boom')
+        }
+
+        then:
+        thrown(MyProgrammaticException)
+        excludeOperations.currentState() == CircuitState.CLOSED
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic circuit breaker preserves async terminal failures"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        CircuitBreakerOperationsFactory factory = context.getBean(CircuitBreakerOperationsFactory)
+        CircuitBreakerOperations operations = factory.createCircuitBreakerOperations(
+            CircuitBreakerPolicy.builder().maxAttempts(2).delay(Duration.ofMillis(5)).build()
+        )
+
+        when:
+        operations.executeCompletionStage {
+            CompletableFuture.failedFuture(new IllegalStateException('bad async'))
+        }.toCompletableFuture().get()
+
+        then:
+        ExecutionException exception = thrown()
+        exception.cause.message == 'bad async'
+        operations.currentState() == CircuitState.OPEN
+
+        cleanup:
+        context.close()
+    }
+
+    static final class MyProgrammaticException extends RuntimeException {
+        MyProgrammaticException(String message) {
+            super(message)
+        }
+    }
+}

--- a/retry/src/test/groovy/io/micronaut/retry/ProgrammaticRetryPolicySpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/ProgrammaticRetryPolicySpec.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry
+
+import io.micronaut.retry.annotation.DefaultRetryPredicate
+import io.micronaut.retry.annotation.RetryPredicate
+import spock.lang.Specification
+
+import java.time.Duration
+import java.util.concurrent.CompletionStage
+import java.util.function.Supplier
+
+class ProgrammaticRetryPolicySpec extends Specification {
+
+    void "retry policy builder defaults match retryable defaults"() {
+        when:
+        RetryPolicy policy = RetryPolicy.builder().build()
+
+        then:
+        policy.maxAttempts == 3
+        policy.delay == Duration.ofSeconds(1)
+        !policy.getMaxDelay().present
+        policy.multiplier == 1.0d
+        policy.jitter == 0.0d
+        policy.capturedException == RuntimeException
+        policy.predicate instanceof DefaultRetryPredicate
+    }
+
+    void "circuit breaker policy builder defaults match annotation defaults"() {
+        when:
+        CircuitBreakerPolicy policy = CircuitBreakerPolicy.builder().build()
+
+        then:
+        policy.maxAttempts == 3
+        policy.delay == Duration.ofMillis(500)
+        policy.maxDelay.get() == Duration.ofSeconds(5)
+        policy.multiplier == 0.0d
+        policy.jitter == 0.0d
+        policy.capturedException == RuntimeException
+        policy.resetTimeout == Duration.ofSeconds(20)
+        !policy.throwWrappedException
+        policy.predicate instanceof DefaultRetryPredicate
+    }
+
+    void "circuit breaker operations extends retry operations"() {
+        expect:
+        RetryOperations.isAssignableFrom(CircuitBreakerOperations)
+    }
+
+    void "factories create reusable operations instances"() {
+        given:
+        RetryOperationsFactory retryOperationsFactory = Mock()
+        CircuitBreakerOperationsFactory circuitBreakerOperationsFactory = Mock()
+        RetryPolicy retryPolicy = RetryPolicy.builder().build()
+        CircuitBreakerPolicy circuitBreakerPolicy = CircuitBreakerPolicy.builder().build()
+        RetryOperations retryOperations = Mock()
+        CircuitBreakerOperations circuitBreakerOperations = Mock()
+
+        when:
+        RetryOperations createdRetryOperations = retryOperationsFactory.createRetryOperations(retryPolicy)
+        CircuitBreakerOperations createdCircuitBreakerOperations = circuitBreakerOperationsFactory.createCircuitBreakerOperations(circuitBreakerPolicy)
+
+        then:
+        1 * retryOperationsFactory.createRetryOperations(retryPolicy) >> retryOperations
+        1 * circuitBreakerOperationsFactory.createCircuitBreakerOperations(circuitBreakerPolicy) >> circuitBreakerOperations
+        createdRetryOperations.is(retryOperations)
+        createdCircuitBreakerOperations.is(circuitBreakerOperations)
+    }
+
+    void "operations contracts are supplier based"() {
+        given:
+        RetryOperations retryOperations = Stub() {
+            execute(_ as Supplier<String>) >> "value"
+            executeCompletionStage(_ as Supplier<CompletionStage<String>>) >> Stub(CompletionStage)
+            executePublisher(_ as Supplier) >> null
+        }
+
+        expect:
+        retryOperations.execute({ "value" }) == "value"
+        retryOperations.executeCompletionStage({ throw new UnsupportedOperationException("stub") }) != null
+        retryOperations.executePublisher({ null }) == null
+    }
+
+    void "explicit predicate is preserved on retry policy"() {
+        given:
+        RetryPredicate predicate = { throwable -> throwable instanceof IllegalStateException } as RetryPredicate
+
+        when:
+        RetryPolicy policy = RetryPolicy.builder()
+            .includes(RuntimeException)
+            .excludes(IllegalArgumentException)
+            .predicate(predicate)
+            .build()
+
+        then:
+        policy.predicate.is(predicate)
+    }
+}

--- a/retry/src/test/groovy/io/micronaut/retry/ProgrammaticRetryPolicyValidationSpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/ProgrammaticRetryPolicyValidationSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry
+
+import io.micronaut.retry.annotation.RetryPredicate
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Duration
+
+class ProgrammaticRetryPolicyValidationSpec extends Specification {
+
+    @Unroll
+    void "retry policy rejects invalid attempts #attempts"() {
+        when:
+        RetryPolicy.builder().maxAttempts(attempts).build()
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        attempts << [0, -1]
+    }
+
+    @Unroll
+    void "retry policy rejects negative durations"(Duration delay, Duration maxDelay) {
+        when:
+        RetryPolicy.builder()
+            .delay(delay)
+            .maxDelay(maxDelay)
+            .build()
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        delay                  | maxDelay
+        Duration.ofMillis(-1)  | null
+        Duration.ZERO          | Duration.ofMillis(-1)
+    }
+
+    @Unroll
+    void "retry policy rejects invalid multiplier #multiplier"() {
+        when:
+        RetryPolicy.builder().multiplier(multiplier).build()
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        multiplier << [-1d, -0.01d]
+    }
+
+    @Unroll
+    void "retry policy rejects invalid jitter #jitter"() {
+        when:
+        RetryPolicy.builder().jitter(jitter).build()
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        jitter << [-0.1d, 1.01d]
+    }
+
+    void "retry policy rejects null predicate"() {
+        when:
+        RetryPolicy.builder().predicate(null as RetryPredicate).build()
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    void "retry policy rejects null captured exception"() {
+        when:
+        RetryPolicy.builder().capturedException(null).build()
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    @Unroll
+    void "circuit breaker policy rejects invalid reset timeout #resetTimeout"() {
+        when:
+        CircuitBreakerPolicy.builder().resetTimeout(resetTimeout).build()
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        resetTimeout << [Duration.ZERO, Duration.ofMillis(-1)]
+    }
+}

--- a/retry/src/test/groovy/io/micronaut/retry/ProgrammaticRetrySpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/ProgrammaticRetrySpec.groovy
@@ -21,6 +21,7 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import spock.lang.Specification
 
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.ExecutionException

--- a/retry/src/test/groovy/io/micronaut/retry/ProgrammaticRetrySpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/ProgrammaticRetrySpec.groovy
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.retry
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.retry.annotation.RetryPredicate
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.atomic.AtomicInteger
+
+class ProgrammaticRetrySpec extends Specification {
+
+    void "programmatic retry supports synchronous flows"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        RetryOperationsFactory factory = context.getBean(RetryOperationsFactory)
+        RetryOperations operations = factory.createRetryOperations(
+            RetryPolicy.builder().maxAttempts(5).delay(Duration.ofMillis(5)).build()
+        )
+        AtomicInteger counter = new AtomicInteger()
+
+        when:
+        int result = operations.execute {
+            int current = counter.incrementAndGet()
+            if (current < 3) {
+                throw new IllegalStateException("Bad count")
+            }
+            return current
+        }
+
+        then:
+        result == 3
+        counter.get() == 3
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic retry supports publisher flows and retries fresh publishers"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        RetryOperationsFactory factory = context.getBean(RetryOperationsFactory)
+        RetryOperations operations = factory.createRetryOperations(
+            RetryPolicy.builder().maxAttempts(5).delay(Duration.ofMillis(5)).build()
+        )
+        AtomicInteger counter = new AtomicInteger()
+
+        when:
+        int result = Mono.from(operations.executePublisher {
+            Mono.fromCallable {
+                int current = counter.incrementAndGet()
+                if (current < 3) {
+                    throw new IllegalStateException("Bad count")
+                }
+                return current
+            }
+        }).block()
+
+        then:
+        result == 3
+        counter.get() == 3
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic retry supports completion stage flows"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        RetryOperationsFactory factory = context.getBean(RetryOperationsFactory)
+        RetryOperations operations = factory.createRetryOperations(
+            RetryPolicy.builder().maxAttempts(5).delay(Duration.ofMillis(5)).build()
+        )
+        AtomicInteger counter = new AtomicInteger()
+
+        when:
+        int result = operations.executeCompletionStage {
+            CompletableFuture.supplyAsync {
+                int current = counter.incrementAndGet()
+                if (current < 3) {
+                    throw new IllegalStateException("Bad count")
+                }
+                return current
+            }
+        }.toCompletableFuture().get()
+
+        then:
+        result == 3
+        counter.get() == 3
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic retry supports pre-stage and pre-publisher failures"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        RetryOperationsFactory factory = context.getBean(RetryOperationsFactory)
+        RetryOperations operations = factory.createRetryOperations(
+            RetryPolicy.builder().maxAttempts(5).delay(Duration.ofMillis(5)).build()
+        )
+        AtomicInteger publisherCounter = new AtomicInteger()
+        AtomicInteger stageCounter = new AtomicInteger()
+
+        when:
+        int publisherResult = Mono.from(operations.executePublisher {
+            int current = publisherCounter.incrementAndGet()
+            if (current < 3) {
+                throw new IllegalStateException("Bad publisher")
+            }
+            return Mono.just(current)
+        }).block()
+        int stageResult = operations.executeCompletionStage {
+            int current = stageCounter.incrementAndGet()
+            if (current < 3) {
+                throw new IllegalStateException("Bad stage")
+            }
+            return CompletableFuture.completedFuture(current)
+        }.toCompletableFuture().get()
+
+        then:
+        publisherResult == 3
+        stageResult == 3
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic retry honors includes excludes predicate and captured exception"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        RetryOperationsFactory factory = context.getBean(RetryOperationsFactory)
+        RetryPredicate predicate = { failure -> failure instanceof MyProgrammaticException } as RetryPredicate
+
+        when:
+        factory.createRetryOperations(RetryPolicy.builder().maxAttempts(5).delay(Duration.ofMillis(5)).includes(MyProgrammaticException).build())
+            .execute(new ThrowingSupplier(new IllegalStateException("bad")))
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        factory.createRetryOperations(RetryPolicy.builder().maxAttempts(5).delay(Duration.ofMillis(5)).excludes(MyProgrammaticException).build())
+            .execute(new ThrowingSupplier(new MyProgrammaticException("bad")))
+
+        then:
+        thrown(MyProgrammaticException)
+
+        when:
+        factory.createRetryOperations(RetryPolicy.builder().maxAttempts(5).delay(Duration.ofMillis(5)).predicate(predicate).build())
+            .execute(new ThrowingSupplier(new IllegalStateException("bad")))
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        factory.createRetryOperations(RetryPolicy.builder().maxAttempts(5).delay(Duration.ofMillis(5)).capturedException(Throwable).build())
+            .execute {
+                throw new Throwable("captured")
+            }
+
+        then:
+        Throwable throwable = thrown()
+        throwable.cause?.message == 'captured' || throwable.message == 'captured'
+
+        cleanup:
+        context.close()
+    }
+
+    void "programmatic retry exhausts with original failure"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        RetryOperationsFactory factory = context.getBean(RetryOperationsFactory)
+        RetryOperations operations = factory.createRetryOperations(
+            RetryPolicy.builder().maxAttempts(3).delay(Duration.ofMillis(5)).build()
+        )
+
+        when:
+        operations.execute {
+            throw new IllegalStateException("still bad")
+        }
+
+        then:
+        IllegalStateException e = thrown()
+        e.message == 'still bad'
+
+        when:
+        operations.executeCompletionStage {
+            CompletableFuture.failedFuture(new IllegalStateException("still bad async"))
+        }.toCompletableFuture().get()
+
+        then:
+        ExecutionException executionException = thrown()
+        executionException.cause.message == 'still bad async'
+
+        cleanup:
+        context.close()
+    }
+
+    static final class ThrowingSupplier implements java.util.function.Supplier<Integer> {
+        private final RuntimeException runtimeException
+
+        ThrowingSupplier(RuntimeException runtimeException) {
+            this.runtimeException = runtimeException
+        }
+
+        @Override
+        Integer get() {
+            throw runtimeException
+        }
+    }
+
+    static final class MyProgrammaticException extends RuntimeException {
+        MyProgrammaticException(String message) {
+            super(message)
+        }
+    }
+}

--- a/src/main/docs/guide/aop/retry.adoc
+++ b/src/main/docs/guide/aop/retry.adoc
@@ -50,6 +50,34 @@ snippet::io.micronaut.docs.aop.retry.BookService[tags="circuit", indent=0, title
 
 The above example retries the `findBooks` method three times and then opens the circuit for 30 seconds, rethrowing the original exception and preventing potential downstream traffic such as HTTP requests and I/O operations flooding the system.
 
+== Programmatic Retry
+
+For cases where annotations are not desirable, Micronaut Retry also provides programmatic retry creation through typed policies and injected factory beans.
+
+Create a policy once and derive reusable operations from the injected factory:
+
+snippet::io.micronaut.docs.aop.retry.ProgrammaticBookService[tags="programmatic-policy", indent=0, title="Creating a Programmatic Retry Policy"]
+
+The programmatic API uses typed values such as `Duration` and `int` instead of annotation strings.
+
+For synchronous work, execute the supplier directly through `RetryOperations`:
+
+snippet::io.micronaut.docs.aop.retry.ProgrammaticBookService[tags="programmatic-sync", indent=0, title="Programmatic Retry for Synchronous Code"]
+
+Reactive retry is also supported. Pass a supplier so each retry attempt creates a fresh `Publisher`:
+
+snippet::io.micronaut.docs.aop.retry.ProgrammaticBookService[tags="programmatic-reactive", indent=0, title="Programmatic Retry for Reactive Code"]
+
+For asynchronous work, pass a supplier that creates a new `CompletionStage` for each attempt:
+
+snippet::io.micronaut.docs.aop.retry.ProgrammaticBookService[tags="programmatic-async", indent=0, title="Programmatic Retry for Asynchronous Code"]
+
+== Programmatic Circuit Breaker
+
+Programmatic circuit breakers are created in the same way, using a typed `CircuitBreakerPolicy` and an injected `CircuitBreakerOperationsFactory`. The resulting `CircuitBreakerOperations` instance owns the shared breaker state.
+
+snippet::io.micronaut.docs.aop.retry.ProgrammaticBookService[tags="programmatic-circuit", indent=0, title="Programmatic Circuit Breaker"]
+
 == Factory Bean Retry
 
 When ann:retry.annotation.Retryable[] is applied to bean factory methods, it behaves as if the annotation was placed on the type being returned. The retry behavior applies when the methods on the returned object are invoked. Note that the bean factory method itself is *not* retried. If you want the functionality of creating the bean to be retried, it should be delegated to another singleton that has the ann:retry.annotation.Retryable[] annotation applied.

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/retry/ProgrammaticBookService.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/retry/ProgrammaticBookService.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.aop.retry
+
+import io.micronaut.retry.CircuitBreakerOperations
+import io.micronaut.retry.CircuitBreakerOperationsFactory
+import io.micronaut.retry.CircuitBreakerPolicy
+import io.micronaut.retry.RetryOperations
+import io.micronaut.retry.RetryOperationsFactory
+import io.micronaut.retry.RetryPolicy
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.atomic.AtomicInteger
+
+@Singleton
+class ProgrammaticBookService {
+
+    private final RetryOperations retryOperations
+    private final CircuitBreakerOperations circuitBreakerOperations
+    private final AtomicInteger syncCounter = new AtomicInteger()
+    private final AtomicInteger reactiveCounter = new AtomicInteger()
+    private final AtomicInteger asyncCounter = new AtomicInteger()
+    private final AtomicInteger circuitCounter = new AtomicInteger()
+
+    ProgrammaticBookService(RetryOperationsFactory retryOperationsFactory,
+                            CircuitBreakerOperationsFactory circuitBreakerOperationsFactory) {
+        // tag::programmatic-policy[]
+        RetryPolicy retryPolicy = RetryPolicy.builder()
+            .maxAttempts(5)
+            .delay(Duration.ofMillis(5))
+            .build()
+        CircuitBreakerPolicy circuitBreakerPolicy = CircuitBreakerPolicy.builder()
+            .maxAttempts(3)
+            .delay(Duration.ofMillis(5))
+            .resetTimeout(Duration.ofMillis(100))
+            .build()
+        // end::programmatic-policy[]
+        this.retryOperations = retryOperationsFactory.createRetryOperations(retryPolicy)
+        this.circuitBreakerOperations = circuitBreakerOperationsFactory.createCircuitBreakerOperations(circuitBreakerPolicy)
+    }
+
+    void reset() {
+        syncCounter.set(0)
+        reactiveCounter.set(0)
+        asyncCounter.set(0)
+        circuitCounter.set(0)
+    }
+
+    // tag::programmatic-sync[]
+    List<Book> listBooks() {
+        retryOperations.execute {
+            if (syncCounter.incrementAndGet() < 3) {
+                throw new IllegalStateException('Temporary failure')
+            }
+            [new Book('The Stand')]
+        }
+    }
+    // end::programmatic-sync[]
+
+    // tag::programmatic-reactive[]
+    Publisher<Book> streamBooks() {
+        retryOperations.executePublisher {
+            Flux.defer {
+                if (reactiveCounter.incrementAndGet() < 3) {
+                    Flux.error(new IllegalStateException('Temporary failure'))
+                } else {
+                    Flux.just(new Book('The Stand'))
+                }
+            }
+        }
+    }
+    // end::programmatic-reactive[]
+
+    // tag::programmatic-async[]
+    CompletionStage<Book> findBook(String title) {
+        retryOperations.executeCompletionStage {
+            CompletableFuture.supplyAsync {
+                if (asyncCounter.incrementAndGet() < 3) {
+                    throw new IllegalStateException('Temporary failure')
+                }
+                new Book(title)
+            }
+        }
+    }
+    // end::programmatic-async[]
+
+    // tag::programmatic-circuit[]
+    Book findBookWithCircuitBreaker(String title) {
+        circuitBreakerOperations.execute {
+            if (circuitCounter.incrementAndGet() < 4) {
+                throw new IllegalStateException('Circuit failure')
+            }
+            new Book(title)
+        }
+    }
+    // end::programmatic-circuit[]
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.groovy
@@ -16,7 +16,6 @@
 package io.micronaut.docs.aop.retry
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.retry.exception.CircuitOpenException
 import reactor.core.publisher.Mono
 import spock.lang.Specification
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.aop.retry
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.retry.exception.CircuitOpenException
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+class ProgrammaticRetrySpec extends Specification {
+
+    void 'test programmatic retry examples'() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        ProgrammaticBookService service = context.getBean(ProgrammaticBookService)
+
+        when:
+        service.reset()
+        String syncTitle = service.listBooks().first().title
+        service.reset()
+        String reactiveTitle = Mono.from(service.streamBooks()).block().title
+        service.reset()
+        String asyncTitle = service.findBook('The Stand').toCompletableFuture().get().title
+
+        then:
+        syncTitle == 'The Stand'
+        reactiveTitle == 'The Stand'
+        asyncTitle == 'The Stand'
+
+        when:
+        service.reset()
+        String circuitTitle = service.findBookWithCircuitBreaker('The Stand').title
+
+        then:
+        circuitTitle == 'The Stand'
+
+        cleanup:
+        context.close()
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/retry/ProgrammaticBookService.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/retry/ProgrammaticBookService.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.aop.retry
+
+import io.micronaut.retry.CircuitBreakerOperations
+import io.micronaut.retry.CircuitBreakerOperationsFactory
+import io.micronaut.retry.CircuitBreakerPolicy
+import io.micronaut.retry.RetryOperations
+import io.micronaut.retry.RetryOperationsFactory
+import io.micronaut.retry.RetryPolicy
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.atomic.AtomicInteger
+
+@Singleton
+open class ProgrammaticBookService(
+    retryOperationsFactory: RetryOperationsFactory,
+    circuitBreakerOperationsFactory: CircuitBreakerOperationsFactory
+) {
+
+    private val retryOperations: RetryOperations
+    private val circuitBreakerOperations: CircuitBreakerOperations
+    private val syncCounter = AtomicInteger()
+    private val reactiveCounter = AtomicInteger()
+    private val asyncCounter = AtomicInteger()
+    private val circuitCounter = AtomicInteger()
+
+    init {
+        // tag::programmatic-policy[]
+        val retryPolicy = RetryPolicy.builder()
+            .maxAttempts(5)
+            .delay(Duration.ofMillis(5))
+            .build()
+        val circuitBreakerPolicy = CircuitBreakerPolicy.builder()
+            .maxAttempts(3)
+            .delay(Duration.ofMillis(5))
+            .resetTimeout(Duration.ofMillis(100))
+            .build()
+        // end::programmatic-policy[]
+        retryOperations = retryOperationsFactory.createRetryOperations(retryPolicy)
+        circuitBreakerOperations = circuitBreakerOperationsFactory.createCircuitBreakerOperations(circuitBreakerPolicy)
+    }
+
+    fun reset() {
+        syncCounter.set(0)
+        reactiveCounter.set(0)
+        asyncCounter.set(0)
+        circuitCounter.set(0)
+    }
+
+    // tag::programmatic-sync[]
+    open fun listBooks(): List<Book> = retryOperations.execute {
+        if (syncCounter.incrementAndGet() < 3) {
+            throw IllegalStateException("Temporary failure")
+        }
+        listOf(Book("The Stand"))
+    }
+    // end::programmatic-sync[]
+
+    // tag::programmatic-reactive[]
+    open fun streamBooks(): Publisher<Book> = retryOperations.executePublisher {
+        Flux.defer {
+            if (reactiveCounter.incrementAndGet() < 3) {
+                Flux.error(IllegalStateException("Temporary failure"))
+            } else {
+                Flux.just(Book("The Stand"))
+            }
+        }
+    }
+    // end::programmatic-reactive[]
+
+    // tag::programmatic-async[]
+    open fun findBook(title: String): CompletionStage<Book> = retryOperations.executeCompletionStage {
+        CompletableFuture.supplyAsync {
+            if (asyncCounter.incrementAndGet() < 3) {
+                throw IllegalStateException("Temporary failure")
+            }
+            Book(title)
+        }
+    }
+    // end::programmatic-async[]
+
+    // tag::programmatic-circuit[]
+    open fun findBookWithCircuitBreaker(title: String): Book = circuitBreakerOperations.execute {
+        if (circuitCounter.incrementAndGet() < 4) {
+            throw IllegalStateException("Circuit failure")
+        }
+        Book(title)
+    }
+    // end::programmatic-circuit[]
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.kt
@@ -1,0 +1,31 @@
+package io.micronaut.docs.aop.retry
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.retry.exception.CircuitOpenException
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ProgrammaticRetrySpec {
+
+    @Test
+    fun testProgrammaticRetryExamples() {
+        val context = ApplicationContext.run()
+        val service = context.getBean(ProgrammaticBookService::class.java)
+
+        service.reset()
+        assertEquals("The Stand", service.listBooks().first().title)
+
+        service.reset()
+        assertEquals("The Stand", Mono.from(service.streamBooks()).block()!!.title)
+
+        service.reset()
+        assertEquals("The Stand", service.findBook("The Stand").toCompletableFuture().get().title)
+
+        service.reset()
+        assertEquals("The Stand", service.findBookWithCircuitBreaker("The Stand").title)
+
+        context.close()
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.kt
@@ -1,31 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.docs.aop.retry
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.retry.exception.CircuitOpenException
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 class ProgrammaticRetrySpec {
 
     @Test
     fun testProgrammaticRetryExamples() {
-        val context = ApplicationContext.run()
-        val service = context.getBean(ProgrammaticBookService::class.java)
+        ApplicationContext.run().use { context ->
+            val service = context.getBean(ProgrammaticBookService::class.java)
 
-        service.reset()
-        assertEquals("The Stand", service.listBooks().first().title)
+            service.reset()
+            assertEquals("The Stand", service.listBooks().first().title)
 
-        service.reset()
-        assertEquals("The Stand", Mono.from(service.streamBooks()).block()!!.title)
+            service.reset()
+            assertEquals("The Stand", Mono.from(service.streamBooks()).block()!!.title)
 
-        service.reset()
-        assertEquals("The Stand", service.findBook("The Stand").toCompletableFuture().get().title)
+            service.reset()
+            assertEquals("The Stand", service.findBook("The Stand").toCompletableFuture().get().title)
 
-        service.reset()
-        assertEquals("The Stand", service.findBookWithCircuitBreaker("The Stand").title)
-
-        context.close()
+            service.reset()
+            assertEquals("The Stand", service.findBookWithCircuitBreaker("The Stand").title)
+        }
     }
 }

--- a/test-suite/src/test/java/io/micronaut/docs/aop/retry/ProgrammaticBookService.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/retry/ProgrammaticBookService.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.aop.retry;
+
+import io.micronaut.retry.CircuitBreakerOperations;
+import io.micronaut.retry.CircuitBreakerOperationsFactory;
+import io.micronaut.retry.CircuitBreakerPolicy;
+import io.micronaut.retry.RetryOperations;
+import io.micronaut.retry.RetryOperationsFactory;
+import io.micronaut.retry.RetryPolicy;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Singleton
+public class ProgrammaticBookService {
+
+    private final RetryOperations retryOperations;
+    private final CircuitBreakerOperations circuitBreakerOperations;
+    private final AtomicInteger syncCounter = new AtomicInteger();
+    private final AtomicInteger reactiveCounter = new AtomicInteger();
+    private final AtomicInteger asyncCounter = new AtomicInteger();
+    private final AtomicInteger circuitCounter = new AtomicInteger();
+
+    public ProgrammaticBookService(RetryOperationsFactory retryOperationsFactory,
+                                   CircuitBreakerOperationsFactory circuitBreakerOperationsFactory) {
+        // tag::programmatic-policy[]
+        RetryPolicy retryPolicy = RetryPolicy.builder()
+            .maxAttempts(5)
+            .delay(Duration.ofMillis(5))
+            .build();
+        CircuitBreakerPolicy circuitBreakerPolicy = CircuitBreakerPolicy.builder()
+            .maxAttempts(3)
+            .delay(Duration.ofMillis(5))
+            .resetTimeout(Duration.ofMillis(100))
+            .build();
+        // end::programmatic-policy[]
+        this.retryOperations = retryOperationsFactory.createRetryOperations(retryPolicy);
+        this.circuitBreakerOperations = circuitBreakerOperationsFactory.createCircuitBreakerOperations(circuitBreakerPolicy);
+    }
+
+    public void reset() {
+        syncCounter.set(0);
+        reactiveCounter.set(0);
+        asyncCounter.set(0);
+        circuitCounter.set(0);
+    }
+
+    // tag::programmatic-sync[]
+    public List<Book> listBooks() {
+        return retryOperations.execute(() -> {
+            if (syncCounter.incrementAndGet() < 3) {
+                throw new IllegalStateException("Temporary failure");
+            }
+            return Collections.singletonList(new Book("The Stand"));
+        });
+    }
+    // end::programmatic-sync[]
+
+    // tag::programmatic-reactive[]
+    public Publisher<Book> streamBooks() {
+        return retryOperations.executePublisher(() -> Flux.defer(() -> {
+            if (reactiveCounter.incrementAndGet() < 3) {
+                return Flux.error(new IllegalStateException("Temporary failure"));
+            }
+            return Flux.just(new Book("The Stand"));
+        }));
+    }
+    // end::programmatic-reactive[]
+
+    // tag::programmatic-async[]
+    public CompletionStage<Book> findBook(String title) {
+        return retryOperations.executeCompletionStage(() -> CompletableFuture.supplyAsync(() -> {
+            if (asyncCounter.incrementAndGet() < 3) {
+                throw new IllegalStateException("Temporary failure");
+            }
+            return new Book(title);
+        }));
+    }
+    // end::programmatic-async[]
+
+    // tag::programmatic-circuit[]
+    public Book findBookWithCircuitBreaker(String title) {
+        return circuitBreakerOperations.execute(() -> {
+            if (circuitCounter.incrementAndGet() < 4) {
+                throw new IllegalStateException("Circuit failure");
+            }
+            return new Book(title);
+        });
+    }
+    // end::programmatic-circuit[]
+}

--- a/test-suite/src/test/java/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.java
@@ -16,11 +16,8 @@
 package io.micronaut.docs.aop.retry;
 
 import io.micronaut.context.ApplicationContext;
-import io.micronaut.retry.exception.CircuitOpenException;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
-
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/test-suite/src/test/java/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/retry/ProgrammaticRetrySpec.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.aop.retry;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.retry.exception.CircuitOpenException;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProgrammaticRetrySpec {
+
+    @Test
+    void testProgrammaticRetryExamples() throws Exception {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ProgrammaticBookService service = context.getBean(ProgrammaticBookService.class);
+
+            service.reset();
+            assertEquals("The Stand", service.listBooks().get(0).getTitle());
+
+            service.reset();
+            assertEquals("The Stand", Mono.from(service.streamBooks()).block().getTitle());
+
+            service.reset();
+            assertEquals("The Stand", service.findBook("The Stand").toCompletableFuture().get().getTitle());
+
+            service.reset();
+            assertEquals("The Stand", service.findBookWithCircuitBreaker("The Stand").getTitle());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add programmatic retry and circuit breaker APIs alongside the existing annotation model
- refactor retry execution so annotation-driven and programmatic flows share the same runtime path
- document the new API with executable Java, Kotlin, and Groovy snippet-backed examples
- apply follow-up review fixes: new API `@since` values set to `5.0.0`, policy types converted to records, private builder constructors, and maintainer Javadocs on default implementations

## What changed
### Programmatic API
- added `RetryOperations` / `CircuitBreakerOperations`
- added `RetryOperationsFactory` / `CircuitBreakerOperationsFactory`
- added typed `RetryPolicy` and `CircuitBreakerPolicy` builders for non-annotation use cases
- kept support for synchronous, reactive `Publisher`, and asynchronous `CompletionStage` flows

### Shared runtime refactor
- extracted shared retry execution logic into `DefaultRetryRunner`
- added `PolicyRetryStateBuilder` so typed policies and annotations flow through the same state-building path
- updated `DefaultRetryInterceptor` and annotation metadata handling to delegate through the shared runtime/policy path while preserving existing annotation defaults and behavior

### Tests and docs
- added retry-module specs covering programmatic retry and circuit breaker behavior
- added executable test-suite examples in:
  - `test-suite`
  - `test-suite-kotlin`
  - `test-suite-groovy`
- updated `src/main/docs/guide/aop/retry.adoc` to include snippet-backed programmatic retry and circuit breaker sections

## Verification
- `./gradlew :micronaut-retry:compileJava`
- `./gradlew :micronaut-retry:test`

## Notes
- the focused retry verification is green
- pre-existing repo/environment noise remains outside this change scope (for example broader Gradle/Kotlin plugin warnings and unrelated module warnings)
