### PR TITLE
Introduce Introspected.Property annotation to support explicit bean properties

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -1,5 +1,8 @@
 import io.micronaut.build.internal.ext.MicronautCoreExtension
 import io.micronaut.build.internal.ext.DefaultMicronautCoreExtension
+import io.micronaut.build.compat.AcceptedApiChangesRule
+import me.champeau.gradle.japicmp.JapicmpTask
+import org.gradle.api.tasks.PathSensitivity
 
 plugins {
     id "io.micronaut.build.internal.common"
@@ -51,6 +54,20 @@ tasks.withType(GroovyCompile).configureEach {
     options.compilerArgs.add("-Amicronaut.processing.group=$project.group")
     options.compilerArgs.add("-Amicronaut.processing.module=micronaut-$project.name")
     groovyOptions.forkOptions.memoryMaximumSize = "2g"
+}
+
+tasks.withType(JapicmpTask).configureEach {
+    def acceptedApiChanges = rootProject.layout.projectDirectory.file("config/accepted-api-changes.json")
+    inputs.file(acceptedApiChanges)
+        .withPropertyName("accepted-api-changes-root")
+        .withPathSensitivity(PathSensitivity.NONE)
+        .optional(true)
+    richReport {
+        addViolationTransformer(
+            AcceptedApiChangesRule.class,
+            [(AcceptedApiChangesRule.CHANGES_FILE): acceptedApiChanges.asFile.absolutePath]
+        )
+    }
 }
 
 // This is for reproducible builds
@@ -119,4 +136,3 @@ spotless {
         targetExclude '**/io/micronaut/http/netty/stream/package-info.java'
     }
 }
