### PR TITLE
Fix locale converter throwing IllegalArgumentException for invalid input

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -812,7 +812,13 @@ public class DefaultMutableConversionService implements MutableConversionService
         });
 
         // String -> Locale
-        addInternalConverter(CharSequence.class, Locale.class, object -> StringUtils.parseLocale(object.toString()));
+        addInternalConverter(CharSequence.class, Locale.class, object -> {
+            try {
+                return StringUtils.parseLocale(object.toString());
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        });
 
         // String -> UUID
         addInternalConverter(CharSequence.class, UUID.class, (CharSequence object, Class<UUID> targetType, ConversionContext context) -> {

--- a/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
@@ -92,6 +92,15 @@ class DefaultConversionServiceSpec extends Specification {
         targetType << [File, Date, Integer, BigInteger, Float, Double, Long, Short, Byte, BigDecimal, URL, URI, Locale, UUID, Currency, TimeZone, Charset, Status]
     }
 
+    void "test locale conversion with invalid characters does not throw IllegalArgumentException"() {
+        given:
+        ConversionService conversionService = new DefaultMutableConversionService()
+
+        expect: "invalid locale input returns empty instead of throwing"
+        !conversionService.convert("\u05EB", Locale).isPresent()
+        !conversionService.convert("not valid!", Locale).isPresent()
+    }
+
     void "test convert required"() {
         given:
         ConversionService conversionService = new DefaultMutableConversionService()


### PR DESCRIPTION
 ConversionService.convert(value, Locale.class) throws IllegalArgumentException instead of returning Optional.empty() when the input contains invalid characters.       
 This was discovered by fuzzing :
== Java Exception: java.lang.IllegalArgumentException: Locale part "" contains invalid characters
        at io.micronaut.core.util.StringUtils.validateLocalePart(StringUtils.java:222)
        at io.micronaut.core.util.StringUtils.parseLocale(StringUtils.java:184)
        at io.micronaut.core.convert.DefaultMutableConversionService.lambda$registerDefaultConverters$39(DefaultMutableConversionService.java:814)
        at io.micronaut.core.convert.TypeConverter$1.convert(TypeConverter.java:79)
        at io.micronaut.core.convert.DefaultMutableConversionService.lambda$addConverterAnalyzeSource$0(DefaultMutableConversionService.java:329)
        at io.micronaut.core.convert.DefaultMutableConversionService.convert(DefaultMutableConversionService.java:255)
        at io.micronaut.core.convert.ConversionService.convert(ConversionService.java:50)
        at io.micronaut.core.convert.ConversionService.convert(ConversionService.java:89)
        at io.micronaut.fuzzing.http.TypeConversionFuzzTarget.fuzzerTestOneInput(TypeConversionFuzzTarget.java:160)
 Fix   :                                                                                                                                                                
                                                                                                                                                                         
  Wrap the StringUtils.parseLocale call in a try-catch so that IllegalArgumentException is caught and null is returned instead, which TypeConverter converts to  Optional.empty().                                                                                                                                                      
                                                                                                                                                                       
  Test   :                                                                                                                                                             
                                                                                                                                                                       
  Added a regression test in DefaultConversionServiceSpec verifying that invalid locale inputs return Optional.empty() without throwin