### PR TITLE
fix: use Http2ClientConfiguration.PREFIX for ServiceHttp2ClientConfiguration

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
@@ -321,7 +321,7 @@ public class ServiceHttpClientConfiguration extends HttpClientConfiguration impl
     /**
      * The service HTTP/2 configuration.
      */
-    @ConfigurationProperties(WebSocketCompressionConfiguration.PREFIX)
+    @ConfigurationProperties(Http2ClientConfiguration.PREFIX)
     public static class ServiceHttp2ClientConfiguration extends Http2ClientConfiguration {
     }
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
@@ -159,6 +159,23 @@ class ManualHttpServiceDefinitionSpec extends Specification {
         ctx.close()
     }
 
+    void 'test HTTP/2 configuration binds under the http2 prefix'() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(
+                'micronaut.http.services.foo.http2.max-header-list-size': 16384,
+                'micronaut.http.services.foo.http2.ping-interval-read': '30s',
+        )
+
+        ServiceHttpClientConfiguration clientConfiguration = ctx.getBean(ServiceHttpClientConfiguration, Qualifiers.byName("foo"))
+
+        expect:
+        clientConfiguration.http2Configuration.maxHeaderListSize == 16384
+        clientConfiguration.http2Configuration.pingIntervalRead == Duration.ofSeconds(30)
+
+        cleanup:
+        ctx.close()
+    }
+
     void "test that manually defining an HTTP client without URL doesn't create bean"() {
         given:
         ApplicationContext clientApp = ApplicationContext.run(


### PR DESCRIPTION
## Summary

The `@ConfigurationProperties` annotation on `ServiceHttp2ClientConfiguration` (a nested class inside `ServiceHttpClientConfiguration`) was referencing `WebSocketCompressionConfiguration.PREFIX` (`"ws.compression"`) instead of `Http2ClientConfiguration.PREFIX` (`"http2"`).

This appears to be a copy-paste slip from the adjacent `ServiceWebSocketCompressionConfiguration` class, and causes the nested HTTP/2 client configuration for per-service clients to bind under the wrong property path (and collide with the WebSocket compression configuration prefix).

## Change

```diff
-    @ConfigurationProperties(WebSocketCompressionConfiguration.PREFIX)
+    @ConfigurationProperties(Http2ClientConfiguration.PREFIX)
     public static class ServiceHttp2ClientConfiguration extends Http2ClientConfiguration {
     }
```

This aligns `ServiceHttp2ClientConfiguration` with its parent class `Http2ClientConfiguration` (`PREFIX = "http2"`), consistent with how the sibling pool/compression/ssl nested configurations use their respective parent-class prefixes.

## Reference

Fixes https://github.com/micronaut-projects/micronaut-core/issues/12620
