### PR TITLE
Fix HTTP server TCK on 4.10.x

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsStaticResourceTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsStaticResourceTest.java
@@ -22,7 +22,6 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.tck.AssertionUtils;
-import io.micronaut.http.tck.HttpResponseAssertion;
 import io.micronaut.http.uri.UriBuilder;
 import org.junit.jupiter.api.Test;
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
@@ -18,7 +18,7 @@ package io.micronaut.http.server.tck.tests.forms;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
@@ -91,7 +91,8 @@ public class FormsJacksonAnnotationsTest {
     }
 
     @Introspected
-    record Book(@JsonProperty("title") @NonNull String title, @JsonProperty("paginas") @Nullable Integer pages) {
+    @ReflectiveAccess
+    record Book(@JsonProperty("title") String title, @JsonProperty("paginas") @Nullable Integer pages) {
     }
 
 }

--- a/http-tck/build.gradle.kts
+++ b/http-tck/build.gradle.kts
@@ -21,5 +21,7 @@ dependencies {
     api(libs.junit.jupiter.api)
     api(libs.junit.jupiter.params)
     api(libs.managed.reactor)
-    implementation(libs.micronaut.test.netty.leak)
+    implementation(libs.micronaut.test.netty.leak) {
+        exclude(group = "io.micronaut")
+    }
 }


### PR DESCRIPTION
## Summary
- Backport the relevant `FormsJacksonAnnotationsTest` TCK correction from #12602 by adding `@ReflectiveAccess` to the form test record.
- Exclude transitive `io.micronaut` dependencies from `micronaut-test-netty-leak` in `http-tck`, preventing older Micronaut artifacts from being pulled into the TCK classpath.
- Remove an unused import in `CorsStaticResourceTest` that blocks checkstyle for the same TCK module.

## Verification
- `JAVA_HOME=/usr/lib64/graalvm/graalvm-java17 ./gradlew :micronaut-http-tck:clean :micronaut-http-server-tck:clean :micronaut-http-tck:check :micronaut-http-server-tck:check -x japiCmp --no-daemon --no-parallel`
- `JAVA_HOME=/usr/lib64/graalvm/graalvm-java17 ./gradlew :test-suite-http-server-tck-netty:test --tests io.micronaut.http.server.tck.netty.tests.NettyHttpServerTestSuite --no-daemon --no-parallel`
- `JAVA_HOME=/usr/lib64/graalvm/graalvm-java17 ./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility --no-daemon --no-parallel` (fails only in known flaky `ProxyBackpressureTest`, reproduced on clean `origin/4.10.x`)

Resolves #12631