### PR TITLE
Fix heap ByteBuf release in NettyReadBuffer.useFastHeapBuffer

### DIFF
--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBuffer.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBuffer.java
@@ -140,7 +140,11 @@ final class NettyReadBuffer extends ReadBuffer {
         ByteBuf b = getBuf();
         if (b.hasArray()) {
             buf = null;
-            return function.apply(java.nio.ByteBuffer.wrap(b.array(), b.arrayOffset() + b.readerIndex(), b.readableBytes()));
+            try {
+                return function.apply(java.nio.ByteBuffer.wrap(b.array(), b.arrayOffset() + b.readerIndex(), b.readableBytes()));
+            } finally {
+                b.release();
+            }
         } else {
             return super.useFastHeapBuffer(function);
         }

--- a/buffer-netty/src/test/java/io/micronaut/buffer/netty/NettyReadBufferTest.java
+++ b/buffer-netty/src/test/java/io/micronaut/buffer/netty/NettyReadBufferTest.java
@@ -1,9 +1,31 @@
 package io.micronaut.buffer.netty;
 
+import io.micronaut.core.io.buffer.ReadBuffer;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NettyReadBufferTest extends AbstractReadBufferTest {
     public NettyReadBufferTest() {
         super(NettyReadBufferFactory.of(ByteBufAllocator.DEFAULT));
+    }
+
+    @Test
+    void useFastHeapBufferReleasesHeapByteBuf() {
+        ByteBuf byteBuf = Unpooled.wrappedBuffer(new byte[]{1, 2, 3});
+        ReadBuffer readBuffer = NettyReadBufferFactory.of(ByteBufAllocator.DEFAULT).adapt(byteBuf);
+        try {
+            assertEquals(3, readBuffer.useFastHeapBuffer(java.nio.ByteBuffer::remaining));
+            assertEquals(0, byteBuf.refCnt());
+            readBuffer.close();
+        } finally {
+            if (byteBuf.refCnt() > 0) {
+                byteBuf.release(byteBuf.refCnt());
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #12680

`NettyReadBuffer.useFastHeapBuffer` consumes heap-backed buffers, so it should also release the underlying `ByteBuf` once the callback has run.

Added a small regression test for that path.

Verified with:

- `./gradlew :micronaut-buffer-netty:test`
- `./gradlew :micronaut-buffer-netty:check`