### PR TITLE
fix: match @EachProperty record properties by name

### DIFF
--- a/core-processor/src/main/java/io/micronaut/context/visitor/ConfigurationMetadataWriterVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/context/visitor/ConfigurationMetadataWriterVisitor.java
@@ -280,10 +280,13 @@ public class ConfigurationMetadataWriterVisitor implements TypeElementVisitor<Co
                 .getBeanProperties();
             final ParameterElement[] parameters = constructor.getParameters();
             if (beanProperties.size() == parameters.length) {
-                for (int i = 0; i < parameters.length; i++) {
-                    ParameterElement parameter = parameters[i];
-                    final PropertyElement bp = beanProperties.get(i);
-                    if (CONSTRUCTOR_PARAMETERS_INJECTION_ANN.stream().noneMatch(bp::hasStereotype)) {
+                for (ParameterElement parameter : parameters) {
+                    final String paramName = parameter.getName();
+                    final PropertyElement bp = beanProperties.stream()
+                        .filter(p -> p.getName().equals(paramName))
+                        .findFirst()
+                        .orElse(null);
+                    if (bp == null || CONSTRUCTOR_PARAMETERS_INJECTION_ANN.stream().noneMatch(bp::hasStereotype)) {
                         processConfigurationInjectParameter(constructor.getDeclaringType(), parameter, visitorContext);
                     }
                 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/records/RecordNestingSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/records/RecordNestingSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.inject.configproperties.records
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.inject.qualifiers.Qualifiers
 
 class RecordNestingSpec extends AbstractTypeElementSpec {
 
@@ -50,6 +51,29 @@ record RecordOuterConfig(
         config.inners().size() == 1
         config.inners()[0].count() == 30
         config.inners()[0].thirdLevel().num() == 40
+    }
+
+    void "test EachProperty record where @Parameter field is not alphabetically first"() {
+        given:
+        def context = buildContext('test.UnorderedConfig', '''
+package test;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+
+@EachProperty("demos")
+record UnorderedConfig(
+    @Parameter String name,
+    boolean enabled) {
+}
+''', false, ['demos.test.enabled': 'true'])
+
+        when:
+        def config = getBean(context, 'test.UnorderedConfig', Qualifiers.byName('test'))
+
+        then:
+        config.name() == 'test'
+        config.enabled()
     }
 
     @Override


### PR DESCRIPTION
JDT returns TypeElement.getEnclosedElements() in alphabetical order while javac uses declaration order. The positional zip in applyConfigurationInjectionIfNecessary caused @Property/@Parameter to be applied to the wrong constructor parameters under JDT.

Fixes #12658