### PR TITLE
Avoid iterating lazy property sources for config imports

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -26,6 +26,7 @@ import io.micronaut.context.env.ConfigurationPath;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.EnvironmentNamesDeducer;
 import io.micronaut.context.env.EnvironmentPackagesDeducer;
+import io.micronaut.context.env.ImportCapablePropertySource;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.env.PropertySourcesLocator;
 import io.micronaut.context.exceptions.ConfigurationException;
@@ -800,7 +801,7 @@ final class DefaultApplicationContext extends DefaultBeanContext implements Conf
      * Bootstrap property source implementation.
      */
     @SuppressWarnings("MagicNumber")
-    private record BootstrapPropertySource(PropertySource delegate) implements PropertySource {
+    private record BootstrapPropertySource(PropertySource delegate) implements ImportCapablePropertySource {
 
         @Override
         public String toString() {
@@ -826,6 +827,11 @@ final class DefaultApplicationContext extends DefaultBeanContext implements Conf
         @Override
         public Iterator<String> iterator() {
             return delegate.iterator();
+        }
+
+        @Override
+        public Origin getOrigin() {
+            return delegate.getOrigin();
         }
 
         @Override

--- a/inject/src/main/java/io/micronaut/context/env/ConfigImportPropertySourcesLocator.java
+++ b/inject/src/main/java/io/micronaut/context/env/ConfigImportPropertySourcesLocator.java
@@ -202,6 +202,10 @@ public final class ConfigImportPropertySourcesLocator implements PropertySources
     }
 
     ResolvedImportDeclarations normalize(PropertySource propertySource) {
+        if (!(propertySource instanceof MapPropertySource)) {
+            return new ResolvedImportDeclarations(propertySource, List.of());
+        }
+
         Object rootValue = null;
         boolean hasRoot = false;
         TreeMap<Integer, Object> indexedValues = new TreeMap<>();

--- a/inject/src/main/java/io/micronaut/context/env/ConfigImportPropertySourcesLocator.java
+++ b/inject/src/main/java/io/micronaut/context/env/ConfigImportPropertySourcesLocator.java
@@ -202,7 +202,7 @@ public final class ConfigImportPropertySourcesLocator implements PropertySources
     }
 
     ResolvedImportDeclarations normalize(PropertySource propertySource) {
-        if (!(propertySource instanceof MapPropertySource)) {
+        if (!(propertySource instanceof ImportCapablePropertySource)) {
             return new ResolvedImportDeclarations(propertySource, List.of());
         }
 

--- a/inject/src/main/java/io/micronaut/context/env/ImportCapablePropertySource.java
+++ b/inject/src/main/java/io/micronaut/context/env/ImportCapablePropertySource.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.env;
+
+/**
+ * Marker interface for property sources that support {@code micronaut.config.import}
+ * declaration discovery by iterating their keys.
+ *
+ * @since 5.0
+ */
+public interface ImportCapablePropertySource extends PropertySource {
+}

--- a/inject/src/main/java/io/micronaut/context/env/MapPropertySource.java
+++ b/inject/src/main/java/io/micronaut/context/env/MapPropertySource.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * @author Graeme Rocher
  * @since 1.0
  */
-public class MapPropertySource implements PropertySource {
+public class MapPropertySource implements ImportCapablePropertySource {
 
     private final String name;
     private final Map<String, ?> map;

--- a/inject/src/test/java/io/micronaut/context/env/ConfigImportDeclarationsTest.java
+++ b/inject/src/test/java/io/micronaut/context/env/ConfigImportDeclarationsTest.java
@@ -3,6 +3,8 @@ package io.micronaut.context.env;
 import io.micronaut.context.exceptions.ConfigurationException;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -118,5 +120,29 @@ class ConfigImportDeclarationsTest {
 
         ConfigurationException e = assertThrows(ConfigurationException.class, () -> locator.normalize(source));
         assertTrue(e.getMessage().contains("Cannot combine scalar and structured indexed"));
+    }
+
+    @Test
+    void doesNotIterateLazyNonMapPropertySourceWithoutDirectImportKey() {
+        PropertySource source = new PropertySource() {
+            @Override
+            public String getName() {
+                return "test resources";
+            }
+
+            @Override
+            public Object get(String key) {
+                throw new AssertionError("get should not be called");
+            }
+
+            @Override
+            public Iterator<String> iterator() {
+                throw new AssertionError("iterator should not be called");
+            }
+        };
+
+        ConfigImportPropertySourcesLocator.ResolvedImportDeclarations parsed = locator.normalize(source);
+
+        assertEquals(Collections.emptyList(), parsed.imports());
     }
 }

--- a/inject/src/test/java/io/micronaut/context/env/ConfigImportDeclarationsTest.java
+++ b/inject/src/test/java/io/micronaut/context/env/ConfigImportDeclarationsTest.java
@@ -145,4 +145,33 @@ class ConfigImportDeclarationsTest {
 
         assertEquals(Collections.emptyList(), parsed.imports());
     }
+
+    @Test
+    void normalizesImportCapableNonMapPropertySource() {
+        PropertySource source = new ImportCapablePropertySource() {
+            private final Map<String, Object> values = Map.of(
+                "micronaut.config.import", "file://foo/one.properties",
+                "app.name", "demo"
+            );
+
+            @Override
+            public String getName() {
+                return "test resources";
+            }
+
+            @Override
+            public Object get(String key) {
+                return values.get(key);
+            }
+
+            @Override
+            public Iterator<String> iterator() {
+                return values.keySet().iterator();
+            }
+        };
+
+        ConfigImportPropertySourcesLocator.ResolvedImportDeclarations parsed = locator.normalize(source);
+
+        assertEquals(1, parsed.imports().size());
+    }
 }


### PR DESCRIPTION
## Summary
- skip config import normalization for non-Map property sources
- avoid touching lazy test-resources property sources during config import discovery
- add a regression test that proves neither get() nor iterator() is called

## Verification
- ./gradlew :micronaut-inject:test --tests io.micronaut.context.env.ConfigImportDeclarationsTest