-

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -61,7 +61,6 @@ tasks.withType(JapicmpTask).configureEach {
     inputs.file(acceptedApiChanges)
         .withPropertyName("accepted-api-changes-root")
         .withPathSensitivity(PathSensitivity.NONE)
-        .optional(true)
     richReport {
         addViolationTransformer(
             AcceptedApiChangesRule.class,

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -1353,21 +1353,6 @@
     "reason": "New major-version config import SPI provider/map redesign"
   },
   {
-    "type": "io.micronaut.inject.writer.BeanClassWriter",
-    "member": "Implemented interface io.micronaut.inject.writer.ClassOutputWriter",
-    "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"
-  },
-  {
-    "type": "io.micronaut.inject.writer.BeanDefinitionVisitor",
-    "member": "Implemented interface io.micronaut.inject.writer.OriginatingElements",
-    "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"
-  },
-  {
-    "type": "io.micronaut.inject.writer.BeanDefinitionVisitor",
-    "member": "Implemented interface io.micronaut.core.util.Toggleable",
-    "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"
-  },
-  {
     "type": "io.micronaut.inject.writer.ProxyingBeanDefinitionVisitor",
     "member": "Implemented interface io.micronaut.inject.writer.OriginatingElements",
     "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -1351,5 +1351,35 @@
     "type": "io.micronaut.context.env.ClasspathWildcardPropertySourceImporter",
     "member": "Method io.micronaut.context.env.ClasspathWildcardPropertySourceImporter.newImportDeclaration(io.micronaut.core.convert.value.ConvertibleValues)",
     "reason": "New major-version config import SPI provider/map redesign"
+  },
+  {
+    "type": "io.micronaut.inject.writer.BeanClassWriter",
+    "member": "Implemented interface io.micronaut.inject.writer.ClassOutputWriter",
+    "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"
+  },
+  {
+    "type": "io.micronaut.inject.writer.BeanDefinitionVisitor",
+    "member": "Implemented interface io.micronaut.inject.writer.OriginatingElements",
+    "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"
+  },
+  {
+    "type": "io.micronaut.inject.writer.BeanDefinitionVisitor",
+    "member": "Implemented interface io.micronaut.core.util.Toggleable",
+    "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"
+  },
+  {
+    "type": "io.micronaut.inject.writer.ProxyingBeanDefinitionVisitor",
+    "member": "Implemented interface io.micronaut.inject.writer.OriginatingElements",
+    "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"
+  },
+  {
+    "type": "io.micronaut.inject.writer.ProxyingBeanDefinitionVisitor",
+    "member": "Implemented interface io.micronaut.inject.writer.BeanDefinitionVisitor",
+    "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"
+  },
+  {
+    "type": "io.micronaut.inject.writer.ProxyingBeanDefinitionVisitor",
+    "member": "Implemented interface io.micronaut.core.util.Toggleable",
+    "reason": "Compiler writer internals changed by the sourcegen-backed bean definition writer refactor"
   }
 ]

--- a/core-processor/src/main/java/io/micronaut/inject/ast/JsonAutoDetectConfiguration.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/JsonAutoDetectConfiguration.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.ast;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Internal metadata mapped from Jackson's {@code JsonAutoDetect}.
+ *
+ * @author Denis Stepanov
+ * @since 5.0.0
+ */
+@Internal
+@Documented
+@Retention(CLASS)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+public @interface JsonAutoDetectConfiguration {
+
+    String MEMBER_GETTER_VISIBILITY = "getterVisibility";
+    String MEMBER_IS_GETTER_VISIBILITY = "isGetterVisibility";
+    String MEMBER_SETTER_VISIBILITY = "setterVisibility";
+    String MEMBER_FIELD_VISIBILITY = "fieldVisibility";
+
+    /**
+     * Returns the getter visibility.
+     *
+     * @return The getter visibility.
+     */
+    Visibility getterVisibility() default Visibility.DEFAULT;
+
+    /**
+     * Returns the is-getter visibility.
+     *
+     * @return The is-getter visibility.
+     */
+    Visibility isGetterVisibility() default Visibility.DEFAULT;
+
+    /**
+     * Returns the setter visibility.
+     *
+     * @return The setter visibility.
+     */
+    Visibility setterVisibility() default Visibility.DEFAULT;
+
+    /**
+     * Returns the field visibility.
+     *
+     * @return The field visibility.
+     */
+    Visibility fieldVisibility() default Visibility.DEFAULT;
+
+    /**
+     * Jackson auto-detect visibility values.
+     */
+    enum Visibility {
+        /**
+         * All members are visible.
+         */
+        ANY,
+
+        /**
+         * Non-private members are visible.
+         */
+        NON_PRIVATE,
+
+        /**
+         * Protected and public members are visible.
+         */
+        PROTECTED_AND_PUBLIC,
+
+        /**
+         * Only public members are visible.
+         */
+        PUBLIC_ONLY,
+
+        /**
+         * No members are visible.
+         */
+        NONE,
+
+        /**
+         * Use the default visibility for the accessor kind.
+         */
+        DEFAULT
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/ast/JsonAutoDetectConfiguration.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/JsonAutoDetectConfiguration.java
@@ -28,7 +28,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * Internal metadata mapped from Jackson's {@code JsonAutoDetect}.
  *
  * @author Denis Stepanov
- * @since 5.0.0
+ * @since 5.1.0
  */
 @Internal
 @Documented

--- a/core-processor/src/main/java/io/micronaut/inject/ast/PropertyElementQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/PropertyElementQuery.java
@@ -19,9 +19,10 @@ import io.micronaut.context.annotation.BeanProperties;
 import io.micronaut.core.annotation.AccessorsStyle;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
-import org.jspecify.annotations.Nullable;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.EnumSet;
@@ -42,6 +43,10 @@ public final class PropertyElementQuery {
     private static final String[] DEFAULT_READ_PREFIXES = { AccessorsStyle.DEFAULT_READ_PREFIX };
     private static final String[] DEFAULT_WRITE_PREFIXES = { AccessorsStyle.DEFAULT_WRITE_PREFIX };
     private static final EnumSet<BeanProperties.AccessKind> DEFAULT_ACCESS_KINDS = EnumSet.of(BeanProperties.AccessKind.METHOD);
+    private static final JsonAutoDetectConfiguration.Visibility DEFAULT_JSON_FIELD_VISIBILITY = JsonAutoDetectConfiguration.Visibility.PUBLIC_ONLY;
+    private static final JsonAutoDetectConfiguration.Visibility DEFAULT_JSON_GETTER_VISIBILITY = JsonAutoDetectConfiguration.Visibility.PUBLIC_ONLY;
+    private static final JsonAutoDetectConfiguration.Visibility DEFAULT_JSON_IS_GETTER_VISIBILITY = JsonAutoDetectConfiguration.Visibility.PUBLIC_ONLY;
+    private static final JsonAutoDetectConfiguration.Visibility DEFAULT_JSON_SETTER_VISIBILITY = JsonAutoDetectConfiguration.Visibility.ANY;
     private BeanProperties.Visibility visibility = BeanProperties.Visibility.DEFAULT;
     private Set<BeanProperties.AccessKind> accessKinds = DEFAULT_ACCESS_KINDS;
     private Set<String> includes = Collections.emptySet();
@@ -54,6 +59,11 @@ public final class PropertyElementQuery {
 
     private boolean ignoreSettersWithDifferingType;
     private Set<String> excludedAnnotations = Collections.emptySet();
+    private boolean jsonAutoDetectConfigured;
+    private JsonAutoDetectConfiguration.Visibility jsonFieldVisibility = DEFAULT_JSON_FIELD_VISIBILITY;
+    private JsonAutoDetectConfiguration.Visibility jsonGetterVisibility = DEFAULT_JSON_GETTER_VISIBILITY;
+    private JsonAutoDetectConfiguration.Visibility jsonIsGetterVisibility = DEFAULT_JSON_IS_GETTER_VISIBILITY;
+    private JsonAutoDetectConfiguration.Visibility jsonSetterVisibility = DEFAULT_JSON_SETTER_VISIBILITY;
 
     /**
      * Creates a query for the given metadata.
@@ -91,7 +101,41 @@ public final class PropertyElementQuery {
         if (ArrayUtils.isNotEmpty(writerPrefixes)) {
             conf.writePrefixes(writerPrefixes);
         }
+
+        AnnotationValue<JsonAutoDetectConfiguration> jsonAutoDetect = annotationMetadata.getAnnotation(JsonAutoDetectConfiguration.class);
+        if (jsonAutoDetect != null) {
+            conf.jsonAutoDetect(
+                resolveJsonVisibility(
+                    jsonAutoDetect,
+                    JsonAutoDetectConfiguration.MEMBER_FIELD_VISIBILITY,
+                    DEFAULT_JSON_FIELD_VISIBILITY
+                ),
+                resolveJsonVisibility(
+                    jsonAutoDetect,
+                    JsonAutoDetectConfiguration.MEMBER_GETTER_VISIBILITY,
+                    DEFAULT_JSON_GETTER_VISIBILITY
+                ),
+                resolveJsonVisibility(
+                    jsonAutoDetect,
+                    JsonAutoDetectConfiguration.MEMBER_IS_GETTER_VISIBILITY,
+                    DEFAULT_JSON_IS_GETTER_VISIBILITY
+                ),
+                resolveJsonVisibility(
+                    jsonAutoDetect,
+                    JsonAutoDetectConfiguration.MEMBER_SETTER_VISIBILITY,
+                    DEFAULT_JSON_SETTER_VISIBILITY
+                )
+            );
+        }
         return conf;
+    }
+
+    private static JsonAutoDetectConfiguration.Visibility resolveJsonVisibility(AnnotationValue<JsonAutoDetectConfiguration> annotation,
+                                                                               String member,
+                                                                               JsonAutoDetectConfiguration.Visibility defaultVisibility) {
+        JsonAutoDetectConfiguration.Visibility visibility = annotation.enumValue(member, JsonAutoDetectConfiguration.Visibility.class)
+            .orElse(JsonAutoDetectConfiguration.Visibility.DEFAULT);
+        return visibility == JsonAutoDetectConfiguration.Visibility.DEFAULT ? defaultVisibility : visibility;
     }
 
     /**
@@ -137,6 +181,109 @@ public final class PropertyElementQuery {
      */
     public Set<BeanProperties.AccessKind> getAccessKinds() {
         return accessKinds;
+    }
+
+    /**
+     * Returns whether Jackson auto-detect visibility metadata is configured.
+     *
+     * @return Whether Jackson auto-detect visibility metadata is configured.
+     */
+    public boolean isJsonAutoDetectConfigured() {
+        return jsonAutoDetectConfigured;
+    }
+
+    /**
+     * Tests field visibility using mapped Jackson auto-detect metadata.
+     *
+     * @param fieldElement The field
+     * @return True if the field is visible.
+     */
+    public boolean isJsonAutoDetectFieldVisible(FieldElement fieldElement) {
+        return isJsonVisible(fieldElement, jsonFieldVisibility);
+    }
+
+    /**
+     * Tests getter visibility using mapped Jackson auto-detect metadata.
+     *
+     * @param methodElement The method
+     * @param methodName The method name
+     * @return True if the getter is visible.
+     */
+    public boolean isJsonAutoDetectGetterVisible(MethodElement methodElement, String methodName) {
+        if (isJsonIsGetterName(methodName)) {
+            return isJsonIsGetter(methodElement, methodName) && isJsonVisible(methodElement, jsonIsGetterVisibility);
+        }
+        return isJsonVisible(methodElement, jsonGetterVisibility);
+    }
+
+    /**
+     * Tests setter visibility using mapped Jackson auto-detect metadata.
+     *
+     * @param methodElement The method
+     * @return True if the setter is visible.
+     */
+    public boolean isJsonAutoDetectSetterVisible(MethodElement methodElement) {
+        return isJsonVisible(methodElement, jsonSetterVisibility);
+    }
+
+    /**
+     * Tests whether the method name is a Jackson auto-detect reader name.
+     *
+     * @param methodElement The method
+     * @param methodName The method name
+     * @return True if the method can be a Jackson auto-detect reader.
+     */
+    public boolean isJsonAutoDetectReaderName(MethodElement methodElement, String methodName) {
+        return (jsonGetterVisibility != JsonAutoDetectConfiguration.Visibility.NONE
+            && NameUtils.isReaderName(methodName, AccessorsStyle.DEFAULT_READ_PREFIX)
+            && !isJsonIsGetterName(methodName))
+            || (jsonIsGetterVisibility != JsonAutoDetectConfiguration.Visibility.NONE
+                && isJsonIsGetter(methodElement, methodName));
+    }
+
+    /**
+     * Tests whether the method name is a Jackson auto-detect writer name.
+     *
+     * @param methodName The method name
+     * @return True if the method can be a Jackson auto-detect writer.
+     */
+    public boolean isJsonAutoDetectWriterName(String methodName) {
+        return jsonSetterVisibility != JsonAutoDetectConfiguration.Visibility.NONE &&
+            NameUtils.isWriterName(methodName, AccessorsStyle.DEFAULT_WRITE_PREFIX);
+    }
+
+    private PropertyElementQuery jsonAutoDetect(JsonAutoDetectConfiguration.Visibility fieldVisibility,
+                                                JsonAutoDetectConfiguration.Visibility getterVisibility,
+                                                JsonAutoDetectConfiguration.Visibility isGetterVisibility,
+                                                JsonAutoDetectConfiguration.Visibility setterVisibility) {
+        jsonAutoDetectConfigured = true;
+        jsonFieldVisibility = fieldVisibility;
+        jsonGetterVisibility = getterVisibility;
+        jsonIsGetterVisibility = isGetterVisibility;
+        jsonSetterVisibility = setterVisibility;
+        return this;
+    }
+
+    private static boolean isJsonVisible(MemberElement memberElement, JsonAutoDetectConfiguration.Visibility visibility) {
+        return switch (visibility) {
+            case ANY -> true;
+            case NON_PRIVATE -> !memberElement.isPrivate();
+            case PROTECTED_AND_PUBLIC -> memberElement.isProtected() || memberElement.isPublic();
+            case PUBLIC_ONLY -> memberElement.isPublic();
+            case NONE, DEFAULT -> false;
+        };
+    }
+
+    private static boolean isJsonIsGetterName(String methodName) {
+        return NameUtils.isReaderName(methodName, "is") && methodName.startsWith("is");
+    }
+
+    private static boolean isJsonIsGetter(MethodElement methodElement, String methodName) {
+        return isJsonIsGetterName(methodName) && isBoolean(methodElement.getReturnType());
+    }
+
+    private static boolean isBoolean(ClassElement type) {
+        return type.getName().equals(PrimitiveElement.BOOLEAN.getName()) || type.getName().equals(Boolean.class.getName());
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -52,6 +52,7 @@ import java.util.function.Supplier;
 public final class AstBeanPropertiesUtils {
 
     private static final String ANN_INTROSPECTED_PROPERTY = Introspected.Property.class.getName();
+    private static final String MEMBER_IGNORE_OTHER_ACCESSORS = "ignoreOtherAccessors";
 
     private AstBeanPropertiesUtils() {
     }
@@ -150,11 +151,12 @@ public final class AstBeanPropertiesUtils {
                 continue;
             }
             BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
+            boolean ignoreOtherAccessors = ignoresOtherAccessors(fieldElement);
             if (allowsPropertyRead(fieldElement)) {
-                resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData);
+                resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
             }
             if (allowsPropertyWrite(fieldElement)) {
-                resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData);
+                resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
             }
             applyIntrospectedPropertyAccess(beanPropertyData, fieldElement);
         }
@@ -184,6 +186,8 @@ public final class AstBeanPropertiesUtils {
                 && value.setter != null
                 && value.setter.getParameters().length > 0) {
                 value.type = value.setter.getParameters()[0].getGenericType();
+            } else if (value.readAccessKind == BeanProperties.AccessKind.FIELD && !value.field.getType().equals(value.type)) {
+                value.type = value.field.getGenericType();
             }
             // In a case when the field's type is the same as the selected property type,
             // and it has more type arguments annotations - use it as the property type
@@ -267,6 +271,11 @@ public final class AstBeanPropertiesUtils {
             }
         }
         return false;
+    }
+
+    private static boolean ignoresOtherAccessors(MemberElement memberElement) {
+        return memberElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) &&
+            memberElement.booleanValue(ANN_INTROSPECTED_PROPERTY, MEMBER_IGNORE_OTHER_ACCESSORS).orElse(false);
     }
 
     private static void processIntrospectedPropertyAccess(Map<String, BeanPropertyData> props,
@@ -434,8 +443,17 @@ public final class AstBeanPropertiesUtils {
         return type;
     }
 
-    private static void resolveWriteAccessForField(FieldElement fieldElement, boolean isAccessor, BeanPropertyData beanPropertyData) {
+    private static void resolveWriteAccessForField(FieldElement fieldElement,
+                                                   boolean isAccessor,
+                                                   BeanPropertyData beanPropertyData,
+                                                   boolean ignoreOtherAccessors) {
         if (fieldElement.isFinal()) {
+            return;
+        }
+        if (ignoreOtherAccessors) {
+            beanPropertyData.field = fieldElement;
+            beanPropertyData.writeAccessKind = BeanProperties.AccessKind.FIELD;
+            beanPropertyData.type = fieldElement.getGenericType();
             return;
         }
         ClassElement fieldType = unwrapType(fieldElement.getGenericType());
@@ -445,7 +463,7 @@ public final class AstBeanPropertiesUtils {
             isAccessor = false; // not compatible field or setter is present
         }
         if (beanPropertyData.setter == null && isAccessor) {
-            // Use the field for read
+            // Use the field for write
             beanPropertyData.writeAccessKind = BeanProperties.AccessKind.FIELD;
         }
         if (beanPropertyData.type == null) {
@@ -453,7 +471,16 @@ public final class AstBeanPropertiesUtils {
         }
     }
 
-    private static void resolveReadAccessForField(FieldElement fieldElement, boolean isAccessor, BeanPropertyData beanPropertyData) {
+    private static void resolveReadAccessForField(FieldElement fieldElement,
+                                                  boolean isAccessor,
+                                                  BeanPropertyData beanPropertyData,
+                                                  boolean ignoreOtherAccessors) {
+        if (ignoreOtherAccessors) {
+            beanPropertyData.field = fieldElement;
+            beanPropertyData.readAccessKind = BeanProperties.AccessKind.FIELD;
+            beanPropertyData.type = fieldElement.getGenericType();
+            return;
+        }
         ClassElement fieldType = unwrapType(fieldElement.getGenericType());
         if (beanPropertyData.type == null || fieldType.isAssignable(unwrapType(beanPropertyData.type))) {
             beanPropertyData.field = fieldElement;
@@ -461,7 +488,7 @@ public final class AstBeanPropertiesUtils {
             isAccessor = false; // not compatible field or getter is present
         }
         if (beanPropertyData.getter == null && isAccessor) {
-            // Use the field for write
+            // Use the field for read
             beanPropertyData.readAccessKind = BeanProperties.AccessKind.FIELD;
         }
         if (beanPropertyData.type == null) {

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -101,28 +101,33 @@ public final class AstBeanPropertiesUtils {
             if (methodName.equals("getMetaClass")) {
                 continue;
             }
-            boolean isAccessor = canMethodBeUsedForAccess(methodElement, accessKinds, visibility) ||
-                isIntrospectedPropertyMethod(methodElement, visibility);
+            boolean isIntrospectedPropertyMethod = isIntrospectedPropertyMethod(methodElement, visibility);
             if (isRecord) {
+                boolean isAccessor = canMethodBeUsedForAccess(methodElement, accessKinds, visibility) ||
+                    isIntrospectedPropertyMethod;
                 if (!isAccessor) {
                     continue;
                 }
                 String propertyName = methodElement.getSimpleName();
                 processRecord(props, methodElement, propertyName);
-            } else if (NameUtils.isReaderName(methodName, readPrefixes)
+            } else if (isReaderName(configuration, methodElement, methodName, readPrefixes)
                 && methodElement.getParameters().length == 0) {
                 String propertyName = customReaderPropertyNameResolver.apply(methodElement)
-                    .orElseGet(() -> NameUtils.getPropertyNameForGetter(methodName, readPrefixes));
+                    .orElseGet(() -> getPropertyNameForGetter(methodName, readPrefixes));
+                boolean isAccessor = canMethodBeUsedForRead(methodElement, methodName, accessKinds, visibility, configuration) ||
+                    isIntrospectedPropertyMethod;
                 processGetter(props, methodElement, propertyName, isAccessor, configuration);
-            } else if (NameUtils.isWriterName(methodName, writePrefixes)
+            } else if (isWriterName(configuration, methodName, writePrefixes)
                 && canMethodBeUsedForWrite(methodElement, configuration)) {
                 String propertyName = customWriterPropertyNameResolver.apply(methodElement)
-                    .orElseGet(() -> NameUtils.getPropertyNameForSetter(methodName, writePrefixes));
+                    .orElseGet(() -> getPropertyNameForSetter(methodName, writePrefixes));
+                boolean isAccessor = canMethodBeUsedForWriteAccess(methodElement, accessKinds, visibility, configuration) ||
+                    isIntrospectedPropertyMethod;
                 processSetter(classElement, props, methodElement, propertyName, isAccessor, configuration);
             } else if (isIntrospectedPropertyReader(methodElement)) {
-                processGetter(props, methodElement, methodName, isAccessor, configuration);
+                processGetter(props, methodElement, methodName, isIntrospectedPropertyMethod, configuration);
             } else if (isIntrospectedPropertyWriter(methodElement)) {
-                processSetter(classElement, props, methodElement, methodName, isAccessor, configuration);
+                processSetter(classElement, props, methodElement, methodName, isIntrospectedPropertyMethod, configuration);
             }
         }
         for (FieldElement fieldElement : fieldSupplier.get()) {
@@ -132,7 +137,7 @@ public final class AstBeanPropertiesUtils {
             String propertyName = fieldElement.getSimpleName();
             boolean isAccessor = propertyFields.contains(propertyName) ||
                 isIntrospectedPropertyField(fieldElement, visibility) ||
-                canFieldBeUsedForAccess(fieldElement, accessKinds, visibility);
+                canFieldBeUsedForAccess(fieldElement, accessKinds, visibility, configuration);
             if (!isAccessor && !props.containsKey(propertyName)) {
                 continue;
             }
@@ -216,6 +221,54 @@ public final class AstBeanPropertiesUtils {
         return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) &&
             (methodElement.getParameters().length == 1 ||
                 (methodElement.getParameters().length == 0 && methodElement.getReturnType().isVoid()));
+    }
+
+    private static boolean isReaderName(PropertyElementQuery configuration,
+                                        MethodElement methodElement,
+                                        String methodName,
+                                        String[] readPrefixes) {
+        return NameUtils.isReaderName(methodName, readPrefixes) ||
+            (configuration.isJsonAutoDetectConfigured() && configuration.isJsonAutoDetectReaderName(methodElement, methodName));
+    }
+
+    private static String getPropertyNameForGetter(String methodName, String[] readPrefixes) {
+        if (NameUtils.isReaderName(methodName, readPrefixes)) {
+            return NameUtils.getPropertyNameForGetter(methodName, readPrefixes);
+        }
+        return NameUtils.getPropertyNameForGetter(methodName);
+    }
+
+    private static boolean isWriterName(PropertyElementQuery configuration, String methodName, String[] writePrefixes) {
+        return NameUtils.isWriterName(methodName, writePrefixes) ||
+            (configuration.isJsonAutoDetectConfigured() && configuration.isJsonAutoDetectWriterName(methodName));
+    }
+
+    private static String getPropertyNameForSetter(String methodName, String[] writePrefixes) {
+        if (NameUtils.isWriterName(methodName, writePrefixes)) {
+            return NameUtils.getPropertyNameForSetter(methodName, writePrefixes);
+        }
+        return NameUtils.getPropertyNameForSetter(methodName);
+    }
+
+    private static boolean canMethodBeUsedForRead(MethodElement methodElement,
+                                                  String methodName,
+                                                  Set<BeanProperties.AccessKind> accessKinds,
+                                                  BeanProperties.Visibility visibility,
+                                                  PropertyElementQuery configuration) {
+        if (configuration.isJsonAutoDetectConfigured()) {
+            return configuration.isJsonAutoDetectGetterVisible(methodElement, methodName);
+        }
+        return canMethodBeUsedForAccess(methodElement, accessKinds, visibility);
+    }
+
+    private static boolean canMethodBeUsedForWriteAccess(MethodElement methodElement,
+                                                         Set<BeanProperties.AccessKind> accessKinds,
+                                                         BeanProperties.Visibility visibility,
+                                                         PropertyElementQuery configuration) {
+        if (configuration.isJsonAutoDetectConfigured()) {
+            return configuration.isJsonAutoDetectSetterVisible(methodElement);
+        }
+        return canMethodBeUsedForAccess(methodElement, accessKinds, visibility);
     }
 
     private static boolean canMethodBeUsedForWrite(MethodElement methodElement, PropertyElementQuery configuration) {
@@ -443,7 +496,7 @@ public final class AstBeanPropertiesUtils {
         } else {
             isAccessor = false; // not compatible field or setter is present
         }
-        if (beanPropertyData.setter == null && isAccessor) {
+        if (beanPropertyData.writeAccessKind == null && isAccessor) {
             // Use the field for write
             beanPropertyData.writeAccessKind = BeanProperties.AccessKind.FIELD;
         }
@@ -468,7 +521,7 @@ public final class AstBeanPropertiesUtils {
         }  else {
             isAccessor = false; // not compatible field or getter is present
         }
-        if (beanPropertyData.getter == null && isAccessor) {
+        if (beanPropertyData.readAccessKind == null && isAccessor) {
             // Use the field for read
             beanPropertyData.readAccessKind = BeanProperties.AccessKind.FIELD;
         }
@@ -479,9 +532,13 @@ public final class AstBeanPropertiesUtils {
 
     private static boolean canFieldBeUsedForAccess(FieldElement fieldElement,
                                                    Set<BeanProperties.AccessKind> accessKinds,
-                                                   BeanProperties.Visibility visibility) {
+                                                   BeanProperties.Visibility visibility,
+                                                   PropertyElementQuery configuration) {
         if (fieldElement.getOwningType().isRecord()) {
             return false;
+        }
+        if (configuration.isJsonAutoDetectConfigured()) {
+            return configuration.isJsonAutoDetectFieldVisible(fieldElement);
         }
         if (accessKinds.contains(BeanProperties.AccessKind.FIELD)) {
             return isAccessible(fieldElement, visibility);

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.BeanProperties;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.inject.ast.ClassElement;
@@ -32,7 +33,6 @@ import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +50,8 @@ import java.util.function.Supplier;
 @NullUnmarked
 @Internal
 public final class AstBeanPropertiesUtils {
+
+    private static final String ANN_INTROSPECTED_PROPERTY = Introspected.Property.class.getName();
 
     private AstBeanPropertiesUtils() {
     }
@@ -89,56 +91,83 @@ public final class AstBeanPropertiesUtils {
         var props = new LinkedHashMap<String, BeanPropertyData>();
         for (MethodElement methodElement : methodsSupplier.get()) {
             // Records include everything
-            if (methodElement.isStatic() && !configuration.isAllowStaticProperties() || !excludeElementsInRole && isMethodInRole(methodElement)) {
+            if ((methodElement.isStatic() && !configuration.isAllowStaticProperties()) || (!excludeElementsInRole && isMethodInRole(methodElement))) {
                 continue;
             }
             String methodName = methodElement.getName();
             if (methodName.equals("getMetaClass")) {
                 continue;
             }
-            boolean isAccessor = canMethodBeUsedForAccess(methodElement, accessKinds, visibility);
+            boolean isAccessor = canMethodBeUsedForAccess(methodElement, accessKinds, visibility) ||
+                isIntrospectedPropertyMethod(methodElement, visibility);
             if (isRecord) {
                 if (!isAccessor) {
                     continue;
                 }
                 String propertyName = methodElement.getSimpleName();
                 processRecord(props, methodElement, propertyName);
-            } else if (NameUtils.isReaderName(methodName, readPrefixes) && methodElement.getParameters().length == 0) {
+            } else if (NameUtils.isReaderName(methodName, readPrefixes)
+                && methodElement.getParameters().length == 0) {
                 String propertyName = customReaderPropertyNameResolver.apply(methodElement)
                     .orElseGet(() -> NameUtils.getPropertyNameForGetter(methodName, readPrefixes));
-                processGetter(props, methodElement, propertyName, isAccessor, configuration);
+                if (allowsPropertyRead(methodElement)) {
+                    processGetter(props, methodElement, propertyName, isAccessor, configuration);
+                } else {
+                    processIntrospectedPropertyAccess(props, methodElement, propertyName);
+                }
             } else if (NameUtils.isWriterName(methodName, writePrefixes)
-                && (methodElement.getParameters().length == 1
-                || configuration.isAllowSetterWithZeroArgs() && methodElement.getParameters().length == 0
-                || configuration.isAllowSetterWithMultipleArgs() && methodElement.getParameters().length > 1)) {
+                && canMethodBeUsedForWrite(methodElement, configuration)) {
                 String propertyName = customWriterPropertyNameResolver.apply(methodElement)
                     .orElseGet(() -> NameUtils.getPropertyNameForSetter(methodName, writePrefixes));
-                processSetter(classElement, props, methodElement, propertyName, isAccessor, configuration);
+                if (allowsPropertyWrite(methodElement)) {
+                    processSetter(classElement, props, methodElement, propertyName, isAccessor, configuration);
+                } else {
+                    processIntrospectedPropertyAccess(props, methodElement, propertyName);
+                }
+            } else if (isIntrospectedPropertyReader(methodElement)) {
+                if (allowsPropertyRead(methodElement)) {
+                    processGetter(props, methodElement, methodName, isAccessor, configuration);
+                } else {
+                    processIntrospectedPropertyAccess(props, methodElement, methodName);
+                }
+            } else if (isIntrospectedPropertyWriter(methodElement)) {
+                if (allowsPropertyWrite(methodElement)) {
+                    processSetter(classElement, props, methodElement, methodName, isAccessor, configuration);
+                } else {
+                    processIntrospectedPropertyAccess(props, methodElement, methodName);
+                }
             }
         }
         for (FieldElement fieldElement : fieldSupplier.get()) {
-            if (fieldElement.isStatic() && !configuration.isAllowStaticProperties() || !excludeElementsInRole && isFieldInRole(fieldElement)) {
+            if ((fieldElement.isStatic() && !configuration.isAllowStaticProperties()) || (!excludeElementsInRole && isFieldInRole(fieldElement))) {
                 continue;
             }
             String propertyName = fieldElement.getSimpleName();
-            boolean isAccessor = propertyFields.contains(propertyName) || canFieldBeUsedForAccess(fieldElement, accessKinds, visibility);
+            boolean isAccessor = propertyFields.contains(propertyName) ||
+                isIntrospectedPropertyField(fieldElement, visibility) ||
+                canFieldBeUsedForAccess(fieldElement, accessKinds, visibility);
             if (!isAccessor && !props.containsKey(propertyName)) {
                 continue;
             }
             BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
-            resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData);
-            resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData);
+            if (allowsPropertyRead(fieldElement)) {
+                resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData);
+            }
+            if (allowsPropertyWrite(fieldElement)) {
+                resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData);
+            }
+            applyIntrospectedPropertyAccess(beanPropertyData, fieldElement);
         }
 
         if (props.isEmpty()) {
-            return Collections.emptyList();
+            return new ArrayList<>(0);
         }
 
         var beanProperties = new ArrayList<PropertyElement>(props.size());
         for (Map.Entry<String, BeanPropertyData> entry : props.entrySet()) {
             String propertyName = entry.getKey();
             BeanPropertyData value = entry.getValue();
-            if (configuration.isIgnoreSettersWithDifferingType() && value.setter != null && value.getter != null) {
+            if (shouldCheckSetterTypeCompatibility(configuration, value) && value.setter != null && value.getter != null) {
                 // ensure types match
                 ClassElement getterType = value.getter.getGenericReturnType();
                 ClassElement setterType = value.setter.getParameters()[0].getGenericType();
@@ -182,6 +211,92 @@ public final class AstBeanPropertiesUtils {
             }
         }
         return beanProperties;
+    }
+
+    private static boolean isIntrospectedPropertyReader(MethodElement methodElement) {
+        return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) &&
+            methodElement.getParameters().length == 0 &&
+            !methodElement.getReturnType().isVoid();
+    }
+
+    private static boolean isIntrospectedPropertyWriter(MethodElement methodElement) {
+        return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) &&
+            (methodElement.getParameters().length == 1 ||
+                (methodElement.getParameters().length == 0 && methodElement.getReturnType().isVoid()));
+    }
+
+    private static boolean canMethodBeUsedForWrite(MethodElement methodElement, PropertyElementQuery configuration) {
+        int parameterCount = methodElement.getParameters().length;
+        return parameterCount == 1 ||
+            (configuration.isAllowSetterWithZeroArgs() && parameterCount == 0) ||
+            (configuration.isAllowSetterWithMultipleArgs() && parameterCount > 1) ||
+            isIntrospectedPropertyWriter(methodElement);
+    }
+
+    private static boolean isIntrospectedPropertyField(FieldElement fieldElement, BeanProperties.Visibility visibility) {
+        return fieldElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) && isAccessible(fieldElement, visibility);
+    }
+
+    private static boolean isIntrospectedPropertyMethod(MethodElement methodElement, BeanProperties.Visibility visibility) {
+        return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) && isAccessible(methodElement, visibility);
+    }
+
+    private static boolean allowsPropertyRead(MemberElement memberElement) {
+        return allowsPropertyAccess(memberElement, Introspected.Property.Access.READ);
+    }
+
+    private static boolean allowsPropertyWrite(MemberElement memberElement) {
+        return allowsPropertyAccess(memberElement, Introspected.Property.Access.WRITE);
+    }
+
+    private static boolean allowsPropertyAccess(MemberElement memberElement, Introspected.Property.Access accessKind) {
+        if (!memberElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY)) {
+            return true;
+        }
+        Introspected.Property.Access[] accessKinds = memberElement.enumValues(
+            ANN_INTROSPECTED_PROPERTY,
+            "accessKind",
+            Introspected.Property.Access.class
+        );
+        if (accessKinds.length == 0) {
+            return true;
+        }
+        for (Introspected.Property.Access value : accessKinds) {
+            if (value == accessKind) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void processIntrospectedPropertyAccess(Map<String, BeanPropertyData> props,
+                                                          MemberElement memberElement,
+                                                          String propertyName) {
+        BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
+        applyIntrospectedPropertyAccess(beanPropertyData, memberElement);
+    }
+
+    private static void applyIntrospectedPropertyAccess(BeanPropertyData beanPropertyData, MemberElement memberElement) {
+        if (memberElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY)) {
+            if (!allowsPropertyRead(memberElement)) {
+                beanPropertyData.readAccessForbidden = true;
+            }
+            if (!allowsPropertyWrite(memberElement)) {
+                beanPropertyData.writeAccessForbidden = true;
+            }
+        }
+        pruneForbiddenAccess(beanPropertyData);
+    }
+
+    private static void pruneForbiddenAccess(BeanPropertyData beanPropertyData) {
+        if (beanPropertyData.readAccessForbidden) {
+            beanPropertyData.getter = null;
+            beanPropertyData.readAccessKind = null;
+        }
+        if (beanPropertyData.writeAccessForbidden) {
+            beanPropertyData.setter = null;
+            beanPropertyData.writeAccessKind = null;
+        }
     }
 
     private static boolean hasMoreAnnotations(ClassElement c1, ClassElement c2) {
@@ -248,7 +363,7 @@ public final class AstBeanPropertiesUtils {
         }
         ClassElement genericReturnType = beanPropertyData.getter.getGenericReturnType();
         ClassElement getterType = unwrapType(genericReturnType);
-        if (configuration.isIgnoreSettersWithDifferingType() && beanPropertyData.type != null) {
+        if (shouldCheckSetterTypeCompatibility(configuration, beanPropertyData) && beanPropertyData.type != null) {
             if (!getterType.isAssignable(unwrapType(beanPropertyData.type))) {
                 beanPropertyData.getter = null; // not a compatible getter
                 beanPropertyData.readAccessKind = null;
@@ -256,6 +371,7 @@ public final class AstBeanPropertiesUtils {
         } else {
             beanPropertyData.type = genericReturnType;
         }
+        applyIntrospectedPropertyAccess(beanPropertyData, methodElement);
     }
 
     private static void processSetter(ClassElement classElement, Map<String, BeanPropertyData> props, MethodElement methodElement, String propertyName, boolean isAccessor, PropertyElementQuery configuration) {
@@ -282,7 +398,7 @@ public final class AstBeanPropertiesUtils {
         if (isAccessor) {
             beanPropertyData.writeAccessKind = BeanProperties.AccessKind.METHOD;
         }
-        if (configuration.isIgnoreSettersWithDifferingType() && beanPropertyData.type != null) {
+        if (shouldCheckSetterTypeCompatibility(configuration, beanPropertyData) && beanPropertyData.type != null) {
             if (existingType != null && isIncompatibleSetterType(setterType, existingType)) {
                 beanPropertyData.setter = null; // not a compatible setter
                 beanPropertyData.writeAccessKind = null;
@@ -290,13 +406,28 @@ public final class AstBeanPropertiesUtils {
         } else {
             beanPropertyData.type = paramType;
         }
+        applyIntrospectedPropertyAccess(beanPropertyData, methodElement);
     }
 
     private static boolean isIncompatibleSetterType(ClassElement setterType, ClassElement existingType) {
         return setterType != null && !existingType.isAssignable(setterType) && !setterType.getName().equals(existingType.getName());
     }
 
-   private static ClassElement unwrapType(ClassElement type) {
+    private static boolean shouldCheckSetterTypeCompatibility(PropertyElementQuery configuration, BeanPropertyData beanPropertyData) {
+        return configuration.isIgnoreSettersWithDifferingType() && !hasIntrospectedPropertyAccess(beanPropertyData);
+    }
+
+    private static boolean hasIntrospectedPropertyAccess(BeanPropertyData beanPropertyData) {
+        return hasIntrospectedPropertyAccess(beanPropertyData.getter) ||
+            hasIntrospectedPropertyAccess(beanPropertyData.setter) ||
+            hasIntrospectedPropertyAccess(beanPropertyData.field);
+    }
+
+    private static boolean hasIntrospectedPropertyAccess(@Nullable MemberElement memberElement) {
+        return memberElement != null && memberElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
+    }
+
+    private static ClassElement unwrapType(ClassElement type) {
         if (type.isOptional()) {
             return type.getOptionalValueType().orElse(type);
         }
@@ -385,6 +516,8 @@ public final class AstBeanPropertiesUtils {
         public BeanProperties.AccessKind writeAccessKind;
         public final String propertyName;
         public boolean isExcluded;
+        public boolean readAccessForbidden;
+        public boolean writeAccessForbidden;
 
         public BeanPropertyData(String propertyName) {
             this.propertyName = propertyName;

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -29,10 +29,12 @@ import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.PrimitiveElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.ast.PropertyElementQuery;
+import io.micronaut.inject.processing.ProcessingException;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -111,32 +113,16 @@ public final class AstBeanPropertiesUtils {
                 && methodElement.getParameters().length == 0) {
                 String propertyName = customReaderPropertyNameResolver.apply(methodElement)
                     .orElseGet(() -> NameUtils.getPropertyNameForGetter(methodName, readPrefixes));
-                if (allowsPropertyRead(methodElement)) {
-                    processGetter(props, methodElement, propertyName, isAccessor, configuration);
-                } else {
-                    processIntrospectedPropertyAccess(props, methodElement, propertyName);
-                }
+                processGetter(props, methodElement, propertyName, isAccessor, configuration);
             } else if (NameUtils.isWriterName(methodName, writePrefixes)
                 && canMethodBeUsedForWrite(methodElement, configuration)) {
                 String propertyName = customWriterPropertyNameResolver.apply(methodElement)
                     .orElseGet(() -> NameUtils.getPropertyNameForSetter(methodName, writePrefixes));
-                if (allowsPropertyWrite(methodElement)) {
-                    processSetter(classElement, props, methodElement, propertyName, isAccessor, configuration);
-                } else {
-                    processIntrospectedPropertyAccess(props, methodElement, propertyName);
-                }
+                processSetter(classElement, props, methodElement, propertyName, isAccessor, configuration);
             } else if (isIntrospectedPropertyReader(methodElement)) {
-                if (allowsPropertyRead(methodElement)) {
-                    processGetter(props, methodElement, methodName, isAccessor, configuration);
-                } else {
-                    processIntrospectedPropertyAccess(props, methodElement, methodName);
-                }
+                processGetter(props, methodElement, methodName, isAccessor, configuration);
             } else if (isIntrospectedPropertyWriter(methodElement)) {
-                if (allowsPropertyWrite(methodElement)) {
-                    processSetter(classElement, props, methodElement, methodName, isAccessor, configuration);
-                } else {
-                    processIntrospectedPropertyAccess(props, methodElement, methodName);
-                }
+                processSetter(classElement, props, methodElement, methodName, isAccessor, configuration);
             }
         }
         for (FieldElement fieldElement : fieldSupplier.get()) {
@@ -152,23 +138,20 @@ public final class AstBeanPropertiesUtils {
             }
             BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
             boolean ignoreOtherAccessors = ignoresOtherAccessors(fieldElement);
-            if (allowsPropertyRead(fieldElement)) {
-                resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
-            }
-            if (allowsPropertyWrite(fieldElement)) {
-                resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
-            }
-            applyIntrospectedPropertyAccess(beanPropertyData, fieldElement);
+            resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
+            resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
+            registerIntrospectedPropertyAccess(beanPropertyData, fieldElement);
         }
 
         if (props.isEmpty()) {
-            return new ArrayList<>(0);
+            return List.of();
         }
 
         var beanProperties = new ArrayList<PropertyElement>(props.size());
         for (Map.Entry<String, BeanPropertyData> entry : props.entrySet()) {
             String propertyName = entry.getKey();
             BeanPropertyData value = entry.getValue();
+            applyIntrospectedPropertyAccess(value);
             if (shouldCheckSetterTypeCompatibility(configuration, value) && value.setter != null && value.getter != null) {
                 // ensure types match
                 ClassElement getterType = value.getter.getGenericReturnType();
@@ -188,6 +171,12 @@ public final class AstBeanPropertiesUtils {
                 value.type = value.setter.getParameters()[0].getGenericType();
             } else if (value.readAccessKind == BeanProperties.AccessKind.FIELD && !value.field.getType().equals(value.type)) {
                 value.type = value.field.getGenericType();
+            }
+            if (value.readAccessKind == BeanProperties.AccessKind.METHOD
+                && value.getter != null
+                && !value.getter.getGenericReturnType().equals(value.type)
+                && value.writeAccessKind == null) {
+                value.type = value.getter.getGenericReturnType();
             }
             // In a case when the field's type is the same as the selected property type,
             // and it has more type arguments annotations - use it as the property type
@@ -245,64 +234,56 @@ public final class AstBeanPropertiesUtils {
         return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) && isAccessible(methodElement, visibility);
     }
 
-    private static boolean allowsPropertyRead(MemberElement memberElement) {
-        return allowsPropertyAccess(memberElement, Introspected.Property.Access.READ);
+    private static boolean ignoresOtherAccessors(MemberElement memberElement) {
+        return memberElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) &&
+            memberElement.booleanValue(ANN_INTROSPECTED_PROPERTY, MEMBER_IGNORE_OTHER_ACCESSORS).orElse(false);
     }
 
-    private static boolean allowsPropertyWrite(MemberElement memberElement) {
-        return allowsPropertyAccess(memberElement, Introspected.Property.Access.WRITE);
-    }
-
-    private static boolean allowsPropertyAccess(MemberElement memberElement, Introspected.Property.Access accessKind) {
-        if (!memberElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY)) {
-            return true;
+    private static void registerIntrospectedPropertyAccess(BeanPropertyData beanPropertyData, MemberElement memberElement) {
+        if (memberElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY)) {
+            EnumSet<Introspected.Property.Access> accessKinds = resolveIntrospectedPropertyAccess(memberElement);
+            if (beanPropertyData.propertyAccessKinds == null) {
+                beanPropertyData.propertyAccessKinds = accessKinds;
+                beanPropertyData.propertyAccessMember = memberElement;
+            } else if (!beanPropertyData.propertyAccessKinds.equals(accessKinds)) {
+                throw new ProcessingException(
+                    memberElement,
+                    "Conflicting @Introspected.Property accessKind declarations for property ["
+                        + beanPropertyData.propertyName + "]: "
+                        + beanPropertyData.propertyAccessKinds + " declared by ["
+                        + beanPropertyData.propertyAccessMember.getDescription()
+                        + "] and " + accessKinds + " declared by ["
+                        + memberElement.getDescription() + "]"
+                );
+            }
         }
+    }
+
+    private static EnumSet<Introspected.Property.Access> resolveIntrospectedPropertyAccess(MemberElement memberElement) {
         Introspected.Property.Access[] accessKinds = memberElement.enumValues(
             ANN_INTROSPECTED_PROPERTY,
             "accessKind",
             Introspected.Property.Access.class
         );
         if (accessKinds.length == 0) {
-            return true;
+            return EnumSet.of(Introspected.Property.Access.READ, Introspected.Property.Access.WRITE);
         }
-        for (Introspected.Property.Access value : accessKinds) {
-            if (value == accessKind) {
-                return true;
-            }
+        EnumSet<Introspected.Property.Access> access = EnumSet.noneOf(Introspected.Property.Access.class);
+        for (Introspected.Property.Access accessKind : accessKinds) {
+            access.add(accessKind);
         }
-        return false;
+        return access;
     }
 
-    private static boolean ignoresOtherAccessors(MemberElement memberElement) {
-        return memberElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) &&
-            memberElement.booleanValue(ANN_INTROSPECTED_PROPERTY, MEMBER_IGNORE_OTHER_ACCESSORS).orElse(false);
-    }
-
-    private static void processIntrospectedPropertyAccess(Map<String, BeanPropertyData> props,
-                                                          MemberElement memberElement,
-                                                          String propertyName) {
-        BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
-        applyIntrospectedPropertyAccess(beanPropertyData, memberElement);
-    }
-
-    private static void applyIntrospectedPropertyAccess(BeanPropertyData beanPropertyData, MemberElement memberElement) {
-        if (memberElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY)) {
-            if (!allowsPropertyRead(memberElement)) {
-                beanPropertyData.readAccessForbidden = true;
-            }
-            if (!allowsPropertyWrite(memberElement)) {
-                beanPropertyData.writeAccessForbidden = true;
-            }
+    private static void applyIntrospectedPropertyAccess(BeanPropertyData beanPropertyData) {
+        if (beanPropertyData.propertyAccessKinds == null) {
+            return;
         }
-        pruneForbiddenAccess(beanPropertyData);
-    }
-
-    private static void pruneForbiddenAccess(BeanPropertyData beanPropertyData) {
-        if (beanPropertyData.readAccessForbidden) {
+        if (!beanPropertyData.propertyAccessKinds.contains(Introspected.Property.Access.READ)) {
             beanPropertyData.getter = null;
             beanPropertyData.readAccessKind = null;
         }
-        if (beanPropertyData.writeAccessForbidden) {
+        if (!beanPropertyData.propertyAccessKinds.contains(Introspected.Property.Access.WRITE)) {
             beanPropertyData.setter = null;
             beanPropertyData.writeAccessKind = null;
         }
@@ -380,11 +361,12 @@ public final class AstBeanPropertiesUtils {
         } else {
             beanPropertyData.type = genericReturnType;
         }
-        applyIntrospectedPropertyAccess(beanPropertyData, methodElement);
+        registerIntrospectedPropertyAccess(beanPropertyData, methodElement);
     }
 
     private static void processSetter(ClassElement classElement, Map<String, BeanPropertyData> props, MethodElement methodElement, String propertyName, boolean isAccessor, PropertyElementQuery configuration) {
         BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
+        registerIntrospectedPropertyAccess(beanPropertyData, methodElement);
         ClassElement paramType = methodElement.getParameters().length == 0 ? PrimitiveElement.BOOLEAN : methodElement.getParameters()[0].getGenericType();
         ClassElement setterType = unwrapType(paramType);
         ClassElement existingType = beanPropertyData.type != null ? unwrapType(beanPropertyData.type) : null;
@@ -415,7 +397,6 @@ public final class AstBeanPropertiesUtils {
         } else {
             beanPropertyData.type = paramType;
         }
-        applyIntrospectedPropertyAccess(beanPropertyData, methodElement);
     }
 
     private static boolean isIncompatibleSetterType(ClassElement setterType, ClassElement existingType) {
@@ -543,8 +524,8 @@ public final class AstBeanPropertiesUtils {
         public BeanProperties.AccessKind writeAccessKind;
         public final String propertyName;
         public boolean isExcluded;
-        public boolean readAccessForbidden;
-        public boolean writeAccessForbidden;
+        public EnumSet<Introspected.Property.Access> propertyAccessKinds;
+        public MemberElement propertyAccessMember;
 
         public BeanPropertyData(String propertyName) {
             this.propertyName = propertyName;

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -94,8 +94,20 @@ public final class AstBeanPropertiesUtils {
         var props = new LinkedHashMap<String, BeanPropertyData>();
         for (MethodElement methodElement : methodsSupplier.get()) {
             // Records include everything
-            if ((methodElement.isStatic() && !configuration.isAllowStaticProperties()) || (!excludeElementsInRole && isMethodInRole(methodElement))) {
+            boolean hasIntrospectedProperty = methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
+            boolean isExcludedMethod = (methodElement.isStatic() && !configuration.isAllowStaticProperties()) ||
+                (!excludeElementsInRole && isMethodInRole(methodElement));
+            if (isExcludedMethod) {
+                if (hasIntrospectedProperty) {
+                    failInvalidIntrospectedProperty(
+                        methodElement,
+                        "the method is excluded from bean property resolution"
+                    );
+                }
                 continue;
+            }
+            if (hasIntrospectedProperty) {
+                validateIntrospectedPropertyMethod(methodElement, visibility);
             }
             String methodName = methodElement.getName();
             if (methodName.equals("getMetaClass")) {
@@ -116,23 +128,65 @@ public final class AstBeanPropertiesUtils {
                     .orElseGet(() -> getPropertyNameForGetter(methodName, readPrefixes));
                 boolean isAccessor = canMethodBeUsedForRead(methodElement, methodName, accessKinds, visibility, configuration) ||
                     isIntrospectedPropertyMethod;
-                processGetter(props, methodElement, propertyName, isAccessor, configuration);
+                processGetter(
+                    props,
+                    methodElement,
+                    propertyName,
+                    isAccessor,
+                    configuration,
+                    ignoresOtherAccessors(methodElement)
+                );
             } else if (isWriterName(configuration, methodName, writePrefixes)
-                && canMethodBeUsedForWrite(methodElement, configuration)) {
+                && canMethodBeUsedForWrite(methodElement, configuration, visibility)) {
                 String propertyName = customWriterPropertyNameResolver.apply(methodElement)
                     .orElseGet(() -> getPropertyNameForSetter(methodName, writePrefixes));
                 boolean isAccessor = canMethodBeUsedForWriteAccess(methodElement, accessKinds, visibility, configuration) ||
                     isIntrospectedPropertyMethod;
-                processSetter(classElement, props, methodElement, propertyName, isAccessor, configuration);
-            } else if (isIntrospectedPropertyReader(methodElement)) {
-                processGetter(props, methodElement, methodName, isIntrospectedPropertyMethod, configuration);
-            } else if (isIntrospectedPropertyWriter(methodElement)) {
-                processSetter(classElement, props, methodElement, methodName, isIntrospectedPropertyMethod, configuration);
+                processSetter(
+                    classElement,
+                    props,
+                    methodElement,
+                    propertyName,
+                    isAccessor,
+                    configuration,
+                    ignoresOtherAccessors(methodElement)
+                );
+            } else if (isIntrospectedPropertyReader(methodElement, visibility)) {
+                processGetter(
+                    props,
+                    methodElement,
+                    methodName,
+                    isIntrospectedPropertyMethod,
+                    configuration,
+                    ignoresOtherAccessors(methodElement)
+                );
+            } else if (isIntrospectedPropertyWriter(methodElement, visibility)) {
+                processSetter(
+                    classElement,
+                    props,
+                    methodElement,
+                    methodName,
+                    isIntrospectedPropertyMethod,
+                    configuration,
+                    ignoresOtherAccessors(methodElement)
+                );
             }
         }
         for (FieldElement fieldElement : fieldSupplier.get()) {
-            if ((fieldElement.isStatic() && !configuration.isAllowStaticProperties()) || (!excludeElementsInRole && isFieldInRole(fieldElement))) {
+            boolean hasIntrospectedProperty = fieldElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
+            boolean isExcludedField = (fieldElement.isStatic() && !configuration.isAllowStaticProperties()) ||
+                (!excludeElementsInRole && isFieldInRole(fieldElement));
+            if (isExcludedField) {
+                if (hasIntrospectedProperty) {
+                    failInvalidIntrospectedProperty(
+                        fieldElement,
+                        "the field is excluded from bean property resolution"
+                    );
+                }
                 continue;
+            }
+            if (hasIntrospectedProperty) {
+                validateIntrospectedPropertyField(fieldElement, visibility);
             }
             String propertyName = fieldElement.getSimpleName();
             boolean isAccessor = propertyFields.contains(propertyName) ||
@@ -211,16 +265,16 @@ public final class AstBeanPropertiesUtils {
         return beanProperties;
     }
 
-    private static boolean isIntrospectedPropertyReader(MethodElement methodElement) {
+    private static boolean isIntrospectedPropertyReader(MethodElement methodElement, BeanProperties.Visibility visibility) {
         return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) &&
-            methodElement.getParameters().length == 0 &&
-            !methodElement.getReturnType().isVoid();
+            isAccessible(methodElement, visibility) &&
+            canMethodProvideReadAccess(methodElement);
     }
 
-    private static boolean isIntrospectedPropertyWriter(MethodElement methodElement) {
+    private static boolean isIntrospectedPropertyWriter(MethodElement methodElement, BeanProperties.Visibility visibility) {
         return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) &&
-            (methodElement.getParameters().length == 1 ||
-                (methodElement.getParameters().length == 0 && methodElement.getReturnType().isVoid()));
+            isAccessible(methodElement, visibility) &&
+            canMethodProvideWriteAccess(methodElement);
     }
 
     private static boolean isReaderName(PropertyElementQuery configuration,
@@ -271,12 +325,14 @@ public final class AstBeanPropertiesUtils {
         return canMethodBeUsedForAccess(methodElement, accessKinds, visibility);
     }
 
-    private static boolean canMethodBeUsedForWrite(MethodElement methodElement, PropertyElementQuery configuration) {
+    private static boolean canMethodBeUsedForWrite(MethodElement methodElement,
+                                                   PropertyElementQuery configuration,
+                                                   BeanProperties.Visibility visibility) {
         int parameterCount = methodElement.getParameters().length;
         return parameterCount == 1 ||
             (configuration.isAllowSetterWithZeroArgs() && parameterCount == 0) ||
             (configuration.isAllowSetterWithMultipleArgs() && parameterCount > 1) ||
-            isIntrospectedPropertyWriter(methodElement);
+            isIntrospectedPropertyWriter(methodElement, visibility);
     }
 
     private static boolean isIntrospectedPropertyField(FieldElement fieldElement, BeanProperties.Visibility visibility) {
@@ -326,6 +382,80 @@ public final class AstBeanPropertiesUtils {
             access.add(accessKind);
         }
         return access;
+    }
+
+    private static void validateIntrospectedPropertyField(FieldElement fieldElement,
+                                                          BeanProperties.Visibility visibility) {
+        EnumSet<Introspected.Property.Access> accessKinds = resolveIntrospectedPropertyAccess(fieldElement);
+        boolean isAccessible = isAccessible(fieldElement, visibility) && !fieldElement.getOwningType().isRecord();
+        boolean canRead = isAccessible;
+        boolean canWrite = isAccessible && !fieldElement.isFinal();
+        boolean hasReadAccess = accessKinds.contains(Introspected.Property.Access.READ);
+        boolean hasWriteAccess = accessKinds.contains(Introspected.Property.Access.WRITE);
+        if ((hasReadAccess && canRead) || (hasWriteAccess && canWrite)) {
+            return;
+        }
+        if (!isAccessible) {
+            failInvalidIntrospectedProperty(
+                fieldElement,
+                "the field is not accessible for visibility [" + visibility + "]"
+            );
+        }
+        if (hasWriteAccess && fieldElement.isFinal()) {
+            failInvalidIntrospectedProperty(fieldElement, "write access requires a non-final field");
+        }
+        failInvalidIntrospectedProperty(
+            fieldElement,
+            "the field does not provide any of the declared access kinds " + accessKinds
+        );
+    }
+
+    private static void validateIntrospectedPropertyMethod(MethodElement methodElement,
+                                                           BeanProperties.Visibility visibility) {
+        if (!isAccessible(methodElement, visibility)) {
+            failInvalidIntrospectedProperty(
+                methodElement,
+                "the method is not accessible for visibility [" + visibility + "]"
+            );
+        }
+        EnumSet<Introspected.Property.Access> accessKinds = resolveIntrospectedPropertyAccess(methodElement);
+        boolean canRead = canMethodProvideReadAccess(methodElement);
+        boolean canWrite = canMethodProvideWriteAccess(methodElement);
+        boolean hasReadAccess = accessKinds.contains(Introspected.Property.Access.READ);
+        boolean hasWriteAccess = accessKinds.contains(Introspected.Property.Access.WRITE);
+        if ((hasReadAccess && canRead) || (hasWriteAccess && canWrite)) {
+            return;
+        }
+        if (hasReadAccess && !hasWriteAccess) {
+            failInvalidIntrospectedProperty(
+                methodElement,
+                "read access requires a zero-argument method with a non-void return type"
+            );
+        }
+        if (hasWriteAccess && !hasReadAccess) {
+            failInvalidIntrospectedProperty(
+                methodElement,
+                "write access requires a one-argument method or a zero-argument void method"
+            );
+        }
+        failInvalidIntrospectedProperty(methodElement, "the method must be a readable or writable property accessor");
+    }
+
+    private static boolean canMethodProvideReadAccess(MethodElement methodElement) {
+        return methodElement.getParameters().length == 0 && !methodElement.getReturnType().isVoid();
+    }
+
+    private static boolean canMethodProvideWriteAccess(MethodElement methodElement) {
+        return methodElement.getParameters().length == 1 ||
+            (methodElement.getParameters().length == 0 && methodElement.getReturnType().isVoid());
+    }
+
+    private static void failInvalidIntrospectedProperty(MemberElement memberElement, String reason) {
+        throw new ProcessingException(
+            memberElement,
+            "Element annotated with @Introspected.Property cannot be used as an introspected property: " +
+                reason
+        );
     }
 
     private static void applyIntrospectedPropertyAccess(BeanPropertyData beanPropertyData) {
@@ -398,13 +528,36 @@ public final class AstBeanPropertiesUtils {
         beanPropertyData.type = beanPropertyData.getter.getGenericReturnType();
     }
 
-    private static void processGetter(Map<String, BeanPropertyData> props, MethodElement methodElement, String propertyName, boolean isAccessor, PropertyElementQuery configuration) {
+    private static void processGetter(Map<String, BeanPropertyData> props,
+                                      MethodElement methodElement,
+                                      String propertyName,
+                                      boolean isAccessor,
+                                      PropertyElementQuery configuration) {
+        processGetter(props, methodElement, propertyName, isAccessor, configuration, false);
+    }
+
+    private static void processGetter(Map<String, BeanPropertyData> props,
+                                      MethodElement methodElement,
+                                      String propertyName,
+                                      boolean isAccessor,
+                                      PropertyElementQuery configuration,
+                                      boolean ignoreOtherAccessors) {
         BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
+        if (beanPropertyData.ignoreReadAccessors && !ignoreOtherAccessors) {
+            registerIntrospectedPropertyAccess(beanPropertyData, methodElement);
+            return;
+        }
         beanPropertyData.getter = methodElement;
         if (isAccessor) {
             beanPropertyData.readAccessKind = BeanProperties.AccessKind.METHOD;
         }
         ClassElement genericReturnType = beanPropertyData.getter.getGenericReturnType();
+        if (ignoreOtherAccessors) {
+            beanPropertyData.type = genericReturnType;
+            beanPropertyData.ignoreReadAccessors = true;
+            registerIntrospectedPropertyAccess(beanPropertyData, methodElement);
+            return;
+        }
         ClassElement getterType = unwrapType(genericReturnType);
         if (shouldCheckSetterTypeCompatibility(configuration, beanPropertyData) && beanPropertyData.type != null) {
             if (!getterType.isAssignable(unwrapType(beanPropertyData.type))) {
@@ -417,10 +570,39 @@ public final class AstBeanPropertiesUtils {
         registerIntrospectedPropertyAccess(beanPropertyData, methodElement);
     }
 
-    private static void processSetter(ClassElement classElement, Map<String, BeanPropertyData> props, MethodElement methodElement, String propertyName, boolean isAccessor, PropertyElementQuery configuration) {
+    private static void processSetter(ClassElement classElement,
+                                      Map<String, BeanPropertyData> props,
+                                      MethodElement methodElement,
+                                      String propertyName,
+                                      boolean isAccessor,
+                                      PropertyElementQuery configuration) {
+        processSetter(classElement, props, methodElement, propertyName, isAccessor, configuration, false);
+    }
+
+    private static void processSetter(ClassElement classElement,
+                                      Map<String, BeanPropertyData> props,
+                                      MethodElement methodElement,
+                                      String propertyName,
+                                      boolean isAccessor,
+                                      PropertyElementQuery configuration,
+                                      boolean ignoreOtherAccessors) {
         BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
         registerIntrospectedPropertyAccess(beanPropertyData, methodElement);
-        ClassElement paramType = methodElement.getParameters().length == 0 ? PrimitiveElement.BOOLEAN : methodElement.getParameters()[0].getGenericType();
+        ClassElement paramType = methodElement.getParameters().length == 0
+            ? PrimitiveElement.BOOLEAN
+            : methodElement.getParameters()[0].getGenericType();
+        if (beanPropertyData.ignoreWriteAccessors && !ignoreOtherAccessors) {
+            return;
+        }
+        if (ignoreOtherAccessors) {
+            beanPropertyData.setter = methodElement;
+            if (isAccessor) {
+                beanPropertyData.writeAccessKind = BeanProperties.AccessKind.METHOD;
+            }
+            beanPropertyData.type = paramType;
+            beanPropertyData.ignoreWriteAccessors = true;
+            return;
+        }
         ClassElement setterType = unwrapType(paramType);
         ClassElement existingType = beanPropertyData.type != null ? unwrapType(beanPropertyData.type) : null;
         if (setterType != null && beanPropertyData.setter != null) {
@@ -583,6 +765,8 @@ public final class AstBeanPropertiesUtils {
         public boolean isExcluded;
         public EnumSet<Introspected.Property.Access> propertyAccessKinds;
         public MemberElement propertyAccessMember;
+        public boolean ignoreReadAccessors;
+        public boolean ignoreWriteAccessors;
 
         public BeanPropertyData(String propertyName) {
             this.propertyName = propertyName;

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -185,20 +185,23 @@ public final class AstBeanPropertiesUtils {
                 }
                 continue;
             }
-            if (hasIntrospectedProperty) {
-                validateIntrospectedPropertyField(fieldElement, visibility);
-            }
             String propertyName = fieldElement.getSimpleName();
             boolean isAccessor = propertyFields.contains(propertyName) ||
                 isIntrospectedPropertyField(fieldElement, visibility) ||
                 canFieldBeUsedForAccess(fieldElement, accessKinds, visibility, configuration);
             if (!isAccessor && !props.containsKey(propertyName)) {
+                if (hasIntrospectedProperty) {
+                    validateIntrospectedPropertyField(fieldElement, visibility, null);
+                }
                 continue;
             }
             BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
             boolean ignoreOtherAccessors = ignoresOtherAccessors(fieldElement);
             resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
             resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
+            if (hasIntrospectedProperty) {
+                validateIntrospectedPropertyField(fieldElement, visibility, beanPropertyData);
+            }
             registerIntrospectedPropertyAccess(beanPropertyData, fieldElement);
         }
 
@@ -385,17 +388,19 @@ public final class AstBeanPropertiesUtils {
     }
 
     private static void validateIntrospectedPropertyField(FieldElement fieldElement,
-                                                          BeanProperties.Visibility visibility) {
+                                                          BeanProperties.Visibility visibility,
+                                                          @Nullable BeanPropertyData beanPropertyData) {
         EnumSet<Introspected.Property.Access> accessKinds = resolveIntrospectedPropertyAccess(fieldElement);
-        boolean isAccessible = isAccessible(fieldElement, visibility) && !fieldElement.getOwningType().isRecord();
-        boolean canRead = isAccessible;
-        boolean canWrite = isAccessible && !fieldElement.isFinal();
+        boolean canReadField = isAccessible(fieldElement, visibility) && !fieldElement.getOwningType().isRecord();
+        boolean canWriteField = canReadField && !fieldElement.isFinal();
+        boolean canRead = canReadField || hasMethodReadAccess(beanPropertyData);
+        boolean canWrite = canWriteField || hasMethodWriteAccess(beanPropertyData);
         boolean hasReadAccess = accessKinds.contains(Introspected.Property.Access.READ);
         boolean hasWriteAccess = accessKinds.contains(Introspected.Property.Access.WRITE);
         if ((hasReadAccess && canRead) || (hasWriteAccess && canWrite)) {
             return;
         }
-        if (!isAccessible) {
+        if (!canReadField && !canWriteField) {
             failInvalidIntrospectedProperty(
                 fieldElement,
                 "the field is not accessible for visibility [" + visibility + "]"
@@ -408,6 +413,18 @@ public final class AstBeanPropertiesUtils {
             fieldElement,
             "the field does not provide any of the declared access kinds " + accessKinds
         );
+    }
+
+    private static boolean hasMethodReadAccess(@Nullable BeanPropertyData beanPropertyData) {
+        return beanPropertyData != null &&
+            beanPropertyData.getter != null &&
+            beanPropertyData.readAccessKind == BeanProperties.AccessKind.METHOD;
+    }
+
+    private static boolean hasMethodWriteAccess(@Nullable BeanPropertyData beanPropertyData) {
+        return beanPropertyData != null &&
+            beanPropertyData.setter != null &&
+            beanPropertyData.writeAccessKind == BeanProperties.AccessKind.METHOD;
     }
 
     private static void validateIntrospectedPropertyMethod(MethodElement methodElement,
@@ -532,14 +549,6 @@ public final class AstBeanPropertiesUtils {
                                       MethodElement methodElement,
                                       String propertyName,
                                       boolean isAccessor,
-                                      PropertyElementQuery configuration) {
-        processGetter(props, methodElement, propertyName, isAccessor, configuration, false);
-    }
-
-    private static void processGetter(Map<String, BeanPropertyData> props,
-                                      MethodElement methodElement,
-                                      String propertyName,
-                                      boolean isAccessor,
                                       PropertyElementQuery configuration,
                                       boolean ignoreOtherAccessors) {
         BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
@@ -568,15 +577,6 @@ public final class AstBeanPropertiesUtils {
             beanPropertyData.type = genericReturnType;
         }
         registerIntrospectedPropertyAccess(beanPropertyData, methodElement);
-    }
-
-    private static void processSetter(ClassElement classElement,
-                                      Map<String, BeanPropertyData> props,
-                                      MethodElement methodElement,
-                                      String propertyName,
-                                      boolean isAccessor,
-                                      PropertyElementQuery configuration) {
-        processSetter(classElement, props, methodElement, propertyName, isAccessor, configuration, false);
     }
 
     private static void processSetter(ClassElement classElement,

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -54,6 +54,7 @@ import java.util.function.Supplier;
 public final class AstBeanPropertiesUtils {
 
     private static final String ANN_INTROSPECTED_PROPERTY = Introspected.Property.class.getName();
+    private static final String ANN_JAKARTA_ACCESS = "jakarta.persistence.Access";
     private static final String MEMBER_IGNORE_OTHER_ACCESSORS = "ignoreOtherAccessors";
 
     private AstBeanPropertiesUtils() {
@@ -83,22 +84,22 @@ public final class AstBeanPropertiesUtils {
                                                               Function<MethodElement, Optional<String>> customWriterPropertyNameResolver,
                                                               Function<BeanPropertyData, @Nullable PropertyElement> propertyCreator) {
         BeanProperties.Visibility visibility = configuration.getVisibility();
-        Set<BeanProperties.AccessKind> accessKinds = configuration.getAccessKinds();
 
         Set<String> includes = configuration.getIncludes();
         Set<String> excludes = configuration.getExcludes();
         String[] readPrefixes = configuration.getReadPrefixes();
         String[] writePrefixes = configuration.getWritePrefixes();
         var isRecord = classElement.isRecord();
+        Set<BeanProperties.AccessKind> effectiveAccessKinds = resolveAccessKinds(configuration, classElement);
 
         var props = new LinkedHashMap<String, BeanPropertyData>();
         for (MethodElement methodElement : methodsSupplier.get()) {
             // Records include everything
-            boolean hasIntrospectedProperty = methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
+            boolean isIntrospectedPropertyMethod = isIntrospectedPropertyMethod(methodElement);
             boolean isExcludedMethod = (methodElement.isStatic() && !configuration.isAllowStaticProperties()) ||
                 (!excludeElementsInRole && isMethodInRole(methodElement));
             if (isExcludedMethod) {
-                if (hasIntrospectedProperty) {
+                if (isIntrospectedPropertyMethod) {
                     failInvalidIntrospectedProperty(
                         methodElement,
                         "the method is excluded from bean property resolution"
@@ -106,16 +107,15 @@ public final class AstBeanPropertiesUtils {
                 }
                 continue;
             }
-            if (hasIntrospectedProperty) {
+            if (isIntrospectedPropertyMethod) {
                 validateIntrospectedPropertyMethod(methodElement, visibility);
             }
             String methodName = methodElement.getName();
             if (methodName.equals("getMetaClass")) {
                 continue;
             }
-            boolean isIntrospectedPropertyMethod = isIntrospectedPropertyMethod(methodElement, visibility);
             if (isRecord) {
-                boolean isAccessor = canMethodBeUsedForAccess(methodElement, accessKinds, visibility) ||
+                boolean isAccessor = canMethodBeUsedForAccess(methodElement, effectiveAccessKinds, visibility) ||
                     isIntrospectedPropertyMethod;
                 if (!isAccessor) {
                     continue;
@@ -126,7 +126,7 @@ public final class AstBeanPropertiesUtils {
                 && methodElement.getParameters().length == 0) {
                 String propertyName = customReaderPropertyNameResolver.apply(methodElement)
                     .orElseGet(() -> getPropertyNameForGetter(methodName, readPrefixes));
-                boolean isAccessor = canMethodBeUsedForRead(methodElement, methodName, accessKinds, visibility, configuration) ||
+                boolean isAccessor = canMethodBeUsedForRead(methodElement, methodName, effectiveAccessKinds, visibility, configuration) ||
                     isIntrospectedPropertyMethod;
                 processGetter(
                     props,
@@ -140,7 +140,7 @@ public final class AstBeanPropertiesUtils {
                 && canMethodBeUsedForWrite(methodElement, configuration, visibility)) {
                 String propertyName = customWriterPropertyNameResolver.apply(methodElement)
                     .orElseGet(() -> getPropertyNameForSetter(methodName, writePrefixes));
-                boolean isAccessor = canMethodBeUsedForWriteAccess(methodElement, accessKinds, visibility, configuration) ||
+                boolean isAccessor = canMethodBeUsedForWriteAccess(methodElement, effectiveAccessKinds, visibility, configuration) ||
                     isIntrospectedPropertyMethod;
                 processSetter(
                     classElement,
@@ -173,11 +173,11 @@ public final class AstBeanPropertiesUtils {
             }
         }
         for (FieldElement fieldElement : fieldSupplier.get()) {
-            boolean hasIntrospectedProperty = fieldElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
+            boolean isIntrospectedPropertyField = isIntrospectedPropertyField(fieldElement);
             boolean isExcludedField = (fieldElement.isStatic() && !configuration.isAllowStaticProperties()) ||
                 (!excludeElementsInRole && isFieldInRole(fieldElement));
             if (isExcludedField) {
-                if (hasIntrospectedProperty) {
+                if (isIntrospectedPropertyField) {
                     failInvalidIntrospectedProperty(
                         fieldElement,
                         "the field is excluded from bean property resolution"
@@ -187,10 +187,10 @@ public final class AstBeanPropertiesUtils {
             }
             String propertyName = fieldElement.getSimpleName();
             boolean isAccessor = propertyFields.contains(propertyName) ||
-                isIntrospectedPropertyField(fieldElement, visibility) ||
-                canFieldBeUsedForAccess(fieldElement, accessKinds, visibility, configuration);
+                isIntrospectedPropertyField ||
+                canFieldBeUsedForAccess(fieldElement, effectiveAccessKinds, visibility, configuration);
             if (!isAccessor && !props.containsKey(propertyName)) {
-                if (hasIntrospectedProperty) {
+                if (isIntrospectedPropertyField) {
                     validateIntrospectedPropertyField(fieldElement, visibility, null);
                 }
                 continue;
@@ -199,7 +199,7 @@ public final class AstBeanPropertiesUtils {
             boolean ignoreOtherAccessors = ignoresOtherAccessors(fieldElement);
             resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
             resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
-            if (hasIntrospectedProperty) {
+            if (isIntrospectedPropertyField) {
                 validateIntrospectedPropertyField(fieldElement, visibility, beanPropertyData);
             }
             registerIntrospectedPropertyAccess(beanPropertyData, fieldElement);
@@ -266,6 +266,19 @@ public final class AstBeanPropertiesUtils {
             }
         }
         return beanProperties;
+    }
+
+    private static Set<BeanProperties.AccessKind> resolveAccessKinds(PropertyElementQuery configuration,
+                                                                     ClassElement classElement) {
+        Optional<String> accessType = classElement.stringValue(ANN_JAKARTA_ACCESS);
+        if (accessType.isEmpty()) {
+            return configuration.getAccessKinds();
+        }
+        return switch (accessType.get()) {
+            case "FIELD" -> EnumSet.of(BeanProperties.AccessKind.FIELD);
+            case "PROPERTY" -> EnumSet.of(BeanProperties.AccessKind.METHOD);
+            default -> configuration.getAccessKinds();
+        };
     }
 
     private static boolean isIntrospectedPropertyReader(MethodElement methodElement, BeanProperties.Visibility visibility) {
@@ -338,12 +351,12 @@ public final class AstBeanPropertiesUtils {
             isIntrospectedPropertyWriter(methodElement, visibility);
     }
 
-    private static boolean isIntrospectedPropertyField(FieldElement fieldElement, BeanProperties.Visibility visibility) {
-        return fieldElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) && isAccessible(fieldElement, visibility);
+    private static boolean isIntrospectedPropertyField(FieldElement fieldElement) {
+        return fieldElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
     }
 
-    private static boolean isIntrospectedPropertyMethod(MethodElement methodElement, BeanProperties.Visibility visibility) {
-        return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY) && isAccessible(methodElement, visibility);
+    private static boolean isIntrospectedPropertyMethod(MethodElement methodElement) {
+        return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
     }
 
     private static boolean ignoresOtherAccessors(MemberElement memberElement) {

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedPropertyTransformer.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedPropertyTransformer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.inject.annotation.TypedAnnotationTransformer;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.util.List;
+
+/**
+ * Normalizes {@link Introspected.Property} name members.
+ *
+ * @author Denis Stepanov
+ * @since 5.0.0
+ */
+@Internal
+public final class IntrospectedPropertyTransformer implements TypedAnnotationTransformer<Introspected.Property> {
+
+    private static final String MEMBER_NAME = "name";
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<Introspected.Property> annotation, VisitorContext visitorContext) {
+        String value = annotation.stringValue().orElse("");
+        String name = annotation.stringValue(MEMBER_NAME).orElse("");
+        if (value.isEmpty() && name.isEmpty()) {
+            return List.of(annotation);
+        }
+        var builder = annotation.mutate();
+        boolean changed = false;
+        if (name.isEmpty()) {
+            builder.member(MEMBER_NAME, value);
+            changed = true;
+        }
+        if (value.isEmpty()) {
+            builder.member(AnnotationMetadata.VALUE_MEMBER, name);
+            changed = true;
+        }
+        if (!changed) {
+            return List.of(annotation);
+        }
+        return List.of(builder.build());
+    }
+
+    @Override
+    public Class<Introspected.Property> annotationType() {
+        return Introspected.Property.class;
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedPropertyTransformer.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedPropertyTransformer.java
@@ -42,6 +42,13 @@ public final class IntrospectedPropertyTransformer implements TypedAnnotationTra
         if (value.isEmpty() && name.isEmpty()) {
             return List.of(annotation);
         }
+        if (!value.isEmpty() && !name.isEmpty() && !value.equals(name)) {
+            visitorContext.fail(
+                "The @Introspected.Property value and name members must match when both are declared",
+                null
+            );
+            return List.of(annotation);
+        }
         var builder = annotation.mutate();
         boolean changed = false;
         if (name.isEmpty()) {

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedPropertyTransformer.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedPropertyTransformer.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Normalizes {@link Introspected.Property} name members.
  *
  * @author Denis Stepanov
- * @since 5.0.0
+ * @since 5.1.0
  */
 @Internal
 public final class IntrospectedPropertyTransformer implements TypedAnnotationTransformer<Introspected.Property> {

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonAutoDetectAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonAutoDetectAnnotationMapper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.ast.JsonAutoDetectConfiguration;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * Maps Jackson's JsonAutoDetect to internal bean property visibility configuration.
+ *
+ * @author Denis Stepanov
+ * @since 5.0.0
+ */
+@Internal
+public final class JsonAutoDetectAnnotationMapper implements NamedAnnotationMapper {
+
+    @Override
+    public String getName() {
+        return "com.fasterxml.jackson.annotation.JsonAutoDetect";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return List.of(AnnotationValue.builder(JsonAutoDetectConfiguration.class)
+            .member(
+                JsonAutoDetectConfiguration.MEMBER_GETTER_VISIBILITY,
+                visibility(annotation, JsonAutoDetectConfiguration.MEMBER_GETTER_VISIBILITY)
+            )
+            .member(
+                JsonAutoDetectConfiguration.MEMBER_IS_GETTER_VISIBILITY,
+                visibility(annotation, JsonAutoDetectConfiguration.MEMBER_IS_GETTER_VISIBILITY)
+            )
+            .member(
+                JsonAutoDetectConfiguration.MEMBER_SETTER_VISIBILITY,
+                visibility(annotation, JsonAutoDetectConfiguration.MEMBER_SETTER_VISIBILITY)
+            )
+            .member(
+                JsonAutoDetectConfiguration.MEMBER_FIELD_VISIBILITY,
+                visibility(annotation, JsonAutoDetectConfiguration.MEMBER_FIELD_VISIBILITY)
+            )
+            .build());
+    }
+
+    private static JsonAutoDetectConfiguration.Visibility visibility(AnnotationValue<Annotation> annotation, String member) {
+        return annotation.enumValue(member, JsonAutoDetectConfiguration.Visibility.class)
+            .orElse(JsonAutoDetectConfiguration.Visibility.DEFAULT);
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonAutoDetectAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonAutoDetectAnnotationMapper.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Maps Jackson's JsonAutoDetect to internal bean property visibility configuration.
  *
  * @author Denis Stepanov
- * @since 5.0.0
+ * @since 5.1.0
  */
 @Internal
 public final class JsonAutoDetectAnnotationMapper implements NamedAnnotationMapper {

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonGetterAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonGetterAnnotationMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * Makes every use of Jackson's JsonGetter also represent an {@link Introspected.Property}.
+ *
+ * @author Denis Stepanov
+ * @since 5.0.0
+ */
+@Internal
+public final class JsonGetterAnnotationMapper implements NamedAnnotationMapper {
+
+    @Override
+    public String getName() {
+        return "com.fasterxml.jackson.annotation.JsonGetter";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        var builder = AnnotationValue.builder(Introspected.Property.class);
+        annotation.stringValue()
+            .filter(name -> !name.isEmpty())
+            .ifPresent(name -> builder.member("name", name));
+        return List.of(builder.build());
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonGetterAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonGetterAnnotationMapper.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Makes every use of Jackson's JsonGetter also represent an {@link Introspected.Property}.
  *
  * @author Denis Stepanov
- * @since 5.0.0
+ * @since 5.1.0
  */
 @Internal
 public final class JsonGetterAnnotationMapper implements NamedAnnotationMapper {

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPropertyAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPropertyAnnotationMapper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * Makes every use of Jackson's JsonProperty also represent an {@link Introspected.Property}.
+ *
+ * @author Denis Stepanov
+ * @since 5.0.0
+ */
+@Internal
+public final class JsonPropertyAnnotationMapper implements NamedAnnotationMapper {
+
+    private static final String MEMBER_ACCESS = "access";
+
+    @Override
+    public String getName() {
+        return "com.fasterxml.jackson.annotation.JsonProperty";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        var builder = AnnotationValue.builder(Introspected.Property.class)
+            .member("accessKind", mapAccess(annotation.stringValue(MEMBER_ACCESS).orElse("AUTO")));
+        annotation.stringValue()
+            .filter(name -> !name.isEmpty())
+            .ifPresent(name -> builder.member("name", name));
+        return List.of(builder.build());
+    }
+
+    private static Introspected.Property.Access[] mapAccess(String access) {
+        return switch (access) {
+            case "READ_ONLY" -> new Introspected.Property.Access[] {
+                Introspected.Property.Access.READ
+            };
+            case "WRITE_ONLY" -> new Introspected.Property.Access[] {
+                Introspected.Property.Access.WRITE
+            };
+            default -> new Introspected.Property.Access[] {
+                Introspected.Property.Access.READ,
+                Introspected.Property.Access.WRITE
+            };
+        };
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPropertyAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPropertyAnnotationMapper.java
@@ -43,19 +43,20 @@ public final class JsonPropertyAnnotationMapper implements NamedAnnotationMapper
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         var builder = AnnotationValue.builder(Introspected.Property.class)
-            .member("accessKind", mapAccess(annotation.stringValue(MEMBER_ACCESS).orElse("AUTO")));
+            .member("accessKind", mapAccess(annotation.enumValue(MEMBER_ACCESS, JsonPropertyAccess.class)
+                .orElse(JsonPropertyAccess.AUTO)));
         annotation.stringValue()
             .filter(name -> !name.isEmpty())
             .ifPresent(name -> builder.member("name", name));
         return List.of(builder.build());
     }
 
-    private static Introspected.Property.Access[] mapAccess(String access) {
+    private static Introspected.Property.Access[] mapAccess(JsonPropertyAccess access) {
         return switch (access) {
-            case "READ_ONLY" -> new Introspected.Property.Access[] {
+            case READ_ONLY -> new Introspected.Property.Access[] {
                 Introspected.Property.Access.READ
             };
-            case "WRITE_ONLY" -> new Introspected.Property.Access[] {
+            case WRITE_ONLY -> new Introspected.Property.Access[] {
                 Introspected.Property.Access.WRITE
             };
             default -> new Introspected.Property.Access[] {
@@ -63,5 +64,12 @@ public final class JsonPropertyAnnotationMapper implements NamedAnnotationMapper
                 Introspected.Property.Access.WRITE
             };
         };
+    }
+
+    private enum JsonPropertyAccess {
+        AUTO,
+        READ_ONLY,
+        WRITE_ONLY,
+        READ_WRITE
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPropertyAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPropertyAnnotationMapper.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Makes every use of Jackson's JsonProperty also represent an {@link Introspected.Property}.
  *
  * @author Denis Stepanov
- * @since 5.0.0
+ * @since 5.1.0
  */
 @Internal
 public final class JsonPropertyAnnotationMapper implements NamedAnnotationMapper {

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonSetterAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonSetterAnnotationMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * Makes every use of Jackson's JsonSetter also represent an {@link Introspected.Property}.
+ *
+ * @author Denis Stepanov
+ * @since 5.0.0
+ */
+@Internal
+public final class JsonSetterAnnotationMapper implements NamedAnnotationMapper {
+
+    @Override
+    public String getName() {
+        return "com.fasterxml.jackson.annotation.JsonSetter";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        var builder = AnnotationValue.builder(Introspected.Property.class);
+        annotation.stringValue()
+            .filter(name -> !name.isEmpty())
+            .ifPresent(name -> builder.member("name", name));
+        return List.of(builder.build());
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonSetterAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonSetterAnnotationMapper.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Makes every use of Jackson's JsonSetter also represent an {@link Introspected.Property}.
  *
  * @author Denis Stepanov
- * @since 5.0.0
+ * @since 5.1.0
  */
 @Internal
 public final class JsonSetterAnnotationMapper implements NamedAnnotationMapper {

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/persistence/JakartaAccessAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/persistence/JakartaAccessAnnotationMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor.persistence;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * Makes each use of Jakarta Persistence's Access annotation also represent an {@link Introspected.Property}.
+ *
+ * @author Denis Stepanov
+ * @since 5.0.0
+ */
+@Internal
+public final class JakartaAccessAnnotationMapper implements NamedAnnotationMapper {
+
+    @Override
+    public String getName() {
+        return "jakarta.persistence.Access";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return List.of(AnnotationValue.builder(Introspected.Property.class)
+            .member("ignoreOtherAccessors", true)
+            .build());
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/persistence/JakartaAccessAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/persistence/JakartaAccessAnnotationMapper.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Makes each use of Jakarta Persistence's Access annotation also represent an {@link Introspected.Property}.
  *
  * @author Denis Stepanov
- * @since 5.0.0
+ * @since 5.1.0
  */
 @Internal
 public final class JakartaAccessAnnotationMapper implements NamedAnnotationMapper {

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -8,6 +8,7 @@ io.micronaut.inject.beans.visitor.JsonCreatorAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonGetterAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonPropertyAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonSetterAnnotationMapper
+io.micronaut.inject.beans.visitor.persistence.JakartaAccessAnnotationMapper
 io.micronaut.inject.beans.visitor.persistence.JakartaEntityIntrospectedAnnotationMapper
 io.micronaut.inject.beans.visitor.persistence.JakartaMappedSuperClassIntrospectionMapper
 io.micronaut.inject.beans.visitor.MapperAnnotationMapper

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -5,6 +5,9 @@ io.micronaut.inject.beans.visitor.EntityIntrospectedAnnotationMapper
 io.micronaut.inject.beans.visitor.EntityReflectiveAccessAnnotationMapper
 io.micronaut.inject.beans.visitor.MappedSuperClassIntrospectionMapper
 io.micronaut.inject.beans.visitor.JsonCreatorAnnotationMapper
+io.micronaut.inject.beans.visitor.JsonGetterAnnotationMapper
+io.micronaut.inject.beans.visitor.JsonPropertyAnnotationMapper
+io.micronaut.inject.beans.visitor.JsonSetterAnnotationMapper
 io.micronaut.inject.beans.visitor.persistence.JakartaEntityIntrospectedAnnotationMapper
 io.micronaut.inject.beans.visitor.persistence.JakartaMappedSuperClassIntrospectionMapper
 io.micronaut.inject.beans.visitor.MapperAnnotationMapper

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -5,6 +5,7 @@ io.micronaut.inject.beans.visitor.EntityIntrospectedAnnotationMapper
 io.micronaut.inject.beans.visitor.EntityReflectiveAccessAnnotationMapper
 io.micronaut.inject.beans.visitor.MappedSuperClassIntrospectionMapper
 io.micronaut.inject.beans.visitor.JsonCreatorAnnotationMapper
+io.micronaut.inject.beans.visitor.JsonAutoDetectAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonGetterAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonPropertyAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonSetterAnnotationMapper

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -7,6 +7,7 @@ io.micronaut.inject.annotation.internal.JavaxPostConstructTransformer
 io.micronaut.inject.annotation.internal.JavaxPreDestroyTransformer
 io.micronaut.inject.annotation.internal.JavaxNullableTransformer
 io.micronaut.inject.annotation.internal.JavaxNonnullTransformer
+io.micronaut.inject.beans.visitor.IntrospectedPropertyTransformer
 io.micronaut.inject.beans.visitor.IntrospectedToBeanPropertiesTransformer
 io.micronaut.inject.annotation.internal.AndroidxNullableTransformer
 io.micronaut.inject.annotation.internal.JdtNullableTransformer

--- a/core/src/main/java/io/micronaut/core/annotation/Introspected.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Introspected.java
@@ -293,6 +293,13 @@ public @interface Introspected {
         };
 
         /**
+         * Returns whether this property member should ignore other accessors for the same property.
+         *
+         * @return True if other accessors should be ignored.
+         */
+        boolean ignoreOtherAccessors() default false;
+
+        /**
          * The access values for introspected properties.
          */
         enum Access {

--- a/core/src/main/java/io/micronaut/core/annotation/Introspected.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Introspected.java
@@ -92,7 +92,7 @@ public @interface Introspected {
      * @return The access type. Defaults to {@link AccessKind#METHOD}
      * @since 3.0
      */
-    AccessKind[] accessKind() default { AccessKind.METHOD };
+    Introspected.AccessKind[] accessKind() default { Introspected.AccessKind.METHOD };
 
     /**
      * Allows specifying the visibility policy to use to control which fields and methods are included.
@@ -257,6 +257,55 @@ public @interface Introspected {
          * @return The member
          */
         String member() default "";
+    }
+
+    /**
+     * Allows a field or method to be treated as an introspected property.
+     *
+     * @since 5.0.0
+     */
+    @Documented
+    @Retention(RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+    @interface Property {
+        /**
+         * Returns the external property name as a shorthand for {@link #name()}.
+         *
+         * @return The external property name.
+         */
+        String value() default "";
+
+        /**
+         * Returns the external property name.
+         *
+         * @return The external property name.
+         */
+        String name() default "";
+
+        /**
+         * Returns the property access values.
+         *
+         * @return The property access values.
+         */
+        Introspected.Property.Access[] accessKind() default {
+            Introspected.Property.Access.READ,
+            Introspected.Property.Access.WRITE
+        };
+
+        /**
+         * The access values for introspected properties.
+         */
+        enum Access {
+            /**
+             * The property can be read.
+             */
+            READ,
+
+            /**
+             * The property can be written.
+             */
+            WRITE
+        }
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/annotation/Introspected.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Introspected.java
@@ -262,7 +262,7 @@ public @interface Introspected {
     /**
      * Allows a field or method to be treated as an introspected property.
      *
-     * @since 5.0.0
+     * @since 5.1.0
      */
     @Documented
     @Retention(RUNTIME)

--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
@@ -338,7 +338,7 @@ public interface BeanIntrospection<T> extends AnnotationMetadataDelegate, BeanIn
         final BeanWriteProperty<T, ?> prop = getWriteProperty(name).orElse(null);
         if (prop != null && ReflectionUtils.getWrapperType(type).isAssignableFrom(ReflectionUtils.getWrapperType(prop.getType()))) {
             //noinspection unchecked
-            return Optional.of((BeanProperty<T, P>) prop);
+            return Optional.of((BeanWriteProperty<T, P>) prop);
         }
         return Optional.empty();
     }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/MixinSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/MixinSpec.groovy
@@ -103,6 +103,7 @@ class MyBeanMixin {
             metadata.annotationNames.sort() == [
                     "com.fasterxml.jackson.annotation.JsonProperty",
                     "io.micronaut.context.annotation.Executable",
+                    "io.micronaut.core.annotation.Introspected\$Property",
                     'jakarta.validation.constraints.NotNull$List'
             ]
     }
@@ -146,7 +147,8 @@ class MyBeanMixin {
             metadata.getAnnotationNameByStereotype(JacksonAnnotation.name).get() == JsonProperty.name
             metadata.annotationNames.sort() == [
                     "com.fasterxml.jackson.annotation.JsonProperty",
-                    "io.micronaut.context.annotation.Executable"
+                    "io.micronaut.context.annotation.Executable",
+                    "io.micronaut.core.annotation.Introspected\$Property"
             ]
     }
 
@@ -191,7 +193,8 @@ class MyBeanMixin {
             metadata.getAnnotationNameByStereotype(JacksonAnnotation.name).get() == JsonProperty.name
             metadata.annotationNames.sort() == [
                     "com.fasterxml.jackson.annotation.JsonProperty",
-                    "io.micronaut.context.annotation.Executable"
+                    "io.micronaut.context.annotation.Executable",
+                    "io.micronaut.core.annotation.Introspected\$Property"
             ]
     }
 
@@ -235,7 +238,8 @@ class MyBeanMixin {
             metadata.getAnnotationNameByStereotype(JacksonAnnotation.name).get() == JsonProperty.name
             metadata.annotationNames.sort() == [
                     "com.fasterxml.jackson.annotation.JsonProperty",
-                    "io.micronaut.context.annotation.Executable"
+                    "io.micronaut.context.annotation.Executable",
+                    "io.micronaut.core.annotation.Introspected\$Property"
             ]
     }
 
@@ -279,7 +283,8 @@ class MyBeanMixin {
             metadata.getAnnotationNameByStereotype(JacksonAnnotation.name).get() == JsonProperty.name
             metadata.annotationNames.sort() == [
                     "com.fasterxml.jackson.annotation.JsonProperty",
-                    "io.micronaut.context.annotation.Executable"
+                    "io.micronaut.context.annotation.Executable",
+                    "io.micronaut.core.annotation.Introspected\$Property"
             ]
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
@@ -377,4 +377,55 @@ class Parameters {
                 'io.micronaut.core.annotation.Introspected'
         ]
     }
+
+    void "test conflicting introspected property access kinds fail compilation"() {
+        when:
+        buildBeanIntrospection('test.ConflictingPropertyAccess', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class ConflictingPropertyAccess {
+    private String name;
+
+    @Introspected.Property(accessKind = Introspected.Property.Access.READ)
+    public String getName() {
+        return name;
+    }
+
+    @Introspected.Property(accessKind = Introspected.Property.Access.WRITE)
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains('Conflicting @Introspected.Property accessKind declarations for property [name]')
+    }
+
+    void "test introspected property value and name must match"() {
+        when:
+        buildBeanIntrospection('test.ConflictingPropertyNames', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class ConflictingPropertyNames {
+    private String name;
+
+    @Introspected.Property(value = "external_name", name = "other_name")
+    public String getName() {
+        return name;
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains('The @Introspected.Property value and name members must match when both are declared')
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
@@ -428,4 +428,122 @@ class ConflictingPropertyNames {
         def e = thrown(RuntimeException)
         e.message.contains('The @Introspected.Property value and name members must match when both are declared')
     }
+
+    void "test inaccessible introspected property field fails compilation"() {
+        when:
+        buildBeanIntrospection('test.InaccessiblePropertyField', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class InaccessiblePropertyField {
+    @Introspected.Property(accessKind = Introspected.Property.Access.READ)
+    private String name;
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains(
+                'Element annotated with @Introspected.Property cannot be used as an introspected property: the field is not accessible'
+        )
+    }
+
+    void "test inaccessible introspected property method fails compilation"() {
+        when:
+        buildBeanIntrospection('test.InaccessiblePropertyMethod', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class InaccessiblePropertyMethod {
+    @Introspected.Property(accessKind = Introspected.Property.Access.READ)
+    private String name() {
+        return "test";
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains(
+                'Element annotated with @Introspected.Property cannot be used as an introspected property: the method is not accessible'
+        )
+    }
+
+    void "test introspected property method must provide declared access"() {
+        when:
+        buildBeanIntrospection('test.InvalidPropertyMethodAccess', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class InvalidPropertyMethodAccess {
+    @Introspected.Property(accessKind = Introspected.Property.Access.WRITE)
+    public String name() {
+        return "test";
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains(
+                'Element annotated with @Introspected.Property cannot be used as an introspected property: ' +
+                        'write access requires a one-argument method or a zero-argument void method'
+        )
+    }
+
+    void "test introspected property field must provide declared access"() {
+        when:
+        buildBeanIntrospection('test.InvalidPropertyFieldAccess', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class InvalidPropertyFieldAccess {
+    @Introspected.Property(accessKind = Introspected.Property.Access.WRITE)
+    public final String name = "test";
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains(
+                'Element annotated with @Introspected.Property cannot be used as an introspected property: ' +
+                        'write access requires a non-final field'
+        )
+    }
+
+    void "test introspected property method can ignore other accessors"() {
+        given:
+        ClassElement classElement = buildClassElement('''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class MethodIgnoresOtherAccessors {
+    private String name;
+
+    public CharSequence getName() {
+        return name;
+    }
+
+    @Introspected.Property(ignoreOtherAccessors = true)
+    public String name() {
+        return name;
+    }
+}
+''')
+        def beanProperty = classElement.beanProperties.find { it.name == 'name' }
+
+        expect:
+        beanProperty.type.name == String.name
+        beanProperty.readMethod.get().name == 'name'
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
@@ -546,4 +546,175 @@ class MethodIgnoresOtherAccessors {
         beanProperty.type.name == String.name
         beanProperty.readMethod.get().name == 'name'
     }
+
+    void "test json auto detect default visibility resolves to jackson defaults"() {
+        given:
+        ClassElement classElement = buildClassElement('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+@JsonAutoDetect(
+    fieldVisibility = JsonAutoDetect.Visibility.DEFAULT,
+    getterVisibility = JsonAutoDetect.Visibility.DEFAULT,
+    isGetterVisibility = JsonAutoDetect.Visibility.DEFAULT,
+    setterVisibility = JsonAutoDetect.Visibility.DEFAULT
+)
+class DefaultJsonAutoDetectBean {
+    private String privateField;
+    public String publicField;
+    private String name;
+    private boolean active;
+    private String writeOnly;
+    private String protectedSetter;
+
+    public String getName() {
+        return name;
+    }
+
+    protected String getProtectedGetter() {
+        return "protected";
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setWriteOnly(String writeOnly) {
+        this.writeOnly = writeOnly;
+    }
+
+    protected void setProtectedSetter(String protectedSetter) {
+        this.protectedSetter = protectedSetter;
+    }
+}
+''')
+        def properties = classElement.beanProperties
+        def propertyNames = properties*.name as Set
+
+        expect:
+        propertyNames == ['publicField', 'name', 'active', 'writeOnly', 'protectedSetter'] as Set
+        !properties.find { it.name == 'publicField' }.isReadOnly()
+        !properties.find { it.name == 'publicField' }.isWriteOnly()
+        properties.find { it.name == 'name' }.isReadOnly()
+        properties.find { it.name == 'active' }.isReadOnly()
+        properties.find { it.name == 'writeOnly' }.isWriteOnly()
+        properties.find { it.name == 'protectedSetter' }.isWriteOnly()
+    }
+
+    void "test json auto detect non private and protected public visibility"() {
+        given:
+        ClassElement classElement = buildClassElement('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+@JsonAutoDetect(
+    fieldVisibility = JsonAutoDetect.Visibility.NON_PRIVATE,
+    getterVisibility = JsonAutoDetect.Visibility.PROTECTED_AND_PUBLIC,
+    isGetterVisibility = JsonAutoDetect.Visibility.PROTECTED_AND_PUBLIC,
+    setterVisibility = JsonAutoDetect.Visibility.NONE
+)
+class RestrictedJsonAutoDetectBean {
+    private String privateField;
+    String packageField;
+    protected String protectedField;
+    public String publicField;
+    private String protectedGetter;
+    private boolean active;
+    private String writeOnly;
+
+    protected String getProtectedGetter() {
+        return protectedGetter;
+    }
+
+    String getPackageGetter() {
+        return "package";
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setWriteOnly(String writeOnly) {
+        this.writeOnly = writeOnly;
+    }
+}
+''')
+        def properties = classElement.beanProperties
+        def propertyNames = properties*.name as Set
+
+        expect:
+        propertyNames == ['packageField', 'protectedField', 'publicField', 'protectedGetter', 'active'] as Set
+        !properties.find { it.name == 'packageField' }.isReadOnly()
+        !properties.find { it.name == 'packageField' }.isWriteOnly()
+        !properties.find { it.name == 'protectedField' }.isReadOnly()
+        !properties.find { it.name == 'protectedField' }.isWriteOnly()
+        !properties.find { it.name == 'publicField' }.isReadOnly()
+        !properties.find { it.name == 'publicField' }.isWriteOnly()
+        properties.find { it.name == 'protectedGetter' }.isReadOnly()
+        properties.find { it.name == 'active' }.isReadOnly()
+    }
+
+    void "test jackson property annotations define explicit property access"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonPropertyAccessBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class JacksonPropertyAccessBean {
+    private String renamed;
+    private String readOnly;
+    private String writeOnly;
+    private String setterOnly;
+
+    @JsonProperty("renamed_value")
+    public String getRenamed() {
+        return renamed;
+    }
+
+    @JsonProperty("renamed_value")
+    public void setRenamed(String renamed) {
+        this.renamed = renamed;
+    }
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public String getReadOnly() {
+        return readOnly;
+    }
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    public void setWriteOnly(String writeOnly) {
+        this.writeOnly = writeOnly;
+    }
+
+    @JsonSetter("setter_only")
+    public void applySetterOnly(String setterOnly) {
+        this.setterOnly = setterOnly;
+    }
+}
+''')
+
+        def properties = introspection.beanProperties
+        def renamed = properties.find { it.name == 'renamed' }
+        def readOnly = properties.find { it.name == 'readOnly' }
+        def writeOnly = properties.find { it.name == 'writeOnly' }
+        def setterOnly = properties.find { it.name == 'applySetterOnly' }
+
+        expect:
+        properties*.name as Set == ['renamed', 'readOnly', 'writeOnly', 'applySetterOnly'] as Set
+        !renamed.isReadOnly()
+        !renamed.isWriteOnly()
+        readOnly.isReadOnly()
+        writeOnly.isWriteOnly()
+        setterOnly.isWriteOnly()
+    }
 }

--- a/src/main/docs/guide/ioc/introspection/introspectedProperty.adoc
+++ b/src/main/docs/guide/ioc/introspection/introspectedProperty.adoc
@@ -1,0 +1,97 @@
+The ann:core.annotation.Introspected.Property[] annotation can be used on an introspected field or method to make that member an explicit bean property.
+This is useful when the member does not follow normal JavaBean getter or setter naming rules, or when the property should expose extra metadata such as an external serialized name.
+
+[source,java]
+----
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class Book {
+    private String title;
+    private String author;
+
+    @Introspected.Property("book_title")
+    public String title() {
+        return title;
+    }
+
+    @Introspected.Property("book_title")
+    public void title(String title) {
+        this.title = title;
+    }
+
+    @Introspected.Property(
+        value = "author_name",
+        accessKind = Introspected.Property.Access.READ
+    )
+    public String author() {
+        return author;
+    }
+}
+----
+
+In the example above, `title()` and `title(String)` are included as read/write bean property accessors even though they are not JavaBean `getTitle` and `setTitle` methods.
+The `author()` method is included as a read-only property because its `accessKind` only contains `Introspected.Property.Access.READ`.
+
+The `value` member is a shorthand for `name`.
+The `name` member represents an external property name and is available through the property annotation metadata.
+It does not change the Micronaut bean property name used with api:core.beans.BeanIntrospection[] lookup methods.
+
+[source,java]
+----
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.beans.BeanIntrospection;
+
+var introspection = BeanIntrospection.getIntrospection(Book.class);
+var property = introspection.getRequiredProperty("title", String.class);
+var externalName = property.stringValue(Introspected.Property.class, "name");
+----
+
+The `accessKind` member controls whether the annotated member contributes read access, write access, or both:
+
+* `Introspected.Property.Access.READ` allows the property to be read.
+* `Introspected.Property.Access.WRITE` allows the property to be written.
+* The default is both `READ` and `WRITE`.
+
+If both a getter and setter exist, Micronaut can still expose a read/write property. Use `accessKind` when a field or method must restrict one side of access, for example read-only or write-only properties.
+
+== Jackson Annotations
+
+When Jackson annotations are present on an introspected type, Micronaut maps the following annotations to ann:core.annotation.Introspected.Property[] at compile time:
+
+* `com.fasterxml.jackson.annotation.JsonProperty`
+* `com.fasterxml.jackson.annotation.JsonGetter`
+* `com.fasterxml.jackson.annotation.JsonSetter`
+
+This means Jackson-style property names are visible through Micronaut bean property annotation metadata, and Jackson-annotated methods that do not follow JavaBean naming rules can still be recognized as bean properties.
+
+[source,java]
+----
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class User {
+    private String displayName;
+
+    @JsonGetter("display_name")
+    public String displayName() {
+        return displayName;
+    }
+
+    @JsonSetter("display_name")
+    public void displayName(String displayName) {
+        this.displayName = displayName;
+    }
+}
+----
+
+The `displayName` methods are treated as a bean property, and the external name `display_name` is available from the mapped ann:core.annotation.Introspected.Property[] metadata.
+For `JsonGetter` and `JsonSetter`, read and write availability is determined by the available bean property reader and writer.
+
+For `JsonProperty`, Micronaut also maps Jackson's `access` member:
+
+* `JsonProperty.Access.READ_ONLY` maps to `Introspected.Property.Access.READ`.
+* `JsonProperty.Access.WRITE_ONLY` maps to `Introspected.Property.Access.WRITE`.
+* `JsonProperty.Access.AUTO` and `JsonProperty.Access.READ_WRITE` map to both read and write access.

--- a/src/main/docs/guide/ioc/introspection/introspectedProperty.adoc
+++ b/src/main/docs/guide/ioc/introspection/introspectedProperty.adoc
@@ -1,34 +1,7 @@
 The ann:core.annotation.Introspected.Property[] annotation can be used on an introspected field or method to make that member an explicit bean property.
 This is useful when the member does not follow normal JavaBean getter or setter naming rules, or when the property should expose extra metadata such as an external serialized name.
 
-[source,java]
-----
-import io.micronaut.core.annotation.Introspected;
-
-@Introspected
-class Book {
-    private String title;
-    private String author;
-
-    @Introspected.Property("book_title")
-    public String title() {
-        return title;
-    }
-
-    @Introspected.Property("book_title")
-    public void title(String title) {
-        this.title = title;
-    }
-
-    @Introspected.Property(
-        value = "author_name",
-        accessKind = Introspected.Property.Access.READ
-    )
-    public String author() {
-        return author;
-    }
-}
-----
+snippet::io.micronaut.docs.ioc.introspection.Book[tags="imports,class", indent=0]
 
 In the example above, `title()` and `title(String)` are included as read/write bean property accessors even though they are not JavaBean `getTitle` and `setTitle` methods.
 The `author()` method is included as a read-only property because its `accessKind` only contains `Introspected.Property.Access.READ`.
@@ -36,24 +9,18 @@ The `author()` method is included as a read-only property because its `accessKin
 The `value` member is a shorthand for `name`.
 The `name` member represents an external property name and is available through the property annotation metadata.
 It does not change the Micronaut bean property name used with api:core.beans.BeanIntrospection[] lookup methods.
+If both `value` and `name` are declared, they must contain the same value.
 
-[source,java]
-----
-import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.beans.BeanIntrospection;
+snippet::io.micronaut.docs.ioc.introspection.IntrospectedPropertyTest[tags="metadata", indent=0]
 
-var introspection = BeanIntrospection.getIntrospection(Book.class);
-var property = introspection.getRequiredProperty("title", String.class);
-var externalName = property.stringValue(Introspected.Property.class, "name");
-----
-
-The `accessKind` member controls whether the annotated member contributes read access, write access, or both:
+The `accessKind` member controls whether the bean property can be read, written, or both:
 
 * `Introspected.Property.Access.READ` allows the property to be read.
 * `Introspected.Property.Access.WRITE` allows the property to be written.
 * The default is both `READ` and `WRITE`.
 
 If both a getter and setter exist, Micronaut can still expose a read/write property. Use `accessKind` when a field or method must restrict one side of access, for example read-only or write-only properties.
+The access declaration applies to the whole bean property. Multiple ann:core.annotation.Introspected.Property[] declarations for the same bean property must declare the same `accessKind`; conflicting declarations are rejected during compilation.
 When ann:core.annotation.Introspected.Property[] is declared on a field that belongs to the same bean property as getter or setter methods, Micronaut uses the normal bean accessor precedence: getter methods are used for reads and setter methods are used for writes when they are present.
 The annotated field still contributes the mapped property metadata and can provide field access when a corresponding getter or setter is absent.
 
@@ -70,27 +37,7 @@ When Jackson annotations are present on an introspected type, Micronaut maps the
 
 This means Jackson-style property names are visible through Micronaut bean property annotation metadata, and Jackson-annotated methods that do not follow JavaBean naming rules can still be recognized as bean properties.
 
-[source,java]
-----
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import io.micronaut.core.annotation.Introspected;
-
-@Introspected
-class User {
-    private String displayName;
-
-    @JsonGetter("display_name")
-    public String displayName() {
-        return displayName;
-    }
-
-    @JsonSetter("display_name")
-    public void displayName(String displayName) {
-        this.displayName = displayName;
-    }
-}
-----
+snippet::io.micronaut.docs.ioc.introspection.User[tags="imports,class", indent=0]
 
 The `displayName` methods are treated as a bean property, and the external name `display_name` is available from the mapped ann:core.annotation.Introspected.Property[] metadata.
 For `JsonGetter` and `JsonSetter`, read and write availability is determined by the available bean property reader and writer.
@@ -101,6 +48,8 @@ For `JsonProperty`, Micronaut also maps Jackson's `access` member:
 * `JsonProperty.Access.READ_ONLY` maps to `Introspected.Property.Access.READ`.
 * `JsonProperty.Access.WRITE_ONLY` maps to `Introspected.Property.Access.WRITE`.
 * `JsonProperty.Access.AUTO` and `JsonProperty.Access.READ_WRITE` map to both read and write access.
+
+Because `accessKind` is property-level, multiple Jackson annotations that map to the same bean property must agree on the mapped access.
 
 == Jakarta Persistence
 

--- a/src/main/docs/guide/ioc/introspection/introspectedProperty.adoc
+++ b/src/main/docs/guide/ioc/introspection/introspectedProperty.adoc
@@ -54,6 +54,11 @@ The `accessKind` member controls whether the annotated member contributes read a
 * The default is both `READ` and `WRITE`.
 
 If both a getter and setter exist, Micronaut can still expose a read/write property. Use `accessKind` when a field or method must restrict one side of access, for example read-only or write-only properties.
+When ann:core.annotation.Introspected.Property[] is declared on a field that belongs to the same bean property as getter or setter methods, Micronaut uses the normal bean accessor precedence: getter methods are used for reads and setter methods are used for writes when they are present.
+The annotated field still contributes the mapped property metadata and can provide field access when a corresponding getter or setter is absent.
+
+Set `ignoreOtherAccessors` to `true` when the annotated member must be used for its access direction even if another field, getter, or setter exists for the same bean property.
+For example, an annotated field with the default read/write `accessKind` will be used for both reads and writes instead of same-name getter and setter methods.
 
 == Jackson Annotations
 
@@ -89,9 +94,16 @@ class User {
 
 The `displayName` methods are treated as a bean property, and the external name `display_name` is available from the mapped ann:core.annotation.Introspected.Property[] metadata.
 For `JsonGetter` and `JsonSetter`, read and write availability is determined by the available bean property reader and writer.
+Jackson annotations do not set `ignoreOtherAccessors`, so Micronaut keeps the same accessor precedence as Jackson Databind: getters are preferred for reads and setters are preferred for writes when they exist.
 
 For `JsonProperty`, Micronaut also maps Jackson's `access` member:
 
 * `JsonProperty.Access.READ_ONLY` maps to `Introspected.Property.Access.READ`.
 * `JsonProperty.Access.WRITE_ONLY` maps to `Introspected.Property.Access.WRITE`.
 * `JsonProperty.Access.AUTO` and `JsonProperty.Access.READ_WRITE` map to both read and write access.
+
+== Jakarta Persistence
+
+Micronaut also maps `jakarta.persistence.Access` on a field or method to ann:core.annotation.Introspected.Property[] with `ignoreOtherAccessors` enabled.
+This allows explicit Jakarta Persistence field-access and property-access attributes to be treated as introspected bean properties.
+When `@Access(AccessType.FIELD)` is declared on a field that also has getter or setter methods, Micronaut uses the field directly for bean property reads and writes.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -50,6 +50,7 @@ ioc:
     atIntrospected: Use the @Introspected Annotation
     introspectedAccessorsStyle: Use @Introspected with @AccessorsStyle
     accessKind: Bean Fields
+    introspectedProperty: Explicit Bean Properties
     atCreator: Constructor Methods
     staticAtCreator: Static Creator Methods
     introspectionBuilders: Builders

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/introspection/Book.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/introspection/Book.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.docs.ioc.introspection
+
+// tag::imports[]
+import io.micronaut.core.annotation.Introspected
+// end::imports[]
+
+// tag::class[]
+@Introspected
+class Book {
+    private String title
+    private String author = 'Ursula Le Guin'
+
+    @Introspected.Property('book_title')
+    String title() {
+        return title
+    }
+
+    @Introspected.Property('book_title')
+    void title(String title) {
+        this.title = title
+    }
+
+    @Introspected.Property(
+        value = 'author_name',
+        accessKind = [Introspected.Property.Access.READ]
+    )
+    String author() {
+        return author
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/introspection/IntrospectedPropertyTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/introspection/IntrospectedPropertyTest.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.docs.ioc.introspection
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.core.beans.BeanProperty
+import spock.lang.Specification
+
+class IntrospectedPropertyTest extends Specification {
+
+    void "test introspected property metadata"() {
+        when:
+        // tag::metadata[]
+        BeanIntrospection<Book> introspection = BeanIntrospection.getIntrospection(Book)
+        BeanProperty<Book, String> property = introspection.getRequiredProperty('title', String)
+        Optional<String> externalName = property.stringValue(Introspected.Property, 'name')
+        // end::metadata[]
+
+        then:
+        externalName.orElseThrow() == 'book_title'
+    }
+
+    void "test Jackson property metadata"() {
+        when:
+        BeanIntrospection<User> introspection = BeanIntrospection.getIntrospection(User)
+        BeanProperty<User, String> property = introspection.getRequiredProperty('displayName', String)
+
+        then:
+        property.stringValue(Introspected.Property, 'name').orElseThrow() == 'display_name'
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/introspection/User.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/introspection/User.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.docs.ioc.introspection
+
+// tag::imports[]
+import com.fasterxml.jackson.annotation.JsonGetter
+import com.fasterxml.jackson.annotation.JsonSetter
+import io.micronaut.core.annotation.Introspected
+// end::imports[]
+
+// tag::class[]
+@Introspected
+class User {
+    private String displayName
+
+    @JsonGetter('display_name')
+    String displayName() {
+        return displayName
+    }
+
+    @JsonSetter('display_name')
+    void displayName(String displayName) {
+        this.displayName = displayName
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/introspection/Book.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/introspection/Book.kt
@@ -1,0 +1,31 @@
+package io.micronaut.docs.ioc.introspection
+
+// tag::imports[]
+import io.micronaut.core.annotation.Introspected
+// end::imports[]
+
+// tag::class[]
+@Introspected
+class Book {
+    private var title: String? = null
+    private val author = "Ursula Le Guin"
+
+    @Introspected.Property("book_title")
+    fun title(): String? {
+        return title
+    }
+
+    @Introspected.Property("book_title")
+    fun title(title: String?) {
+        this.title = title
+    }
+
+    @Introspected.Property(
+        value = "author_name",
+        accessKind = [Introspected.Property.Access.READ]
+    )
+    fun author(): String {
+        return author
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/introspection/IntrospectedPropertyTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/introspection/IntrospectedPropertyTest.kt
@@ -1,0 +1,28 @@
+package io.micronaut.docs.ioc.introspection
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.beans.BeanIntrospection
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class IntrospectedPropertyTest {
+
+    @Test
+    fun testIntrospectedPropertyMetadata() {
+        // tag::metadata[]
+        val introspection = BeanIntrospection.getIntrospection(Book::class.java)
+        val property = introspection.getRequiredProperty("title", String::class.java)
+        val externalName = property.stringValue(Introspected.Property::class.java, "name")
+        // end::metadata[]
+
+        assertEquals("book_title", externalName.orElseThrow())
+    }
+
+    @Test
+    fun testJacksonPropertyMetadata() {
+        val introspection = BeanIntrospection.getIntrospection(User::class.java)
+        val property = introspection.getRequiredProperty("displayName", String::class.java)
+
+        assertEquals("display_name", property.stringValue(Introspected.Property::class.java, "name").orElseThrow())
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/introspection/User.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/introspection/User.kt
@@ -1,0 +1,24 @@
+package io.micronaut.docs.ioc.introspection
+
+// tag::imports[]
+import com.fasterxml.jackson.annotation.JsonGetter
+import com.fasterxml.jackson.annotation.JsonSetter
+import io.micronaut.core.annotation.Introspected
+// end::imports[]
+
+// tag::class[]
+@Introspected
+class User {
+    private var displayName: String? = null
+
+    @JsonGetter("display_name")
+    fun displayName(): String? {
+        return displayName
+    }
+
+    @JsonSetter("display_name")
+    fun displayName(displayName: String?) {
+        this.displayName = displayName
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/Book.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/Book.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.introspection;
+
+// tag::imports[]
+import io.micronaut.core.annotation.Introspected;
+// end::imports[]
+
+// tag::class[]
+@Introspected
+class Book {
+    private String title;
+    private String author = "Ursula Le Guin";
+
+    @Introspected.Property("book_title")
+    public String title() {
+        return title;
+    }
+
+    @Introspected.Property("book_title")
+    public void title(String title) {
+        this.title = title;
+    }
+
+    @Introspected.Property(
+        value = "author_name",
+        accessKind = Introspected.Property.Access.READ
+    )
+    public String author() {
+        return author;
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/IntrospectedPropertyTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/IntrospectedPropertyTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.introspection;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanProperty;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IntrospectedPropertyTest {
+
+    @Test
+    void testIntrospectedPropertyMetadata() {
+        // tag::metadata[]
+        BeanIntrospection<Book> introspection = BeanIntrospection.getIntrospection(Book.class);
+        BeanProperty<Book, String> property = introspection.getRequiredProperty("title", String.class);
+        Optional<String> externalName = property.stringValue(Introspected.Property.class, "name");
+        // end::metadata[]
+
+        assertEquals("book_title", externalName.orElseThrow());
+    }
+
+    @Test
+    void testJacksonPropertyMetadata() {
+        BeanIntrospection<User> introspection = BeanIntrospection.getIntrospection(User.class);
+        BeanProperty<User, String> property = introspection.getRequiredProperty("displayName", String.class);
+
+        assertEquals("display_name", property.stringValue(Introspected.Property.class, "name").orElseThrow());
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/JakartaAccessTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/JakartaAccessTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.introspection;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanProperty;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JakartaAccessTest {
+
+    @Test
+    void testJakartaPersistenceFieldAccessAttributeIsRecognizedAsBeanProperty() {
+        BeanIntrospection<JpaPropertyAccessEntity> introspection = BeanIntrospection.getIntrospection(JpaPropertyAccessEntity.class);
+        BeanProperty<JpaPropertyAccessEntity, String> property = introspection.getRequiredProperty("fieldAccess", String.class);
+        JpaPropertyAccessEntity entity = new JpaPropertyAccessEntity();
+
+        assertMappedAccess(property, AccessType.FIELD);
+
+        property.set(entity, "field");
+        assertEquals("field", entity.fieldAccess);
+        assertEquals("field", property.get(entity));
+    }
+
+    @Test
+    void testJakartaPersistencePropertyAccessAttributeIsRecognizedAsBeanProperty() {
+        BeanIntrospection<JpaFieldAccessEntity> introspection = BeanIntrospection.getIntrospection(JpaFieldAccessEntity.class);
+        BeanProperty<JpaFieldAccessEntity, String> property = introspection.getRequiredProperty("propertyAccess", String.class);
+        JpaFieldAccessEntity entity = new JpaFieldAccessEntity();
+
+        assertMappedAccess(property, AccessType.PROPERTY);
+
+        property.set(entity, "property");
+        assertEquals("property-setter", entity.propertyAccess);
+        assertEquals("property-setter-getter", property.get(entity));
+    }
+
+    private static void assertMappedAccess(BeanProperty<?, ?> property, AccessType accessType) {
+        assertEquals(accessType, property.enumValue(Access.class, AccessType.class).orElseThrow());
+        assertTrue(property.hasAnnotation(Introspected.Property.class));
+        assertTrue(property.booleanValue(Introspected.Property.class, "ignoreOtherAccessors").orElseThrow());
+    }
+
+    @Entity
+    @Access(AccessType.PROPERTY)
+    static final class JpaPropertyAccessEntity {
+        private Long id;
+
+        @Access(AccessType.FIELD)
+        String fieldAccess;
+
+        @Id
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getFieldAccess() {
+            return fieldAccess + "-getter";
+        }
+
+        public void setFieldAccess(String fieldAccess) {
+            this.fieldAccess = fieldAccess + "-setter";
+        }
+    }
+
+    @Entity
+    @Access(AccessType.FIELD)
+    static final class JpaFieldAccessEntity {
+        @Id
+        Long id;
+
+        @Transient
+        private String propertyAccess;
+
+        @Access(AccessType.PROPERTY)
+        public String getPropertyAccess() {
+            return propertyAccess + "-getter";
+        }
+
+        public void setPropertyAccess(String propertyAccess) {
+            this.propertyAccess = propertyAccess + "-setter";
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/JakartaAccessTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/JakartaAccessTest.java
@@ -34,10 +34,14 @@ class JakartaAccessTest {
     void testJakartaPersistenceFieldAccessAttributeIsRecognizedAsBeanProperty() {
         BeanIntrospection<JpaPropertyAccessEntity> introspection = BeanIntrospection.getIntrospection(JpaPropertyAccessEntity.class);
         BeanProperty<JpaPropertyAccessEntity, String> property = introspection.getRequiredProperty("fieldAccess", String.class);
+        BeanProperty<JpaPropertyAccessEntity, Long> idProperty = introspection.getRequiredProperty("id", Long.class);
         JpaPropertyAccessEntity entity = new JpaPropertyAccessEntity();
 
         assertMappedAccess(property, AccessType.FIELD);
 
+        idProperty.set(entity, 123L);
+        assertEquals(123L, entity.id);
+        assertEquals(123L, idProperty.get(entity));
         property.set(entity, "field");
         assertEquals("field", entity.fieldAccess);
         assertEquals("field", property.get(entity));
@@ -47,10 +51,14 @@ class JakartaAccessTest {
     void testJakartaPersistencePropertyAccessAttributeIsRecognizedAsBeanProperty() {
         BeanIntrospection<JpaFieldAccessEntity> introspection = BeanIntrospection.getIntrospection(JpaFieldAccessEntity.class);
         BeanProperty<JpaFieldAccessEntity, String> property = introspection.getRequiredProperty("propertyAccess", String.class);
+        BeanProperty<JpaFieldAccessEntity, Long> idProperty = introspection.getRequiredProperty("id", Long.class);
         JpaFieldAccessEntity entity = new JpaFieldAccessEntity();
 
         assertMappedAccess(property, AccessType.PROPERTY);
 
+        idProperty.set(entity, 456L);
+        assertEquals(456L, entity.id);
+        assertEquals(456L, idProperty.get(entity));
         property.set(entity, "property");
         assertEquals("property-setter", entity.propertyAccess);
         assertEquals("property-setter-getter", property.get(entity));

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/User.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/introspection/User.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.introspection;
+
+// tag::imports[]
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import io.micronaut.core.annotation.Introspected;
+// end::imports[]
+
+// tag::class[]
+@Introspected
+class User {
+    private String displayName;
+
+    @JsonGetter("display_name")
+    public String displayName() {
+        return displayName;
+    }
+
+    @JsonSetter("display_name")
+    public void displayName(String displayName) {
+        this.displayName = displayName;
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/json/bind/JsonAutoDetectBeanIntrospectionTest.java
+++ b/test-suite/src/test/java/io/micronaut/json/bind/JsonAutoDetectBeanIntrospectionTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.json.bind;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.beans.BeanWriteProperty;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonAutoDetectBeanIntrospectionTest {
+
+    @Test
+    void jsonAutoDetectFieldVisibilityIsRecognizedAsBeanProperties() throws IOException {
+        BeanIntrospection<FieldVisibilityBean> introspection = BeanIntrospection.getIntrospection(FieldVisibilityBean.class);
+
+        assertEquals(
+            Set.of("privateField", "packageField", "protectedField", "publicField", "fieldWithAccessors"),
+            propertyNames(introspection)
+        );
+
+        FieldVisibilityBean bean = new FieldVisibilityBean();
+        BeanProperty<FieldVisibilityBean, String> property =
+            introspection.getRequiredProperty("fieldWithAccessors", String.class);
+
+        property.set(bean, "field");
+        assertEquals("field", bean.fieldWithAccessors);
+        assertEquals("field", property.get(bean));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode json = objectMapper.valueToTree(bean);
+        assertEquals("private-field", json.get("privateField").asString());
+        assertEquals("package-field", json.get("packageField").asString());
+        assertEquals("protected-field", json.get("protectedField").asString());
+        assertEquals("public-field", json.get("publicField").asString());
+        assertEquals("field", json.get("fieldWithAccessors").asString());
+
+        FieldVisibilityBean deserialized = objectMapper.readValue(
+            """
+            {
+              "privateField": "private-json",
+              "packageField": "package-json",
+              "protectedField": "protected-json",
+              "publicField": "public-json",
+              "fieldWithAccessors": "field-json"
+            }
+            """,
+            FieldVisibilityBean.class
+        );
+        assertEquals("private-json", deserialized.privateField);
+        assertEquals("package-json", deserialized.packageField);
+        assertEquals("protected-json", deserialized.protectedField);
+        assertEquals("public-json", deserialized.publicField);
+        assertEquals("field-json", deserialized.fieldWithAccessors);
+    }
+
+    @Test
+    void jsonAutoDetectMethodVisibilityIsRecognizedAsBeanProperties() throws IOException {
+        BeanIntrospection<MethodVisibilityBean> introspection = BeanIntrospection.getIntrospection(MethodVisibilityBean.class);
+
+        assertEquals(Set.of("privateGetter", "privateSetter", "active", "name"), propertyNames(introspection));
+
+        MethodVisibilityBean bean = new MethodVisibilityBean();
+        BeanProperty<MethodVisibilityBean, String> getterProperty =
+            introspection.getRequiredProperty("privateGetter", String.class);
+        assertTrue(getterProperty.isReadOnly());
+        assertEquals("private-getter-getter", getterProperty.get(bean));
+        assertThrows(UnsupportedOperationException.class, () -> getterProperty.set(bean, "getter"));
+
+        BeanWriteProperty<MethodVisibilityBean, String> setterProperty =
+            introspection.getRequiredWriteProperty("privateSetter", String.class);
+        setterProperty.set(bean, "setter");
+        assertEquals("setter-setter", bean.privateSetter);
+
+        BeanProperty<MethodVisibilityBean, String> nameProperty =
+            introspection.getRequiredProperty("name", String.class);
+        assertTrue(nameProperty.isWriteOnly());
+        nameProperty.set(bean, "name");
+        assertEquals("name-setter", bean.name);
+        assertThrows(UnsupportedOperationException.class, () -> nameProperty.get(bean));
+
+        BeanProperty<MethodVisibilityBean, Boolean> activeProperty =
+            introspection.getRequiredProperty("active", boolean.class);
+        activeProperty.set(bean, true);
+        assertTrue(activeProperty.get(bean));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode json = objectMapper.valueToTree(bean);
+        assertEquals("private-getter-getter", json.get("privateGetter").asString());
+        assertTrue(json.get("active").asBoolean());
+        assertFalse(json.has("privateSetter"));
+        assertFalse(json.has("name"));
+
+        MethodVisibilityBean deserialized = objectMapper.readValue(
+            """
+            {
+              "privateSetter": "json",
+              "name": "json-name",
+              "active": true
+            }
+            """,
+            MethodVisibilityBean.class
+        );
+        assertEquals("json-setter", deserialized.privateSetter);
+        assertEquals("json-name-setter", deserialized.name);
+        assertTrue(deserialized.active);
+    }
+
+    @Test
+    void jsonAutoDetectPublicOnlyVisibilityRestrictsBeanProperties() throws IOException {
+        BeanIntrospection<PublicOnlyVisibilityBean> introspection =
+            BeanIntrospection.getIntrospection(PublicOnlyVisibilityBean.class);
+
+        assertEquals(Set.of("publicField", "publicGetter", "publicSetter"), propertyNames(introspection));
+
+        PublicOnlyVisibilityBean bean = new PublicOnlyVisibilityBean();
+        BeanWriteProperty<PublicOnlyVisibilityBean, String> setterProperty =
+            introspection.getRequiredWriteProperty("publicSetter", String.class);
+        setterProperty.set(bean, "setter");
+        assertEquals("setter-setter", bean.publicSetter);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode json = objectMapper.valueToTree(bean);
+        assertEquals("public-field", json.get("publicField").asString());
+        assertEquals("public-getter-getter", json.get("publicGetter").asString());
+        assertFalse(json.has("active"));
+        assertFalse(json.has("protectedGetter"));
+        assertFalse(json.has("publicSetter"));
+
+        PublicOnlyVisibilityBean deserialized = objectMapper.readValue(
+            """
+            {
+              "publicField": "public-json",
+              "publicSetter": "public-json",
+              "protectedSetter": "protected-json"
+            }
+            """,
+            PublicOnlyVisibilityBean.class
+        );
+        assertEquals("public-json", deserialized.publicField);
+        assertEquals("public-json-setter", deserialized.publicSetter);
+        assertEquals("protected-setter", deserialized.protectedSetter);
+    }
+
+    private static Set<String> propertyNames(BeanIntrospection<?> introspection) {
+        return introspection.getBeanProperties()
+            .stream()
+            .map(BeanProperty::getName)
+            .collect(Collectors.toSet());
+    }
+
+    @Introspected
+    @JsonAutoDetect(
+        fieldVisibility = JsonAutoDetect.Visibility.ANY,
+        getterVisibility = JsonAutoDetect.Visibility.NONE,
+        isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+        setterVisibility = JsonAutoDetect.Visibility.NONE
+    )
+    static final class FieldVisibilityBean {
+        private String privateField = "private-field";
+        String packageField = "package-field";
+        protected String protectedField = "protected-field";
+        public String publicField = "public-field";
+        private String fieldWithAccessors = "field-with-accessors";
+
+        public String getFieldWithAccessors() {
+            return fieldWithAccessors + "-getter";
+        }
+
+        public void setFieldWithAccessors(String fieldWithAccessors) {
+            this.fieldWithAccessors = fieldWithAccessors + "-setter";
+        }
+    }
+
+    @Introspected
+    @JsonAutoDetect(
+        fieldVisibility = JsonAutoDetect.Visibility.NONE,
+        getterVisibility = JsonAutoDetect.Visibility.ANY,
+        isGetterVisibility = JsonAutoDetect.Visibility.ANY,
+        setterVisibility = JsonAutoDetect.Visibility.ANY
+    )
+    static final class MethodVisibilityBean {
+        private String privateGetter = "private-getter";
+        private String privateSetter;
+        private String name;
+        private boolean active;
+
+        private String getPrivateGetter() {
+            return privateGetter + "-getter";
+        }
+
+        private void setPrivateSetter(String privateSetter) {
+            this.privateSetter = privateSetter + "-setter";
+        }
+
+        private String isName() {
+            return name + "-is-getter";
+        }
+
+        private void setName(String name) {
+            this.name = name + "-setter";
+        }
+
+        private boolean isActive() {
+            return active;
+        }
+
+        private void setActive(boolean active) {
+            this.active = active;
+        }
+    }
+
+    @Introspected
+    @JsonAutoDetect(
+        fieldVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+        getterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+        isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+        setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY
+    )
+    static final class PublicOnlyVisibilityBean {
+        public String publicField = "public-field";
+        String packageField = "package-field";
+        protected String protectedField = "protected-field";
+        private String privateField = "private-field";
+        private String publicGetter = "public-getter";
+        private String protectedGetter = "protected-getter";
+        private boolean active = true;
+        private String publicSetter;
+        private String protectedSetter = "protected-setter";
+
+        public String getPublicGetter() {
+            return publicGetter + "-getter";
+        }
+
+        protected String getProtectedGetter() {
+            return protectedGetter + "-getter";
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setPublicSetter(String publicSetter) {
+            this.publicSetter = publicSetter + "-setter";
+        }
+
+        protected void setProtectedSetter(String protectedSetter) {
+            this.protectedSetter = protectedSetter + "-setter";
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/json/bind/JsonPropertyBeanIntrospectionTest.java
+++ b/test-suite/src/test/java/io/micronaut/json/bind/JsonPropertyBeanIntrospectionTest.java
@@ -1,0 +1,870 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.json.bind;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.beans.BeanReadProperty;
+import io.micronaut.core.beans.BeanWriteProperty;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.value.OptionalMultiValues;
+import io.micronaut.http.hateoas.GenericResource;
+import io.micronaut.http.hateoas.JsonError;
+import io.micronaut.http.hateoas.Link;
+import io.micronaut.http.hateoas.Resource;
+import io.micronaut.json.JsonMapper;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JsonPropertyBeanIntrospectionTest {
+
+    private static final List<JsonPropertyMember> JSON_PROPERTY_MEMBERS = List.of(
+        new JsonPropertyMember("fieldProperty", "field_property", "field", true, true),
+        new JsonPropertyMember("readOnlyFieldProperty", "read_only_field_property", "read-only-field", true, false),
+        new JsonPropertyMember("writeOnlyFieldProperty", "write_only_field_property", "write-only-field", false, true),
+        new JsonPropertyMember("pairedProperty", "paired_property", "paired", true, true),
+        new JsonPropertyMember("readOnlyProperty", "read_only_property", "read-only", true, false),
+        new JsonPropertyMember("writeOnlyProperty", "write_only_property", "write-only", false, true),
+        new JsonPropertyMember("readOnlyAccessorProperty", "read_only_accessor_property", "read-only-accessor", true, false),
+        new JsonPropertyMember("writeOnlyAccessorProperty", "write_only_accessor_property", "write-only-accessor", false, true)
+    );
+    private static final List<JsonPropertyBooleanMember> JSON_PROPERTY_BOOLEAN_MEMBERS = List.of(
+        new JsonPropertyBooleanMember("active", "active_flag", true),
+        new JsonPropertyBooleanMember("visible", "visible_flag", false)
+    );
+    private static final List<JsonPropertyBooleanSetterWithoutParameter> JSON_PROPERTY_BOOLEAN_SETTERS_WITHOUT_PARAMETERS = List.of(
+        new JsonPropertyBooleanSetterWithoutParameter("debug", "debug_flag"),
+        new JsonPropertyBooleanSetterWithoutParameter("methodFlag", "method_flag")
+    );
+    private static final List<JsonGetterSetterMember> JSON_GETTER_SETTER_MEMBERS = List.of(
+        new JsonGetterSetterMember("readWriteAccessor", "read_write_accessor", "read-write", true, true),
+        new JsonGetterSetterMember("getterWithImplicitSetter", "getter_with_implicit_setter", "getter-with-implicit-setter", true, true),
+        new JsonGetterSetterMember("setterWithImplicitGetter", "setter_with_implicit_getter", "setter-with-implicit-getter", true, true),
+        new JsonGetterSetterMember("readOnlyAccessor", "read_only_accessor", "read-only", true, false),
+        new JsonGetterSetterMember("writeOnlyAccessor", "write_only_accessor", "write-only", false, true),
+        new JsonGetterSetterMember("fluentAccessor", "fluent_accessor", "fluent", true, true)
+    );
+    private static final List<IntrospectedPropertyMember> INTROSPECTED_PROPERTY_MEMBERS = List.of(
+        new IntrospectedPropertyMember("valueAccessor", "value_accessor", "value"),
+        new IntrospectedPropertyMember("namedAccessor", "named_accessor", "named")
+    );
+
+    private static final String ISSUE_691_MESSAGE = "Internal Server Error";
+    private static final String ISSUE_691_EMBEDDED_MESSAGE = "Internal Server Error: Something bad happened";
+    private static final String ISSUE_691_LINK = "/resolve";
+    private static final Map<String, Object> ISSUE_691_LINKS = Map.of(
+        Link.SELF.toString(),
+        List.of(Map.of(
+            Link.HREF.toString(), ISSUE_691_LINK,
+            "templated", false
+        ))
+    );
+    private static final Map<String, List<Resource>> ISSUE_691_EMBEDDED = Map.of(
+        "errors",
+        List.of(new JsonError(ISSUE_691_EMBEDDED_MESSAGE))
+    );
+    private static final String ISSUE_691_JSON = """
+        {
+          "_links": {
+            "self": [
+              {
+                "href": "/resolve",
+                "templated": false
+              }
+            ]
+          },
+          "_embedded": {
+            "errors": [
+              {
+                "message": "Internal Server Error: Something bad happened"
+              }
+            ]
+          },
+          "message": "Internal Server Error"
+        }
+        """;
+    private static final List<HateoasProperty> HATEOAS_PROPERTIES = List.of(
+        new HateoasProperty("links", Resource.LINKS, ISSUE_691_LINKS, OptionalMultiValues.class, Map.class),
+        new HateoasProperty("embedded", Resource.EMBEDDED, ISSUE_691_EMBEDDED, OptionalMultiValues.class, Map.class)
+    );
+
+    @Test
+    void jsonPropertyMembersAreRecognizedAsBeanProperties() {
+        BeanIntrospection<JsonPropertyBean> introspection = BeanIntrospection.getIntrospection(JsonPropertyBean.class);
+
+        assertEquals(
+            JSON_PROPERTY_MEMBERS
+                .stream()
+                .map(JsonPropertyMember::beanPropertyName)
+                .collect(Collectors.toSet()),
+            introspection.getBeanProperties()
+                .stream()
+                .map(BeanProperty::getName)
+                .collect(Collectors.toSet())
+        );
+
+        JsonPropertyBean bean = new JsonPropertyBean();
+
+        for (JsonPropertyMember member : JSON_PROPERTY_MEMBERS) {
+            BeanProperty<JsonPropertyBean, String> property =
+                introspection.getRequiredProperty(member.beanPropertyName(), String.class);
+            assertEquals(
+                member.jsonPropertyName(),
+                property.stringValue(JsonProperty.class).orElseThrow(),
+                member.beanPropertyName()
+            );
+            assertEquals(
+                member.jsonPropertyName(),
+                property.stringValue(Introspected.Property.class, "name").orElseThrow(),
+                member.beanPropertyName()
+            );
+            assertEquals(
+                member.accessKinds(),
+                List.of(property.enumValues(
+                    Introspected.Property.class,
+                    "accessKind",
+                    Introspected.Property.Access.class
+                )),
+                member.beanPropertyName()
+            );
+            assertEquals(!member.writable(), property.isReadOnly(), member.beanPropertyName());
+            assertEquals(!member.readable(), property.isWriteOnly(), member.beanPropertyName());
+
+            if (member.writable()) {
+                BeanWriteProperty<JsonPropertyBean, String> writeProperty =
+                    introspection.getRequiredWriteProperty(member.beanPropertyName(), String.class);
+                writeProperty.set(bean, member.value());
+                assertEquals(member.value(), readBeanProperty(bean, member), member.beanPropertyName());
+            }
+
+            if (member.readable()) {
+                BeanReadProperty<JsonPropertyBean, String> readProperty =
+                    introspection.getRequiredReadProperty(member.beanPropertyName(), String.class);
+                assertEquals(member.value(), readProperty.get(bean), member.beanPropertyName());
+                assertEquals(member.value(), property.get(bean), member.beanPropertyName());
+            } else {
+                assertThrows(UnsupportedOperationException.class, () -> property.get(bean), member.beanPropertyName());
+            }
+        }
+    }
+
+    @Test
+    void jacksonDatabindRecognizesJsonPropertyMembersAsBeanProperties() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonPropertyBean bean = new JsonPropertyBean();
+        JSON_PROPERTY_MEMBERS.stream()
+            .filter(JsonPropertyMember::writable)
+            .forEach(member -> writeBeanProperty(bean, member));
+
+        JsonNode json = objectMapper.valueToTree(bean);
+
+        for (JsonPropertyMember member : JSON_PROPERTY_MEMBERS) {
+            if (member.readable()) {
+                assertEquals(
+                    member.value(),
+                    json.get(member.jsonPropertyName()).asString(),
+                    member.beanPropertyName()
+                );
+            } else {
+                assertFalse(json.has(member.jsonPropertyName()), member.beanPropertyName());
+            }
+        }
+
+        JsonPropertyBean deserialized = objectMapper.readValue(
+            objectMapper.writeValueAsString(writableJsonProperties()),
+            JsonPropertyBean.class
+        );
+
+        for (JsonPropertyMember member : JSON_PROPERTY_MEMBERS) {
+            if (member.writable()) {
+                assertEquals(member.value(), readBeanProperty(deserialized, member), member.beanPropertyName());
+            }
+        }
+    }
+
+    @Test
+    void jsonPropertyBooleanMembersAreRecognizedAsBeanProperties() {
+        BeanIntrospection<JsonPropertyBooleanBean> introspection = BeanIntrospection.getIntrospection(JsonPropertyBooleanBean.class);
+
+        assertEquals(
+            Stream.concat(
+                    JSON_PROPERTY_BOOLEAN_MEMBERS
+                        .stream()
+                        .map(JsonPropertyBooleanMember::beanPropertyName),
+                    JSON_PROPERTY_BOOLEAN_SETTERS_WITHOUT_PARAMETERS
+                        .stream()
+                        .map(JsonPropertyBooleanSetterWithoutParameter::beanPropertyName)
+                )
+                .collect(Collectors.toSet()),
+            introspection.getBeanProperties()
+                .stream()
+                .map(BeanProperty::getName)
+                .collect(Collectors.toSet())
+        );
+
+        JsonPropertyBooleanBean bean = new JsonPropertyBooleanBean();
+
+        for (JsonPropertyBooleanMember member : JSON_PROPERTY_BOOLEAN_MEMBERS) {
+            BeanProperty<JsonPropertyBooleanBean, Boolean> property =
+                introspection.getRequiredProperty(member.beanPropertyName(), boolean.class);
+            assertReadWriteJsonProperty(property, member.beanPropertyName(), member.jsonPropertyName());
+
+            BeanWriteProperty<JsonPropertyBooleanBean, Boolean> writeProperty =
+                introspection.getRequiredWriteProperty(member.beanPropertyName(), boolean.class);
+            writeProperty.set(bean, member.value());
+            assertEquals(member.value(), readBooleanBeanProperty(bean, member), member.beanPropertyName());
+
+            BeanReadProperty<JsonPropertyBooleanBean, Boolean> readProperty =
+                introspection.getRequiredReadProperty(member.beanPropertyName(), boolean.class);
+            assertEquals(member.value(), readProperty.get(bean), member.beanPropertyName());
+            assertEquals(member.value(), property.get(bean), member.beanPropertyName());
+        }
+
+        for (JsonPropertyBooleanSetterWithoutParameter member : JSON_PROPERTY_BOOLEAN_SETTERS_WITHOUT_PARAMETERS) {
+            BeanProperty<JsonPropertyBooleanBean, Boolean> property =
+                introspection.getRequiredProperty(member.beanPropertyName(), boolean.class);
+            assertReadWriteJsonProperty(property, member.beanPropertyName(), member.jsonPropertyName());
+            assertEquals(false, property.get(bean), member.beanPropertyName());
+
+            BeanWriteProperty<JsonPropertyBooleanBean, Boolean> writeProperty =
+                introspection.getRequiredWriteProperty(member.beanPropertyName(), boolean.class);
+            writeProperty.set(bean, false);
+            assertEquals(true, property.get(bean), member.beanPropertyName());
+
+            BeanReadProperty<JsonPropertyBooleanBean, Boolean> readProperty =
+                introspection.getRequiredReadProperty(member.beanPropertyName(), boolean.class);
+            assertEquals(true, readProperty.get(bean), member.beanPropertyName());
+        }
+    }
+
+    @Test
+    void jacksonDatabindRecognizesJsonPropertyBooleanMembersAsBeanProperties() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonPropertyBooleanBean bean = new JsonPropertyBooleanBean();
+        JSON_PROPERTY_BOOLEAN_MEMBERS.forEach(member -> writeBooleanBeanProperty(bean, member));
+
+        JsonNode json = objectMapper.valueToTree(bean);
+
+        for (JsonPropertyBooleanMember member : JSON_PROPERTY_BOOLEAN_MEMBERS) {
+            assertEquals(
+                member.value(),
+                json.get(member.jsonPropertyName()).asBoolean(),
+                member.beanPropertyName()
+            );
+        }
+
+        JsonPropertyBooleanBean deserialized = objectMapper.readValue(
+            objectMapper.writeValueAsString(writableJsonBooleanProperties()),
+            JsonPropertyBooleanBean.class
+        );
+
+        for (JsonPropertyBooleanMember member : JSON_PROPERTY_BOOLEAN_MEMBERS) {
+            assertEquals(member.value(), readBooleanBeanProperty(deserialized, member), member.beanPropertyName());
+        }
+    }
+
+    @Test
+    void jsonGetterAndJsonSetterMembersAreRecognizedAsBeanProperties() {
+        BeanIntrospection<JsonGetterSetterBean> introspection = BeanIntrospection.getIntrospection(JsonGetterSetterBean.class);
+
+        assertEquals(
+            JSON_GETTER_SETTER_MEMBERS
+                .stream()
+                .map(JsonGetterSetterMember::beanPropertyName)
+                .collect(Collectors.toSet()),
+            introspection.getBeanProperties()
+                .stream()
+                .map(BeanProperty::getName)
+                .collect(Collectors.toSet())
+        );
+
+        JsonGetterSetterBean bean = new JsonGetterSetterBean();
+
+        for (JsonGetterSetterMember member : JSON_GETTER_SETTER_MEMBERS) {
+            BeanProperty<JsonGetterSetterBean, String> property =
+                introspection.getRequiredProperty(member.beanPropertyName(), String.class);
+            assertEquals(
+                member.jsonPropertyName(),
+                property.stringValue(Introspected.Property.class, "name").orElseThrow(),
+                member.beanPropertyName()
+            );
+            assertEquals(!member.writable(), property.isReadOnly(), member.beanPropertyName());
+            assertEquals(!member.readable(), property.isWriteOnly(), member.beanPropertyName());
+
+            if (member.writable()) {
+                BeanWriteProperty<JsonGetterSetterBean, String> writeProperty =
+                    introspection.getRequiredWriteProperty(member.beanPropertyName(), String.class);
+                writeProperty.set(bean, member.value());
+                assertEquals(member.value(), readJsonGetterSetterBeanProperty(bean, member), member.beanPropertyName());
+            }
+
+            if (member.readable()) {
+                BeanReadProperty<JsonGetterSetterBean, String> readProperty =
+                    introspection.getRequiredReadProperty(member.beanPropertyName(), String.class);
+                assertEquals(member.value(), readProperty.get(bean), member.beanPropertyName());
+                assertEquals(member.value(), property.get(bean), member.beanPropertyName());
+            } else {
+                assertThrows(UnsupportedOperationException.class, () -> property.get(bean), member.beanPropertyName());
+            }
+        }
+    }
+
+    @Test
+    void jacksonDatabindRecognizesJsonGetterAndJsonSetterMembersAsBeanProperties() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonGetterSetterBean bean = new JsonGetterSetterBean();
+        JSON_GETTER_SETTER_MEMBERS.stream()
+            .filter(JsonGetterSetterMember::writable)
+            .forEach(member -> writeJsonGetterSetterBeanProperty(bean, member));
+
+        JsonNode json = objectMapper.valueToTree(bean);
+
+        for (JsonGetterSetterMember member : JSON_GETTER_SETTER_MEMBERS) {
+            if (member.readable()) {
+                assertEquals(
+                    member.value(),
+                    json.get(member.jsonPropertyName()).asString(),
+                    member.beanPropertyName()
+                );
+            } else {
+                assertFalse(json.has(member.jsonPropertyName()), member.beanPropertyName());
+            }
+        }
+
+        JsonGetterSetterBean deserialized = objectMapper.readValue(
+            objectMapper.writeValueAsString(writableJsonGetterSetterProperties()),
+            JsonGetterSetterBean.class
+        );
+
+        for (JsonGetterSetterMember member : JSON_GETTER_SETTER_MEMBERS) {
+            if (member.writable()) {
+                assertEquals(member.value(), readJsonGetterSetterBeanProperty(deserialized, member), member.beanPropertyName());
+            }
+        }
+    }
+
+    @Test
+    void hateoasJsonPropertyMembersAreRecognizedAsReadWriteBeanProperties() {
+        BeanIntrospection<JsonError> introspection = BeanIntrospection.getIntrospection(JsonError.class);
+        JsonError bean = new JsonError(ISSUE_691_MESSAGE);
+
+        for (HateoasProperty member : HATEOAS_PROPERTIES) {
+            BeanProperty<JsonError, Object> property = introspection.getProperty(member.beanPropertyName())
+                .orElseThrow();
+            assertEquals(
+                member.jsonPropertyName(),
+                property.stringValue(Introspected.Property.class, "name").orElseThrow(),
+                member.beanPropertyName()
+            );
+            assertEquals(
+                List.of(Introspected.Property.Access.READ, Introspected.Property.Access.WRITE),
+                List.of(property.enumValues(
+                    Introspected.Property.class,
+                    "accessKind",
+                    Introspected.Property.Access.class
+                )),
+                member.beanPropertyName()
+            );
+            assertFalse(property.isReadOnly(), member.beanPropertyName());
+            assertFalse(property.isWriteOnly(), member.beanPropertyName());
+
+            BeanReadProperty<JsonError, Object> readProperty = introspection.getReadProperty(member.beanPropertyName())
+                .orElseThrow();
+            BeanWriteProperty<JsonError, Object> writeProperty = introspection.getWriteProperty(member.beanPropertyName())
+                .orElseThrow();
+            assertEquals(member.readType(), readProperty.getType(), member.beanPropertyName());
+            assertEquals(member.writeType(), writeProperty.getType(), member.beanPropertyName());
+
+            writeProperty.set(bean, member.writeValue());
+            assertInstanceOf(member.readType(), readProperty.get(bean), member.beanPropertyName());
+            assertInstanceOf(member.readType(), property.get(bean), member.beanPropertyName());
+        }
+
+        assertIssue691Resource(bean);
+    }
+
+    @Test
+    void jacksonDatabindReadsAndWritesIssue691JsonErrorWithoutMicronautSerialization() throws IOException {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            JsonMapper jsonMapper = context.getBean(JsonMapper.class);
+
+            JsonError deserializationResult = jsonMapper.readValue(ISSUE_691_JSON, JsonError.class);
+            assertIssue691JsonError(deserializationResult);
+
+            String serialized = jsonMapper.writeValueAsString(deserializationResult);
+            JsonNode json = new ObjectMapper().readTree(serialized);
+            assertIssue691Json(json);
+
+            Resource resource = jsonMapper.readValue(ISSUE_691_JSON, Argument.of(Resource.class));
+            GenericResource genericResource = assertInstanceOf(GenericResource.class, resource);
+            assertEquals(ISSUE_691_MESSAGE, genericResource.getAdditionalProperties().get("message"));
+            assertIssue691Resource(genericResource);
+        }
+    }
+
+    @Test
+    void introspectedPropertyValueIsTrackedAsNameAnnotationValue() {
+        BeanIntrospection<IntrospectedPropertyBean> introspection =
+            BeanIntrospection.getIntrospection(IntrospectedPropertyBean.class);
+        IntrospectedPropertyBean bean = new IntrospectedPropertyBean();
+
+        for (IntrospectedPropertyMember member : INTROSPECTED_PROPERTY_MEMBERS) {
+            BeanProperty<IntrospectedPropertyBean, String> property =
+                introspection.getRequiredProperty(member.beanPropertyName(), String.class);
+            assertEquals(
+                member.externalPropertyName(),
+                property.stringValue(Introspected.Property.class).orElseThrow(),
+                member.beanPropertyName()
+            );
+            assertEquals(
+                member.externalPropertyName(),
+                property.stringValue(Introspected.Property.class, "name").orElseThrow(),
+                member.beanPropertyName()
+            );
+
+            property.set(bean, member.value());
+            assertEquals(member.value(), property.get(bean), member.beanPropertyName());
+        }
+    }
+
+    private static Map<String, String> writableJsonProperties() {
+        return JSON_PROPERTY_MEMBERS.stream()
+            .filter(JsonPropertyMember::writable)
+            .collect(Collectors.toMap(
+                JsonPropertyMember::jsonPropertyName,
+                JsonPropertyMember::value,
+                (first, second) -> second,
+                LinkedHashMap::new
+            ));
+    }
+
+    private static Map<String, String> writableJsonGetterSetterProperties() {
+        return JSON_GETTER_SETTER_MEMBERS.stream()
+            .filter(JsonGetterSetterMember::writable)
+            .collect(Collectors.toMap(
+                JsonGetterSetterMember::jsonPropertyName,
+                JsonGetterSetterMember::value,
+                (first, second) -> second,
+                LinkedHashMap::new
+            ));
+    }
+
+    private static Map<String, Boolean> writableJsonBooleanProperties() {
+        return JSON_PROPERTY_BOOLEAN_MEMBERS.stream()
+            .collect(Collectors.toMap(
+                JsonPropertyBooleanMember::jsonPropertyName,
+                JsonPropertyBooleanMember::value,
+                (first, second) -> second,
+                LinkedHashMap::new
+            ));
+    }
+
+    private static void writeBeanProperty(JsonPropertyBean bean, JsonPropertyMember member) {
+        switch (member.beanPropertyName()) {
+            case "fieldProperty" -> bean.fieldProperty = member.value();
+            case "writeOnlyFieldProperty" -> bean.writeOnlyFieldProperty = member.value();
+            case "pairedProperty" -> bean.pairedProperty(member.value());
+            case "writeOnlyProperty" -> bean.writeOnlyProperty(member.value());
+            case "writeOnlyAccessorProperty" -> bean.setWriteOnlyAccessorProperty(member.value());
+            default -> throw new IllegalArgumentException("No writer for " + member.beanPropertyName());
+        }
+    }
+
+    private static String readBeanProperty(JsonPropertyBean bean, JsonPropertyMember member) {
+        return switch (member.beanPropertyName()) {
+            case "fieldProperty" -> bean.fieldProperty;
+            case "readOnlyFieldProperty" -> bean.readOnlyFieldProperty;
+            case "writeOnlyFieldProperty" -> bean.writeOnlyFieldProperty;
+            case "pairedProperty" -> bean.pairedProperty();
+            case "readOnlyProperty" -> bean.readOnlyProperty();
+            case "writeOnlyProperty" -> bean.writeOnlyProperty;
+            case "readOnlyAccessorProperty" -> bean.getReadOnlyAccessorProperty();
+            case "writeOnlyAccessorProperty" -> bean.getWriteOnlyAccessorProperty();
+            default -> throw new IllegalArgumentException("No reader for " + member.beanPropertyName());
+        };
+    }
+
+    private static void writeJsonGetterSetterBeanProperty(JsonGetterSetterBean bean, JsonGetterSetterMember member) {
+        switch (member.beanPropertyName()) {
+            case "readWriteAccessor" -> bean.setReadWriteAccessor(member.value());
+            case "getterWithImplicitSetter" -> bean.setGetterWithImplicitSetter(member.value());
+            case "setterWithImplicitGetter" -> bean.setSetterWithImplicitGetter(member.value());
+            case "writeOnlyAccessor" -> bean.setWriteOnlyAccessor(member.value());
+            case "fluentAccessor" -> bean.fluentAccessor(member.value());
+            default -> throw new IllegalArgumentException("No writer for " + member.beanPropertyName());
+        }
+    }
+
+    private static String readJsonGetterSetterBeanProperty(JsonGetterSetterBean bean, JsonGetterSetterMember member) {
+        return switch (member.beanPropertyName()) {
+            case "readWriteAccessor" -> bean.getReadWriteAccessor();
+            case "getterWithImplicitSetter" -> bean.getGetterWithImplicitSetter();
+            case "setterWithImplicitGetter" -> bean.getSetterWithImplicitGetter();
+            case "readOnlyAccessor" -> bean.getReadOnlyAccessor();
+            case "writeOnlyAccessor" -> bean.writeOnlyAccessor;
+            case "fluentAccessor" -> bean.fluentAccessor();
+            default -> throw new IllegalArgumentException("No reader for " + member.beanPropertyName());
+        };
+    }
+
+    private static void writeBooleanBeanProperty(JsonPropertyBooleanBean bean, JsonPropertyBooleanMember member) {
+        switch (member.beanPropertyName()) {
+            case "active" -> bean.setActive(member.value());
+            case "visible" -> bean.visible(member.value());
+            default -> throw new IllegalArgumentException("No writer for " + member.beanPropertyName());
+        }
+    }
+
+    private static boolean readBooleanBeanProperty(JsonPropertyBooleanBean bean, JsonPropertyBooleanMember member) {
+        return switch (member.beanPropertyName()) {
+            case "active" -> bean.isActive();
+            case "visible" -> bean.visible();
+            default -> throw new IllegalArgumentException("No reader for " + member.beanPropertyName());
+        };
+    }
+
+    private static void assertReadWriteJsonProperty(BeanProperty<?, ?> property,
+                                                    String beanPropertyName,
+                                                    String jsonPropertyName) {
+        assertEquals(
+            jsonPropertyName,
+            property.stringValue(JsonProperty.class).orElseThrow(),
+            beanPropertyName
+        );
+        assertEquals(
+            jsonPropertyName,
+            property.stringValue(Introspected.Property.class, "name").orElseThrow(),
+            beanPropertyName
+        );
+        assertEquals(
+            List.of(Introspected.Property.Access.READ, Introspected.Property.Access.WRITE),
+            List.of(property.enumValues(
+                Introspected.Property.class,
+                "accessKind",
+                Introspected.Property.Access.class
+            )),
+            beanPropertyName
+        );
+        assertFalse(property.isReadOnly(), beanPropertyName);
+        assertFalse(property.isWriteOnly(), beanPropertyName);
+    }
+
+    private static void assertIssue691JsonError(JsonError jsonError) {
+        assertNotNull(jsonError);
+        assertEquals(ISSUE_691_MESSAGE, jsonError.getMessage());
+        assertIssue691Resource(jsonError);
+    }
+
+    private static void assertIssue691Resource(Resource resource) {
+        assertNotNull(resource);
+        Link link = resource.getLinks().getFirst(Link.SELF).orElseThrow();
+        assertEquals(ISSUE_691_LINK, link.getHref());
+
+        Resource embedded = resource.getEmbedded().getFirst("errors").orElseThrow();
+        assertEquals(ISSUE_691_EMBEDDED_MESSAGE, resourceMessage(embedded));
+    }
+
+    private static String resourceMessage(Resource resource) {
+        if (resource instanceof JsonError jsonError) {
+            return jsonError.getMessage();
+        }
+        GenericResource genericResource = assertInstanceOf(GenericResource.class, resource);
+        return (String) genericResource.getAdditionalProperties().get("message");
+    }
+
+    private static void assertIssue691Json(JsonNode json) {
+        assertEquals(ISSUE_691_MESSAGE, json.get("message").asString());
+        assertFalse(json.has("links"));
+        assertFalse(json.has("embedded"));
+        assertEquals(
+            ISSUE_691_LINK,
+            firstOrSingle(json.get(Resource.LINKS).get(Link.SELF.toString())).get(Link.HREF.toString()).asString()
+        );
+        assertEquals(
+            ISSUE_691_EMBEDDED_MESSAGE,
+            firstOrSingle(json.get(Resource.EMBEDDED).get("errors")).get("message").asString()
+        );
+    }
+
+    private static JsonNode firstOrSingle(JsonNode json) {
+        assertNotNull(json);
+        JsonNode value = json.isArray() ? json.get(0) : json;
+        assertNotNull(value);
+        return value;
+    }
+
+    private record JsonPropertyMember(
+        String beanPropertyName,
+        String jsonPropertyName,
+        String value,
+        boolean readable,
+        boolean writable
+    ) {
+        List<Introspected.Property.Access> accessKinds() {
+            if (readable && writable) {
+                return List.of(Introspected.Property.Access.READ, Introspected.Property.Access.WRITE);
+            }
+            if (readable) {
+                return List.of(Introspected.Property.Access.READ);
+            }
+            return List.of(Introspected.Property.Access.WRITE);
+        }
+    }
+
+    private record JsonGetterSetterMember(
+        String beanPropertyName,
+        String jsonPropertyName,
+        String value,
+        boolean readable,
+        boolean writable
+    ) {
+    }
+
+    private record JsonPropertyBooleanMember(
+        String beanPropertyName,
+        String jsonPropertyName,
+        boolean value
+    ) {
+    }
+
+    private record JsonPropertyBooleanSetterWithoutParameter(
+        String beanPropertyName,
+        String jsonPropertyName
+    ) {
+    }
+
+    private record HateoasProperty(
+        String beanPropertyName,
+        String jsonPropertyName,
+        Object writeValue,
+        Class<?> readType,
+        Class<?> writeType
+    ) {
+    }
+
+    private record IntrospectedPropertyMember(
+        String beanPropertyName,
+        String externalPropertyName,
+        String value
+    ) {
+    }
+
+    @Introspected
+    static final class JsonPropertyBean {
+        @JsonProperty("field_property")
+        String fieldProperty;
+
+        @JsonProperty(value = "read_only_field_property", access = JsonProperty.Access.READ_ONLY)
+        String readOnlyFieldProperty = "read-only-field";
+
+        @JsonProperty(value = "write_only_field_property", access = JsonProperty.Access.WRITE_ONLY)
+        String writeOnlyFieldProperty;
+
+        private String pairedProperty;
+        private String writeOnlyProperty;
+        private String readOnlyAccessorProperty = "read-only-accessor";
+        private String writeOnlyAccessorProperty;
+
+        @JsonProperty(value = "paired_property", access = JsonProperty.Access.READ_WRITE)
+        public String pairedProperty() {
+            return pairedProperty;
+        }
+
+        @JsonProperty(value = "paired_property", access = JsonProperty.Access.READ_WRITE)
+        public void pairedProperty(String pairedProperty) {
+            this.pairedProperty = pairedProperty;
+        }
+
+        @JsonProperty(value = "read_only_property", access = JsonProperty.Access.READ_ONLY)
+        public String readOnlyProperty() {
+            return "read-only";
+        }
+
+        @JsonProperty(value = "write_only_property", access = JsonProperty.Access.WRITE_ONLY)
+        public void writeOnlyProperty(String writeOnlyProperty) {
+            this.writeOnlyProperty = writeOnlyProperty;
+        }
+
+        @JsonProperty(value = "read_only_accessor_property", access = JsonProperty.Access.READ_ONLY)
+        public String getReadOnlyAccessorProperty() {
+            return readOnlyAccessorProperty;
+        }
+
+        public void setReadOnlyAccessorProperty(String readOnlyAccessorProperty) {
+            this.readOnlyAccessorProperty = readOnlyAccessorProperty;
+        }
+
+        public String getWriteOnlyAccessorProperty() {
+            return writeOnlyAccessorProperty;
+        }
+
+        @JsonProperty(value = "write_only_accessor_property", access = JsonProperty.Access.WRITE_ONLY)
+        public void setWriteOnlyAccessorProperty(String writeOnlyAccessorProperty) {
+            this.writeOnlyAccessorProperty = writeOnlyAccessorProperty;
+        }
+    }
+
+    @Introspected
+    static final class JsonGetterSetterBean {
+        private String readWriteAccessor;
+        private String getterWithImplicitSetter;
+        private String setterWithImplicitGetter;
+        private String readOnlyAccessor = "read-only";
+        private String writeOnlyAccessor;
+        private String fluentAccessor;
+
+        @JsonGetter("read_write_accessor")
+        public String getReadWriteAccessor() {
+            return readWriteAccessor;
+        }
+
+        @JsonSetter("read_write_accessor")
+        public void setReadWriteAccessor(String readWriteAccessor) {
+            this.readWriteAccessor = readWriteAccessor;
+        }
+
+        @JsonGetter("getter_with_implicit_setter")
+        public String getGetterWithImplicitSetter() {
+            return getterWithImplicitSetter;
+        }
+
+        public void setGetterWithImplicitSetter(String getterWithImplicitSetter) {
+            this.getterWithImplicitSetter = getterWithImplicitSetter;
+        }
+
+        public String getSetterWithImplicitGetter() {
+            return setterWithImplicitGetter;
+        }
+
+        @JsonSetter("setter_with_implicit_getter")
+        public void setSetterWithImplicitGetter(String setterWithImplicitGetter) {
+            this.setterWithImplicitGetter = setterWithImplicitGetter;
+        }
+
+        @JsonGetter("read_only_accessor")
+        public String getReadOnlyAccessor() {
+            return readOnlyAccessor;
+        }
+
+        @JsonSetter("write_only_accessor")
+        public void setWriteOnlyAccessor(String writeOnlyAccessor) {
+            this.writeOnlyAccessor = writeOnlyAccessor;
+        }
+
+        @JsonGetter("fluent_accessor")
+        public String fluentAccessor() {
+            return fluentAccessor;
+        }
+
+        @JsonSetter("fluent_accessor")
+        public void fluentAccessor(String fluentAccessor) {
+            this.fluentAccessor = fluentAccessor;
+        }
+    }
+
+    @Introspected
+    static final class JsonPropertyBooleanBean {
+        private boolean active;
+        private boolean visible;
+        private boolean debug;
+        private boolean methodFlag;
+
+        @JsonProperty("active_flag")
+        public boolean isActive() {
+            return active;
+        }
+
+        @JsonProperty("active_flag")
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+
+        @JsonProperty("visible_flag")
+        public boolean visible() {
+            return visible;
+        }
+
+        @JsonProperty("visible_flag")
+        public void visible(boolean visible) {
+            this.visible = visible;
+        }
+
+        @JsonProperty("debug_flag")
+        public boolean isDebug() {
+            return debug;
+        }
+
+        @JsonProperty("debug_flag")
+        public void setDebug() {
+            this.debug = true;
+        }
+
+        @JsonProperty("method_flag")
+        public boolean isMethodFlag() {
+            return methodFlag;
+        }
+
+        @JsonProperty("method_flag")
+        public void methodFlag() {
+            this.methodFlag = true;
+        }
+    }
+
+    @Introspected
+    static final class IntrospectedPropertyBean {
+        private String valueAccessor;
+        private String namedAccessor;
+
+        @Introspected.Property("value_accessor")
+        public String valueAccessor() {
+            return valueAccessor;
+        }
+
+        @Introspected.Property("value_accessor")
+        public void valueAccessor(String valueAccessor) {
+            this.valueAccessor = valueAccessor;
+        }
+
+        @Introspected.Property(name = "named_accessor")
+        public String namedAccessor() {
+            return namedAccessor;
+        }
+
+        @Introspected.Property(name = "named_accessor")
+        public void namedAccessor(String namedAccessor) {
+            this.namedAccessor = namedAccessor;
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/json/bind/JsonPropertyBeanIntrospectionTest.java
+++ b/test-suite/src/test/java/io/micronaut/json/bind/JsonPropertyBeanIntrospectionTest.java
@@ -68,6 +68,35 @@ class JsonPropertyBeanIntrospectionTest {
         new JsonPropertyBooleanSetterWithoutParameter("debug", "debug_flag"),
         new JsonPropertyBooleanSetterWithoutParameter("methodFlag", "method_flag")
     );
+    private static final List<JsonPropertyAccessorMember> JSON_PROPERTY_ACCESSOR_MEMBERS = List.of(
+        new JsonPropertyAccessorMember(
+            "fieldWithAccessors",
+            "field_with_accessors",
+            "field-with-accessors",
+            true,
+            true,
+            "field-with-accessors-setter",
+            "field-with-accessors-setter-getter"
+        ),
+        new JsonPropertyAccessorMember(
+            "readOnlyFieldWithAccessors",
+            "read_only_field_with_accessors",
+            "read-only-field-with-accessors",
+            true,
+            false,
+            "read-only-field-with-accessors",
+            "read-only-field-with-accessors-getter"
+        ),
+        new JsonPropertyAccessorMember(
+            "writeOnlyFieldWithAccessors",
+            "write_only_field_with_accessors",
+            "write-only-field-with-accessors",
+            false,
+            true,
+            "write-only-field-with-accessors-setter",
+            "write-only-field-with-accessors-setter-getter"
+        )
+    );
     private static final List<JsonGetterSetterMember> JSON_GETTER_SETTER_MEMBERS = List.of(
         new JsonGetterSetterMember("readWriteAccessor", "read_write_accessor", "read-write", true, true),
         new JsonGetterSetterMember("getterWithImplicitSetter", "getter_with_implicit_setter", "getter-with-implicit-setter", true, true),
@@ -296,6 +325,95 @@ class JsonPropertyBeanIntrospectionTest {
     }
 
     @Test
+    void jsonPropertyAnnotatedFieldsUseBeanAccessorsWhenPresent() {
+        BeanIntrospection<JsonPropertyAccessorBean> introspection = BeanIntrospection.getIntrospection(JsonPropertyAccessorBean.class);
+
+        assertEquals(
+            JSON_PROPERTY_ACCESSOR_MEMBERS
+                .stream()
+                .map(JsonPropertyAccessorMember::beanPropertyName)
+                .collect(Collectors.toSet()),
+            introspection.getBeanProperties()
+                .stream()
+                .map(BeanProperty::getName)
+                .collect(Collectors.toSet())
+        );
+
+        JsonPropertyAccessorBean bean = new JsonPropertyAccessorBean();
+
+        for (JsonPropertyAccessorMember member : JSON_PROPERTY_ACCESSOR_MEMBERS) {
+            BeanProperty<JsonPropertyAccessorBean, String> property =
+                introspection.getRequiredProperty(member.beanPropertyName(), String.class);
+            assertEquals(
+                member.jsonPropertyName(),
+                property.stringValue(JsonProperty.class).orElseThrow(),
+                member.beanPropertyName()
+            );
+            assertEquals(
+                member.jsonPropertyName(),
+                property.stringValue(Introspected.Property.class, "name").orElseThrow(),
+                member.beanPropertyName()
+            );
+            assertFalse(
+                property.booleanValue(Introspected.Property.class, "ignoreOtherAccessors").orElse(false),
+                member.beanPropertyName()
+            );
+            assertEquals(!member.writable(), property.isReadOnly(), member.beanPropertyName());
+            assertEquals(!member.readable(), property.isWriteOnly(), member.beanPropertyName());
+
+            if (member.writable()) {
+                BeanWriteProperty<JsonPropertyAccessorBean, String> writeProperty =
+                    introspection.getRequiredWriteProperty(member.beanPropertyName(), String.class);
+                writeProperty.set(bean, member.value());
+                assertEquals(member.storedValue(), readAccessorBeanField(bean, member), member.beanPropertyName());
+            } else {
+                assertThrows(UnsupportedOperationException.class, () -> property.set(bean, member.value()), member.beanPropertyName());
+            }
+
+            if (member.readable()) {
+                BeanReadProperty<JsonPropertyAccessorBean, String> readProperty =
+                    introspection.getRequiredReadProperty(member.beanPropertyName(), String.class);
+                assertEquals(member.readValue(), readProperty.get(bean), member.beanPropertyName());
+                assertEquals(member.readValue(), property.get(bean), member.beanPropertyName());
+            } else {
+                assertThrows(UnsupportedOperationException.class, () -> property.get(bean), member.beanPropertyName());
+            }
+        }
+    }
+
+    @Test
+    void jacksonDatabindUsesBeanAccessorsForJsonPropertyAnnotatedFieldsWhenPresent() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonPropertyAccessorBean bean = new JsonPropertyAccessorBean();
+        JSON_PROPERTY_ACCESSOR_MEMBERS.stream()
+            .filter(JsonPropertyAccessorMember::writable)
+            .forEach(member -> writeAccessorBeanProperty(bean, member));
+
+        JsonNode json = objectMapper.valueToTree(bean);
+
+        for (JsonPropertyAccessorMember member : JSON_PROPERTY_ACCESSOR_MEMBERS) {
+            if (member.readable()) {
+                assertEquals(
+                    member.readValue(),
+                    json.get(member.jsonPropertyName()).asString(),
+                    member.beanPropertyName()
+                );
+            } else {
+                assertFalse(json.has(member.jsonPropertyName()), member.beanPropertyName());
+            }
+        }
+
+        JsonPropertyAccessorBean deserialized = objectMapper.readValue(
+            objectMapper.writeValueAsString(allJsonAccessorProperties()),
+            JsonPropertyAccessorBean.class
+        );
+
+        for (JsonPropertyAccessorMember member : JSON_PROPERTY_ACCESSOR_MEMBERS) {
+            assertEquals(member.storedValue(), readAccessorBeanField(deserialized, member), member.beanPropertyName());
+        }
+    }
+
+    @Test
     void jsonGetterAndJsonSetterMembersAreRecognizedAsBeanProperties() {
         BeanIntrospection<JsonGetterSetterBean> introspection = BeanIntrospection.getIntrospection(JsonGetterSetterBean.class);
 
@@ -459,6 +577,28 @@ class JsonPropertyBeanIntrospectionTest {
         }
     }
 
+    @Test
+    void introspectedPropertyCanIgnoreOtherAccessors() {
+        BeanIntrospection<IntrospectedPropertyIgnoreAccessorsBean> introspection =
+            BeanIntrospection.getIntrospection(IntrospectedPropertyIgnoreAccessorsBean.class);
+        BeanProperty<IntrospectedPropertyIgnoreAccessorsBean, String> property =
+            introspection.getRequiredProperty("memberAccess", String.class);
+        IntrospectedPropertyIgnoreAccessorsBean bean = new IntrospectedPropertyIgnoreAccessorsBean();
+
+        assertEquals(
+            "member_access",
+            property.stringValue(Introspected.Property.class, "name").orElseThrow()
+        );
+        assertEquals(
+            true,
+            property.booleanValue(Introspected.Property.class, "ignoreOtherAccessors").orElseThrow()
+        );
+
+        property.set(bean, "member");
+        assertEquals("member", bean.memberAccess);
+        assertEquals("member", property.get(bean));
+    }
+
     private static Map<String, String> writableJsonProperties() {
         return JSON_PROPERTY_MEMBERS.stream()
             .filter(JsonPropertyMember::writable)
@@ -491,6 +631,16 @@ class JsonPropertyBeanIntrospectionTest {
             ));
     }
 
+    private static Map<String, String> allJsonAccessorProperties() {
+        return JSON_PROPERTY_ACCESSOR_MEMBERS.stream()
+            .collect(Collectors.toMap(
+                JsonPropertyAccessorMember::jsonPropertyName,
+                JsonPropertyAccessorMember::value,
+                (first, second) -> second,
+                LinkedHashMap::new
+            ));
+    }
+
     private static void writeBeanProperty(JsonPropertyBean bean, JsonPropertyMember member) {
         switch (member.beanPropertyName()) {
             case "fieldProperty" -> bean.fieldProperty = member.value();
@@ -513,6 +663,23 @@ class JsonPropertyBeanIntrospectionTest {
             case "readOnlyAccessorProperty" -> bean.getReadOnlyAccessorProperty();
             case "writeOnlyAccessorProperty" -> bean.getWriteOnlyAccessorProperty();
             default -> throw new IllegalArgumentException("No reader for " + member.beanPropertyName());
+        };
+    }
+
+    private static void writeAccessorBeanProperty(JsonPropertyAccessorBean bean, JsonPropertyAccessorMember member) {
+        switch (member.beanPropertyName()) {
+            case "fieldWithAccessors" -> bean.setFieldWithAccessors(member.value());
+            case "writeOnlyFieldWithAccessors" -> bean.setWriteOnlyFieldWithAccessors(member.value());
+            default -> throw new IllegalArgumentException("No writer for " + member.beanPropertyName());
+        }
+    }
+
+    private static String readAccessorBeanField(JsonPropertyAccessorBean bean, JsonPropertyAccessorMember member) {
+        return switch (member.beanPropertyName()) {
+            case "fieldWithAccessors" -> bean.fieldWithAccessors;
+            case "readOnlyFieldWithAccessors" -> bean.readOnlyFieldWithAccessors;
+            case "writeOnlyFieldWithAccessors" -> bean.writeOnlyFieldWithAccessors;
+            default -> throw new IllegalArgumentException("No field for " + member.beanPropertyName());
         };
     }
 
@@ -652,6 +819,17 @@ class JsonPropertyBeanIntrospectionTest {
     ) {
     }
 
+    private record JsonPropertyAccessorMember(
+        String beanPropertyName,
+        String jsonPropertyName,
+        String value,
+        boolean readable,
+        boolean writable,
+        String storedValue,
+        String readValue
+    ) {
+    }
+
     private record JsonPropertyBooleanMember(
         String beanPropertyName,
         String jsonPropertyName,
@@ -733,6 +911,42 @@ class JsonPropertyBeanIntrospectionTest {
         @JsonProperty(value = "write_only_accessor_property", access = JsonProperty.Access.WRITE_ONLY)
         public void setWriteOnlyAccessorProperty(String writeOnlyAccessorProperty) {
             this.writeOnlyAccessorProperty = writeOnlyAccessorProperty;
+        }
+    }
+
+    @Introspected
+    static final class JsonPropertyAccessorBean {
+        @JsonProperty("field_with_accessors")
+        String fieldWithAccessors;
+
+        @JsonProperty(value = "read_only_field_with_accessors", access = JsonProperty.Access.READ_ONLY)
+        String readOnlyFieldWithAccessors = "read-only-field-with-accessors";
+
+        @JsonProperty(value = "write_only_field_with_accessors", access = JsonProperty.Access.WRITE_ONLY)
+        String writeOnlyFieldWithAccessors;
+
+        public String getFieldWithAccessors() {
+            return fieldWithAccessors + "-getter";
+        }
+
+        public void setFieldWithAccessors(String fieldWithAccessors) {
+            this.fieldWithAccessors = fieldWithAccessors + "-setter";
+        }
+
+        public String getReadOnlyFieldWithAccessors() {
+            return readOnlyFieldWithAccessors + "-getter";
+        }
+
+        public void setReadOnlyFieldWithAccessors(String readOnlyFieldWithAccessors) {
+            this.readOnlyFieldWithAccessors = readOnlyFieldWithAccessors + "-setter";
+        }
+
+        public String getWriteOnlyFieldWithAccessors() {
+            return writeOnlyFieldWithAccessors + "-getter";
+        }
+
+        public void setWriteOnlyFieldWithAccessors(String writeOnlyFieldWithAccessors) {
+            this.writeOnlyFieldWithAccessors = writeOnlyFieldWithAccessors + "-setter";
         }
     }
 
@@ -865,6 +1079,20 @@ class JsonPropertyBeanIntrospectionTest {
         @Introspected.Property(name = "named_accessor")
         public void namedAccessor(String namedAccessor) {
             this.namedAccessor = namedAccessor;
+        }
+    }
+
+    @Introspected
+    static final class IntrospectedPropertyIgnoreAccessorsBean {
+        @Introspected.Property(name = "member_access", ignoreOtherAccessors = true)
+        String memberAccess;
+
+        public String getMemberAccess() {
+            return memberAccess + "-getter";
+        }
+
+        public void setMemberAccess(String memberAccess) {
+            this.memberAccess = memberAccess + "-setter";
         }
     }
 }

--- a/test-suite/src/test/java/io/micronaut/json/bind/JsonPropertyBeanIntrospectionTest.java
+++ b/test-suite/src/test/java/io/micronaut/json/bind/JsonPropertyBeanIntrospectionTest.java
@@ -414,6 +414,37 @@ class JsonPropertyBeanIntrospectionTest {
     }
 
     @Test
+    void jsonPropertyAnnotatedPrivateFinalFieldsCanUseExistingBeanAccessors() {
+        BeanIntrospection<JsonPropertyPrivateFinalAccessorBean> introspection =
+            BeanIntrospection.getIntrospection(JsonPropertyPrivateFinalAccessorBean.class);
+        BeanProperty<JsonPropertyPrivateFinalAccessorBean, String> property =
+            introspection.getRequiredProperty("homePageUrl", String.class);
+        JsonPropertyPrivateFinalAccessorBean bean =
+            new JsonPropertyPrivateFinalAccessorBean("https://example.org/");
+
+        assertEquals("home_page_url", property.stringValue(JsonProperty.class).orElseThrow());
+        assertEquals("home_page_url", property.stringValue(Introspected.Property.class, "name").orElseThrow());
+        assertEquals("https://example.org/-getter", property.get(bean));
+        assertEquals(true, property.isReadOnly());
+        assertThrows(UnsupportedOperationException.class, () -> property.set(bean, "https://micronaut.io/"));
+    }
+
+    @Test
+    void jsonPropertyAnnotatedRecordComponentsCanUseRecordAccessors() {
+        BeanIntrospection<JsonPropertyRecord> introspection =
+            BeanIntrospection.getIntrospection(JsonPropertyRecord.class);
+        BeanProperty<JsonPropertyRecord, String> property =
+            introspection.getRequiredProperty("homePageUrl", String.class);
+        JsonPropertyRecord bean = new JsonPropertyRecord("https://example.org/");
+
+        assertEquals("home_page_url", property.stringValue(JsonProperty.class).orElseThrow());
+        assertEquals("home_page_url", property.stringValue(Introspected.Property.class, "name").orElseThrow());
+        assertEquals("https://example.org/", property.get(bean));
+        assertEquals(true, property.isReadOnly());
+        assertThrows(UnsupportedOperationException.class, () -> property.set(bean, "https://micronaut.io/"));
+    }
+
+    @Test
     void jsonGetterAndJsonSetterMembersAreRecognizedAsBeanProperties() {
         BeanIntrospection<JsonGetterSetterBean> introspection = BeanIntrospection.getIntrospection(JsonGetterSetterBean.class);
 
@@ -948,6 +979,24 @@ class JsonPropertyBeanIntrospectionTest {
         public void setWriteOnlyFieldWithAccessors(String writeOnlyFieldWithAccessors) {
             this.writeOnlyFieldWithAccessors = writeOnlyFieldWithAccessors + "-setter";
         }
+    }
+
+    @Introspected
+    static final class JsonPropertyPrivateFinalAccessorBean {
+        @JsonProperty("home_page_url")
+        private final String homePageUrl;
+
+        JsonPropertyPrivateFinalAccessorBean(String homePageUrl) {
+            this.homePageUrl = homePageUrl;
+        }
+
+        public String getHomePageUrl() {
+            return homePageUrl + "-getter";
+        }
+    }
+
+    @Introspected
+    record JsonPropertyRecord(@JsonProperty("home_page_url") String homePageUrl) {
     }
 
     @Introspected


### PR DESCRIPTION
  - Added @Introspected.Property annotation with external name and read/write access support.
  - Mapped Jackson @JsonProperty, @JsonGetter, and @JsonSetter to @Introspected.Property.

Fixes https://github.com/micronaut-projects/micronaut-serialization/issues/691