### PR TITLE
Jackson upgrade to 2.21.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,10 +73,10 @@ jfrunit = "1.0.0.Alpha2"
 #
 managed-groovy = "4.0.28"
 managed-jakarta-annotation-api = "2.1.1"
-managed-jackson = "2.21.1"
+managed-jackson = "2.21.2"
 managed-jackson-annotations = "2.21"
 #@NextMajorVersion @Deprecated Delete in Micronaut Framework 5.
-managed-jackson-databind = "2.21.1"
+managed-jackson-databind = "2.21.2"
 managed-kotlin = "1.9.25"
 managed-kotlin2 = "2.1.21"
 managed-kotlin-coroutines = "1.8.1"


### PR DESCRIPTION
Jackson 2.21.2 is necessary due to: https://github.com/FasterXML/jackson-module-kotlin/issues/1129

Otherwise we get errors such as:

```
om.fasterxml.jackson.module/jackson-module-kotlinon-module-kotlin-2.21.1.jar!/META-INF/jackson-module-kotlin.kotlin_moduleModule was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.1.0, expected version is 1.9.0.``