### PR TITLE
Fix whatsNew.adoc section heading levels and "scoped values" terminology

### DIFF
--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfiguration.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfiguration.adoc
@@ -1,6 +1,8 @@
 As you can see, the Micronaut framework features a robust system for externalizing and adapting configuration to the environment inspired by similar approaches in Grails and Spring Boot.
 
-However, what if you want multiple microservices to share configuration? the Micronaut framework includes APIs for distributed configuration.
+However, what if you want multiple microservices to share configuration? The Micronaut framework includes APIs for distributed configuration.
+
+For new applications and new integrations, the recommended approach is to use <<configImport, configuration import>> via `micronaut.config.import` instead of relying on the bootstrap context. Configuration imports let you load remote or shared configuration as part of normal property source resolution, and custom remote sources can be integrated with <<customPropertySourceImporter, PropertySourceImporter>> implementations.
 
 The api:discovery.config.ConfigurationClient[] interface has a `getPropertySources` method that can be implemented to read and resolve configuration from distributed sources.
 
@@ -8,6 +10,6 @@ The `getPropertySources` returns a rs:Publisher[] that emits zero or many api:co
 
 The default implementation is api:discovery.config.DefaultCompositeConfigurationClient[] which merges all registered `ConfigurationClient` beans into a single bean.
 
-You can either implement your own api:discovery.config.ConfigurationClient[] or use the implementations provided by Micronaut. The following sections cover those.
+You can either implement your own api:discovery.config.ConfigurationClient[] or use the implementations provided by Micronaut. For new work, prefer implementing distributed configuration through configuration import support and `PropertySourceImporter`. The following sections cover the available integrations.
 
-NOTE: When implementing custom distributed configuration that is loaded during bootstrap, implementing api:discovery.config.ConfigurationClient[] alone is not enough. The application also needs the discovery client infrastructure, which normally comes from the `io.micronaut.discovery:micronaut-discovery-client` dependency, and any beans involved in resolving that configuration must still be bootstrap-compatible.
+NOTE: The bootstrap context is still available for legacy integrations and compatibility scenarios, but it is no longer the recommended default for distributed configuration. If you still load distributed configuration during bootstrap, implementing api:discovery.config.ConfigurationClient[] alone is not enough. The application also needs the discovery client infrastructure, which normally comes from the `io.micronaut.discovery:micronaut-discovery-client` dependency, and any beans involved in resolving that configuration must still be bootstrap-compatible. See <<bootstrap, Bootstrap Configuration>> for those legacy requirements.

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -23,6 +23,7 @@ Micronaut framework by default contains `PropertySourceLoader` implementations t
 
 NOTE: 'micronaut.config.files' will be ignored in bootstrap.yml or application.yml.
 
+[[configImport]]
 === Importing Additional Configuration
 
 You can import additional configuration directly from a configuration file using `micronaut.config.import`.
@@ -60,6 +61,7 @@ When multiple resources with the same classpath name are present:
 
 IMPORTANT: `file:///tmp/bar.properties` (with three slashes) resolves to the absolute path `/tmp/bar.properties`.
 
