### PR TITLE
Handle malformed Forwarded host ports

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/util/DefaultHttpHostSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/util/DefaultHttpHostSpec.groovy
@@ -248,6 +248,86 @@ class DefaultHttpHostSpec extends Specification {
         server.close()
     }
 
+    void "test malformed forwarded host port falls back to URI host"() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer)
+        HttpHostResolver hostResolver = server.applicationContext.getBean(HttpHostResolver)
+        def request = Stub(HttpRequest) {
+            getHeaders() >> new MockHttpHeaders([
+                    "Forwarded": ["host=\"example.com:notaport\";proto=https"],
+            ])
+            getUri() >> new URI("http://localhost:8080")
+        }
+
+        when:
+        String host = hostResolver.resolve(request)
+
+        then:
+        host == "http://localhost:8080"
+
+        cleanup:
+        server.close()
+    }
+
+    void "test bracketed IPv6 host retrieved from forwarded"() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer)
+        HttpHostResolver hostResolver = server.applicationContext.getBean(HttpHostResolver)
+        def request = Stub(HttpRequest) {
+            getHeaders() >> new MockHttpHeaders([
+                    "Forwarded": ["host=\"[::1]:5000\";proto=https"],
+            ])
+            getUri() >> new URI("http://localhost:8080")
+        }
+
+        when:
+        String host = hostResolver.resolve(request)
+
+        then:
+        host == "https://[::1]:5000"
+
+        cleanup:
+        server.close()
+    }
+
+    void "test bracketed IPv6 host without port retrieved from forwarded"() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer)
+        HttpHostResolver hostResolver = server.applicationContext.getBean(HttpHostResolver)
+        def request = Stub(HttpRequest) {
+            getHeaders() >> new MockHttpHeaders([
+                    "Forwarded": ["host=\"[::1]\";proto=https"],
+            ])
+            getUri() >> new URI("http://localhost:8080")
+        }
+
+        when:
+        String host = hostResolver.resolve(request)
+
+        then:
+        host == "https://[::1]"
+
+        cleanup:
+        server.close()
+    }
+
+    void "test unbracketed IPv6 forwarded host falls back to URI host"() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer)
+        HttpHostResolver hostResolver = server.applicationContext.getBean(HttpHostResolver)
+        def request = Stub(HttpRequest) {
+            getHeaders() >> new MockHttpHeaders([
+                    "Forwarded": ["host=\"2001:db8::1\";proto=https"],
+            ])
+            getUri() >> new URI("http://localhost:8080")
+        }
+
+        when:
+        String host = hostResolver.resolve(request)
+
+        then:
+        host == "http://localhost:8080"
+
+        cleanup:
+        server.close()
+    }
+
     void "test host retrieved from x-forwarded"() {
         EmbeddedServer server = ApplicationContext.run(EmbeddedServer)
         HttpHostResolver hostResolver = server.applicationContext.getBean(HttpHostResolver)

--- a/http-server/src/main/java/io/micronaut/http/server/util/ProxyHeaderParser.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/ProxyHeaderParser.java
@@ -87,13 +87,7 @@ public class ProxyHeaderParser {
                                 } else if (key.equalsIgnoreCase(PROTO) && forwardedProto == null) {
                                     forwardedProto = value;
                                 } else if (key.equalsIgnoreCase(HOST) && forwardedHost == null) {
-                                    if (value.contains(":")) {
-                                        String[] host = value.split(":");
-                                        forwardedHost = host[0];
-                                        forwardedPort = Integer.valueOf(host[1]);
-                                    } else {
-                                        forwardedHost = value;
-                                    }
+                                    parseForwardedHost(value);
                                 }
                             }
                         }
