### PR TITLE
Add jakarta Priority annotation mapper

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/JakartaPriorityAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/JakartaPriorityAnnotationMapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation.internal;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+@Internal
+public final class JakartaPriorityAnnotationMapper implements NamedAnnotationMapper {
+
+    private static final String SOURCE_ANNOTATION = "jakarta.annotation.Priority";
+
+    @Override
+    public String getName() {
+        return SOURCE_ANNOTATION;
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+            AnnotationValue.builder(Order.class)
+                .value(annotation.intValue().orElse(0))
+                .build()
+        );
+    }
+}

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -1,5 +1,6 @@
 io.micronaut.inject.annotation.internal.JavaxPersistenceContextAnnotationMapper
 io.micronaut.inject.annotation.internal.JakartaPersistenceContextAnnotationMapper
+io.micronaut.inject.annotation.internal.JakartaPriorityAnnotationMapper
 io.micronaut.inject.beans.visitor.EntityIntrospectedAnnotationMapper
 io.micronaut.inject.beans.visitor.EntityReflectiveAccessAnnotationMapper
 io.micronaut.inject.beans.visitor.MappedSuperClassIntrospectionMapper
@@ -8,4 +9,3 @@ io.micronaut.inject.beans.visitor.persistence.JakartaEntityIntrospectedAnnotatio
 io.micronaut.inject.beans.visitor.persistence.JakartaMappedSuperClassIntrospectionMapper
 io.micronaut.inject.beans.visitor.MapperAnnotationMapper
 io.micronaut.aop.mapper.InterceptorBeanMapper
