### PR TITLE
Add RFC 9110-aware idempotent HTTP client retry filter

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/DefaultHttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/DefaultHttpClientConfiguration.java
@@ -41,6 +41,7 @@ public class DefaultHttpClientConfiguration extends HttpClientConfiguration {
     private final DefaultConnectionPoolConfiguration connectionPoolConfiguration;
     private final DefaultWebSocketCompressionConfiguration webSocketCompressionConfiguration;
     private final DefaultHttp2ClientConfiguration http2Configuration;
+    private DefaultRetryConfiguration retryConfiguration = new DefaultRetryConfiguration();
 
     /**
      * Default constructor.
@@ -118,6 +119,23 @@ public class DefaultHttpClientConfiguration extends HttpClientConfiguration {
         return http2Configuration;
     }
 
+    @Override
+    public RetryConfiguration getRetryConfiguration() {
+        return retryConfiguration;
+    }
+
+    /**
+     * Sets the retry configuration.
+     *
+     * @param retryConfiguration The retry configuration
+     */
+    @Inject
+    public void setRetryConfiguration(@Nullable DefaultRetryConfiguration retryConfiguration) {
+        if (retryConfiguration != null) {
+            this.retryConfiguration = retryConfiguration;
+        }
+    }
+
     /**
      * The default connection pool configuration.
      */
@@ -143,5 +161,14 @@ public class DefaultHttpClientConfiguration extends HttpClientConfiguration {
     @BootstrapContextCompatible
     @Primary
     public static class DefaultHttp2ClientConfiguration extends Http2ClientConfiguration {
+    }
+
+    /**
+     * The default retry configuration.
+     */
+    @ConfigurationProperties(RetryConfiguration.PREFIX)
+    @BootstrapContextCompatible
+    @Primary
+    public static class DefaultRetryConfiguration extends RetryConfiguration {
     }
 }

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -1608,8 +1608,12 @@ public abstract class HttpClientConfiguration {
          * Sets the jitter factor applied to back-off delays, in [0, 1]. Default value (0.25).
          *
          * @param jitter The jitter factor
+         * @throws IllegalArgumentException if {@code jitter} is outside {@code [0, 1]}
          */
         public void setJitter(double jitter) {
+            if (jitter < 0 || jitter > 1) {
+                throw new IllegalArgumentException("jitter must be in the range [0, 1]");
+            }
             this.jitter = jitter;
         }
 

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -1553,9 +1553,14 @@ public abstract class HttpClientConfiguration {
          * Sets the initial back-off delay. Default value (500ms).
          *
          * @param delay The initial delay
+         * @throws IllegalArgumentException if {@code delay} is negative
          */
         public void setDelay(Duration delay) {
-            this.delay = Objects.requireNonNull(delay, "delay");
+            Objects.requireNonNull(delay, "delay");
+            if (delay.isNegative()) {
+                throw new IllegalArgumentException("delay cannot be negative");
+            }
+            this.delay = delay;
         }
 
         /**
@@ -1571,8 +1576,12 @@ public abstract class HttpClientConfiguration {
          * Sets the exponential back-off multiplier. Default value (1.5).
          *
          * @param multiplier The multiplier
+         * @throws IllegalArgumentException if {@code multiplier} is negative
          */
         public void setMultiplier(double multiplier) {
+            if (multiplier < 0) {
+                throw new IllegalArgumentException("multiplier cannot be negative");
+            }
             this.multiplier = multiplier;
         }
 
@@ -1589,9 +1598,14 @@ public abstract class HttpClientConfiguration {
          * Sets the maximum back-off delay between retries. Default value (10s).
          *
          * @param maxDelay The maximum delay
+         * @throws IllegalArgumentException if {@code maxDelay} is negative
          */
         public void setMaxDelay(Duration maxDelay) {
-            this.maxDelay = Objects.requireNonNull(maxDelay, "maxDelay");
+            Objects.requireNonNull(maxDelay, "maxDelay");
+            if (maxDelay.isNegative()) {
+                throw new IllegalArgumentException("maxDelay cannot be negative");
+            }
+            this.maxDelay = maxDelay;
         }
 
         /**

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -998,6 +998,16 @@ public abstract class HttpClientConfiguration {
     }
 
     /**
+     * Obtains the idempotent retry configuration.
+     *
+     * @return The retry configuration, or {@code null} if retry is not configured.
+     * @since 5.0.0
+     */
+    public HttpClientConfiguration.@Nullable RetryConfiguration getRetryConfiguration() {
+        return null;
+    }
+
+    /**
      * The path pattern to use for logging outgoing connections to pcap. This is an unsupported option: Behavior may
      * change, or it may disappear entirely, without notice! Only implemented for netty.
      *
@@ -1430,6 +1440,201 @@ public abstract class HttpClientConfiguration {
          */
         public void setMaxHeaderListSize(@ReadableBytes int maxHeaderListSize) {
             this.maxHeaderListSize = maxHeaderListSize;
+        }
+    }
+
+    /**
+     * Configuration for <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>-aware
+     * idempotent client-side retry. Disabled by default. See
+     * {@link io.micronaut.http.client.retry.HttpRequestRetryPredicate} and
+     * {@link io.micronaut.http.client.retry.HttpResponseRetryPredicate} for the default policy.
+     *
+     * @since 5.0.0
+     */
+    public static class RetryConfiguration implements Toggleable {
+
+        /**
+         * The prefix to use for configuration.
+         */
+        public static final String PREFIX = "retry";
+
+        /**
+         * The default enable value.
+         */
+        public static final boolean DEFAULT_ENABLED = false;
+
+        /**
+         * The default total number of attempts (including the first).
+         */
+        public static final int DEFAULT_ATTEMPTS = 3;
+
+        /**
+         * The default initial back-off delay in milliseconds.
+         */
+        public static final long DEFAULT_DELAY_MILLIS = 500;
+
+        /**
+         * The default back-off multiplier.
+         */
+        public static final double DEFAULT_MULTIPLIER = 1.5;
+
+        /**
+         * The default maximum back-off delay in seconds.
+         */
+        public static final long DEFAULT_MAX_DELAY_SECONDS = 10;
+
+        /**
+         * The default jitter factor.
+         */
+        public static final double DEFAULT_JITTER = 0.25;
+
+        /**
+         * The default value for honoring server {@code Retry-After} hints.
+         */
+        public static final boolean DEFAULT_RESPECT_RETRY_AFTER = true;
+
+        private boolean enabled = DEFAULT_ENABLED;
+        private int attempts = DEFAULT_ATTEMPTS;
+        private Duration delay = Duration.ofMillis(DEFAULT_DELAY_MILLIS);
+        private double multiplier = DEFAULT_MULTIPLIER;
+        private Duration maxDelay = Duration.ofSeconds(DEFAULT_MAX_DELAY_SECONDS);
+        private double jitter = DEFAULT_JITTER;
+        private boolean respectRetryAfter = DEFAULT_RESPECT_RETRY_AFTER;
+
+        /**
+         * Whether idempotent retry is enabled. Default ({@value #DEFAULT_ENABLED}).
+         *
+         * @return {@code true} if retry is enabled
+         */
+        @Override
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        /**
+         * Sets whether idempotent retry is enabled. Default value (false).
+         *
+         * @param enabled {@code true} to enable retry
+         */
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        /**
+         * Total attempts including the first; {@code 1} disables retry. Default
+         * ({@value #DEFAULT_ATTEMPTS}).
+         *
+         * @return The total attempts
+         */
+        public int getAttempts() {
+            return attempts;
+        }
+
+        /**
+         * Sets the total attempts including the first; 1 disables retry. Values below 1 are
+         * coerced to 1. Default value (3).
+         *
+         * @param attempts The total attempts
+         */
+        public void setAttempts(int attempts) {
+            this.attempts = Math.max(1, attempts);
+        }
+
+        /**
+         * Initial back-off delay. Default ({@value #DEFAULT_DELAY_MILLIS} ms).
+         *
+         * @return The initial delay
+         */
+        public Duration getDelay() {
+            return delay;
+        }
+
+        /**
+         * Sets the initial back-off delay. Default value (500ms).
+         *
+         * @param delay The initial delay
+         */
+        public void setDelay(Duration delay) {
+            this.delay = Objects.requireNonNull(delay, "delay");
+        }
+
+        /**
+         * Exponential back-off multiplier. Default ({@value #DEFAULT_MULTIPLIER}).
+         *
+         * @return The multiplier
+         */
+        public double getMultiplier() {
+            return multiplier;
+        }
+
+        /**
+         * Sets the exponential back-off multiplier. Default value (1.5).
+         *
+         * @param multiplier The multiplier
+         */
+        public void setMultiplier(double multiplier) {
+            this.multiplier = multiplier;
+        }
+
+        /**
+         * Maximum back-off delay between retries. Default ({@value #DEFAULT_MAX_DELAY_SECONDS} s).
+         *
+         * @return The maximum delay
+         */
+        public Duration getMaxDelay() {
+            return maxDelay;
+        }
+
+        /**
+         * Sets the maximum back-off delay between retries. Default value (10s).
+         *
+         * @param maxDelay The maximum delay
+         */
+        public void setMaxDelay(Duration maxDelay) {
+            this.maxDelay = Objects.requireNonNull(maxDelay, "maxDelay");
+        }
+
+        /**
+         * Jitter factor applied to back-off delays, in {@code [0, 1]}. Default
+         * ({@value #DEFAULT_JITTER}).
+         *
+         * @return The jitter factor
+         */
+        public double getJitter() {
+            return jitter;
+        }
+
+        /**
+         * Sets the jitter factor applied to back-off delays, in [0, 1]. Default value (0.25).
+         *
+         * @param jitter The jitter factor
+         */
+        public void setJitter(double jitter) {
+            this.jitter = jitter;
+        }
+
+        /**
+         * Whether to honor the server-supplied {@code Retry-After} header on {@code 429}
+         * (<a href="https://www.rfc-editor.org/rfc/rfc6585.html#section-4">RFC 6585 §4</a>)
+         * and {@code 503}
+         * (<a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after">RFC 9110 §10.2.3</a>)
+         * responses, capped by {@link #getMaxDelay()}. Default
+         * ({@value #DEFAULT_RESPECT_RETRY_AFTER}).
+         *
+         * @return {@code true} if {@code Retry-After} is honored
+         */
+        public boolean isRespectRetryAfter() {
+            return respectRetryAfter;
+        }
+
+        /**
+         * Sets whether to honor the server-supplied Retry-After header on 429 and 503
+         * responses. Default value (true).
+         *
+         * @param respectRetryAfter {@code true} to honor {@code Retry-After}
+         */
+        public void setRespectRetryAfter(boolean respectRetryAfter) {
+            this.respectRetryAfter = respectRetryAfter;
         }
     }
 

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/DefaultRetryPredicateFactory.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/DefaultRetryPredicateFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.retry;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Singleton;
+
+/**
+ * Provides default {@link HttpRequestRetryPredicate} and {@link HttpResponseRetryPredicate} beans.
+ * Both can be replaced by declaring a user-defined bean of the same type.
+ *
+ * @since 5.0.0
+ */
+@Internal
+@Factory
+final class DefaultRetryPredicateFactory {
+
+    @Bean
+    @Singleton
+    @Requires(missingBeans = HttpRequestRetryPredicate.class)
+    HttpRequestRetryPredicate defaultRequestRetryPredicate() {
+        return HttpRequestRetryPredicate.rfc9110();
+    }
+
+    @Bean
+    @Singleton
+    @Requires(missingBeans = HttpResponseRetryPredicate.class)
+    HttpResponseRetryPredicate defaultResponseRetryPredicate() {
+        return HttpResponseRetryPredicate.rfc9110();
+    }
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/HttpRequestRetryPredicate.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/HttpRequestRetryPredicate.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.retry;
+
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequest;
+
+/**
+ * Decides whether an HTTP request is safe to retry. Replace this bean to broaden or narrow the
+ * default <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods">RFC 9110</a>
+ * idempotency policy without modifying the retry filter.
+ *
+ * @since 5.0.0
+ */
+@FunctionalInterface
+public interface HttpRequestRetryPredicate {
+
+    /**
+     * The {@code Idempotency-Key} request header — a de facto convention (see the expired
+     * <a href="https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/">
+     * draft-ietf-httpapi-idempotency-key-header</a>) used to mark otherwise non-idempotent
+     * requests as safe to retry.
+     */
+    String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+
+    /**
+     * @param request The request
+     * @return {@code true} if the request may be retried on a transport or response failure
+     */
+    boolean isRetryable(HttpRequest<?> request);
+
+    /**
+     * Default predicate matching {@link HttpMethod#isIdempotent()} or any request carrying an
+     * {@value #IDEMPOTENCY_KEY_HEADER} header.
+     *
+     * @return The default predicate
+     */
+    static HttpRequestRetryPredicate rfc9110() {
+        return request -> request.getMethod().isIdempotent()
+            || request.getHeaders().contains(IDEMPOTENCY_KEY_HEADER);
+    }
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/HttpResponseRetryPredicate.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/HttpResponseRetryPredicate.java
@@ -63,7 +63,7 @@ public interface HttpResponseRetryPredicate {
      * @return {@code true} if the status is retryable by default
      */
     static boolean isRetryableStatus(int statusCode) {
-        return statusCode >= HttpStatus.INTERNAL_SERVER_ERROR.getCode()
+        return (statusCode >= HttpStatus.INTERNAL_SERVER_ERROR.getCode() && statusCode < 600)
             || statusCode == HttpStatus.TOO_MANY_REQUESTS.getCode()
             || statusCode == HttpStatus.REQUEST_TIMEOUT.getCode();
     }

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/HttpResponseRetryPredicate.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/HttpResponseRetryPredicate.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.retry;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.exceptions.HttpClientException;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+
+/**
+ * Decides whether a transport error or error-status response warrants a retry. Replace this
+ * bean to extend the default policy.
+ *
+ * <p>Default policy retries:</p>
+ * <ul>
+ *     <li>Transport failures ({@link HttpClientException} that is not an
+ *     {@link HttpClientResponseException})</li>
+ *     <li>{@code 5xx} —
+ *     <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-server-error-5xx">RFC 9110 §15.6</a></li>
+ *     <li>{@code 429 Too Many Requests} —
+ *     <a href="https://www.rfc-editor.org/rfc/rfc6585.html#section-4">RFC 6585 §4</a></li>
+ *     <li>{@code 408 Request Timeout} —
+ *     <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-408-request-timeout">RFC 9110 §15.5.9</a></li>
+ * </ul>
+ *
+ * <p>Other 4xx are deliberately excluded: a filter-level retry shares one read-timeout budget
+ * with the original request (unlike AOP {@link io.micronaut.retry.annotation.Retryable}, which
+ * gets a fresh budget per attempt), so retrying a terminal 4xx burns the budget on back-off
+ * delays and surfaces as {@link io.micronaut.http.client.exceptions.ReadTimeoutException}
+ * instead of the original status.</p>
+ *
+ * @since 5.0.0
+ */
+@FunctionalInterface
+public interface HttpResponseRetryPredicate {
+
+    /**
+     * @param throwable A transport error, or an {@link HttpClientResponseException} carrying an
+     *                  error-status response
+     * @return {@code true} if the failure warrants a retry
+     */
+    boolean shouldRetry(Throwable throwable);
+
+    /**
+     * Returns {@code true} if the given status code is in the default retryable set
+     * ({@code 5xx}, {@code 429}, {@code 408}). See the type-level Javadoc for rationale and
+     * RFC references.
+     *
+     * @param statusCode The HTTP status code
+     * @return {@code true} if the status is retryable by default
+     */
+    static boolean isRetryableStatus(int statusCode) {
+        return statusCode >= HttpStatus.INTERNAL_SERVER_ERROR.getCode()
+            || statusCode == HttpStatus.TOO_MANY_REQUESTS.getCode()
+            || statusCode == HttpStatus.REQUEST_TIMEOUT.getCode();
+    }
+
+    /**
+     * The default predicate, applying the policy described in the type-level Javadoc.
+     *
+     * @return The default predicate
+     */
+    static HttpResponseRetryPredicate rfc9110() {
+        return throwable -> {
+            if (throwable instanceof HttpClientResponseException ex) {
+                HttpResponse<?> response = ex.getResponse();
+                return isRetryableStatus(response.getStatus().getCode());
+            }
+            return throwable instanceof HttpClientException;
+        };
+    }
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/HttpResponseRetryPredicate.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/HttpResponseRetryPredicate.java
@@ -36,11 +36,10 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException;
  *     <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-408-request-timeout">RFC 9110 §15.5.9</a></li>
  * </ul>
  *
- * <p>Other 4xx are deliberately excluded: a filter-level retry shares one read-timeout budget
- * with the original request (unlike AOP {@link io.micronaut.retry.annotation.Retryable}, which
- * gets a fresh budget per attempt), so retrying a terminal 4xx burns the budget on back-off
- * delays and surfaces as {@link io.micronaut.http.client.exceptions.ReadTimeoutException}
- * instead of the original status.</p>
+ * <p>Other 4xx are deliberately excluded: a filter-level retry shares one request-timeout
+ * budget with the original request (unlike AOP {@link io.micronaut.retry.annotation.Retryable},
+ * which gets a fresh budget per attempt), so retrying a terminal 4xx burns the budget on
+ * back-off delays and may surface as a timeout instead of the original status.</p>
  *
  * @since 5.0.0
  */

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/IdempotentRetryClientFilter.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/IdempotentRetryClientFilter.java
@@ -115,6 +115,11 @@ public final class IdempotentRetryClientFilter implements Ordered {
     @RequestFilter
     public Publisher<HttpResponse<?>> filter(MutableHttpRequest<?> request,
                                              FilterContinuation<Publisher<HttpResponse<?>>> continuation) {
+        // Bypass branch invokes continuation.proceed() eagerly — Micronaut filter convention
+        // (see clientFilter.adoc / MethodFilter.ReactiveContinuationImpl). Wrapping in
+        // Mono.defer would change the publisher shape vs. every other filter and defer the
+        // propagated-context pickup that downstream filters expect to be done. The retry
+        // branch defers proceed() per attempt inside setUpRetryPipeline.
         return shouldBypassRetry(request)
             ? continuation.proceed()
             : setUpRetryPipeline(request, continuation);
@@ -130,16 +135,16 @@ public final class IdempotentRetryClientFilter implements Ordered {
 
     private Publisher<HttpResponse<?>> setUpRetryPipeline(MutableHttpRequest<?> request,
                                                           FilterContinuation<Publisher<HttpResponse<?>>> continuation) {
-        request.setAttribute(IN_RETRY_LOOP, Boolean.TRUE);
         long retries = (long) config.getAttempts() - 1;
         // Two nested Mono.defers serve different purposes:
         //   - OUTER defer: each subscription of the returned publisher gets its OWN retry
-        //     counter (AtomicLong). Sharing one counter would let exhausted retries from a
-        //     previous subscription deny retries to a later one.
+        //     counter (AtomicLong) and sets IN_RETRY_LOOP, paired with doFinally cleanup —
+        //     so the request is not mutated unless someone actually subscribes.
         //   - INNER defer: each retryWhen attempt invokes continuation.proceed() afresh,
         //     producing a fresh downstream publisher (not a cached, single-shot result).
         // (No manual ByteBuf release needed — see class Javadoc.)
         return Mono.defer(() -> {
+            request.setAttribute(IN_RETRY_LOOP, Boolean.TRUE);
             AtomicLong attempted = new AtomicLong();
             return Mono.defer(() -> Mono.from(continuation.proceed()))
                 .retryWhen(buildRetrySpec(retries, attempted));

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/IdempotentRetryClientFilter.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/IdempotentRetryClientFilter.java
@@ -22,6 +22,7 @@ import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.ServerHttpRequest;
 import io.micronaut.http.annotation.ClientFilter;
 import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.client.DefaultHttpClientConfiguration;
@@ -33,17 +34,23 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.channels.ReadableByteChannel;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.BaseStream;
 
 /**
  * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>-aware client-side retry
  * filter, opt-in via {@code micronaut.http.client.retry.enabled=true}. Eligibility follows
  * {@link HttpRequestRetryPredicate} and {@link HttpResponseRetryPredicate}; back-off is
  * exponential with jitter, capped by {@link RetryConfiguration#getMaxDelay()} and overridden
- * by {@code Retry-After} when present. Streamed-body requests are bypassed (no replay);
+ * by {@code Retry-After} when present. Requests with a non-replayable body are bypassed
+ * (reactive {@link Publisher} bodies and {@link ServerHttpRequest} raw byte-body wrappers);
  * exhausted retries propagate the final throwable.
  *
  * <p><b>Implementation Note regarding Netty ByteBufs:</b></p>
@@ -54,7 +61,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * block before propagating the {@link HttpClientResponseException}. By the time the failure
  * reaches this filter, the response carries a decoded Java body, the buffer is already
  * released, and the connection is back in the pool. Adding a manual {@code release()} call
- * here would result in an {@link io.netty.util.IllegalReferenceCountException}.</p>
+ * here would result in an {@code IllegalReferenceCountException}.</p>
  *
  *
  * @since 5.0.0
@@ -108,28 +115,69 @@ public final class IdempotentRetryClientFilter implements Ordered {
     @RequestFilter
     public Publisher<HttpResponse<?>> filter(MutableHttpRequest<?> request,
                                              FilterContinuation<Publisher<HttpResponse<?>>> continuation) {
-        if (!config.isEnabled() || config.getAttempts() <= 1
-            || !requestPredicate.isRetryable(request)
-            || hasStreamedBody(request)) {
-            return continuation.proceed();
-        }
-        // Skip re-entries from upstream reactive retries
-        if (Boolean.TRUE.equals(request.getAttributes().get(IN_RETRY_LOOP, Boolean.class).orElse(null))) {
-            return continuation.proceed();
-        }
-        request.setAttribute(IN_RETRY_LOOP, Boolean.TRUE);
-        long retries = (long) config.getAttempts() - 1;
-        AtomicLong attempted = new AtomicLong();
-        // Note: Do not manually release or drain the response body here.
-        // Micronaut's NettyHttpClient safely releases the underlying ByteBuf before
-        // propagating the exception. See class Javadoc for implementation details.
-        return Mono.defer(() -> Mono.from(continuation.proceed()))
-            .retryWhen(buildRetrySpec(retries, attempted))
-            .doFinally(ignored -> request.getAttributes().remove(IN_RETRY_LOOP));
+        return shouldBypassRetry(request)
+            ? continuation.proceed()
+            : setUpRetryPipeline(request, continuation);
     }
 
-    private static boolean hasStreamedBody(MutableHttpRequest<?> request) {
-        return request.getBody().filter(b -> b instanceof Publisher<?>).isPresent();
+    private boolean shouldBypassRetry(MutableHttpRequest<?> request) {
+        return !config.isEnabled()
+            || config.getAttempts() <= 1
+            || !requestPredicate.isRetryable(request)
+            || hasNonReplayableBody(request)
+            || Boolean.TRUE.equals(request.getAttributes().get(IN_RETRY_LOOP, Boolean.class).orElse(null));
+    }
+
+    private Publisher<HttpResponse<?>> setUpRetryPipeline(MutableHttpRequest<?> request,
+                                                          FilterContinuation<Publisher<HttpResponse<?>>> continuation) {
+        request.setAttribute(IN_RETRY_LOOP, Boolean.TRUE);
+        long retries = (long) config.getAttempts() - 1;
+        // Two nested Mono.defers serve different purposes:
+        //   - OUTER defer: each subscription of the returned publisher gets its OWN retry
+        //     counter (AtomicLong). Sharing one counter would let exhausted retries from a
+        //     previous subscription deny retries to a later one.
+        //   - INNER defer: each retryWhen attempt invokes continuation.proceed() afresh,
+        //     producing a fresh downstream publisher (not a cached, single-shot result).
+        // (No manual ByteBuf release needed — see class Javadoc.)
+        return Mono.defer(() -> {
+            AtomicLong attempted = new AtomicLong();
+            return Mono.defer(() -> Mono.from(continuation.proceed()))
+                .retryWhen(buildRetrySpec(retries, attempted));
+        }).doFinally(ignored -> request.removeAttribute(IN_RETRY_LOOP, Boolean.class));
+    }
+
+    private static boolean hasNonReplayableBody(MutableHttpRequest<?> request) {
+        // Framework-level wrapper holding a single-use ByteBody: NettyHttpClient and the JDK
+        // client wrap raw client requests as RawHttpRequestWrapper, which implements
+        // ServerHttpRequest with a CloseableByteBody that closes after the first attempt.
+        // Catching this at the wrapper level (rather than inspecting `getBody()`) avoids
+        // mis-classifying future replayable ByteBody implementations.
+        if (request instanceof ServerHttpRequest) {
+            return true;
+        }
+        return request.getBody().map(IdempotentRetryClientFilter::isNonReplayableBody).orElse(false);
+    }
+
+    /**
+     * User-supplied body shapes that are inherently single-pass / single-subscription. A second
+     * attempt would observe an exhausted source. Replayable shapes ({@code String}, {@code byte[]},
+     * POJOs, {@code Map}, {@code Iterable}, {@code ByteBuffer}, {@code Path}/{@code File}) are
+     * intentionally NOT in this list — re-serialization or re-iteration produces the same bytes.
+     *
+     * <p>Note: this list deliberately does not include
+     * {@code io.micronaut.http.body.CloseableByteBody} or {@code ByteBody}. The framework-level
+     * wrapper check ({@code instanceof ServerHttpRequest}) handles the case where Micronaut
+     * itself uses a single-use {@code ByteBody}; inspecting body content for those types would
+     * couple the filter to evolving transport internals and risk false-positives against any
+     * future buffered/replayable {@code ByteBody} implementations.</p>
+     */
+    private static boolean isNonReplayableBody(Object body) {
+        return body instanceof Publisher<?>                // reactive stream
+            || body instanceof InputStream                 // single-pass byte stream
+            || body instanceof Reader                      // single-pass char stream
+            || body instanceof ReadableByteChannel         // NIO single-use channel
+            || body instanceof Iterator<?>                 // single-pass iterator (Iterable is fine)
+            || body instanceof BaseStream<?, ?>;           // java.util.stream.{Stream,IntStream,...}
     }
 
     private Retry buildRetrySpec(long retries, AtomicLong attempted) {

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/IdempotentRetryClientFilter.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/IdempotentRetryClientFilter.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.retry;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.ClientFilter;
+import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.client.DefaultHttpClientConfiguration;
+import io.micronaut.http.client.HttpClientConfiguration.RetryConfiguration;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.filter.FilterContinuation;
+import org.jspecify.annotations.Nullable;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>-aware client-side retry
+ * filter, opt-in via {@code micronaut.http.client.retry.enabled=true}. Eligibility follows
+ * {@link HttpRequestRetryPredicate} and {@link HttpResponseRetryPredicate}; back-off is
+ * exponential with jitter, capped by {@link RetryConfiguration#getMaxDelay()} and overridden
+ * by {@code Retry-After} when present. Streamed-body requests are bypassed (no replay);
+ * exhausted retries propagate the final throwable.
+ *
+ * <p><b>Implementation Note regarding Netty ByteBufs:</b></p>
+ * <p>Unlike raw Reactor Netty or Spring WebClient, where an unconsumed 5xx body publisher
+ * will hold the connection open and exhaust the pool, this filter does not manually drain
+ * or release the response body on retry. Micronaut's {@code NettyHttpClient} materializes
+ * the error body and explicitly releases the underlying {@code ByteBuf} in a {@code finally}
+ * block before propagating the {@link HttpClientResponseException}. By the time the failure
+ * reaches this filter, the response carries a decoded Java body, the buffer is already
+ * released, and the connection is back in the pool. Adding a manual {@code release()} call
+ * here would result in an {@link io.netty.util.IllegalReferenceCountException}.</p>
+ *
+ *
+ * @since 5.0.0
+ */
+@Internal
+@ClientFilter
+@Requires(property = DefaultHttpClientConfiguration.PREFIX + "." + RetryConfiguration.PREFIX + ".enabled", value = "true")
+public final class IdempotentRetryClientFilter implements Ordered {
+
+    /**
+     * Calling continuation.proceed() inside a reactive retry operator re-runs the
+     * filter chain (including this filter). To prevent infinite re-entry loops and
+     * ensure the outermost invocation owns the retry loop (and tracks attempts correctly),
+     * we mark the request with this attribute on first entry.
+     */
+    private static final CharSequence IN_RETRY_LOOP = "io.micronaut.http.client.retry.in_loop";
+
+    private final RetryConfiguration config;
+    private final HttpRequestRetryPredicate requestPredicate;
+    private final HttpResponseRetryPredicate responsePredicate;
+    private final Clock clock;
+
+    public IdempotentRetryClientFilter(DefaultHttpClientConfiguration clientConfiguration,
+                                       HttpRequestRetryPredicate requestPredicate,
+                                       HttpResponseRetryPredicate responsePredicate) {
+        this(clientConfiguration.getRetryConfiguration(), requestPredicate, responsePredicate, Clock.systemUTC());
+    }
+
+    IdempotentRetryClientFilter(RetryConfiguration config,
+                                HttpRequestRetryPredicate requestPredicate,
+                                HttpResponseRetryPredicate responsePredicate,
+                                Clock clock) {
+        this.config = config;
+        this.requestPredicate = requestPredicate;
+        this.responsePredicate = responsePredicate;
+        this.clock = clock;
+    }
+
+    /**
+     * Outermost in the request direction (low order value = high precedence). Each retry
+     * triggers the entire downstream chain again, so auth filters re-issue fresh tokens and
+     * tracing filters create new spans per attempt.
+     *
+     * @return The filter order
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 100;
+    }
+
+    @RequestFilter
+    public Publisher<HttpResponse<?>> filter(MutableHttpRequest<?> request,
+                                             FilterContinuation<Publisher<HttpResponse<?>>> continuation) {
+        if (!config.isEnabled() || config.getAttempts() <= 1
+            || !requestPredicate.isRetryable(request)
+            || hasStreamedBody(request)) {
+            return continuation.proceed();
+        }
+        // Skip re-entries from upstream reactive retries
+        if (Boolean.TRUE.equals(request.getAttributes().get(IN_RETRY_LOOP, Boolean.class).orElse(null))) {
+            return continuation.proceed();
+        }
+        request.setAttribute(IN_RETRY_LOOP, Boolean.TRUE);
+        long retries = (long) config.getAttempts() - 1;
+        AtomicLong attempted = new AtomicLong();
+        // Note: Do not manually release or drain the response body here.
+        // Micronaut's NettyHttpClient safely releases the underlying ByteBuf before
+        // propagating the exception. See class Javadoc for implementation details.
+        return Mono.defer(() -> Mono.from(continuation.proceed()))
+            .retryWhen(buildRetrySpec(retries, attempted));
+    }
+
+    private static boolean hasStreamedBody(MutableHttpRequest<?> request) {
+        return request.getBody().filter(b -> b instanceof Publisher<?>).isPresent();
+    }
+
+    private Retry buildRetrySpec(long retries, AtomicLong attempted) {
+        return Retry.from(signals -> signals.concatMap(signal -> {
+            Throwable failure = signal.failure();
+            long n = attempted.getAndIncrement();
+            if (n >= retries || !responsePredicate.shouldRetry(failure)) {
+                return Mono.error(failure);
+            }
+            Duration delay = computeDelay(n, failure);
+            return delay.isZero() ? Mono.just(n) : Mono.delay(delay).map(i -> n);
+        }));
+    }
+
+    private Duration computeDelay(long retryIndex, Throwable failure) {
+        Duration retryAfter = retryAfterFromFailure(failure);
+        if (retryAfter != null) {
+            return cap(retryAfter, config.getMaxDelay());
+        }
+        double base = config.getDelay().toMillis() * Math.pow(config.getMultiplier(), retryIndex);
+        double jitter = config.getJitter();
+        if (jitter > 0) {
+            double random = ThreadLocalRandom.current().nextDouble(-jitter, jitter);
+            base = base * (1.0 + random);
+        }
+        long millis = (long) Math.max(0, base);
+        Duration delay = Duration.ofMillis(millis);
+        return cap(delay, config.getMaxDelay());
+    }
+
+    @Nullable
+    private Duration retryAfterFromFailure(Throwable failure) {
+        if (!config.isRespectRetryAfter() || !(failure instanceof HttpClientResponseException ex)) {
+            return null;
+        }
+        // Retry-After is canonically associated with 503 by RFC 9110 §10.2.3
+        // (https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after) and with 429 by
+        // RFC 6585 §4 (https://www.rfc-editor.org/rfc/rfc6585.html#section-4). RFC 9110
+        // §10.2.3 also lists 3xx (handled by redirect-following, not retry). Other statuses
+        // may carry it but are not honored here — replace HttpResponseRetryPredicate to broaden.
+        HttpStatus status = ex.getStatus();
+        if (status != HttpStatus.TOO_MANY_REQUESTS && status != HttpStatus.SERVICE_UNAVAILABLE) {
+            return null;
+        }
+        String header = ex.getResponse().getHeaders().get(HttpHeaders.RETRY_AFTER);
+        return RetryAfterParser.parse(header, clock);
+    }
+
+    private static Duration cap(Duration value, Duration max) {
+        return value.compareTo(max) > 0 ? max : value;
+    }
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/IdempotentRetryClientFilter.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/IdempotentRetryClientFilter.java
@@ -124,7 +124,8 @@ public final class IdempotentRetryClientFilter implements Ordered {
         // Micronaut's NettyHttpClient safely releases the underlying ByteBuf before
         // propagating the exception. See class Javadoc for implementation details.
         return Mono.defer(() -> Mono.from(continuation.proceed()))
-            .retryWhen(buildRetrySpec(retries, attempted));
+            .retryWhen(buildRetrySpec(retries, attempted))
+            .doFinally(ignored -> request.getAttributes().remove(IN_RETRY_LOOP));
     }
 
     private static boolean hasStreamedBody(MutableHttpRequest<?> request) {

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/RetryAfterParser.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/RetryAfterParser.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.retry;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Pattern;
+
+/**
+ * Parses the {@code Retry-After} header per
+ * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after">RFC 9110 §10.2.3</a>,
+ * supporting both the delta-seconds form and the HTTP-date form.
+ *
+ * @since 5.0.0
+ */
+@Internal
+final class RetryAfterParser {
+
+    private static final Pattern DELTA_SECONDS = Pattern.compile("\\d+");
+
+    private RetryAfterParser() {
+    }
+
+    /**
+     * Parses a {@code Retry-After} header value into a duration relative to the current instant.
+     *
+     * @param headerValue The raw header value, possibly {@code null}
+     * @param clock       The clock used to compute deltas from HTTP-date values
+     * @return The hint, or {@code null} if the header is absent or unparseable. Negative values
+     *         are coerced to {@link Duration#ZERO}.
+     */
+    @Nullable
+    static Duration parse(@Nullable String headerValue, Clock clock) {
+        if (headerValue == null) {
+            return null;
+        }
+        String trimmed = headerValue.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        if (DELTA_SECONDS.matcher(trimmed).matches()) {
+            // delta-seconds form; only failure path is overflow on a huge digit string
+            try {
+                long seconds = Long.parseLong(trimmed);
+                return seconds <= 0 ? Duration.ZERO : Duration.ofSeconds(seconds);
+            } catch (NumberFormatException ignore) {
+                return null;
+            }
+        }
+        try {
+            ZonedDateTime target = ZonedDateTime.parse(trimmed, DateTimeFormatter.RFC_1123_DATE_TIME);
+            ZonedDateTime now = ZonedDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
+            Duration delta = Duration.between(now, target);
+            return delta.isNegative() ? Duration.ZERO : delta;
+        } catch (DateTimeParseException ignore) {
+            return null;
+        }
+    }
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/retry/RetryAfterParser.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/retry/RetryAfterParser.java
@@ -29,7 +29,16 @@ import java.util.regex.Pattern;
 /**
  * Parses the {@code Retry-After} header per
  * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after">RFC 9110 §10.2.3</a>,
- * supporting both the delta-seconds form and the HTTP-date form.
+ * supporting the delta-seconds form and the IMF-fixdate (RFC 1123) HTTP-date form.
+ *
+ * <p><b>HTTP-date scope.</b>
+ * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-date-time-formats">RFC 9110 §5.6.7</a>
+ * defines three HTTP-date forms — IMF-fixdate (preferred, mandated for senders), and the
+ * obsolete RFC 850 and ANSI C asctime forms. This parser accepts only IMF-fixdate. Modern
+ * servers send IMF-fixdate exclusively (the obsolete forms haven't been emitted in practice
+ * for decades). When a server does send an obsolete form, parsing returns {@code null} and
+ * the retry filter falls back to its configured exponential backoff — graceful degradation,
+ * not a runtime error. Broader HTTP-date parsing is a possible follow-up.</p>
  *
  * @since 5.0.0
  */

--- a/http-client-core/src/test/groovy/io/micronaut/http/client/HttpClientConfigurationSpec.groovy
+++ b/http-client-core/src/test/groovy/io/micronaut/http/client/HttpClientConfigurationSpec.groovy
@@ -66,6 +66,75 @@ class HttpClientConfigurationSpec extends Specification {
         Integer.MAX_VALUE | Integer.MAX_VALUE
     }
 
+    void "RetryConfiguration#setDelay rejects negative durations"() {
+        given:
+        def cfg = new RetryConfiguration()
+
+        when: 'negative duration'
+        cfg.delay = Duration.ofMillis(-1)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when: 'null duration'
+        cfg.delay = null
+
+        then:
+        thrown(NullPointerException)
+
+        when: 'zero accepted (no backoff between retries is a valid choice)'
+        cfg.delay = Duration.ZERO
+
+        then:
+        cfg.delay == Duration.ZERO
+    }
+
+    void "RetryConfiguration#setMaxDelay rejects negative durations"() {
+        given:
+        def cfg = new RetryConfiguration()
+
+        when: 'negative duration'
+        cfg.maxDelay = Duration.ofSeconds(-1)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when: 'null duration'
+        cfg.maxDelay = null
+
+        then:
+        thrown(NullPointerException)
+
+        when: 'zero accepted'
+        cfg.maxDelay = Duration.ZERO
+
+        then:
+        cfg.maxDelay == Duration.ZERO
+    }
+
+    void "RetryConfiguration#setMultiplier rejects negative values"() {
+        given:
+        def cfg = new RetryConfiguration()
+
+        when:
+        cfg.multiplier = -0.5d
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when: 'zero accepted (degenerate but coherent — every retry at base delay)'
+        cfg.multiplier = 0d
+
+        then:
+        cfg.multiplier == 0d
+
+        when: 'positive accepted'
+        cfg.multiplier = 2.0d
+
+        then:
+        cfg.multiplier == 2.0d
+    }
+
     void "RetryConfiguration#setJitter rejects values outside [0, 1]"() {
         given:
         def cfg = new RetryConfiguration()

--- a/http-client-core/src/test/groovy/io/micronaut/http/client/HttpClientConfigurationSpec.groovy
+++ b/http-client-core/src/test/groovy/io/micronaut/http/client/HttpClientConfigurationSpec.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client
+
+import io.micronaut.http.client.HttpClientConfiguration.RetryConfiguration
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Duration
+
+class HttpClientConfigurationSpec extends Specification {
+
+    void "RetryConfiguration defaults match the published contract"() {
+        given:
+        def cfg = new RetryConfiguration()
+
+        expect: 'opt-in: disabled by default — zero behavior change for existing users'
+        !cfg.enabled
+
+        and: 'numeric defaults match the public RFC 9110 retry policy'
+        cfg.attempts == 3
+        cfg.delay == Duration.ofMillis(500)
+        cfg.multiplier == 1.5d
+        cfg.maxDelay == Duration.ofSeconds(10)
+        cfg.jitter == 0.25d
+        cfg.respectRetryAfter
+    }
+
+    void "RetryConfiguration#isEnabled returns false by default (Toggleable contract)"() {
+        expect:
+        !new RetryConfiguration().enabled
+    }
+
+    @Unroll
+    void "RetryConfiguration setAttempts coerces #input to #expected (must be at least 1)"() {
+        given:
+        def cfg = new RetryConfiguration()
+
+        when:
+        cfg.attempts = input
+
+        then:
+        cfg.attempts == expected
+
+        where:
+        input         | expected
+        Integer.MIN_VALUE | 1
+        -5            | 1
+        0             | 1
+        1             | 1
+        2             | 2
+        7             | 7
+        Integer.MAX_VALUE | Integer.MAX_VALUE
+    }
+
+    void "RetryConfiguration#setJitter rejects values outside [0, 1]"() {
+        given:
+        def cfg = new RetryConfiguration()
+
+        when:
+        cfg.jitter = -0.1
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        cfg.jitter = 1.5
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when: 'boundary values accepted'
+        cfg.jitter = 0.0
+        cfg.jitter = 1.0
+
+        then:
+        cfg.jitter == 1.0
+    }
+}

--- a/http-client-core/src/test/groovy/io/micronaut/http/client/retry/HttpResponseRetryPredicateSpec.groovy
+++ b/http-client-core/src/test/groovy/io/micronaut/http/client/retry/HttpResponseRetryPredicateSpec.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.retry
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientException
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class HttpResponseRetryPredicateSpec extends Specification {
+
+    @Unroll
+    void "isRetryableStatus(#code) == #expected"() {
+        expect:
+        HttpResponseRetryPredicate.isRetryableStatus(code) == expected
+
+        where:
+        code | expected
+        // 5xx — server-error range, retryable
+        500  | true
+        502  | true
+        503  | true
+        504  | true
+        599  | true
+        // 429 — rate-limited, retryable
+        429  | true
+        // 408 — request timeout, retryable
+        408  | true
+        // Other 4xx — terminal client errors, NOT retryable
+        400  | false
+        401  | false
+        403  | false
+        404  | false
+        409  | false
+        422  | false
+        425  | false   // Too Early — not in default set; a custom predicate can opt in
+        // 2xx / 3xx — not error responses
+        200  | false
+        301  | false
+    }
+
+    void "default predicate retries 5xx HttpClientResponseException"() {
+        given:
+        def predicate = HttpResponseRetryPredicate.rfc9110()
+        def failure = new HttpClientResponseException('boom',
+            HttpResponse.status(HttpStatus.SERVICE_UNAVAILABLE))
+
+        expect:
+        predicate.shouldRetry(failure)
+    }
+
+    void "default predicate does NOT retry 404"() {
+        given:
+        def predicate = HttpResponseRetryPredicate.rfc9110()
+        def failure = new HttpClientResponseException('not found',
+            HttpResponse.status(HttpStatus.NOT_FOUND))
+
+        expect:
+        !predicate.shouldRetry(failure)
+    }
+
+    void "default predicate retries transport-level HttpClientException"() {
+        given:
+        def predicate = HttpResponseRetryPredicate.rfc9110()
+        def failure = new HttpClientException('connect timeout')
+
+        expect:
+        predicate.shouldRetry(failure)
+    }
+
+    void "default predicate does NOT retry arbitrary RuntimeException"() {
+        given:
+        def predicate = HttpResponseRetryPredicate.rfc9110()
+
+        expect:
+        !predicate.shouldRetry(new IllegalStateException('not transport related'))
+    }
+}

--- a/http-client-core/src/test/groovy/io/micronaut/http/client/retry/HttpResponseRetryPredicateSpec.groovy
+++ b/http-client-core/src/test/groovy/io/micronaut/http/client/retry/HttpResponseRetryPredicateSpec.groovy
@@ -52,6 +52,9 @@ class HttpResponseRetryPredicateSpec extends Specification {
         // 2xx / 3xx — not error responses
         200  | false
         301  | false
+        // ≥ 600 — not valid HTTP statuses; bounded out of the 5xx range
+        600  | false
+        700  | false
     }
 
     void "default predicate retries 5xx HttpClientResponseException"() {

--- a/http-client-core/src/test/groovy/io/micronaut/http/client/retry/RetryAfterParserSpec.groovy
+++ b/http-client-core/src/test/groovy/io/micronaut/http/client/retry/RetryAfterParserSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.retry
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+
+class RetryAfterParserSpec extends Specification {
+
+    static final Clock SYSTEM = Clock.systemUTC()
+
+    @Unroll
+    void "absent / empty value parses to null (#desc)"() {
+        expect:
+        RetryAfterParser.parse(value, SYSTEM) == null
+
+        where:
+        desc        | value
+        'null'      | null
+        'empty'     | ''
+        'whitespace'| '   '
+    }
+
+    @Unroll
+    void "delta-seconds form: #raw → #expected"() {
+        expect:
+        RetryAfterParser.parse(raw, SYSTEM) == expected
+
+        where:
+        raw                       | expected
+        '0'                       | Duration.ZERO
+        '1'                       | Duration.ofSeconds(1)
+        '120'                     | Duration.ofSeconds(120)
+        '   42   '                | Duration.ofSeconds(42)   // surrounding whitespace tolerated
+        '99999999999999999999'    | null                      // overflow → unparseable
+    }
+
+    void "HTTP-date form: future date with fixed clock yields the delta"() {
+        given:
+        def now = Instant.parse('2026-04-28T12:00:00Z')
+        def clock = Clock.fixed(now, ZoneOffset.UTC)
+
+        expect:
+        RetryAfterParser.parse('Tue, 28 Apr 2026 12:00:30 GMT', clock) == Duration.ofSeconds(30)
+    }
+
+    void "HTTP-date form: past date coerces to ZERO"() {
+        given:
+        def now = Instant.parse('2026-04-28T12:00:00Z')
+        def clock = Clock.fixed(now, ZoneOffset.UTC)
+
+        expect:
+        RetryAfterParser.parse('Tue, 28 Apr 2026 11:00:00 GMT', clock) == Duration.ZERO
+    }
+
+    void "malformed HTTP-date returns null"() {
+        expect:
+        RetryAfterParser.parse('not-a-date', SYSTEM) == null
+        RetryAfterParser.parse('Mon, 32 Apr 2026 12:00:00 GMT', SYSTEM) == null
+    }
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryClientFilterSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryClientFilterSpec.groovy
@@ -309,6 +309,20 @@ class IdempotentRetryClientFilterSpec extends Specification {
         continuation.calls.get() == 1
     }
 
+    void "filter() does NOT mutate the request when the returned publisher is never subscribed"() {
+        given: 'a continuation that would record any proceed() call'
+        def continuation = countingContinuation { Mono.just(HttpResponse.ok('done')) as Publisher }
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+        def request = HttpRequest.GET('/x')
+
+        when: 'the filter is invoked but the resulting publisher is discarded without subscription'
+        filter.filter(request, continuation)
+
+        then: 'no IN_RETRY_LOOP attribute set; no proceed() invoked'
+        !request.getAttributes().get(IN_RETRY_LOOP_KEY, Boolean.class).isPresent()
+        continuation.calls.get() == 0
+    }
+
     void "IN_RETRY_LOOP request attribute is cleared after successful completion"() {
         given:
         def continuation = scriptedContinuation([

--- a/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryClientFilterSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryClientFilterSpec.groovy
@@ -15,9 +15,9 @@
  */
 package io.micronaut.http.client.retry
 
-import io.micronaut.http.HttpRequest
-import io.micronaut.http.HttpResponse
-import io.micronaut.http.HttpStatus
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.http.*
+import io.micronaut.http.body.ByteBody
 import io.micronaut.http.client.HttpClientConfiguration.RetryConfiguration
 import io.micronaut.http.client.exceptions.HttpClientException
 import io.micronaut.http.client.exceptions.HttpClientResponseException
@@ -25,12 +25,16 @@ import io.micronaut.http.filter.FilterContinuation
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import spock.lang.Specification
+import spock.lang.Unroll
 
+import java.nio.channels.Channels
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.stream.IntStream
+import java.util.stream.Stream
 
 class IdempotentRetryClientFilterSpec extends Specification {
 
@@ -251,6 +255,60 @@ class IdempotentRetryClientFilterSpec extends Specification {
         continuation.calls.get() == 1
     }
 
+    @Unroll
+    void "non-replayable body shape is bypassed: #desc"() {
+        given:
+        def continuation = countingContinuation { responseException(HttpStatus.SERVICE_UNAVAILABLE) }
+        def filter = newFilter(attempts: 5, delay: Duration.ZERO)
+        def request = HttpRequest.PUT('/upload', body)
+
+        when:
+        Mono.from(filter.filter(request, continuation)).block()
+
+        then:
+        thrown(HttpClientResponseException)
+        continuation.calls.get() == 1   // single attempt; retry bypassed
+
+        where:
+        desc                | body
+        'InputStream'       | new ByteArrayInputStream('payload'.bytes)
+        'Reader'            | new StringReader('payload')
+        'ReadableByteChannel' | Channels.newChannel(new ByteArrayInputStream('payload'.bytes))
+        'Iterator<?>'       | ['a', 'b', 'c'].iterator()
+        'Stream<?>'         | Stream.of('a', 'b', 'c')
+        'IntStream'         | IntStream.range(0, 5)
+    }
+
+    void "replayable body (String) IS retried — confirms we don't over-block"() {
+        given:
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.BAD_GATEWAY) },
+            { Mono.just(HttpResponse.ok('done')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+
+        when: 'PUT (idempotent) with a String body — replayable, should retry'
+        def response = Mono.from(filter.filter(HttpRequest.PUT('/upload', 'hello'), continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 2
+    }
+
+    void "ServerHttpRequest (raw byte-body wrapper) is bypassed (single attempt)"() {
+        given: 'simulates the RawHttpRequestWrapper Netty/JDK clients use for raw requests'
+        def continuation = countingContinuation { responseException(HttpStatus.SERVICE_UNAVAILABLE) }
+        def filter = newFilter(attempts: 5, delay: Duration.ZERO)
+        def rawRequest = new FakeRawRequest(HttpRequest.GET('/x'))
+
+        when:
+        Mono.from(filter.filter(rawRequest, continuation)).block()
+
+        then:
+        thrown(HttpClientResponseException)
+        continuation.calls.get() == 1
+    }
+
     void "IN_RETRY_LOOP request attribute is cleared after successful completion"() {
         given:
         def continuation = scriptedContinuation([
@@ -281,6 +339,33 @@ class IdempotentRetryClientFilterSpec extends Specification {
 
         and: 'doFinally cleared the guard attribute even on the error terminal signal'
         !request.getAttributes().get(IN_RETRY_LOOP_KEY, Boolean.class).isPresent()
+    }
+
+    void "retry counter is per-subscription, not shared across multiple subscribes of the same returned publisher"() {
+        given: 'four scripted responses — one fail+success per subscription'
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.BAD_GATEWAY) },                  // sub 1, attempt 1
+            { Mono.just(HttpResponse.ok('first')) as Publisher },           // sub 1, attempt 2 — success
+            { responseException(HttpStatus.BAD_GATEWAY) },                  // sub 2, attempt 1
+            { Mono.just(HttpResponse.ok('second')) as Publisher }           // sub 2, attempt 2 — success
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+        def request = HttpRequest.GET('/x')
+        def publisher = filter.filter(request, continuation)
+
+        when: 'first subscription burns 1 retry'
+        def first = Mono.from(publisher).block()
+
+        then:
+        first.status == HttpStatus.OK
+        continuation.calls.get() == 2
+
+        when: 'second subscription on the SAME publisher must retry independently'
+        def second = Mono.from(publisher).block()
+
+        then: 'a shared retry counter would have been at 1 already and prevented the retry'
+        second.status == HttpStatus.OK
+        continuation.calls.get() == 4
     }
 
     void "IN_RETRY_LOOP attribute is cleared after the call so request reuse works"() {
@@ -354,6 +439,23 @@ class IdempotentRetryClientFilterSpec extends Specification {
         def response = HttpResponse.status(status)
         headers.each { k, v -> response.header(k, v) }
         Mono.error(new HttpClientResponseException(status.reason, response))
+    }
+
+    /**
+     * Mirrors the shape of NettyHttpClient/JdkHttpClient {@code RawHttpRequestWrapper} —
+     * a {@link MutableHttpRequest} that ALSO implements {@link ServerHttpRequest}, holding
+     * a {@link ByteBody} that would be consumed/closed on the first attempt. The retry
+     * filter must bypass these to avoid second-attempt failures on a closed body.
+     */
+    private static class FakeRawRequest<B> extends MutableHttpRequestWrapper<B> implements ServerHttpRequest<B> {
+        FakeRawRequest(MutableHttpRequest<B> delegate) {
+            super(ConversionService.SHARED, delegate)
+        }
+
+        @Override
+        ByteBody byteBody() {
+            return null   // unused; the filter inspects the type, not the body contents
+        }
     }
 
     private static class CountingContinuation implements FilterContinuation<Publisher<HttpResponse<?>>> {

--- a/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryClientFilterSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryClientFilterSpec.groovy
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.retry
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClientConfiguration.RetryConfiguration
+import io.micronaut.http.client.exceptions.HttpClientException
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.filter.FilterContinuation
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.atomic.AtomicInteger
+
+class IdempotentRetryClientFilterSpec extends Specification {
+
+    void "non-idempotent POST is not retried on 503"() {
+        given:
+        def continuation = countingContinuation { responseException(HttpStatus.SERVICE_UNAVAILABLE) }
+        def filter = newFilter(attempts: 3)
+
+        when:
+        Mono.from(filter.filter(HttpRequest.POST('/orders', '{}'), continuation)).block()
+
+        then:
+        thrown(HttpClientResponseException)
+        continuation.calls.get() == 1
+    }
+
+    void "POST with Idempotency-Key header is retried on 503 and succeeds"() {
+        given:
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.SERVICE_UNAVAILABLE) },
+            { Mono.just(HttpResponse.ok('done')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+        def request = HttpRequest.POST('/payments', '{}').header('Idempotency-Key', 'uuid-1')
+
+        when:
+        def response = Mono.from(filter.filter(request, continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 2
+    }
+
+    void "GET 404 is not retried (terminal 4xx)"() {
+        given:
+        def continuation = countingContinuation { responseException(HttpStatus.NOT_FOUND) }
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+
+        when:
+        Mono.from(filter.filter(HttpRequest.GET('/missing'), continuation)).block()
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.NOT_FOUND
+        continuation.calls.get() == 1
+    }
+
+    void "GET 502 is retried up to configured attempts and succeeds"() {
+        given:
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.BAD_GATEWAY) },
+            { responseException(HttpStatus.BAD_GATEWAY) },
+            { Mono.just(HttpResponse.ok('ok')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+
+        when:
+        def response = Mono.from(filter.filter(HttpRequest.GET('/status'), continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 3
+    }
+
+    void "exhaustion propagates the final exception"() {
+        given:
+        def continuation = countingContinuation { responseException(HttpStatus.SERVICE_UNAVAILABLE) }
+        def filter = newFilter(attempts: 2, delay: Duration.ZERO)
+
+        when:
+        Mono.from(filter.filter(HttpRequest.GET('/flaky'), continuation)).block()
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.SERVICE_UNAVAILABLE
+        continuation.calls.get() == 2
+    }
+
+    void "transport errors are retried"() {
+        given:
+        def continuation = scriptedContinuation([
+            { Mono.error(new HttpClientException('connect timeout')) as Publisher },
+            { Mono.just(HttpResponse.ok('ok')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+
+        when:
+        def response = Mono.from(filter.filter(HttpRequest.GET('/x'), continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 2
+    }
+
+    void "Retry-After header (delta-seconds form) is honored on 503"() {
+        given:
+        def headers = ['Retry-After': '0']
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.SERVICE_UNAVAILABLE, headers) },
+            { Mono.just(HttpResponse.ok('ok')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ofSeconds(60))
+
+        when:
+        def response = Mono.from(filter.filter(HttpRequest.GET('/rate'), continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 2
+    }
+
+    void "Retry-After HTTP-date form is honored on 503 with a fixed clock"() {
+        given:
+        def fixedNow = Instant.parse('2026-04-28T12:00:00Z')
+        def clock = Clock.fixed(fixedNow, ZoneOffset.UTC)
+        // Header at the same instant → delta of zero
+        def headers = ['Retry-After': 'Tue, 28 Apr 2026 12:00:00 GMT']
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.SERVICE_UNAVAILABLE, headers) },
+            { Mono.just(HttpResponse.ok('ok')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ofSeconds(60), clock: clock)
+
+        when:
+        def response = Mono.from(filter.filter(HttpRequest.GET('/rate'), continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 2
+    }
+
+    void "Retry-After HTTP-date in the past coerces to zero delay"() {
+        given:
+        def fixedNow = Instant.parse('2026-04-28T12:00:00Z')
+        def clock = Clock.fixed(fixedNow, ZoneOffset.UTC)
+        // Header date is one hour in the past → would be a negative delta; parser coerces to ZERO
+        def headers = ['Retry-After': 'Tue, 28 Apr 2026 11:00:00 GMT']
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.SERVICE_UNAVAILABLE, headers) },
+            { Mono.just(HttpResponse.ok('ok')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ofSeconds(60), clock: clock)
+
+        when:
+        def response = Mono.from(filter.filter(HttpRequest.GET('/rate'), continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 2
+    }
+
+    void "GET 408 Request Timeout is retried"() {
+        given:
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.REQUEST_TIMEOUT) },
+            { Mono.just(HttpResponse.ok('ok')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+
+        when:
+        def response = Mono.from(filter.filter(HttpRequest.GET('/slow'), continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 2
+    }
+
+    void "GET 429 (no Retry-After header) is retried"() {
+        given:
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.TOO_MANY_REQUESTS) },
+            { Mono.just(HttpResponse.ok('ok')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+
+        when:
+        def response = Mono.from(filter.filter(HttpRequest.GET('/rate'), continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 2
+    }
+
+    void "respectRetryAfter=false ignores the header (would otherwise block for minutes)"() {
+        given:
+        // Retry-After: 600 would block ~10 minutes if honored. With respectRetryAfter=false the
+        // configured delay (Duration.ZERO) is used instead, so the test completes in ms.
+        def headers = ['Retry-After': '600']
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.SERVICE_UNAVAILABLE, headers) },
+            { Mono.just(HttpResponse.ok('ok')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO, respectRetryAfter: false)
+
+        when:
+        def response = Mono.from(filter.filter(HttpRequest.GET('/rate'), continuation)).block()
+
+        then:
+        response.status == HttpStatus.OK
+        continuation.calls.get() == 2
+    }
+
+    void "streamed body request is bypassed (single attempt)"() {
+        given:
+        def continuation = countingContinuation { responseException(HttpStatus.SERVICE_UNAVAILABLE) }
+        def filter = newFilter(attempts: 5, delay: Duration.ZERO)
+        def streamed = HttpRequest.PUT('/upload', Mono.just('chunk') as Publisher)
+
+        when:
+        Mono.from(filter.filter(streamed, continuation)).block()
+
+        then:
+        thrown(HttpClientResponseException)
+        continuation.calls.get() == 1
+    }
+
+    void "disabled config is a pass-through"() {
+        given:
+        def continuation = countingContinuation { responseException(HttpStatus.SERVICE_UNAVAILABLE) }
+        def filter = newFilter(enabled: false, attempts: 5)
+
+        when:
+        Mono.from(filter.filter(HttpRequest.GET('/x'), continuation)).block()
+
+        then:
+        thrown(HttpClientResponseException)
+        continuation.calls.get() == 1
+    }
+
+    private static IdempotentRetryClientFilter newFilter(Map opts) {
+        def cfg = new RetryConfiguration()
+        cfg.enabled = opts.getOrDefault('enabled', true)
+        cfg.attempts = (int) opts.getOrDefault('attempts', 3)
+        cfg.delay = (Duration) opts.getOrDefault('delay', Duration.ofMillis(1))
+        cfg.maxDelay = (Duration) opts.getOrDefault('maxDelay', Duration.ofSeconds(10))
+        cfg.multiplier = (double) opts.getOrDefault('multiplier', 1.0)
+        cfg.jitter = (double) opts.getOrDefault('jitter', 0.0)
+        cfg.respectRetryAfter = (boolean) opts.getOrDefault('respectRetryAfter', true)
+        Clock clock = (Clock) opts.getOrDefault('clock', Clock.systemUTC())
+        new IdempotentRetryClientFilter(
+            cfg,
+            HttpRequestRetryPredicate.rfc9110(),
+            HttpResponseRetryPredicate.rfc9110(),
+            clock
+        )
+    }
+
+    private static CountingContinuation countingContinuation(Closure<Publisher<HttpResponse<?>>> response) {
+        new CountingContinuation(scripted: [response], cycle: true)
+    }
+
+    private static CountingContinuation scriptedContinuation(List<Closure<Publisher<HttpResponse<?>>>> scripted) {
+        new CountingContinuation(scripted: scripted, cycle: false)
+    }
+
+    private static Publisher<HttpResponse<?>> responseException(HttpStatus status, Map<String, String> headers = [:]) {
+        def response = HttpResponse.status(status)
+        headers.each { k, v -> response.header(k, v) }
+        Mono.error(new HttpClientResponseException(status.reason, response))
+    }
+
+    private static class CountingContinuation implements FilterContinuation<Publisher<HttpResponse<?>>> {
+        AtomicInteger calls = new AtomicInteger()
+        List<Closure<Publisher<HttpResponse<?>>>> scripted
+        boolean cycle
+
+        @Override
+        FilterContinuation<Publisher<HttpResponse<?>>> request(HttpRequest<?> request) {
+            return this
+        }
+
+        @Override
+        Publisher<HttpResponse<?>> proceed() {
+            int idx = calls.getAndIncrement()
+            int slot = cycle ? 0 : idx
+            if (slot >= scripted.size()) {
+                throw new IllegalStateException("Continuation invoked more times than scripted (${idx + 1})")
+            }
+            return scripted[slot].call()
+        }
+    }
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryClientFilterSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryClientFilterSpec.groovy
@@ -34,6 +34,10 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class IdempotentRetryClientFilterSpec extends Specification {
 
+    // Mirrors the private constant in IdempotentRetryClientFilter; kept here as a literal so
+    // the test exercises the actual stored attribute name without enlarging public API.
+    private static final String IN_RETRY_LOOP_KEY = 'io.micronaut.http.client.retry.in_loop'
+
     void "non-idempotent POST is not retried on 503"() {
         given:
         def continuation = countingContinuation { responseException(HttpStatus.SERVICE_UNAVAILABLE) }
@@ -247,6 +251,64 @@ class IdempotentRetryClientFilterSpec extends Specification {
         continuation.calls.get() == 1
     }
 
+    void "IN_RETRY_LOOP request attribute is cleared after successful completion"() {
+        given:
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.BAD_GATEWAY) },
+            { Mono.just(HttpResponse.ok('done')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+        def request = HttpRequest.GET('/x')
+
+        when:
+        Mono.from(filter.filter(request, continuation)).block()
+
+        then: 'doFinally cleared the guard attribute'
+        !request.getAttributes().get(IN_RETRY_LOOP_KEY, Boolean.class).isPresent()
+    }
+
+    void "IN_RETRY_LOOP request attribute is cleared after exhaustion (error terminal)"() {
+        given:
+        def continuation = countingContinuation { responseException(HttpStatus.SERVICE_UNAVAILABLE) }
+        def filter = newFilter(attempts: 2, delay: Duration.ZERO)
+        def request = HttpRequest.GET('/x')
+
+        when:
+        Mono.from(filter.filter(request, continuation)).block()
+
+        then:
+        thrown(HttpClientResponseException)
+
+        and: 'doFinally cleared the guard attribute even on the error terminal signal'
+        !request.getAttributes().get(IN_RETRY_LOOP_KEY, Boolean.class).isPresent()
+    }
+
+    void "IN_RETRY_LOOP attribute is cleared after the call so request reuse works"() {
+        given:
+        def continuation = scriptedContinuation([
+            { responseException(HttpStatus.BAD_GATEWAY) },
+            { Mono.just(HttpResponse.ok('first')) as Publisher },
+            { responseException(HttpStatus.BAD_GATEWAY) },
+            { Mono.just(HttpResponse.ok('second')) as Publisher }
+        ])
+        def filter = newFilter(attempts: 3, delay: Duration.ZERO)
+        def request = HttpRequest.GET('/x')
+
+        when: 'first call retries once and succeeds'
+        def first = Mono.from(filter.filter(request, continuation)).block()
+
+        then:
+        first.status == HttpStatus.OK
+        continuation.calls.get() == 2
+
+        when: 'reuse the same request — without cleanup the second call would bypass retry'
+        def second = Mono.from(filter.filter(request, continuation)).block()
+
+        then:
+        second.status == HttpStatus.OK
+        continuation.calls.get() == 4   // two more attempts; retry engaged on the second call
+    }
+
     void "disabled config is a pass-through"() {
         given:
         def continuation = countingContinuation { responseException(HttpStatus.SERVICE_UNAVAILABLE) }
@@ -259,6 +321,8 @@ class IdempotentRetryClientFilterSpec extends Specification {
         thrown(HttpClientResponseException)
         continuation.calls.get() == 1
     }
+
+
 
     private static IdempotentRetryClientFilter newFilter(Map opts) {
         def cfg = new RetryConfiguration()

--- a/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryIntegrationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/retry/IdempotentRetryIntegrationSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.retry
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class IdempotentRetryIntegrationSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+        'spec.name'                                  : 'IdempotentRetryIntegrationSpec',
+        'micronaut.http.client.retry.enabled'        : 'true',
+        'micronaut.http.client.retry.attempts'       : '4',
+        'micronaut.http.client.retry.delay'          : '1ms',
+        'micronaut.http.client.retry.max-delay'      : '10ms',
+        'micronaut.http.client.retry.multiplier'     : '1.0',
+        'micronaut.http.client.retry.jitter'         : '0.0'
+    ])
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = server.applicationContext.createBean(HttpClient, server.URL)
+
+    void "GET retries on 503 from server until success"() {
+        given:
+        def controller = server.applicationContext.getBean(FlakyController)
+        controller.reset(3)
+
+        when:
+        def response = client.toBlocking().exchange('/retry-it/get', String)
+
+        then:
+        response.status == HttpStatus.OK
+        controller.attempts.get() == 3
+    }
+
+    void "GET exhausts retries and propagates the original exception"() {
+        given:
+        def controller = server.applicationContext.getBean(FlakyController)
+        controller.reset(99)
+
+        when:
+        client.toBlocking().exchange('/retry-it/get', String)
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.SERVICE_UNAVAILABLE
+        controller.attempts.get() == 4
+    }
+
+    void "POST is not retried even on 503"() {
+        given:
+        def controller = server.applicationContext.getBean(FlakyController)
+        controller.reset(99)
+
+        when:
+        client.toBlocking().exchange(HttpRequest.POST('/retry-it/post', 'body'), String)
+
+        then:
+        thrown(HttpClientResponseException)
+        controller.attempts.get() == 1
+    }
+
+    @Requires(property = 'spec.name', value = 'IdempotentRetryIntegrationSpec')
+    @Controller('/retry-it')
+    static class FlakyController {
+        AtomicInteger attempts = new AtomicInteger()
+        int succeedAt = 1
+
+        void reset(int succeedAt) {
+            this.succeedAt = succeedAt
+            attempts.set(0)
+        }
+
+        @Get('/get')
+        HttpResponse<?> get() {
+            int n = attempts.incrementAndGet()
+            return n >= succeedAt ? HttpResponse.ok('done') : HttpResponse.status(HttpStatus.SERVICE_UNAVAILABLE)
+        }
+
+        @Post('/post')
+        HttpResponse<?> post(@Body String body) {
+            int n = attempts.incrementAndGet()
+            return n >= succeedAt ? HttpResponse.ok('done') : HttpResponse.status(HttpStatus.SERVICE_UNAVAILABLE)
+        }
+    }
+}

--- a/http/src/main/java/io/micronaut/http/HttpMethod.java
+++ b/http/src/main/java/io/micronaut/http/HttpMethod.java
@@ -129,6 +129,32 @@ import org.jspecify.annotations.Nullable;
     }
 
     /**
+     * Whether the method is <em>safe</em> per
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-safe-methods">RFC 9110 §9.2.1</a>:
+     * a safe method has no intended server-side state change and is therefore inherently
+     * idempotent.
+     *
+     * @return {@code true} for {@link #GET}, {@link #HEAD}, {@link #OPTIONS}, {@link #TRACE}
+     * @since 5.0.0
+     */
+    public boolean isSafe() {
+        return this == GET || this == HEAD || this == OPTIONS || this == TRACE;
+    }
+
+    /**
+     * Whether the method is <em>idempotent</em> per
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods">RFC 9110 §9.2.2</a>:
+     * repeating the request has the same effect as a single invocation. All safe methods are
+     * idempotent; additionally {@link #PUT} and {@link #DELETE} are idempotent.
+     *
+     * @return {@code true} for the safe methods plus {@link #PUT} and {@link #DELETE}
+     * @since 5.0.0
+     */
+    public boolean isIdempotent() {
+        return isSafe() || this == PUT || this == DELETE;
+    }
+
+    /**
      * Whether the given method requires a request body.
      *
      * @param method The {@link HttpMethod}

--- a/http/src/test/groovy/io/micronaut/http/HttpMethodSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/HttpMethodSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class HttpMethodSpec extends Specification {
+
+    @Unroll
+    void "#method.isSafe() == #expected (RFC 9110 §9.2.1)"() {
+        expect:
+        method.isSafe() == expected
+
+        where:
+        method                | expected
+        HttpMethod.GET        | true
+        HttpMethod.HEAD       | true
+        HttpMethod.OPTIONS    | true
+        HttpMethod.TRACE      | true
+        HttpMethod.PUT        | false
+        HttpMethod.DELETE     | false
+        HttpMethod.POST       | false
+        HttpMethod.PATCH      | false
+        HttpMethod.CONNECT    | false
+        HttpMethod.CUSTOM     | false
+    }
+
+    @Unroll
+    void "#method.isIdempotent() == #expected (RFC 9110 §9.2.2)"() {
+        expect:
+        method.isIdempotent() == expected
+
+        where:
+        method                | expected
+        HttpMethod.GET        | true
+        HttpMethod.HEAD       | true
+        HttpMethod.OPTIONS    | true
+        HttpMethod.TRACE      | true
+        HttpMethod.PUT        | true
+        HttpMethod.DELETE     | true
+        HttpMethod.POST       | false
+        HttpMethod.PATCH      | false
+        HttpMethod.CONNECT    | false
+        HttpMethod.CUSTOM     | false
+    }
+
+    void "every safe method is also idempotent"() {
+        expect:
+        HttpMethod.values().every { !it.isSafe() || it.isIdempotent() }
+    }
+}

--- a/src/main/docs/guide/httpClient/clientAnnotation/clientRetry.adoc
+++ b/src/main/docs/guide/httpClient/clientAnnotation/clientRetry.adoc
@@ -1,4 +1,9 @@
-Recovering from failure is critical for HTTP clients, and that is where Micronaut's integrated <<retry, Retry Advice>> comes in handy.
+Recovering from failure is critical for HTTP clients. Micronaut offers two complementary retry mechanisms:
+
+* The ann:retry.annotation.Retryable[] annotation described below — AOP advice that wraps ann:http.client.annotation.Client[] interface methods. Requires the `micronaut-retry` dependency.
+* <<idempotentRetry, RFC 9110 Idempotent Retry>> — an HTTP-aware transport-level filter built into the HTTP client core. No extra dependency. Applies to programmatic and declarative clients.
+
+This section covers ann:retry.annotation.Retryable[]; see <<retry, Retry Advice>> for general retry mechanics.
 
 NOTE: Since Micronaut Framework 4.0, declarative clients annotated with ann:http.client.annotation.Client[] no longer invoke fallbacks by default. To restore the previous behaviour add the following dependency and annotate any declarative clients with ann:retry.annotation.Recoverable[].
 

--- a/src/main/docs/guide/httpClient/idempotentRetry.adoc
+++ b/src/main/docs/guide/httpClient/idempotentRetry.adoc
@@ -1,0 +1,67 @@
+Since Micronaut Framework 5.0, the HTTP client supports an opt-in transport-level retry filter that automatically retries idempotent requests on transient failures, following https://www.rfc-editor.org/rfc/rfc9110.html[RFC 9110]. The filter ships with the HTTP client core — no additional dependency is required, unlike ann:retry.annotation.Retryable[] which requires the `micronaut-retry` library.
+
+Compared to ann:retry.annotation.Retryable[]: this filter operates below `@Client` interfaces, applies to programmatic clients as well, and never retries non-idempotent requests (such as a `POST` without an `Idempotency-Key` header).
+
+[NOTE]
+====
+This filter is in-process and self-contained. If you run inside a service mesh (Istio, Linkerd, Consul Connect), in-mesh service-to-service retries are typically best handled by the mesh's `VirtualService` / equivalent — the mesh sees every call, applies retry budgets across services, and is language-agnostic. The application-side filter is most valuable when:
+
+* Calling **external APIs** (Stripe, Twilio, S3, OAuth providers, partner integrations) — traffic that leaves the mesh.
+* Running on **deployment targets without a mesh** (AWS Lambda, ECS, App Runner, Heroku, plain VMs).
+* You need **idempotency-key-aware** `POST` retry, which mesh proxies cannot do safely without application help.
+* You want **per-`@Client` retry policy** that's finer-grained than per-destination mesh rules.
+
+When the mesh and this filter both retry the same request, you get retry storms. Pick one layer per traffic class.
+====
+
+Enable it via configuration:
+
+[configuration]
+----
+micronaut:
+  http:
+    client:
+      retry:
+        enabled: true
+        attempts: 3        # total attempts including the first
+        delay: 500ms       # initial back-off
+        multiplier: 1.5    # exponential factor
+        max-delay: 10s
+        jitter: 0.25
+        respect-retry-after: true
+----
+
+The default policy retries:
+
+* Methods designated as idempotent by https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods[RFC 9110 Section 9.2.2]: `GET`, `HEAD`, `PUT`, `DELETE`, `OPTIONS`, `TRACE`.
+* Any request carrying an `Idempotency-Key` header (a de facto convention for marking `POST`/`PATCH` as safe to retry).
+* Failures with status `5xx` (https://www.rfc-editor.org/rfc/rfc9110.html#name-server-error-5xx[RFC 9110 Section 15.6]), `429` (https://www.rfc-editor.org/rfc/rfc6585.html#section-4[RFC 6585 Section 4]), or `408` (https://www.rfc-editor.org/rfc/rfc9110.html#name-408-request-timeout[RFC 9110 Section 15.5.9]).
+* Transport-level errors (connect/read timeouts, connection resets).
+
+For `429` and `503` responses carrying a `Retry-After` header, the server-supplied delay is honored (capped by `max-delay`). The header format (delta-seconds or HTTP-date) is defined by https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after[RFC 9110 Section 10.2.3], which canonically associates it with `503` (and 3xx redirects, handled separately by the redirect follower); the `429` association comes from https://www.rfc-editor.org/rfc/rfc6585.html#section-4[RFC 6585 Section 4].
+
+NOTE: Requests with a streamed body (a `Publisher<ByteBuffer>` or similar) are not retried, since the body cannot be replayed. Buffer the body before sending if retries are desired.
+
+[IMPORTANT]
+====
+*Timeout interaction.* Each attempt has its own `read-timeout` (it's a fresh network call). However, retry delays are spent inside the same reactive stream as the original request, so they count against `request-timeout`. The cumulative worst-case is roughly `attempts × read-timeout + (attempts - 1) × max-delay`. Default Micronaut sets `request-timeout` to `read-timeout + 1s`, which is too small for even one retry. When enabling this filter, raise `request-timeout` accordingly:
+
+[configuration]
+----
+micronaut:
+  http:
+    client:
+      read-timeout: 5s          # per attempt
+      request-timeout: 30s      # ≥ attempts × read-timeout + sum_of_backoffs
+      retry:
+        enabled: true
+        attempts: 3
+        max-delay: 2s
+----
+====
+
+To customize the policy, replace either of the predicate beans. The example below extends the default response predicate to also retry HTTP `425 Too Early`:
+
+snippet::io.micronaut.docs.http.client.retry.CustomResponseRetryPredicate[tags="class", indent=0, title="Custom HttpResponseRetryPredicate"]
+
+<1> The `@Requires` line scopes the bean to a single test spec; remove it in production code so the predicate is always picked up.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -253,6 +253,7 @@ httpClient:
     clientFallback: Client Fallbacks
     netflixHystrix: Netflix Hystrix Support
   clientFilter: HTTP Client Filters
+  idempotentRetry: RFC 9110 Idempotent Retry
   clientHttp2: HTTP/2 Support
   clientHttp3: HTTP/3 Support
   clientSample: HTTP Client Sample

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicate.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicate.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.http.client.retry
+
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.retry.HttpResponseRetryPredicate
+import jakarta.inject.Singleton
+
+// tag::class[]
+@Singleton
+@Replaces(HttpResponseRetryPredicate::class)
+@Requires(property = "spec.name", value = "CustomResponseRetryPredicateSpec") // <1>
+class CustomResponseRetryPredicate : HttpResponseRetryPredicate {
+
+    override fun shouldRetry(failure: Throwable): Boolean {
+        // Extend the default policy: also retry HTTP 425 Too Early.
+        if (HttpResponseRetryPredicate.rfc9110().shouldRetry(failure)) {
+            return true
+        }
+        return failure is HttpClientResponseException && failure.status == HttpStatus.TOO_EARLY
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicate.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.http.client.retry;
+
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.client.retry.HttpResponseRetryPredicate;
+import jakarta.inject.Singleton;
+
+// tag::class[]
+@Singleton
+@Replaces(HttpResponseRetryPredicate.class)
+@Requires(property = "spec.name", value = "CustomResponseRetryPredicateSpec") // <1>
+public class CustomResponseRetryPredicate implements HttpResponseRetryPredicate {
+
+    @Override
+    public boolean shouldRetry(Throwable failure) {
+        // Extend the default policy: also retry HTTP 425 Too Early.
+        if (HttpResponseRetryPredicate.rfc9110().shouldRetry(failure)) {
+            return true;
+        }
+        return failure instanceof HttpClientResponseException ex
+            && ex.getStatus() == HttpStatus.TOO_EARLY;
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicateSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicateSpec.java
@@ -83,7 +83,7 @@ class CustomResponseRetryPredicateSpec {
     void customPredicateStillRespectsTerminal4xx() {
         // The custom predicate delegates to rfc9110() for non-425 statuses, so 404 is still terminal.
         TooEarlyController controller = server.getApplicationContext().getBean(TooEarlyController.class);
-        controller.reset(0); // never succeed → keep returning 404 from /not-found
+        controller.reset(0);  // reset controller state; /not-found always returns 404 regardless of succeedAt
 
         var ex = assertThrows(HttpClientResponseException.class,
             () -> client.toBlocking().retrieve("/not-found"));

--- a/test-suite/src/test/java/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicateSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicateSpec.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.http.client.retry;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.client.retry.HttpResponseRetryPredicate;
+import io.micronaut.runtime.server.EmbeddedServer;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Exercises the {@link CustomResponseRetryPredicate} doc-example end-to-end: replaces the
+ * default {@link HttpResponseRetryPredicate} with a custom one that also retries
+ * {@code 425 Too Early}, fires a request to a controller that returns 425 then 200, and
+ * asserts the retry happened.
+ */
+class CustomResponseRetryPredicateSpec {
+
+    EmbeddedServer server;
+    HttpClient client;
+
+    @BeforeEach
+    void setUp() {
+        server = ApplicationContext.run(EmbeddedServer.class, Map.of(
+            "spec.name", getClass().getSimpleName(),
+            "micronaut.http.client.retry.enabled", "true",
+            "micronaut.http.client.retry.attempts", "3",
+            "micronaut.http.client.retry.delay", "1ms",
+            "micronaut.http.client.retry.max-delay", "10ms",
+            "micronaut.http.client.retry.multiplier", "1.0",
+            "micronaut.http.client.retry.jitter", "0.0",
+            "micronaut.http.client.read-timeout", "5s",
+            "micronaut.http.client.request-timeout", "10s"
+        ));
+        client = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+    }
+
+    @AfterEach
+    void tearDown() {
+        client.close();
+        server.close();
+    }
+
+    @Test
+    void customPredicateRetries425TooEarly() {
+        TooEarlyController controller = server.getApplicationContext().getBean(TooEarlyController.class);
+        controller.reset(2); // succeed on the second attempt
+
+        String body = client.toBlocking().retrieve("/too-early");
+
+        assertEquals("ok", body);
+        assertEquals(2, controller.attempts.get());
+    }
+
+    @Test
+    void customPredicateStillRespectsTerminal4xx() {
+        // The custom predicate delegates to rfc9110() for non-425 statuses, so 404 is still terminal.
+        TooEarlyController controller = server.getApplicationContext().getBean(TooEarlyController.class);
+        controller.reset(0); // never succeed → keep returning 404 from /not-found
+
+        var ex = assertThrows(HttpClientResponseException.class,
+            () -> client.toBlocking().retrieve("/not-found"));
+
+        assertEquals(HttpStatus.NOT_FOUND, ex.getStatus());
+        assertEquals(1, controller.notFoundAttempts.get()); // single attempt only
+    }
+
+    @Requires(property = "spec.name", value = "CustomResponseRetryPredicateSpec")
+    @Controller
+    @Singleton
+    static class TooEarlyController {
+        final AtomicInteger attempts = new AtomicInteger();
+        final AtomicInteger notFoundAttempts = new AtomicInteger();
+        int succeedAt = 1;
+
+        void reset(int succeedAt) {
+            this.succeedAt = succeedAt;
+            attempts.set(0);
+            notFoundAttempts.set(0);
+        }
+
+        @Get("/too-early")
+        HttpResponse<?> tooEarly() {
+            int n = attempts.incrementAndGet();
+            return n >= succeedAt ? HttpResponse.ok("ok") : HttpResponse.status(HttpStatus.TOO_EARLY);
+        }
+
+        @Get("/not-found")
+        HttpResponse<?> notFound() {
+            notFoundAttempts.incrementAndGet();
+            return HttpResponse.status(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicateSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/client/retry/CustomResponseRetryPredicateSpec.java
@@ -25,7 +25,6 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.client.retry.HttpResponseRetryPredicate;
 import io.micronaut.runtime.server.EmbeddedServer;
-import jakarta.inject.Singleton;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,7 +94,6 @@ class CustomResponseRetryPredicateSpec {
 
     @Requires(property = "spec.name", value = "CustomResponseRetryPredicateSpec")
     @Controller
-    @Singleton
     static class TooEarlyController {
         final AtomicInteger attempts = new AtomicInteger();
         final AtomicInteger notFoundAttempts = new AtomicInteger();


### PR DESCRIPTION
# Add RFC 9110-aware idempotent HTTP client retry filter

## Summary

Introduces an opt-in client-side retry filter that automatically retries idempotent HTTP requests on transient failures, following [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html). Disabled by default; zero behavior change for existing users.

```yaml
micronaut.http.client.retry:
  enabled: true
  attempts: 3
  delay: 500ms
  multiplier: 1.5
  max-delay: 10s
  jitter: 0.25
  respect-retry-after: true
```

<details>

<summary>Rendered Adocs</summary>

<img width="1300" height="748" alt="Screenshot 2026-04-28 at 5 49 32 PM" src="https://github.com/user-attachments/assets/da2121fb-6980-4d22-b6d7-aa98a7ad5cd6" />
<img width="1314" height="1328" alt="Screenshot 2026-04-28 at 5 49 37 PM" src="https://github.com/user-attachments/assets/d588b3d2-322d-464e-9563-a3e307f103a1" />

<img width="1300" height="922" alt="Screenshot 2026-04-28 at 5 49 41 PM" src="https://github.com/user-attachments/assets/43254d98-e15e-43b2-b47e-bb2ff088c5d3" />

</details>

## Out of scope (good follow-up candidates)

To keep this initial PR focused strictly on core reactive behavior and RFC compliance, the following items were intentionally deferred:

* Per-service config (`micronaut.http.services.<id>.retry.*`) — V1 uses the global `@Primary` config.
* Extracting shared exponential-backoff / jitter math to `core` so `SimpleRetry` (in `retry`) and `IdempotentRetryClientFilter` can share one implementation. The math is duplicated today; deduplicating in this PR would require depending on `micronaut-retry`, which defeats this filter's "no extra dependency" property.
* Promoting `RetryAfterParser` to `HttpHeaders.findRetryAfter()`.
* Promoting `IDEMPOTENCY_KEY_HEADER` to `HttpHeaders` if/when the IETF draft is republished.
* Adding RFC 9110 §15 category methods (`isInformational()`, `isSuccess()`, `isRedirection()`, `isClientError()`, `isServerError()`) to `HttpStatus`. These don't exist today and would be useful in many places beyond this filter.

## Why

`@Retryable` already exists for declarative `@Client` interfaces, but it's a different tool with a real gap:

| Concern                                  | `@Retryable` (AOP)                                                                | This filter                                     |
|:-----------------------------------------|:----------------------------------------------------------------------------------|:------------------------------------------------|
| **Applies to programmatic `HttpClient`** | No (AOP needs an interface)                                                       | Yes                                             |
| **Default predicate**                    | Type-based: retries any `Exception` (incl. `HttpClientResponseException` for 404) | HTTP-aware: 5xx / 429 / 408 / transport errors  |
| **Method-aware (idempotency)**           | No — retries `POST` same as `GET`                                                 | Yes — RFC 9110 §9.2.2                           |
| **`Retry-After` header**                 | No                                                                                | Yes (delta-seconds + HTTP-date)                 |
| **Total-latency cap (SLA)**              | None — N attempts × per-call timeout (latency multiplies with retries)            | Implicit — bounded by `request-timeout`         |
| **`Idempotency-Key` opt-in**             | No                                                                                | Yes                                             |

The shared-vs-fresh budget is the key architectural consequence. For callers that need predictable p99 latency — payment gateways with strict SLAs, sync APIs feeding into a request-response chain — shared-clock is the desired model: the whole call cannot exceed `request-timeout` regardless of how many retries fire. A naive filter that retries every `HttpClientException` will, on a 404, churn through `Mono.delay(1s + 2s + 4s + 8s)` inside the same stream — and the upstream `request-timeout` window kills the stream with a misleading timeout instead of the original 404. Scoping retries to statuses that can recover keeps the budget for failures that justify spending it.

**On service meshes**: For in-mesh traffic, an Istio (or Linkerd) `VirtualService` retry policy provides the same total-latency-cap behavior as this filter's shared-clock model — the filter doesn't add SLA value there. Its value is for traffic that *leaves* the mesh (external APIs), deployments *without* a mesh (Lambda, ECS, App Runner, plain VMs), and `Idempotency-Key`-aware `POST` retry, which mesh proxies cannot do safely without application help.

The two complement each other: `@Retryable` for cross-cutting business logic (with fresh per-attempt timeouts), this filter for transport-level recovery on idempotent requests.

**A note on `Retry-After`**: `HttpHeaders.RETRY_AFTER` has existed as a name constant in `http/src/main/java/io/micronaut/http/HttpHeaders.java` since the early days, but a full-tree grep confirms nothing in Micronaut core, the HTTP client, the HTTP server, or any test parsed or honored the header. Netty doesn't either — it's a protocol library, not a retry orchestrator. This PR is the first place in the framework where the constant has operational meaning.

### Related issues

This PR addresses long-standing community concerns that `@Retryable` is HTTP-agnostic and unsafe-by-default for HTTP clients. It does **not** modify `@Retryable`'s behavior; instead it provides a complementary HTTP-aware filter that ships with the client core. Concrete linkage:

* See https://github.com/micronaut-projects/micronaut-core/issues/1920
* See https://github.com/micronaut-projects/micronaut-core/issues/2123

Maintainers: please decide whether either issue can be closed in light of this — the original concerns about `@Retryable` itself remain technically open, but the practical "give me a safe default for HTTP retry" outcome is now available.

## What changes

**New (`http-client-core/src/main/java/io/micronaut/http/client/retry/`):**

* `HttpRequestRetryPredicate` — public functional interface; default classifies via `HttpMethod.isIdempotent()` + `Idempotency-Key` header
* `HttpResponseRetryPredicate` — public functional interface; default retries 5xx / 429 / 408 / transport errors
* `IdempotentRetryClientFilter` — `@Internal` `@ClientFilter`, opt-in via property
* `RetryAfterParser` — `@Internal` parser for delta-seconds + HTTP-date forms
* `DefaultRetryPredicateFactory` — `@Internal` factory providing replaceable defaults

**Modified:**

* `HttpClientConfiguration` — added nested `RetryConfiguration` (mirrors `Http2ClientConfiguration` shape)
* `DefaultHttpClientConfiguration` — wired `DefaultRetryConfiguration`
* `HttpMethod` — added `isSafe()` and `isIdempotent()` instance methods (RFC 9110 §9.2.1 / §9.2.2)
* `clientRetry.adoc` — opening paragraph now frames the two complementary retry mechanisms (`@Retryable` AOP advice vs. this filter) with cross-links to both, so a reader landing on either page can self-route
* `idempotentRetry.adoc` — new top-level section under `httpClient/` with linked RFC references, service-mesh interaction note, timeout-correlation guidance, and parallel Java/Kotlin example
* `toc.yml` — registered the new section between `clientFilter` and `clientHttp2`

**Tests:**

* `HttpMethodSpec` (new) — direct unit coverage for `isSafe()` / `isIdempotent()` over every enum constant.
* `HttpClientConfigurationSpec` (new) — locks the `RetryConfiguration` contract: defaults match the published values, `Toggleable` defaults to disabled, `setAttempts` clamps via parametrized data table, and `setDelay` / `setMaxDelay` / `setMultiplier` / `setJitter` reject invalid inputs with `IllegalArgumentException`.
* `RetryAfterParserSpec` (new) — delta-seconds, HTTP-date with fixed `Clock`, past-date coercion, malformed input, overflow.
* `HttpResponseRetryPredicateSpec` (new) — full status-code matrix for `isRetryableStatus(int)` + default-predicate behavior across `HttpClientResponseException`, transport `HttpClientException`, and arbitrary throwables.
* `IdempotentRetryClientFilterSpec` (new) — covers idempotent dispatch, terminal 4xx fast-fail, 5xx / 429 / 408 retry, transport errors, `Retry-After` (both forms with a fixed clock), `respectRetryAfter: false`, streamed-body bypass, `IN_RETRY_LOOP` cleanup on success / error / request-reuse, and `enabled: false` pass-through.
* `IdempotentRetryIntegrationSpec` (new) — EmbeddedServer integration cases for retry-on-503, exhaustion, and POST non-retry.
* `CustomResponseRetryPredicate.java` / `.kt` (new doc-example sources) + `CustomResponseRetryPredicateSpec.java` (new) — exercises the doc-example end-to-end with a real `EmbeddedServer`, asserting both the 425 retry path and the still-terminal-4xx path.

## Design decisions

1. **Opt-in default.** Zero behavior change for existing users.
2. **Two predicates, both replaceable via `@Replaces`.** One axis decides "is this safe to retry," the other "did the failure warrant a retry." Splitting them lets users extend one without rebuilding the other.
3. **Idempotency by method, not interface annotation.** New `HttpMethod.isSafe()` / `isIdempotent()` follow the existing `requiresRequestBody()` pattern; programmatic and declarative clients share semantics.
4. **Streamed-body bypass.** Requests with a `Publisher<?>` body cannot be replayed without unbounded buffering. Documented.
5. **Filter re-entry guard.** `continuation.proceed()` re-runs the filter chain (see `MethodFilter.ReactiveContinuationImpl`). An `IN_RETRY_LOOP` request attribute makes re-entries pass through; outermost invocation owns the retry loop. Captured in a code comment.
6. **No manual Netty buffer release.** `NettyHttpClient` already releases the underlying `ByteBuf` in a `finally` block before propagating `HttpClientResponseException`. Calling `release()` here would no-op or throw `IllegalReferenceCountException`. Captured in a code comment so a Spring/raw-Reactor-Netty reader doesn't independently "fix" it.
7. **Filter ordered outermost (`HIGHEST_PRECEDENCE + 100`).** Each retry triggers the entire downstream chain again, so auth filters re-issue fresh tokens and tracing filters create new spans per attempt.
8. **Per-service config (`micronaut.http.services.<id>.retry.*`) deliberately deferred.** (See Out of Scope.)
9. **`Idempotency-Key` constant on the predicate, not `HttpHeaders`.** The IETF draft (`draft-ietf-httpapi-idempotency-key-header`) has expired without publication; promoting it to `HttpHeaders` would imply IANA-registered status it doesn't have.
10. **`RetryAfterParser` kept `@Internal`.** Could plausibly live as `HttpHeaders.findRetryAfter()` alongside `findDate()`, but only one consumer needs it today. Promotion is a one-commit refactor if a second consumer appears.

### Mermaid Diagram

> AI generated

```mermaid
sequenceDiagram
    autonumber
    actor Sub as Caller
    participant Filter as Retry Filter
    participant Outer as Outer Mono.defer
    participant Retry as retryWhen
    participant Inner as Inner Mono.defer
    participant Downstream as Downstream Filters
    participant Netty as NettyHttpClient

    Note over Filter: filter(request, continuation) called synchronously
    Filter->>Filter: shouldBypassRetry(request) - false (config OK, idempotent, replayable, not re-entry)
    Filter-->>Sub: return Mono.defer(...).doFinally(...)
    Note right of Filter: No request mutation yet -<br/>side effects deferred to subscription

    Sub->>Outer: subscribe()
    Outer->>Outer: Evaluate Outer Supplier
    Note right of Outer: setAttribute(IN_RETRY_LOOP, TRUE)<br/>AtomicLong attempted = 0<br/>(both per-subscription)
    Outer->>Retry: subscribe Inner.retryWhen(spec)
    Retry->>Inner: subscribe()
    Inner->>Inner: Evaluate Inner Supplier
    Inner->>Downstream: continuation.proceed()
    Downstream->>Netty: Execute attempt 1
    Netty-->>Downstream: 503 + ByteBuf released by NettyHttpClient
    Downstream-->>Inner: HttpClientResponseException
    Inner-->>Retry: error signal

    Note right of Retry: companion runs:<br/>attempted.getAndIncrement()<br/>shouldRetry == true
    Retry->>Retry: Mono.delay(backoff with jitter)

    Note over Retry, Inner: RETRY - re-subscribe Inner
    Retry->>Inner: resubscribe()
    Inner->>Inner: Evaluate Inner Supplier (fresh proceed)
    Inner->>Filter: continuation.proceed() re-enters chain

    Note over Filter: IN_RETRY_LOOP == TRUE on re-entry
    Filter->>Downstream: continuation.proceed() (bypass - no retry wrapper)
    Downstream->>Netty: Execute attempt 2
    Netty-->>Downstream: 200 OK
    Downstream-->>Inner: HttpResponse
    Inner-->>Retry: response signal (terminal)
    Retry-->>Outer: HttpResponse passes through

    Outer-->>Sub: HttpResponse
    Note over Outer: .doFinally(SignalType.ON_COMPLETE)<br/>removeAttribute(IN_RETRY_LOOP)
```

## Compatibility

* `./gradlew :micronaut-http-client-core:japiCmp` clean — additions only, no binary breaks.
* All RFC text references in Javadoc, code comments, and the user guide use clickable links.
* Public API surface: 2 functional interfaces + 1 nested config class + 2 new instance methods on `HttpMethod`. All new types `@since 5.0.0`.

## Verification

`./gradlew :micronaut-http-client-core:test :micronaut-http-client:test cM spotlessCheck japiCmp docs` — all green. New unit + integration specs cover: idempotent / non-idempotent dispatch, 4xx fast-fail, transport-error retry, exhaustion behavior, `Retry-After` (both delta-seconds and HTTP-date with a fixed `Clock`), streamed-body bypass, and disabled pass-through. No regressions in the existing `:micronaut-http-client` suite.