@@ -159,6 +153,54 @@ public class ProxyHeaderParser {
     @Nullable
     public Integer getPort() {
         return forwardedPort;
+    }
+
+    private void parseForwardedHost(String value) {
+        if (value.startsWith("[")) {
+            int closingBracketIndex = value.indexOf(']');
+            if (closingBracketIndex == -1) {
+                return;
+            }
+            String host = value.substring(0, closingBracketIndex + 1);
+            if (closingBracketIndex == value.length() - 1) {
+                forwardedHost = host;
+                return;
+            }
+            if (value.charAt(closingBracketIndex + 1) == ':') {
+                Integer port = parsePort(value.substring(closingBracketIndex + 2));
+                if (port != null) {
+                    forwardedHost = host;
+                    forwardedPort = port;
+                }
+            }
+            return;
+        }
+        int portSeparatorIndex = value.lastIndexOf(':');
+        if (portSeparatorIndex == -1) {
+            forwardedHost = value;
+            return;
+        }
+        if (value.indexOf(':') != portSeparatorIndex) {
+            return;
+        }
+        Integer port = parsePort(value.substring(portSeparatorIndex + 1));
+        if (port != null) {
+            forwardedHost = value.substring(0, portSeparatorIndex);
+            forwardedPort = port;
+        }
+    }
+
+    @Nullable
+    private Integer parsePort(String value) {
+        try {
+            int port = Integer.parseInt(value);
+            if (port >= 0 && port <= 65535) {
+                return port;
+            }
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+        return null;
     }
 
     private String trimQuotes(String value) {

--- a/http-server/src/main/java/io/micronaut/http/server/util/ProxyHeaderParser.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/ProxyHeaderParser.java
@@ -157,6 +157,7 @@ public class ProxyHeaderParser {
 
     private void parseForwardedHost(String value) {
         if (value.startsWith("[")) {
+            // IPv6
             int closingBracketIndex = value.indexOf(']');
             if (closingBracketIndex == -1) {
                 return;
@@ -164,29 +165,28 @@ public class ProxyHeaderParser {
             String host = value.substring(0, closingBracketIndex + 1);
             if (closingBracketIndex == value.length() - 1) {
                 forwardedHost = host;
-                return;
-            }
-            if (value.charAt(closingBracketIndex + 1) == ':') {
+            } else if (value.charAt(closingBracketIndex + 1) == ':') {
                 Integer port = parsePort(value.substring(closingBracketIndex + 2));
                 if (port != null) {
                     forwardedHost = host;
                     forwardedPort = port;
                 }
             }
-            return;
-        }
-        int portSeparatorIndex = value.lastIndexOf(':');
-        if (portSeparatorIndex == -1) {
-            forwardedHost = value;
-            return;
-        }
-        if (value.indexOf(':') != portSeparatorIndex) {
-            return;
-        }
-        Integer port = parsePort(value.substring(portSeparatorIndex + 1));
-        if (port != null) {
-            forwardedHost = value.substring(0, portSeparatorIndex);
-            forwardedPort = port;
+        } else {
+            // IPv4
+            int portSeparatorIndex = value.lastIndexOf(':');
+            if (portSeparatorIndex == -1) {
+                forwardedHost = value;
+                return;
+            }
+            if (value.indexOf(':') != portSeparatorIndex) {
+                return;
+            }
+            Integer port = parsePort(value.substring(portSeparatorIndex + 1));
+            if (port != null) {
+                forwardedHost = value.substring(0, portSeparatorIndex);
+                forwardedPort = port;
+            }
         }
     }
 
@@ -198,7 +198,7 @@ public class ProxyHeaderParser {
                 return port;
             }
         } catch (NumberFormatException ignored) {
-            return null;
+            // Fall through
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- parse RFC 7239 `Forwarded` `host=` values defensively instead of splitting on every colon
- ignore malformed forwarded host/port values so host resolution can fall back normally
- cover malformed ports and bracketed/unbracketed IPv6 forwarded hosts

## Verification
- `./gradlew :micronaut-http-server:compileJava -q -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew :micronaut-http-server-netty:test --tests io.micronaut.http.server.netty.util.DefaultHttpHostSpec -q -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew :micronaut-http-server:test --tests io.micronaut.http.server.util.DefaultHttpHostResolverSpec -q -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew :micronaut-http-server:spotlessCheck :micronaut-http-server-netty:spotlessCheck -q -x japiCmp -x checkVersionCatalogCompatibility`
- `git diff --check`

Resolves #12687