-

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/PriorityAnnotationMapperSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/PriorityAnnotationMapperSpec.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.Order
+
+class PriorityAnnotationMapperSpec extends AbstractTypeElementSpec {
+
+    void 'maps jakarta.annotation.Priority to Order preserving positive value'() {
+        given:
+        def definition = buildBeanDefinition('test.Test', '''
+package test;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Priority(10)
+class Test {
+}
+''')
+
+        expect:
+        definition.intValue(Order).orElseThrow() == 10
+    }
+
+    void 'maps jakarta.annotation.Priority to Order preserving negative value'() {
+        given:
+        def definition = buildBeanDefinition('test.Test', '''
+package test;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Priority(-3)
+class Test {
+}
+''')
+
+        expect:
+        definition.intValue(Order).orElseThrow() == -3
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/PriorityOrderingSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/PriorityOrderingSpec.groovy
@@ -1,0 +1,65 @@
+package io.micronaut.inject.ordered
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.NonUniqueBeanException
+import jakarta.annotation.Priority
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class PriorityOrderingSpec extends Specification {
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+
+    void 'test priority selects highest precedence bean'() {
+        expect:
+        context.getBean(PriorityProduct) instanceof PriorityHighValueProduct
+    }
+
+    void 'test priority orders bean collections'() {
+        expect:
+        context.streamOfType(PriorityProduct).toList()*.class == [
+            PriorityHighValueProduct,
+            PriorityMidValueProduct,
+            PriorityLowValueProduct
+        ]
+    }
+
+    void 'test duplicate priority remains non unique'() {
+        when:
+        context.getBean(PriorityFruit)
+
+        then:
+        thrown(NonUniqueBeanException)
+    }
+}
+
+interface PriorityProduct {
+}
+
+@Singleton
+@Priority(-10)
+class PriorityHighValueProduct implements PriorityProduct {
+}
+
+@Singleton
+class PriorityMidValueProduct implements PriorityProduct {
+}
+
+@Singleton
+@Priority(10)
+class PriorityLowValueProduct implements PriorityProduct {
+}
+
+interface PriorityFruit {
+}
+
+@Singleton
+@Priority(-3)
+class PriorityApple implements PriorityFruit {
+}
+
+@Singleton
+@Priority(-3)
+class PriorityBanana implements PriorityFruit {
+}

--- a/src/main/docs/guide/httpServer/filters/filtermethods/order.adoc
+++ b/src/main/docs/guide/httpServer/filters/filtermethods/order.adoc
@@ -1,12 +1,12 @@
-Filters can be ordered by annotating the filter method or filter class with api:order.Order[] or jakarta.annotation.Priority, or by implementing api:order.Ordered[] in the filter class.
+Filters can be ordered by annotating the filter method or filter class with api:order.Order[] or link:{jakartaapi}/jakarta/annotation/Priority.html[jakarta.annotation.Priority], or by implementing api:order.Ordered[] in the filter class.
 
-. An api:order.Order[] or jakarta.annotation.Priority annotation on the filter method
-. An api:order.Order[] or jakarta.annotation.Priority annotation on the filter class
+. An api:order.Order[] or link:{jakartaapi}/jakarta/annotation/Priority.html[@Priority] annotation on the filter method
+. An api:order.Order[] or link:{jakartaapi}/jakarta/annotation/Priority.html[@Priority] annotation on the filter class
 . Implementing api:order.Ordered[] in the filter class
 
 Request filters are executed in order from the highest precedence (the smallest integer value, as defined by `Ordered.HIGHEST_PRECEDENCE`) to the lowest precedence (the biggest integer value, as defined by `Ordered.LOWEST_PRECEDENCE`). Response filters are executed in reverse order.
 
-Micronaut applies the same numeric precedence rule to jakarta.annotation.Priority because Priority is mapped to io.micronaut.core.annotation.Order during annotation processing.
+Micronaut applies the same numeric precedence rule to link:{jakartaapi}/jakarta/annotation/Priority.html[jakarta.annotation.Priority] because link:{jakartaapi}/jakarta/annotation/Priority.html[@Priority] is mapped to ann:core.annotation.Order[] during annotation processing.
 
 image::filter-order.svg[]
 

--- a/src/main/docs/guide/httpServer/filters/filtermethods/order.adoc
+++ b/src/main/docs/guide/httpServer/filters/filtermethods/order.adoc
@@ -1,10 +1,12 @@
-Filters can be ordered in one of three ways:
+Filters can be ordered by annotating the filter method or filter class with api:order.Order[] or jakarta.annotation.Priority, or by implementing api:order.Ordered[] in the filter class.
 
-. An api:order.Order[] annotation on the filter method
+. An api:order.Order[] or jakarta.annotation.Priority annotation on the filter method
+. An api:order.Order[] or jakarta.annotation.Priority annotation on the filter class
 . Implementing api:order.Ordered[] in the filter class
-. An api:order.Order[] annotation on the filter class
 
 Request filters are executed in order from the highest precedence (the smallest integer value, as defined by `Ordered.HIGHEST_PRECEDENCE`) to the lowest precedence (the biggest integer value, as defined by `Ordered.LOWEST_PRECEDENCE`). Response filters are executed in reverse order.
+
+Micronaut applies the same numeric precedence rule to jakarta.annotation.Priority because Priority is mapped to io.micronaut.core.annotation.Order during annotation processing.
 
 image::filter-order.svg[]
 

--- a/src/main/docs/guide/ioc/types.adoc
+++ b/src/main/docs/guide/ioc/types.adoc
@@ -67,10 +67,10 @@ The ann:core.annotation.Order[] annotation is especially useful for ordering bea
 
 snippet::io.micronaut.docs.config.env.RateLimitsFactory[tags="clazz", indent=0, title="Factory with @Order"]
 
-When a collection of `RateLimit` beans are requested from the context, they are returned in ascending order based on the value in the annotation.
+When a collection of `RateLimit` beans are requested from the context, they are returned in ascending order based on the value in the annotation. Micronaut maps jakarta.annotation.Priority to ann:core.annotation.Order[] at build time, so @Priority values are treated the same as @Order and follow the same ascending numeric precedence (lower numbers mean higher precedence).
 
 === Injecting a Bean by Order
 
-When injecting a single instance of a bean the ann:core.annotation.Order[] annotation can also be used to define which bean has the highest precedence and hence should be injected.
+When injecting a single instance of a bean the ann:core.annotation.Order[] annotation can also be used to define which bean has the highest precedence and hence should be injected. Micronaut also maps jakarta.annotation.Priority to ann:core.annotation.Order[] at build time, so the same mapped @Priority numeric semantics determine which bean has the highest precedence for single-bean injection.
 
 NOTE: The api:core.order.Ordered[] interface is not taken into account when selecting a single instance as this would require instantiating the bean to resolve the order.

--- a/src/main/docs/guide/ioc/types.adoc
+++ b/src/main/docs/guide/ioc/types.adoc
@@ -67,10 +67,10 @@ The ann:core.annotation.Order[] annotation is especially useful for ordering bea
 
 snippet::io.micronaut.docs.config.env.RateLimitsFactory[tags="clazz", indent=0, title="Factory with @Order"]
 
-When a collection of `RateLimit` beans are requested from the context, they are returned in ascending order based on the value in the annotation. Micronaut maps jakarta.annotation.Priority to ann:core.annotation.Order[] at build time, so @Priority values are treated the same as @Order and follow the same ascending numeric precedence (lower numbers mean higher precedence).
+When a collection of `RateLimit` beans are requested from the context, they are returned in ascending order based on the value in the annotation. Micronaut maps link:{jakartaapi}/jakarta/annotation/Priority.html[jakarta.annotation.Priority] to ann:core.annotation.Order[] at build time, so link:{jakartaapi}/jakarta/annotation/Priority.html[@Priority] values are treated the same as ann:core.annotation.Order[] and follow the same ascending numeric precedence (lower numbers mean higher precedence).
 
 === Injecting a Bean by Order
 
-When injecting a single instance of a bean the ann:core.annotation.Order[] annotation can also be used to define which bean has the highest precedence and hence should be injected. Micronaut also maps jakarta.annotation.Priority to ann:core.annotation.Order[] at build time, so the same mapped @Priority numeric semantics determine which bean has the highest precedence for single-bean injection.
+When injecting a single instance of a bean the ann:core.annotation.Order[] annotation can also be used to define which bean has the highest precedence and hence should be injected. Micronaut also maps link:{jakartaapi}/jakarta/annotation/Priority.html[jakarta.annotation.Priority] to ann:core.annotation.Order[] at build time, so the same mapped link:{jakartaapi}/jakarta/annotation/Priority.html[@Priority] numeric semantics determine which bean has the highest precedence for single-bean injection.
 
 NOTE: The api:core.order.Ordered[] interface is not taken into account when selecting a single instance as this would require instantiating the bean to resolve the order.


### PR DESCRIPTION
## Summary
- add a build-time `NamedAnnotationMapper` that maps `jakarta.annotation.Priority` to Micronaut `@Order`
- register the mapper and add focused regressions for metadata mapping and bean ordering behavior
- document `@Priority` support in the IoC ordering and HTTP filter ordering guides

## Verification
- `./gradlew -q :micronaut-core-processor:compileJava`
- `./gradlew -q :micronaut-inject-java:compileTestGroovy`
- `./gradlew :micronaut-inject-java:test --tests 'io.micronaut.inject.annotation.PriorityAnnotationMapperSpec' --tests 'io.micronaut.inject.ordered.PriorityOrderingSpec'`
- `./gradlew -q spotlessCheck`
- `./gradlew japiCmp`

## Notes
- `./gradlew -q cM` is currently blocked by a pre-existing checkstyle failure in `http/src/main/java/io/micronaut/http/MediaType.java:1516`
- `./gradlew check jacocoReport --no-daemon --continue` is currently blocked by unrelated existing repo-wide failures outside the changed files
- `./gradlew docs --no-daemon` is currently blocked by unrelated existing Javadoc failures in code modules
