### PR TITLE
Preserve Content-Length for HEAD responses using stored head body metadata

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/ResponseLifecycle.java
+++ b/http-server/src/main/java/io/micronaut/http/server/ResponseLifecycle.java
@@ -131,9 +131,9 @@ public abstract class ResponseLifecycle {
         if (nettyRequest.getMethod() == HttpMethod.HEAD && !response.getHeaders().contains(HttpHeaders.CONTENT_LENGTH)) {
             RouteAttributes.getHeadBody(response).ifPresent(headBody -> {
                 if (headBody instanceof byte[] bytes) {
-                    response.header(HttpHeaders.CONTENT_LENGTH, Integer.toString(bytes.length));
+                    response.contentLength(bytes.length);
                 } else if (headBody instanceof CharSequence sequence) {
-                    response.header(HttpHeaders.CONTENT_LENGTH, Integer.toString(sequence.toString().getBytes().length));
+                    response.contentLength(sequence.toString().getBytes(MessageBodyWriter.getCharset(response.getContentType().orElse(null), response.getHeaders())).length);
                 }
             });
         }

--- a/http-server/src/main/java/io/micronaut/http/server/ResponseLifecycle.java
+++ b/http-server/src/main/java/io/micronaut/http/server/ResponseLifecycle.java
@@ -23,6 +23,7 @@ import io.micronaut.core.execution.ExecutionFlow;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.ByteBodyHttpResponse;
 import io.micronaut.http.ByteBodyHttpResponseWrapper;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -127,6 +128,15 @@ public abstract class ResponseLifecycle {
         HttpResponse<?> httpResponse) {
         Object body = httpResponse.body();
         MutableHttpResponse<?> response = httpResponse.toMutableResponse();
+        if (nettyRequest.getMethod() == HttpMethod.HEAD && !response.getHeaders().contains(HttpHeaders.CONTENT_LENGTH)) {
+            RouteAttributes.getHeadBody(response).ifPresent(headBody -> {
+                if (headBody instanceof byte[] bytes) {
+                    response.header(HttpHeaders.CONTENT_LENGTH, Integer.toString(bytes.length));
+                } else if (headBody instanceof CharSequence sequence) {
+                    response.header(HttpHeaders.CONTENT_LENGTH, Integer.toString(sequence.toString().getBytes().length));
+                }
+            });
+        }
         if (nettyRequest.getMethod() != HttpMethod.HEAD && body != null) {
             Object routeInfoO = RouteAttributes.getRouteInfo(response).orElse(null);
             // usually this is a UriRouteInfo, avoid scalability issues here


### PR DESCRIPTION
## What changed

This change restores `Content-Length` for `HEAD` responses when the body has been stripped from the response but preserved in `RouteAttributes.HEAD_BODY`.

In `ResponseLifecycle`, when handling a `HEAD` response:

- if `Content-Length` is already present, it is left unchanged
- if it is missing, the response checks `RouteAttributes.getHeadBody(response)`
- for simple deterministic body types, `Content-Length` is synthesized:
  - `byte[]`
  - `CharSequence`

## Why

`FilterProxyTest#testHeadProxyPreservesContentLength` expects proxied `HEAD` responses to preserve the effective content length of the corresponding body.

Before this change:

- the `HEAD` body was removed early
- the no-body response path did not restore `Content-Length`
- proxied `HEAD` responses could lose the header entirely

After this change:

- `HEAD` responses can preserve `Content-Length` when the body metadata is available
- proxied `HEAD` behavior matches the TCK expectation

## Validation

- `FilterProxyTest` no longer fails in the Netty HTTP server TCK
- the downstream `micronaut-serialization` TCK run passes when using a locally published core build containing this change https://github.com/micronaut-projects/micronaut-serialization/pull/1281