+[[customPropertySourceImporter]]
 === Implementing a Custom PropertySourceImporter
 
 You can add support for a custom import protocol by implementing api:io.micronaut.context.env.PropertySourceImporter[] and registering it with Java ServiceLoader. Each importer declares its provider with `getProvider()`, converts the parsed api:io.micronaut.core.util.ConnectionString[] into a typed declaration via `newImportDeclaration(..)`, and then reads configuration from `importPropertySource(..)`.

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -1,0 +1,51 @@
+Micronaut Framework 5.0.x continues the work started in the first 5.0 milestones and adds a number of improvements across the core container, HTTP stack, configuration system, and developer-facing APIs.
+
+This page is a curated overview of the most important additions on the `5.0.x` line. For upgrade guidance, see <<upgrading, Upgrading your Micronaut Application>>, and for incompatible changes, review <<breaks, Breaking Changes>>.
+
+== Core Themes in Micronaut Framework 5.0.x
+
+Micronaut Framework 5 modernizes the core platform with newer JVM and language support, including a new JDK 25 baseline, an Apache Groovy 5 baseline, a Kotlin 2.3 baseline, broader support for current JDK capabilities, and deeper investment in compile-time metadata. See also <<breaks, Breaking Changes>> for version-specific migration notes.
+
+The framework APIs now embrace <<nullabilityAnnotations, nullability annotations>> and specifically <<jspecify, JSpecify nullability annotations>>, with `@NullMarked` adoption across the codebase and stronger static analysis integration. The result is clearer API contracts, improved Kotlin interoperability, and better IDE feedback.
+
+The IoC container and compile-time infrastructure also received substantial work in the 5.0 branch. Bean resolution, qualifier handling, replacement metadata, eager initialization, and runtime annotation processing were refined to reduce runtime work and improve predictability.
+
+== Container, AOP, and Runtime Improvements
+
+The bean context was reworked in several areas during the 5.0 development cycle, including precomputed bean indexes, compile-time `@Replaces` handling, and broader bean context optimizations. Together, these changes continue Micronaut's focus on startup performance and low runtime overhead.
+
+Micronaut 5 also added support for creating AOP proxies at runtime when build-time proxy generation is not the right fit. This enables integrations such as Byte Buddy-based proxies, JDK dynamic proxies for interfaces, and test-oriented proxy scenarios such as mocks and spies. For background on Micronaut's AOP model, see <<aop, Aspect Oriented Programming>>.
+
+Recent 5.0.x work also improved interoperability with Jakarta APIs by adding support for `jakarta.annotation.Priority`, mapping it to Micronaut ordering semantics for beans and HTTP filters. Related ordering documentation can be found in <<types, Injectable Container Types>> and <<order, Filter Order>>.
+
+== HTTP, Configuration, and Metadata
+
+On the HTTP side, HTTP/3 support on the Netty stack was promoted to stable. See <<http3Server, HTTP/3 Support>> and <<clientHttp3, HTTP/3 in Clients>>. The 5.0 line also includes a multipart/form handling refactor that introduces a lower-level, more server-independent form API and improves resource management in higher-level binders. See <<form, Forms>>, <<formCapable, Detailed Form API>>, and <<uploads, File Uploads>>.
+
+Configuration support expanded significantly in 5.0.x. Micronaut now supports config imports and a `PropertySourceImporter` SPI, enabling configuration loading from sources such as files, classpath locations, environment variables, config trees, and custom importer implementations. See <<configImport, Importing Additional Configuration>>, <<customPropertySourceImporter, Implementing a Custom PropertySourceImporter>>, and <<propertySource, Externalized Configuration with PropertySources>>.
+
+Configuration metadata also became more useful for tooling. Micronaut 5 can generate JSON Schema documents from `@ConfigurationProperties`, making it easier to drive IDE completion, validation, and external tooling from the same configuration model used by the framework. For the underlying configuration model, see <<configurationProperties, Configuration Properties>>.
+
+The JSON and serialization stack was updated as well, with work across `JsonMapper`, Jackson 3 preparation, and additional configuration coverage so applications can adopt newer JSON infrastructure more smoothly.
+
+== Resilience and Context Propagation
+
+Micronaut Retry gained programmatic retry and circuit breaker APIs in addition to the existing annotation-driven model documented in <<retry, Retry Advice>>. This makes it possible to define typed retry and circuit breaker policies in code and reuse them for synchronous, reactive, and asynchronous flows.
+
+The 5.0.x line also expanded context propagation capabilities, including support for scope values and continued alignment with modern JDK context propagation patterns. See <<contextPropagation, Context Propagation>>.
+
+== Closed Enhancement PRs Reviewed for 5.0.x
+
+The following closed pull requests on the `5.0.x` branch were tagged `type: enhancement` and informed this summary:
+
+* https://github.com/micronaut-projects/micronaut-core/pull/12223[PR #12223] - Support for creating AOP proxies at runtime if necessary
+* https://github.com/micronaut-projects/micronaut-core/pull/12246[PR #12246] - Multipart and form API refactor
+* https://github.com/micronaut-projects/micronaut-core/pull/12377[PR #12377] - JSON Schema generation from Micronaut configuration properties
+* https://github.com/micronaut-projects/micronaut-core/pull/12435[PR #12435] - Truffle polyglot language support improvements
+* https://github.com/micronaut-projects/micronaut-core/pull/12571[PR #12571] - Config import support and importer SPI
+* https://github.com/micronaut-projects/micronaut-core/pull/12585[PR #12585] - Programmatic retry and circuit breaker APIs
+* https://github.com/micronaut-projects/micronaut-core/pull/12592[PR #12592] - `jakarta.annotation.Priority` annotation mapper
+
+== In Practice
+
+For teams adopting Micronaut Framework 5.0.x, the biggest benefits are stronger null-safety, more flexible AOP and retry models, better HTTP and multipart capabilities, richer configuration tooling, and continued improvements to the container's compile-time-first runtime model.

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -2,7 +2,7 @@ Micronaut Framework 5.0.x continues the work started in the first 5.0 milestones
 
 This page is a curated overview of the most important additions on the `5.0.x` line. For upgrade guidance, see <<upgrading, Upgrading your Micronaut Application>>, and for incompatible changes, review <<breaks, Breaking Changes>>.
 
