### PR TITLE
Fix @ExecuteOn ignored for suspend functions

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
+++ b/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
@@ -25,6 +25,7 @@ import jakarta.inject.Singleton;
 import reactor.util.context.ContextView;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Coroutines helper.
@@ -45,5 +46,10 @@ public final class CoroutineHelper {
 
     public void setupCoroutineContext(HttpRequest<?> httpRequest, ContextView contextView, PropagatedContext propagatedContext) {
         ContinuationArgumentBinder.setupCoroutineContext(httpRequest, contextView, propagatedContext, coroutineContextFactories);
+    }
+
+
+    public void setupCoroutineContext(HttpRequest<?> httpRequest, ContextView contextView, PropagatedContext propagatedContext, ExecutorService executorService) {
+        ContinuationArgumentBinder.setupCoroutineContext(httpRequest, contextView, propagatedContext, coroutineContextFactories, executorService);
     }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
+++ b/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
@@ -48,7 +48,6 @@ public final class CoroutineHelper {
         ContinuationArgumentBinder.setupCoroutineContext(httpRequest, contextView, propagatedContext, coroutineContextFactories);
     }
 
-
     public void setupCoroutineContext(HttpRequest<?> httpRequest, ContextView contextView, PropagatedContext propagatedContext, ExecutorService executorService) {
         ContinuationArgumentBinder.setupCoroutineContext(httpRequest, contextView, propagatedContext, coroutineContextFactories, executorService);
     }

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -431,12 +431,13 @@ public final class RouteExecutor {
         ExecutionFlow<HttpResponse<?>> executeMethodResponseFlow;
         if (executorService != null) {
             if (routeInfo.isSuspended()) {
+                Scheduler scheduler = Schedulers.fromExecutor(executorService);
                 executeMethodResponseFlow = ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(contextView -> {
-                        coroutineHelper.ifPresent(helper -> helper.setupCoroutineContext(request, contextView, propagatedContext));
+                        coroutineHelper.ifPresent(helper -> helper.setupCoroutineContext(request, contextView, propagatedContext, executorService));
                         return Mono.from(
                             ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request)).toPublisher()
                         );
-                    }));
+                    }).subscribeOn(scheduler));
             } else if (routeInfo.isReactive()) {
                 executeMethodResponseFlow = ReactiveExecutionFlow.async(executorService, () -> executeRouteAndConvertBody(propagatedContext, routeMatch, request));
             } else {

--- a/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
+++ b/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
@@ -24,10 +24,12 @@ import io.micronaut.core.reflect.ClassUtils
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.reactor.ReactorContext
 import reactor.util.context.ContextView
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
 import java.util.function.Supplier
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
@@ -56,9 +58,18 @@ class ContinuationArgumentBinder : TypedRequestArgumentBinder<Continuation<*>> {
                                   contextView: ContextView,
                                   propagatedContext: PropagatedContext,
                                   continuationArgumentBinderCoroutineContextFactories: Collection<HttpCoroutineContextFactory<*>>) {
+            setupCoroutineContext(source, contextView, propagatedContext, continuationArgumentBinderCoroutineContextFactories, null)
+        }
+
+        @JvmStatic
+        fun setupCoroutineContext(source: HttpRequest<*>,
+                                  contextView: ContextView,
+                                  propagatedContext: PropagatedContext,
+                                  continuationArgumentBinderCoroutineContextFactories: Collection<HttpCoroutineContextFactory<*>>,
+                                  executorService: ExecutorService?) {
             val customContinuation = source.getAttribute(CONTINUATION_ARGUMENT_ATTRIBUTE_KEY, CustomContinuation::class.java).orElse(null)
             if (customContinuation != null) {
-                var coroutineContext: CoroutineContext = Dispatchers.Default
+                var coroutineContext: CoroutineContext = executorService?.asCoroutineDispatcher() ?: Dispatchers.Default
                 if (reactorContextPresent) {
                     coroutineContext += propagateReactorContext(contextView)
                 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendExecuteOnSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendExecuteOnSpec.kt
@@ -1,0 +1,48 @@
+package io.micronaut.docs.server.suspend
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldStartWith
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.LoomSupport
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import kotlinx.coroutines.reactive.awaitSingle
+
+class SuspendExecuteOnSpec : StringSpec() {
+
+    val embeddedServer = autoClose(
+        ApplicationContext.run(
+            EmbeddedServer::class.java,
+            mapOf("spec.name" to "SuspendExecuteOnSpec")
+        )
+    )
+
+    val client = autoClose(
+        embeddedServer.applicationContext.createBean(HttpClient::class.java, embeddedServer.url)
+    )
+
+    init {
+        "suspend function with @ExecuteOn should run on the IO thread pool, not the event loop" {
+            val threadName = client.retrieve("/suspend-execute-on/thread").awaitSingle()
+            threadName shouldStartWith "${TaskExecutors.IO}-executor"
+        }
+    }
+
+    @Requires(property = "spec.name", value = "SuspendExecuteOnSpec")
+    @Controller("/suspend-execute-on")
+    @Produces("text/plain")
+    class SuspendExecuteOnController {
+
+        @Get("/thread")
+        @ExecuteOn(TaskExecutors.IO)
+        suspend fun threadName(): String {
+            return Thread.currentThread().name
+        }
+    }
+}


### PR DESCRIPTION
When a Kotlin controller method is a suspend function and annotated with @ExecuteOn(TaskExecutors.IO), the handler runs on the Netty event
 loop thread instead of the IO thread pool. The same annotation works
 correctly for Java methods and Kotlin non-suspend methods.

In RouteExecutor.callRoute(), the executorService retrieved from @ExecuteOn is correctly obtained but silently ignored in the isSuspended() branch. Also,
ContinuationArgumentBinder.setupCoroutineContext hardcodes Dispatchers.Default as the coroutine dispatcher, so post-suspension resumptions always run on the default pool.

Fixing issue https://github.com/micronaut-projects/micronaut-core/issues/12326