### PR TITLE
Fix Kotlin default dispatch for inherited methods

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/DispatchWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/DispatchWriter.java
@@ -23,9 +23,7 @@ import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.FieldElement;
-import io.micronaut.inject.ast.KotlinParameterElement;
 import io.micronaut.inject.ast.MethodElement;
-import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.sourcegen.model.ClassTypeDef;
@@ -154,8 +152,8 @@ public final class DispatchWriter implements ClassOutputWriter {
     }
 
     private DispatchTarget findDispatchTarget(TypedElement declaringType, MethodElement methodElement, boolean useOneDispatch) {
-        List<ParameterElement> argumentTypes = Arrays.asList(methodElement.getSuspendParameters());
-        boolean isKotlinDefault = argumentTypes.stream().anyMatch(p -> p instanceof KotlinParameterElement kp && kp.hasDefault());
+        MethodElement kotlinDefaultMethod = findKotlinDefaultMethod(methodElement);
+        boolean isKotlinDefault = kotlinDefaultMethod != null;
         ClassElement declaringClassType = (ClassElement) declaringType;
         if (methodElement.isReflectionRequired(ClassElement.of(thisType))) {
             if (isKotlinDefault) {
@@ -163,9 +161,25 @@ public final class DispatchWriter implements ClassOutputWriter {
             }
             return new MethodReflectionDispatchTarget(declaringType, methodElement, dispatchTargets.size(), useOneDispatch);
         } else if (isKotlinDefault) {
-            return new KotlinMethodWithDefaultsDispatchTarget(declaringClassType, methodElement, useOneDispatch);
+            return new KotlinMethodWithDefaultsDispatchTarget(declaringClassType, methodElement, kotlinDefaultMethod, useOneDispatch);
         }
         return new MethodDispatchTarget(declaringClassType, methodElement, useOneDispatch);
+    }
+
+    @Nullable
+    private MethodElement findKotlinDefaultMethod(MethodElement methodElement) {
+        if (MethodGenUtils.hasKotlinDefaultsParameters(Arrays.asList(methodElement.getSuspendParameters()))
+            && methodElement.getOverriddenMethods().isEmpty()) {
+            return methodElement;
+        }
+        List<MethodElement> defaultMethods = new ArrayList<>();
+        for (MethodElement overriddenMethod : methodElement.getOverriddenMethods()) {
+            MethodElement defaultMethod = findKotlinDefaultMethod(overriddenMethod);
+            if (defaultMethod != null && defaultMethods.stream().noneMatch(existing -> existing.getDeclaringType().equals(defaultMethod.getDeclaringType()))) {
+                defaultMethods.add(defaultMethod);
+            }
+        }
+        return defaultMethods.size() == 1 ? defaultMethods.get(0) : null;
     }
 
     /**
@@ -738,13 +752,16 @@ public final class DispatchWriter implements ClassOutputWriter {
     public static final class KotlinMethodWithDefaultsDispatchTarget extends AbstractDispatchTarget {
         final ClassElement declaringType;
         final MethodElement methodElement;
+        final MethodElement kotlinDefaultMethod;
         private final boolean useOneDispatch;
 
         private KotlinMethodWithDefaultsDispatchTarget(ClassElement targetType,
                                                        MethodElement methodElement,
+                                                       MethodElement kotlinDefaultMethod,
                                                        boolean useOneDispatch) {
             this.declaringType = targetType;
             this.methodElement = methodElement;
+            this.kotlinDefaultMethod = kotlinDefaultMethod;
             this.useOneDispatch = useOneDispatch;
         }
 
@@ -770,12 +787,12 @@ public final class DispatchWriter implements ClassOutputWriter {
 
         @Override
         public ExpressionDef dispatchMultiExpression(ExpressionDef target, List<? extends ExpressionDef> values) {
-            return MethodGenUtils.invokeKotlinDefaultMethod(declaringType, methodElement, target, values);
+            return MethodGenUtils.invokeKotlinDefaultMethod(kotlinDefaultMethod.getDeclaringType(), kotlinDefaultMethod, target, values);
         }
 
         @Override
         public ExpressionDef dispatchOneExpression(ExpressionDef target, ExpressionDef value) {
-            return MethodGenUtils.invokeKotlinDefaultMethod(declaringType, methodElement, target, List.of(value));
+            return MethodGenUtils.invokeKotlinDefaultMethod(kotlinDefaultMethod.getDeclaringType(), kotlinDefaultMethod, target, List.of(value));
         }
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/writer/DispatchWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/DispatchWriter.java
@@ -38,8 +38,10 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
@@ -168,13 +170,22 @@ public final class DispatchWriter implements ClassOutputWriter {
 
     @Nullable
     private MethodElement findKotlinDefaultMethod(MethodElement methodElement) {
+        return findKotlinDefaultMethod(methodElement, new HashSet<>());
+    }
+
+    @Nullable
+    private MethodElement findKotlinDefaultMethod(MethodElement methodElement, Set<String> visited) {
+        String methodKey = methodElement.getDeclaringType().getName() + '#' + methodElement.getDescription(true);
+        if (!visited.add(methodKey)) {
+            return null;
+        }
         if (MethodGenUtils.hasKotlinDefaultsParameters(Arrays.asList(methodElement.getSuspendParameters()))
             && methodElement.getOverriddenMethods().isEmpty()) {
             return methodElement;
         }
         List<MethodElement> defaultMethods = new ArrayList<>();
         for (MethodElement overriddenMethod : methodElement.getOverriddenMethods()) {
-            MethodElement defaultMethod = findKotlinDefaultMethod(overriddenMethod);
+            MethodElement defaultMethod = findKotlinDefaultMethod(overriddenMethod, visited);
             if (defaultMethod != null && defaultMethods.stream().noneMatch(existing -> existing.getDeclaringType().equals(defaultMethod.getDeclaringType()))) {
                 defaultMethods.add(defaultMethod);
             }

--- a/inject-java/build.gradle.kts
+++ b/inject-java/build.gradle.kts
@@ -67,3 +67,7 @@ tasks.withType<Test>().configureEach {
 
 //compileTestGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
 //compileTestGroovy.groovyOptions.fork = true
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("5.0.0")
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/executable/ExecutableSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/executable/ExecutableSpec.groovy
@@ -21,6 +21,7 @@ import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ExecutableMethod
 import io.micronaut.inject.ExecutionHandle
 import io.micronaut.inject.MethodExecutionHandle
+import spock.lang.Issue
 import spock.lang.Specification
 
 import static io.micronaut.annotation.processing.test.KotlinCompiler.*
@@ -104,5 +105,38 @@ class MyBean {
         "showPrimitiveArray"  | [long[].class]   | [[1L] as long[]] | "1 - The Stand"
         "showVoidReturn"      | [Iterable.class] | [['test']]       | null
         "showPrimitiveReturn" | [int[].class]    | [[1] as int[]]   | 1
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/12666")
+    void "test executable method overriding interface with default parameter"() {
+        given:
+        ApplicationContext context = buildContext('''
+package test
+
+import io.micronaut.context.annotation.Executable
+import jakarta.inject.Singleton
+
+interface Api {
+    fun send(name: String? = "default"): String
+}
+
+@Singleton
+open class Controller : Api {
+    @Executable
+    override fun send(name: String?): String {
+        return name ?: "missing"
+    }
+}
+''')
+
+        when:
+        ExecutionHandle method = context.findExecutionHandle(context.classLoader.loadClass('test.Controller'), "send", String).get()
+
+        then:
+        method.invoke("test") == "test"
+        method.invoke([null] as Object[]) == "default"
+
+        cleanup:
+        context.close()
     }
 }


### PR DESCRIPTION
## Summary

Closes #12666.

Fix Kotlin default-parameter dispatch for executable methods where the Kotlin default value is declared on an overridden method, such as an interface method, instead of on the concrete implementation.

Previously, `DispatchWriter` detected Kotlin defaults from the executable method parameters and always generated `$default` dispatch against the concrete declaring type. For a controller/bean implementation like:

```kotlin
interface Api {
    fun send(name: String? = "default"): String
}

open class Controller : Api {
    override fun send(name: String?): String = name ?: "missing"
}
```

Kotlin does not generate `Controller.send$default(...)`; the default belongs to the interface declaration. The generated Micronaut dispatch could therefore call a non-existent method and fail with `NoSuchMethodError`.

## Fix

- Resolve the Kotlin default-parameter owner before selecting the dispatch target.
- Use the concrete method for the normal dispatch target, but use the resolved Kotlin default owner when emitting `$default` dispatch.
- Walk overridden methods recursively and only use inherited default dispatch when a single default owner can be resolved.
- Fall back to normal dispatch when no default owner or an ambiguous inherited default owner is found.

## Tests

Added a regression test for an executable Kotlin method that overrides an interface method with a default parameter. The test verifies both explicit argument dispatch and inherited default dispatch.

Verification performed:

```bash
./gradlew :micronaut-core-processor:compileJava :micronaut-inject-kotlin:test --tests io.micronaut.kotlin.processing.beans.executable.ExecutableSpec --rerun-tasks
```

Result: `BUILD SUCCESSFUL`, 9 tests executed.

Also published this branch locally as `5.0.0-local1` and verified the fix against Micronaut OpenAPI's previously failing KSP server-generator suite:

```bash
./gradlew :test-suite-server-generator-kotlin-ksp:test
```