-== Core Themes in Micronaut Framework 5.0.x
+=== Core Themes in Micronaut Framework 5.0.x
 
 Micronaut Framework 5 modernizes the core platform with newer JVM and language support, including a new JDK 25 baseline, an Apache Groovy 5 baseline, a Kotlin 2.3 baseline, broader support for current JDK capabilities, and deeper investment in compile-time metadata. See also <<breaks, Breaking Changes>> for version-specific migration notes.
 
@@ -10,7 +10,7 @@ The framework APIs now embrace <<nullabilityAnnotations, nullability annotations
 
 The IoC container and compile-time infrastructure also received substantial work in the 5.0 branch. Bean resolution, qualifier handling, replacement metadata, eager initialization, and runtime annotation processing were refined to reduce runtime work and improve predictability.
 
-== Container, AOP, and Runtime Improvements
+=== Container, AOP, and Runtime Improvements
 
 The bean context was reworked in several areas during the 5.0 development cycle, including precomputed bean indexes, compile-time `@Replaces` handling, and broader bean context optimizations. Together, these changes continue Micronaut's focus on startup performance and low runtime overhead.
 
@@ -18,7 +18,7 @@ Micronaut 5 also added support for creating AOP proxies at runtime when build-ti
 
 Recent 5.0.x work also improved interoperability with Jakarta APIs by adding support for `jakarta.annotation.Priority`, mapping it to Micronaut ordering semantics for beans and HTTP filters. Related ordering documentation can be found in <<types, Injectable Container Types>> and <<order, Filter Order>>.
 
-== HTTP, Configuration, and Metadata
+=== HTTP, Configuration, and Metadata
 
 On the HTTP side, HTTP/3 support on the Netty stack was promoted to stable. See <<http3Server, HTTP/3 Support>> and <<clientHttp3, HTTP/3 in Clients>>. The 5.0 line also includes a multipart/form handling refactor that introduces a lower-level, more server-independent form API and improves resource management in higher-level binders. See <<form, Forms>>, <<formCapable, Detailed Form API>>, and <<uploads, File Uploads>>.
 
@@ -28,12 +28,12 @@ Configuration metadata also became more useful for tooling. Micronaut 5 can gene
 
 The JSON and serialization stack was updated as well, with work across `JsonMapper`, the update to Jackson 3, and additional configuration coverage so applications can adopt the newer JSON infrastructure more smoothly.
 
