### PR TITLE
fix #12651: reuse underlying HttpClient in toBlocking() to prevent thread leak [backport 4.10.x]

### DIFF
--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
@@ -145,21 +145,7 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
 
     @Override
     public BlockingHttpClient toBlocking() {
-        return new JdkBlockingHttpClient(
-            loadBalancer,
-            httpVersion,
-            configuration,
-            contextPath,
-            filterResolver,
-            clientFilterEntries,
-            mediaTypeCodecRegistry,
-            messageBodyHandlerRegistry,
-            requestBinderRegistry,
-            clientId,
-            conversionService,
-            sslBuilder,
-            cookieDecoder
-        );
+        return new JdkBlockingHttpClient(this);
     }
 
     @Override

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/JdkBlockingHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/JdkBlockingHttpClient.java
@@ -44,6 +44,9 @@ import java.util.List;
 @Internal
 @Experimental
 public class JdkBlockingHttpClient extends AbstractJdkHttpClient implements BlockingHttpClient {
+    JdkBlockingHttpClient(AbstractJdkHttpClient prototype) {
+        super(prototype);
+    }
 
     public JdkBlockingHttpClient(
         LoadBalancer loadBalancer,

--- a/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/JdkBlockingHttpClientReuseSpec.groovy
+++ b/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/JdkBlockingHttpClientReuseSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.http.client.jdk
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.HttpClient
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class JdkBlockingHttpClientReuseSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext ctx = ApplicationContext.run()
+
+    def "toBlocking reuses the same underlying java.net.http.HttpClient on every call"() {
+        given:
+        DefaultJdkHttpClient parent = ctx.createBean(HttpClient, new URL('http://localhost:65530')) as DefaultJdkHttpClient
+
+        when:
+        def blockingClients = (1..100).collect { parent.toBlocking() }
+
+        then: 'every blocking client wraps the SAME java.net.http.HttpClient instance'
+        blockingClients.every { (it as AbstractJdkHttpClient).@client.is(parent.@client) }
+
+        cleanup:
+        parent.close()
+    }
+}

--- a/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/JdkBlockingHttpClientThreadLeakSpec.groovy
+++ b/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/JdkBlockingHttpClientThreadLeakSpec.groovy
@@ -1,0 +1,60 @@
+package io.micronaut.http.client.jdk
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.regex.Pattern
+
+class JdkBlockingHttpClientThreadLeakSpec extends Specification {
+
+    private static final Pattern JDK_HTTP_CLIENT_SELECTOR = Pattern.compile(/HttpClient-\d+-SelectorManager/)
+
+    @Shared @AutoCleanup
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+        'spec.name': 'JdkBlockingHttpClientThreadLeakSpec'
+    ])
+
+    @Shared @AutoCleanup
+    ApplicationContext clientCtx = ApplicationContext.run([
+        'spec.name': 'JdkBlockingHttpClientThreadLeakSpec',
+        'micronaut.http.services.leakspec.url': server.URL.toString()
+    ])
+
+    def "synchronous declarative @Client does not spawn a new JDK HttpClient per call"() {
+        given:
+        LeakClient client = clientCtx.getBean(LeakClient)
+        int baseline = countSelectorThreads()
+
+        when:
+        500.times { client.ping() }
+
+        then: 'thread count is measured immediately, before GC can reap leaked clients'
+        int after = countSelectorThreads()
+        (after - baseline) <= 1
+    }
+
+    private static int countSelectorThreads() {
+        Thread.getAllStackTraces().keySet().count { JDK_HTTP_CLIENT_SELECTOR.matcher(it.name).matches() } as int
+    }
+
+    @Requires(property = 'spec.name', value = 'JdkBlockingHttpClientThreadLeakSpec')
+    @Client('leakspec')
+    static interface LeakClient {
+        @Get('/leak/ping')
+        String ping()
+    }
+
+    @Requires(property = 'spec.name', value = 'JdkBlockingHttpClientThreadLeakSpec')
+    @Controller('/leak')
+    static class LeakController {
+        @Get('/ping')
+        String ping() { 'pong' }
+    }
+}


### PR DESCRIPTION
Backport of #12652 to `4.10.x`.

Fixes #12651

## Problem
- `DefaultJdkHttpClient.toBlocking()` constructs new `JdkBlockingHttpClient` + new `java.net.http.HttpClient` on every call
- each `HttpClient` spawns threads and under sync declarative `@Client` load threads accumulate without bound causing OOMKills

## Fix
- added prototype copy constructor to `JdkBlockingHttpClient` delegating to `AbstractJdkHttpClient(AbstractJdkHttpClient prototype)`
- `toBlocking()` now calls `new JdkBlockingHttpClient(this)` and shares existing `HttpClient` and threads

This mirrors pattern in `JdkRawHttpClient`