### PR TITLE
Fix IllegalArgumentException synthesizing bootstrap-loaded annotations (e.g. @Deprecated)

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -471,7 +471,14 @@ public final class AnnotationMetadataSupport {
     @SuppressWarnings("unchecked")
     static Optional<Constructor<InvocationHandler>> getProxyClass(Class<? extends Annotation> annotation) {
         return ANNOTATION_PROXY_CACHE.computeIfAbsent(annotation, aClass -> {
-            Class proxyClass = Proxy.getProxyClass(annotation.getClassLoader(), annotation, AnnotationValueProvider.class);
+            // Annotations loaded by the bootstrap or platform classloader (e.g. java.lang.Deprecated)
+            // cannot see Micronaut's AnnotationValueProvider; in that case fall back to the loader of
+            // AnnotationValueProvider, which still resolves the JDK annotation via parent delegation.
+            ClassLoader annotationLoader = annotation.getClassLoader();
+            ClassLoader proxyLoader = (annotationLoader == null || annotationLoader == ClassLoader.getPlatformClassLoader())
+                ? AnnotationValueProvider.class.getClassLoader()
+                : annotationLoader;
+            Class proxyClass = Proxy.getProxyClass(proxyLoader, annotation, AnnotationValueProvider.class);
             return ReflectionUtils.findConstructor(proxyClass, InvocationHandler.class);
         });
     }

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
@@ -47,6 +47,20 @@ class AnnotationMetadataSpec extends Specification {
         noExceptionThrown()
     }
 
+    void "test buildAnnotation works for bootstrap-loaded JDK annotations"() {
+        // Regression test for https://github.com/micronaut-projects/micronaut-jaxrs/issues/640
+        // java.lang.Deprecated is loaded by the bootstrap classloader (getClassLoader() == null).
+        // The proxy must implement both the annotation type and AnnotationValueProvider, so the
+        // chosen classloader has to be able to see AnnotationValueProvider.
+        when:
+        Deprecated deprecated = AnnotationMetadataSupport.buildAnnotation(Deprecated, null)
+
+        then:
+        noExceptionThrown()
+        deprecated != null
+        deprecated.annotationType() == Deprecated
+    }
+
     AnnotationMetadata newMetadata(AnnotationValueBuilder... builders) {
 
         def values = builders.collect({ it.build() })


### PR DESCRIPTION
## Summary

`AnnotationMetadataSupport.buildAnnotation` crashes with `IllegalArgumentException: io.micronaut.core.annotation.AnnotationValueProvider referenced from a method is not visible from class loader: null` for any annotation whose class is loaded by the bootstrap classloader (e.g. `java.lang.Deprecated`).

`getProxyClass` was calling `Proxy.getProxyClass(annotation.getClassLoader(), annotation, AnnotationValueProvider.class)`. For bootstrap-loaded annotations, `annotation.getClassLoader()` is `null`, and the bootstrap loader cannot see Micronaut's `AnnotationValueProvider` — so `Proxy.ensureVisible` rejects the second proxied interface.

This fix falls back to `AnnotationValueProvider.class.getClassLoader()` when the annotation's loader is the bootstrap (or platform) loader. That loader can see Micronaut classes and resolves the JDK annotation via parent delegation.

## Visible symptom

The failure surfaces through `micronaut-jaxrs-server` because `JaxRsContainerMessageBodyHandlerRegistry.findJaxRsBodyWriter` calls `type.getAnnotationMetadata().synthesizeAll()` on controller annotation metadata. Any `@Deprecated`-annotated `@Path` controller crashes on its first request:

```
java.lang.IllegalArgumentException: io.micronaut.core.annotation.AnnotationValueProvider referenced from a method is not visible from class loader: null
    at java.base/java.lang.reflect.Proxy$ProxyBuilder.ensureVisible(Proxy.java:881)
    ...
    at io.micronaut.inject.annotation.AnnotationMetadataSupport.lambda$getProxyClass$1(AnnotationMetadataSupport.java:474)
    ...
    at io.micronaut.jaxrs.common.JaxRsContainerMessageBodyHandlerRegistry.findJaxRsBodyWriter(...)
```

The fix lives in `micronaut-core` because any consumer that synthesizes a bootstrap-loaded annotation could hit it, not just JAX-RS.

- Bug report (with full trace and reproducer link): https://github.com/micronaut-projects/micronaut-jaxrs/issues/640
- Standalone runnable reproducer: https://github.com/szabelin/micronaut-jaxrs-deprecated-repro

## Change

`inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java` — `getProxyClass`:

```java
ClassLoader annotationLoader = annotation.getClassLoader();
ClassLoader proxyLoader = (annotationLoader == null || annotationLoader == ClassLoader.getPlatformClassLoader())
    ? AnnotationValueProvider.class.getClassLoader()
    : annotationLoader;
Class proxyClass = Proxy.getProxyClass(proxyLoader, annotation, AnnotationValueProvider.class);
```

## Test

Added a regression test in `AnnotationMetadataSpec` that calls `AnnotationMetadataSupport.buildAnnotation(Deprecated.class, null)` and asserts no exception. Verified locally that:

- With the fix → the new test passes; all 212 tests in `:micronaut-inject:test` pass.
- Without the fix (sanity-revert) → the new test fails with the exact `IllegalArgumentException` from the bug report.

## Branch

Targeting `4.10.x` per CONTRIBUTING.md. The same code exists on `master` so the fix likely applies there too; happy to forward-port if maintainers prefer.

## Test plan

- [x] `./gradlew :micronaut-inject:test` — all green (212 tests)
- [x] `./gradlew :micronaut-inject:spotlessCheck` — passes
- [x] Regression test sanity-checked: fails without the fix, passes with it
- [x] End-to-end repro from a JAX-RS-server app on `micronaut-jaxrs 4.10.0` + this fix → 200 OK (verified locally against the public reproducer linked above)