-== Resilience and Context Propagation
+=== Resilience and Context Propagation
 
 Micronaut Retry gained programmatic retry and circuit breaker APIs in addition to the existing annotation-driven model documented in <<retry, Retry Advice>>. This makes it possible to define typed retry and circuit breaker policies in code and reuse them for synchronous, reactive, and asynchronous flows.
 
-The 5.0.x line also expanded context propagation capabilities, including support for scope values and continued alignment with modern JDK context propagation patterns. See <<contextPropagation, Context Propagation>>.
+The 5.0.x line also expanded context propagation capabilities, including support for scoped values and continued alignment with modern JDK context propagation patterns. See <<contextPropagation, Context Propagation>>.
 
-== Summary
+=== Summary
 
 For teams adopting Micronaut Framework 5.0.x, the biggest benefits are stronger null-safety, more flexible AOP and retry models, better HTTP and multipart capabilities, richer configuration tooling, and continued improvements to the container's compile-time-first runtime model.

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -26,7 +26,7 @@ Configuration support expanded significantly in 5.0.x. Micronaut now supports co
 
 Configuration metadata also became more useful for tooling. Micronaut 5 can generate JSON Schema documents from `@ConfigurationProperties`, making it easier to drive IDE completion, validation, and external tooling from the same configuration model used by the framework. For the underlying configuration model, see <<configurationProperties, Configuration Properties>>.
 
-The JSON and serialization stack was updated as well, with work across `JsonMapper`, Jackson 3 preparation, and additional configuration coverage so applications can adopt newer JSON infrastructure more smoothly.
+The JSON and serialization stack was updated as well, with work across `JsonMapper`, the update to Jackson 3, and additional configuration coverage so applications can adopt the newer JSON infrastructure more smoothly.
 
 == Resilience and Context Propagation
 

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -34,18 +34,6 @@ Micronaut Retry gained programmatic retry and circuit breaker APIs in addition t
 
 The 5.0.x line also expanded context propagation capabilities, including support for scope values and continued alignment with modern JDK context propagation patterns. See <<contextPropagation, Context Propagation>>.
 
-== Closed Enhancement PRs Reviewed for 5.0.x
-
-The following closed pull requests on the `5.0.x` branch were tagged `type: enhancement` and informed this summary:
-
-* https://github.com/micronaut-projects/micronaut-core/pull/12223[PR #12223] - Support for creating AOP proxies at runtime if necessary
-* https://github.com/micronaut-projects/micronaut-core/pull/12246[PR #12246] - Multipart and form API refactor
-* https://github.com/micronaut-projects/micronaut-core/pull/12377[PR #12377] - JSON Schema generation from Micronaut configuration properties
-* https://github.com/micronaut-projects/micronaut-core/pull/12435[PR #12435] - Truffle polyglot language support improvements
-* https://github.com/micronaut-projects/micronaut-core/pull/12571[PR #12571] - Config import support and importer SPI
-* https://github.com/micronaut-projects/micronaut-core/pull/12585[PR #12585] - Programmatic retry and circuit breaker APIs
-* https://github.com/micronaut-projects/micronaut-core/pull/12592[PR #12592] - `jakarta.annotation.Priority` annotation mapper
-
-== In Practice
+== Summary
 
 For teams adopting Micronaut Framework 5.0.x, the biggest benefits are stronger null-safety, more flexible AOP and retry models, better HTTP and multipart capabilities, richer configuration tooling, and continued improvements to the container's compile-time-first runtime model.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,5 +1,6 @@
 introduction:
   title: Introduction
+  whatsNew: What's New in Micronaut Framework 5.0.x
   upgrading: Upgrading your Micronaut Application
 quickStart:
   title: Quick Start


### PR DESCRIPTION
Two issues flagged in review on the Micronaut 5.0.x What's New page.

## Changes

- **Heading levels**: Demoted all section headings from `==` to `===`. The TOC entry supplies the page-level title (`==`), so subsections must start at `===` to avoid flattening the rendered document structure.
- **Terminology**: Corrected "scope values" → "scoped values" (JDK Scoped Values / `ScopedValue` API).