### PR TITLE
Raise test-library baseline to Java 25

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-test-library.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-test-library.gradle
@@ -14,6 +14,6 @@ dependencies {
     testRuntimeOnly(libs.junit.platform.launcher)
 }
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }


### PR DESCRIPTION
## Summary
- raise the shared `convention-test-library` Java baseline from 21 to 25 on `5.0.x`
- align core TCK and test-library modules with the Micronaut 5.x Java 25 baseline
- avoid downstream variant mismatches where Java 25 producers are consumed by test modules constrained to Java 21

## Verification
- `./gradlew --no-daemon :test-suite-http-server-tck-jdk:properties --property sourceCompatibility`
- attempted focused `:test-suite-http-server-tck-jdk:compileTestJava` / `:test-suite-http-server-tck-jdk:test --tests 'io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest'` locally; the build graph is broad in `micronaut-core`, but the convention change itself configured and progressed cleanly with no failure attributable to the Java 25 baseline change
