### PR TITLE
Clean up NoSuchBeanException error message (closes #11320)

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -233,7 +233,7 @@ interface MyConfig {
 
         then:"we expect a bean resolution"
         def e = thrown(NoSuchBeanException)
-        e.message.contains("No bean of type [test.MyConfig\$ChildConfig] exists")
+        e.message.contains("No bean of type test.MyConfig\$ChildConfig exists")
 
         cleanup:
         context.close()

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/ConstructorDependencyFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/ConstructorDependencyFailureSpec.groovy
@@ -38,7 +38,7 @@ class ConstructorDependencyFailureSpec extends Specification {
         e.message.normalize() == """\
 Failed to inject value for parameter [propA] of class: io.micronaut.inject.failures.ConstructorDependencyFailureSpec\$MyClassB
 
-Message: No bean of type [io.micronaut.inject.failures.ConstructorDependencyFailureSpec\$MyClassA] exists.$space
+Message: No bean of type io.micronaut.inject.failures.ConstructorDependencyFailureSpec\$MyClassA exists.$space
 Path Taken:$space
 new i.m.i.f.C\$MyClassB(MyClassA propA)
 \\---> new i.m.i.f.C\$MyClassB([MyClassA propA])"""

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/FieldDependencyMissingFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/FieldDependencyMissingFailureSpec.groovy
@@ -38,7 +38,7 @@ class FieldDependencyMissingFailureSpec extends Specification {
         e.message.normalize() == """\
 Failed to inject value for field [propA] of class: io.micronaut.inject.failures.FieldDependencyMissingFailureSpec\$MyClassB
 
-Message: No bean of type [io.micronaut.inject.failures.FieldDependencyMissingFailureSpec\$MyClassA] exists.$space
+Message: No bean of type io.micronaut.inject.failures.FieldDependencyMissingFailureSpec\$MyClassA exists.$space
 Path Taken:$space
 new i.m.i.f.F\$MyClassB()
 \\---> i.m.i.f.F\$MyClassB#propA"""

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/NestedDependencyFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/NestedDependencyFailureSpec.groovy
@@ -39,7 +39,7 @@ class NestedDependencyFailureSpec extends Specification {
         e.message.normalize() == """\
 Failed to inject value for parameter [propD] of class: io.micronaut.inject.failures.NestedDependencyFailureSpec\$MyClassC
 
-Message: No bean of type [io.micronaut.inject.failures.NestedDependencyFailureSpec\$MyClassD] exists.$space
+Message: No bean of type io.micronaut.inject.failures.NestedDependencyFailureSpec\$MyClassD exists.$space
 Path Taken:$space
 new i.m.i.f.N\$MyClassB()
 \\---> i.m.i.f.N\$MyClassB#propA

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyDependencyMissingSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyDependencyMissingSpec.groovy
@@ -38,7 +38,7 @@ class PropertyDependencyMissingSpec  extends Specification {
         e.message.normalize() == """\
 Failed to inject value for parameter [propA] of method [setPropA] of class: io.micronaut.inject.failures.PropertyDependencyMissingSpec\$MyClassB
 
-Message: No bean of type [io.micronaut.inject.failures.PropertyDependencyMissingSpec\$MyClassA] exists.$space
+Message: No bean of type io.micronaut.inject.failures.PropertyDependencyMissingSpec\$MyClassA exists.$space
 Path Taken:$space
 new i.m.i.f.P\$MyClassB()
 \\---> i.m.i.f.P\$MyClassB#setPropA([MyClassA propA])"""

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -250,7 +250,7 @@ interface MyConfig {
 
         then:"we expect a bean resolution"
         def e = thrown(NoSuchBeanException)
-        e.message.contains("No bean of type [test.MyConfig\$ChildConfig] exists")
+        e.message.contains("No bean of type test.MyConfig\$ChildConfig exists")
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/nesting/EachPropertyNestingSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/nesting/EachPropertyNestingSpec.groovy
@@ -129,9 +129,9 @@ class ClassOuterConfig {
         then:
         def e = thrown(NoSuchBeanException)
         def lines = e.message.lines().toList()
-        lines[0] == 'No bean of type [test.ClassOuterConfig$ClassInnerConfig$ClassInnerEachConfig] exists for the given qualifier: @Named(\'foo-bar\'). '
-        lines[1] == '* [ClassInnerEachConfig] is disabled because:'
-        lines[2] == ' - Configuration requires entries under the prefix: [test.*.inner.inners.*]'
+        lines[0] == 'No bean of type test.ClassOuterConfig$ClassInnerConfig$ClassInnerEachConfig exists for the given qualifier: @Named(\'foo-bar\'). '
+        lines[1] == '* ClassInnerEachConfig is disabled because:'
+        lines[2] == ' - Configuration requires entries under the prefix: test.*.inner.inners.*'
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanCompileSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanCompileSpec.groovy
@@ -51,8 +51,8 @@ class RequiresProperty {
         then:
         NoSuchBeanException e = thrown()
         def list = e.message.readLines().toList()
-        list[0] == 'No bean of type [io.micronaut.inject.configurations.requiresproperty.RequiresProperty] exists. '
-        list[1] == '* [RequiresProperty] is disabled because it is within the package [io.micronaut.inject.configurations.requiresproperty] which is disabled due to bean requirements: '
+        list[0] == 'No bean of type io.micronaut.inject.configurations.requiresproperty.RequiresProperty exists. '
+        list[1] == '* RequiresProperty is disabled because it is within the package io.micronaut.inject.configurations.requiresproperty which is disabled due to bean requirements: '
         list[2] == ' - Required property [data-source.url] not present'
 
         cleanup:

--- a/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanSpec.groovy
@@ -119,8 +119,8 @@ class RequiresBeanSpec extends Specification {
         then:
         NoSuchBeanException e = thrown()
         def list = e.message.readLines().toList()
-        list[0] == 'No bean of type [io.micronaut.inject.configurations.requiresproperty.RequiresProperty] exists. '
-        list[1] == '* [RequiresProperty] is disabled because it is within the package [io.micronaut.inject.configurations.requiresproperty] which is disabled due to bean requirements: '
+        list[0] == 'No bean of type io.micronaut.inject.configurations.requiresproperty.RequiresProperty exists. '
+        list[1] == '* RequiresProperty is disabled because it is within the package io.micronaut.inject.configurations.requiresproperty which is disabled due to bean requirements: '
         list[2] == ' - Required property [data-source.url] not present'
 
         cleanup:

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/generics/GenericFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/generics/GenericFactorySpec.groovy
@@ -112,7 +112,7 @@ class CacheImpl implements Cache {
 
         then:
         def e  = thrown(DependencyInjectionException)
-        e.message.contains("No bean of type [genfact.Cache<java.lang.Boolean,java.lang.Integer>] exists")
+        e.message.contains("No bean of type genfact.Cache<java.lang.Boolean,java.lang.Integer> exists")
 
         cleanup:
         context.close()
@@ -185,7 +185,7 @@ class CacheImpl implements Cache {
 
         then:
         def e  = thrown(DependencyInjectionException)
-        e.message.contains("No bean of type [genfact.Cache<java.lang.Boolean,java.lang.Integer>] exists")
+        e.message.contains("No bean of type genfact.Cache<java.lang.Boolean,java.lang.Integer> exists")
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/ctordependencyfailure/ConstructorDependencyFailureSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/ctordependencyfailure/ConstructorDependencyFailureSpec.groovy
@@ -34,7 +34,7 @@ class ConstructorDependencyFailureSpec extends Specification {
         e.message.normalize() == """\
 Failed to inject value for parameter [propA] of class: io.micronaut.inject.failures.ctordependencyfailure.MyClassB
 
-Message: No bean of type [io.micronaut.inject.failures.ctordependencyfailure.MyClassA] exists.$space
+Message: No bean of type io.micronaut.inject.failures.ctordependencyfailure.MyClassA exists.$space
 Path Taken:$space
 new i.m.i.f.c.MyClassB(MyClassA propA)
 \\---> new i.m.i.f.c.MyClassB([MyClassA propA])"""

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/fielddependencymissing/FieldDependencyMissingFailureSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/fielddependencymissing/FieldDependencyMissingFailureSpec.groovy
@@ -35,7 +35,7 @@ class FieldDependencyMissingFailureSpec extends Specification {
         e.message.normalize() == """\
 Failed to inject value for field [propA] of class: io.micronaut.inject.failures.fielddependencymissing.MyClassB
 
-Message: No bean of type [io.micronaut.inject.failures.fielddependencymissing.MyClassA] exists.$space
+Message: No bean of type io.micronaut.inject.failures.fielddependencymissing.MyClassA exists.$space
 Path Taken:$space
 new i.m.i.f.f.MyClassB()
 \\---> i.m.i.f.f.MyClassB#propA"""

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/nesteddependency/NestedDependencyFailureSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/nesteddependency/NestedDependencyFailureSpec.groovy
@@ -35,7 +35,7 @@ class NestedDependencyFailureSpec extends Specification {
         e.message.normalize() == """\
 Failed to inject value for parameter [propD] of class: io.micronaut.inject.failures.nesteddependency.MyClassC
 
-Message: No bean of type [io.micronaut.inject.failures.nesteddependency.MyClassD] exists.$space
+Message: No bean of type io.micronaut.inject.failures.nesteddependency.MyClassD exists.$space
 Path Taken:$space
 new i.m.i.f.n.MyClassB()
 \\---> i.m.i.f.n.MyClassB#propA

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
@@ -41,9 +41,9 @@ class EachPropertySpec extends Specification {
         then:
         def error = thrown(NoSuchBeanException)
         def lines = error.message.lines().toList()
-        lines[0] == "No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists. "
-        lines[1] == "* [MyConfiguration] is disabled because:"
-        lines[2] == " - Configuration requires entries under the prefix: [foo.bar.*]"
+        lines[0] == "No bean of type io.micronaut.inject.foreach.MyConfiguration exists. "
+        lines[1] == "* MyConfiguration is disabled because:"
+        lines[2] == " - Configuration requires entries under the prefix: foo.bar.*"
 
         when:
         context.getBean(MyConfiguration, Qualifiers.byName("baz"))
@@ -51,9 +51,9 @@ class EachPropertySpec extends Specification {
         then:
         error = thrown(NoSuchBeanException)
         def lines2 = error.message.lines().toList()
-        lines2[0] == "No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists for the given qualifier: @Named('baz'). "
-        lines2[1] == "* [MyConfiguration] is disabled because:"
-        lines2[2] == " - Configuration requires entries under the prefix: [foo.bar.baz]"
+        lines2[0] == "No bean of type io.micronaut.inject.foreach.MyConfiguration exists for the given qualifier: @Named('baz'). "
+        lines2[1] == "* MyConfiguration is disabled because:"
+        lines2[2] == " - Configuration requires entries under the prefix: foo.bar.baz"
 
         cleanup:
         context.close()
@@ -69,10 +69,10 @@ class EachPropertySpec extends Specification {
         then:
         def error = thrown(NoSuchBeanException)
         def lines = error.message.lines().toList()
-        lines[0] == "No bean of type [io.micronaut.inject.foreach.MyBean] exists. "
-        lines[1] == "* [MyBean] requires the presence of a bean of type [io.micronaut.inject.foreach.MyConfiguration]."
-        lines[2] == " * [MyConfiguration] is disabled because:"
-        lines[3] == "  - Configuration requires entries under the prefix: [foo.bar.*]"
+        lines[0] == "No bean of type io.micronaut.inject.foreach.MyBean exists. "
+        lines[1] == "* MyBean requires the presence of a bean of type io.micronaut.inject.foreach.MyConfiguration."
+        lines[2] == " * MyConfiguration is disabled because:"
+        lines[3] == "  - Configuration requires entries under the prefix: foo.bar.*"
 
         when:
         context.getBean(C.class, Qualifiers.byName("test"))
@@ -80,11 +80,11 @@ class EachPropertySpec extends Specification {
         then:
         error = thrown(NoSuchBeanException)
         def lines2 = error.message.lines().toList()
-        lines2[0] == "No bean of type [io.micronaut.inject.foreach.nested.C] exists for the given qualifier: @Named('test'). "
-        lines2[1] == "* [C] requires the presence of a bean of type [io.micronaut.inject.foreach.nested.B] with qualifier [@Named('test')]."
-        lines2[2] == " * [B] requires the presence of a bean of type [io.micronaut.inject.foreach.nested.A] with qualifier [@Named('test')]."
-        lines2[3] == "  * [A] is disabled because:"
-        lines2[4] == "   - Configuration requires entries under the prefix: [foo.test]"
+        lines2[0] == "No bean of type io.micronaut.inject.foreach.nested.C exists for the given qualifier: @Named('test'). "
+        lines2[1] == "* C requires the presence of a bean of type io.micronaut.inject.foreach.nested.B with qualifier @Named('test')."
+        lines2[2] == " * B requires the presence of a bean of type io.micronaut.inject.foreach.nested.A with qualifier @Named('test')."
+        lines2[3] == "  * A is disabled because:"
+        lines2[4] == "   - Configuration requires entries under the prefix: foo.test"
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/provider/DisableErrorOnMissingBeanProviderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/provider/DisableErrorOnMissingBeanProviderSpec.groovy
@@ -73,7 +73,7 @@ class Test {
 
         then:
         def e = thrown(NoSuchBeanException)
-        e.message.contains("No bean of type [java.lang.String] exists for the given qualifier: @MyQualifier")
+        e.message.contains("No bean of type java.lang.String exists for the given qualifier: @MyQualifier")
 
         cleanup:
         context.close()
@@ -113,7 +113,7 @@ class Test {
 
         then:
         def e = thrown(NoSuchBeanException)
-        e.message.contains("No bean of type [java.lang.String] exists for the given qualifier: @MyQualifier")
+        e.message.contains("No bean of type java.lang.String exists for the given qualifier: @MyQualifier")
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/provider/ProviderNamedInjectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/provider/ProviderNamedInjectionSpec.groovy
@@ -47,7 +47,7 @@ class ProviderNamedInjectionSpec extends Specification {
 
         then:
         def ex = thrown(BeanInstantiationException)
-        ex.cause.message.contains("No bean of type [io.micronaut.inject.provider.NotABean] exists for the given qualifier")
+        ex.cause.message.contains("No bean of type io.micronaut.inject.provider.NotABean exists for the given qualifier")
 
         cleanup:
         ctx.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/requires/RequiresSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/requires/RequiresSpec.groovy
@@ -40,10 +40,10 @@ class MyBean {
         then:
             def e = thrown(NoSuchBeanException)
             def lines = e.message.readLines()
-            lines[0] == "No bean of type [test.MyBean] exists. "
-            lines[1] == "* [MyBean] requires the presence of a bean of type [test.MyClient]."
-            lines[2] == " * [MyClient] requires the presence of a bean of type [test.MyConfiguration]."
-            lines[3] == "  * [MyConfiguration] is disabled because:"
+            lines[0] == "No bean of type test.MyBean exists. "
+            lines[1] == "* MyBean requires the presence of a bean of type test.MyClient."
+            lines[2] == " * MyClient requires the presence of a bean of type test.MyConfiguration."
+            lines[3] == "  * MyConfiguration is disabled because:"
             lines[4] == "   - Required property [myconf] not present"
         cleanup:
             context.close()
@@ -83,12 +83,12 @@ class MyBean {
         then:
             def e = thrown(NoSuchBeanException)
             def lines = e.message.readLines()
-            lines[0] == "No bean of type [test.MyBean] exists. "
-            lines[1] == "* [MyBean] requires the presence of a bean of type [test.MyClient]."
-            lines[2] == " * [MyClient] requires the presence of a bean of type [test.MyConfiguration]."
-            lines[3] == "  * [MyMultiConfiguration] a candidate of [MyConfiguration] is disabled because:"
-            lines[4] == "   - Configuration requires entries under the prefix: [myconf2.multiple.default]"
-            lines[5] == "  * [MyDefaultConfiguration] a candidate of [MyConfiguration] is disabled because:"
+            lines[0] == "No bean of type test.MyBean exists. "
+            lines[1] == "* MyBean requires the presence of a bean of type test.MyClient."
+            lines[2] == " * MyClient requires the presence of a bean of type test.MyConfiguration."
+            lines[3] == "  * MyMultiConfiguration, a candidate of MyConfiguration, is disabled because:"
+            lines[4] == "   - Configuration requires entries under the prefix: myconf2.multiple.default"
+            lines[5] == "  * MyDefaultConfiguration, a candidate of MyConfiguration, is disabled because:"
             lines[6] == "   - Required property [myconf] not present"
             lines.size() == 7
         cleanup:
@@ -136,14 +136,14 @@ class MyBean {
         then:
             def e = thrown(NoSuchBeanException)
             def lines = e.message.readLines()
-            lines[0] == "No bean of type [test.MyBean] exists. "
-            lines[1] == "* [MyBean] requires the presence of a bean of type [test.MyClient]."
-            lines[2] == " * [MyClient] requires the presence of a bean of type [test.MyConfiguration]."
-            lines[3] == "  * [MyDefaultConfiguration] a candidate of [MyConfiguration] is disabled because:"
+            lines[0] == "No bean of type test.MyBean exists. "
+            lines[1] == "* MyBean requires the presence of a bean of type test.MyClient."
+            lines[2] == " * MyClient requires the presence of a bean of type test.MyConfiguration."
+            lines[3] == "  * MyDefaultConfiguration, a candidate of MyConfiguration, is disabled because:"
             lines[4] == "   - Required property [myconf] not present"
-            lines[5] == "  * [MyMultiConfiguration] a candidate of [MyConfiguration] is disabled because:"
-            lines[6] == "   - No bean of type [test.MyHelper] present within context"
-            lines[7] == "   * [MyHelper] is disabled because:"
+            lines[5] == "  * MyMultiConfiguration, a candidate of MyConfiguration, is disabled because:"
+            lines[6] == "   - No bean of type test.MyHelper present within context"
+            lines[7] == "   * MyHelper is disabled because:"
             lines[8] == "    - Required property [myconf.helper] not present"
 
             lines.size() == 9
@@ -188,8 +188,8 @@ class MyBean {
         then:
         def e = thrown(NoSuchBeanException)
         def lines = e.message.readLines()
-        lines[0] == 'No bean of type [test.MyBean] exists. '
-        lines[1] == '* [MyBean] is disabled because:'
+        lines[0] == 'No bean of type test.MyBean exists. '
+        lines[1] == '* MyBean is disabled because:'
         lines[2] == " - Java major version [${Runtime.version().feature()}] must be at least 800"
 
         cleanup:
@@ -215,8 +215,8 @@ class MyBean {
         then:
         def e = thrown(NoSuchBeanException)
         def lines = e.message.readLines()
-        lines[0] == 'No bean of type [test.MyBean] exists. '
-        lines[1] == '* [MyBean] is disabled because:'
+        lines[0] == 'No bean of type test.MyBean exists. '
+        lines[1] == '* MyBean is disabled because:'
         lines[2] == ' - Required property [foo] with value [bar] not present'
 
         cleanup:

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
@@ -103,8 +103,8 @@ class ExampleTest(private val application: EmbeddedApplication<*>): StringSpec({
         then:
         def e = thrown(NoSuchBeanException)
         def lines = e.message.lines().toList()
-        lines[0] == 'No bean of type [test.ExampleTest] exists. '
-        lines[1] == '* [ExampleTest] is disabled because:'
+        lines[0] == 'No bean of type test.ExampleTest exists. '
+        lines[1] == '* ExampleTest is disabled because:'
         lines[2] == ' - Custom condition [class io.micronaut.test.condition.TestActiveCondition] failed evaluation'
     }
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -233,7 +233,7 @@ interface MyConfig {
 
         then:"we expect a bean resolution"
         def e = thrown(NoSuchBeanException)
-        e.message.contains("No bean of type [test.MyConfig\$ChildConfig] exists")
+        e.message.contains("No bean of type test.MyConfig\$ChildConfig exists")
 
         cleanup:
         context.close()

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -376,12 +376,11 @@ public class DefaultApplicationContext extends DefaultBeanContext implements Con
         messageBuilder
             .append(lineSeparator)
             .append(linePrefix)
-            .append("* [").append(beanType.getTypeString(true))
-            .append("] requires the presence of a bean of type [")
-            .append(dependentBean.getName())
-            .append("]");
+            .append("* ").append(beanType.getTypeString(true))
+            .append(" requires the presence of a bean of type ")
+            .append(dependentBean.getName());
         if (qualifier != null) {
-            messageBuilder.append(" with qualifier [").append(qualifier).append("]");
+            messageBuilder.append(" with qualifier ").append(qualifier);
         }
         messageBuilder.append(".");
 
@@ -436,20 +435,20 @@ public class DefaultApplicationContext extends DefaultBeanContext implements Con
         messageBuilder
             .append(lineSeparator)
             .append(linePrefix)
-            .append("* [")
-            .append(definition.asArgument().getTypeString(true));
+            .append("* ")
+            .append(definition.getBeanType().getSimpleName());
         if (!definition.getBeanType().equals(beanType.getType())) {
-            messageBuilder.append("] a candidate of [")
-                .append(beanType.getTypeString(true));
+            messageBuilder.append(", a candidate of ")
+                .append(beanType.getTypeString(true))
+                .append(",");
         }
-        messageBuilder.append("] is disabled because:")
+        messageBuilder.append(" is disabled because:")
             .append(lineSeparator);
         messageBuilder
             .append(linePrefix)
             .append(" - ")
-            .append("Configuration requires entries under the prefix: [")
-            .append(prefix)
-            .append("]");
+            .append("Configuration requires entries under the prefix: ")
+            .append(prefix);
     }
 
     private <T> String calculatePrefix(BeanResolutionContext resolutionContext, Qualifier<T> qualifier, BeanDefinition<?> definition) {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2857,11 +2857,11 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
             if (beanType.getTypeName().startsWith(pkg + ".")) {
                 messageBuilder.append(lineSeparator)
                     .append(linePrefix)
-                    .append("* [")
+                    .append("* ")
                     .append(beanType.getTypeString(true))
-                    .append("] is disabled because it is within the package [")
+                    .append(" is disabled because it is within the package ")
                     .append(pkg)
-                    .append("] which is disabled due to bean requirements: ")
+                    .append(" which is disabled due to bean requirements: ")
                     .append(lineSeparator);
                 for (String failure : entry.getValue()) {
                     messageBuilder
@@ -2893,12 +2893,13 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
                 messageBuilder
                     .append(lineSeparator)
                     .append(linePrefix)
-                    .append("* [").append(beanDefinition.asArgument().getTypeString(true));
+                    .append("* ").append(beanDefinition.getBeanType().getSimpleName());
                 if (!beanDefinition.getBeanType().equals(beanType.getType())) {
-                    messageBuilder.append("] a candidate of [")
-                        .append(beanType.getTypeString(true));
+                    messageBuilder.append(", a candidate of ")
+                        .append(beanType.getTypeString(true))
+                        .append(",");
                 }
-                messageBuilder.append("] is disabled because:")
+                messageBuilder.append(" is disabled because:")
                     .append(lineSeparator);
                 if (beanDefinition instanceof DisabledBean<T> disabledBean) {
                     for (String failure : disabledBean.reasons()) {
@@ -2907,9 +2908,11 @@ public class DefaultBeanContext implements InitializableBeanContext, Configurabl
                             .append(" - ")
                             .append(failure)
                             .append(lineSeparator);
-                        String prefix = "No bean of type [";
-                        if (failure.startsWith(prefix)) {
-                            ClassUtils.forName(failure.substring(prefix.length(), failure.indexOf("]")), classLoader)
+                        String prefix = "No bean of type ";
+                        String suffix = " present within context";
+                        if (failure.startsWith(prefix) && failure.endsWith(suffix)) {
+                            String className = failure.substring(prefix.length(), failure.length() - suffix.length());
+                            ClassUtils.forName(className, classLoader)
                                 .ifPresent(beanClass -> {
                                     messageBuilder.setLength(messageBuilder.length() - lineSeparator.length());
                                     resolveDisabledBeanMessage(linePrefix + " ",

--- a/inject/src/main/java/io/micronaut/context/conditions/MatchesAbsenceOfBeansCondition.java
+++ b/inject/src/main/java/io/micronaut/context/conditions/MatchesAbsenceOfBeansCondition.java
@@ -58,7 +58,7 @@ public record MatchesAbsenceOfBeansCondition(AnnotationClassValue<?>[] missingBe
                 );
                 for (BeanDefinition<?> beanDefinition : beanDefinitions) {
                     if (!beanDefinition.isAbstract()) {
-                        context.fail("Existing bean [" + beanDefinition.getName() + "] of type [" + type.getName() + "] registered in context");
+                        context.fail("Existing bean " + beanDefinition.getName() + " of type " + type.getName() + " registered in context");
                         return false;
                     }
                 }

--- a/inject/src/main/java/io/micronaut/context/conditions/MatchesAbsenceOfClassNamesCondition.java
+++ b/inject/src/main/java/io/micronaut/context/conditions/MatchesAbsenceOfClassNamesCondition.java
@@ -39,7 +39,7 @@ public record MatchesAbsenceOfClassNamesCondition(String[] classes) implements C
         final ClassLoader classLoader = context.getBeanContext().getClassLoader();
         for (String name : classes) {
             if (ClassUtils.isPresent(name, classLoader)) {
-                context.fail("Class [" + name + "] is not absent");
+                context.fail("Class " + name + " is not absent");
                 return false;
             }
         }

--- a/inject/src/main/java/io/micronaut/context/conditions/MatchesAbsenceOfClassesCondition.java
+++ b/inject/src/main/java/io/micronaut/context/conditions/MatchesAbsenceOfClassesCondition.java
@@ -38,7 +38,7 @@ public record MatchesAbsenceOfClassesCondition(AnnotationClassValue<?>[] classes
     public boolean matches(ConditionContext context) {
         for (AnnotationClassValue<?> classValue : classes) {
             if (classValue.getType().isPresent()) {
-                context.fail("Class [" + classValue.getName() + "] is not absent");
+                context.fail("Class " + classValue.getName() + " is not absent");
                 return false;
             }
         }

--- a/inject/src/main/java/io/micronaut/context/conditions/MatchesPresenceOfBeansCondition.java
+++ b/inject/src/main/java/io/micronaut/context/conditions/MatchesPresenceOfBeansCondition.java
@@ -43,7 +43,7 @@ public record MatchesPresenceOfBeansCondition(
         for (AnnotationClassValue<?> bean : beans) {
             Class<?> type = bean.getType().orElse(null);
             if (type == null || !beanContext.containsBean(type)) {
-                context.fail("No bean of type [" + bean.getName() + "] present within context");
+                context.fail("No bean of type " + bean.getName() + " present within context");
                 return false;
             }
         }

--- a/inject/src/main/java/io/micronaut/context/conditions/MatchesPresenceOfClassesCondition.java
+++ b/inject/src/main/java/io/micronaut/context/conditions/MatchesPresenceOfClassesCondition.java
@@ -39,7 +39,7 @@ public record MatchesPresenceOfClassesCondition(
     public boolean matches(ConditionContext context) {
         for (AnnotationClassValue<?> classValue : classes) {
             if (classValue.getType().isEmpty()) {
-                context.fail("Class [" + classValue.getName() + "] is not present");
+                context.fail("Class " + classValue.getName() + " is not present");
                 return false;
             }
         }

--- a/inject/src/main/java/io/micronaut/context/exceptions/NoSuchBeanException.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/NoSuchBeanException.java
@@ -28,9 +28,9 @@ import io.micronaut.core.type.Argument;
  */
 public class NoSuchBeanException extends BeanContextException {
 
-    private static final String MESSAGE_PREFIX = "No bean of type [";
-    private static final String MESSAGE_SUFFIX = "] exists.";
-    private static final String MESSAGE_EXISTS = "] exists";
+    private static final String MESSAGE_PREFIX = "No bean of type ";
+    private static final String MESSAGE_SUFFIX = " exists.";
+    private static final String MESSAGE_EXISTS = " exists";
     private static final String MESSAGE_FOR_THE_GIVEN_QUALIFIER = " for the given qualifier: ";
 
     /**

--- a/inject/src/test/groovy/io/micronaut/context/MultipleMatchingNoSuchBeanSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/MultipleMatchingNoSuchBeanSpec.groovy
@@ -20,11 +20,11 @@ class MultipleMatchingNoSuchBeanSpec extends Specification {
 
         then:
         def ex = thrown(NoSuchBeanException)
-        ex.message.contains '''* [MyInterface] requires the presence of a bean of type [io.micronaut.context.MultipleMatchingNoSuchBeanSpec$BeanBConfig].
-                              | * [BeanBConfig] is disabled because:
+        ex.message.contains '''* MyInterface requires the presence of a bean of type io.micronaut.context.MultipleMatchingNoSuchBeanSpec$BeanBConfig.
+                              | * BeanBConfig is disabled because:
                               |  - Required property [excluded] with value [so ignored] not present'''.stripMargin()
-        ex.message.contains '''* [MyInterface] requires the presence of a bean of type [io.micronaut.context.MultipleMatchingNoSuchBeanSpec$BeanAConfig].
-                              | * [BeanAConfig] is disabled because:
+        ex.message.contains '''* MyInterface requires the presence of a bean of type io.micronaut.context.MultipleMatchingNoSuchBeanSpec$BeanAConfig.
+                              | * BeanAConfig is disabled because:
                               |  - Required property [excluded] with value [so ignored] not present'''.stripMargin()
 
         cleanup:

--- a/inject/src/test/groovy/io/micronaut/context/NoSuchBeanMessageFormatSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/NoSuchBeanMessageFormatSpec.groovy
@@ -1,0 +1,50 @@
+package io.micronaut.context
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.exceptions.NoSuchBeanException
+import jakarta.inject.Singleton
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue("https://github.com/micronaut-projects/micronaut-core/issues/11320")
+class NoSuchBeanMessageFormatSpec extends Specification {
+
+    void "NoSuchBeanException top line has no surrounding brackets"() {
+        expect:
+        new NoSuchBeanException(MyBean).message.startsWith(
+                "No bean of type io.micronaut.context.NoSuchBeanMessageFormatSpec\$MyBean exists.")
+    }
+
+    void "disabled bean candidates and their failure reasons are listed without brackets"() {
+        given:
+        def ctx = ApplicationContext.run('spec.name': 'NoSuchBeanMessageFormatSpec')
+
+        when:
+        ctx.getBean(MyBean)
+
+        then:
+        def ex = thrown(NoSuchBeanException)
+
+        and: "the candidate is listed by its user-facing simple name, not a generated proxy class name"
+        ex.message.contains("* MyBean is disabled because:")
+        !ex.message.contains("[MyBean]")
+        !ex.message.contains('$Definition')
+        !ex.message.contains('$Intercepted')
+
+        and: "the failure reason from a bean-presence requirement has no brackets"
+        ex.message.contains(
+                "- No bean of type io.micronaut.context.NoSuchBeanMessageFormatSpec\$RequiredBean present within context")
+        !ex.message.contains(
+                "- No bean of type [io.micronaut.context.NoSuchBeanMessageFormatSpec\$RequiredBean] present within context")
+
+        cleanup:
+        ctx.close()
+    }
+
+    static interface RequiredBean {}
+
+    @Singleton
+    @Requires(property = "spec.name", value = "NoSuchBeanMessageFormatSpec")
+    @Requires(beans = RequiredBean)
+    static class MyBean {}
+}

--- a/test-inject-kotlin2-ksp2/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
+++ b/test-inject-kotlin2-ksp2/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
@@ -103,8 +103,8 @@ class ExampleTest(private val application: EmbeddedApplication<*>): StringSpec({
         then:
         def e = thrown(NoSuchBeanException)
         def lines = e.message.lines().toList()
-        lines[0] == 'No bean of type [test.ExampleTest] exists. '
-        lines[1] == '* [ExampleTest] is disabled because:'
+        lines[0] == 'No bean of type test.ExampleTest exists. '
+        lines[1] == '* ExampleTest is disabled because:'
         lines[2] == ' - Custom condition [class io.micronaut.test.condition.TestActiveCondition] failed evaluation'
     }
 

--- a/test-inject-kotlin2-ksp2/src/test/groovy/io/micronaut/kotlin/processing/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/test-inject-kotlin2-ksp2/src/test/groovy/io/micronaut/kotlin/processing/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -233,7 +233,7 @@ interface MyConfig {
 
         then:"we expect a bean resolution"
         def e = thrown(NoSuchBeanException)
-        e.message.contains("No bean of type [test.MyConfig\$ChildConfig] exists")
+        e.message.contains("No bean of type test.MyConfig\$ChildConfig exists")
 
         cleanup:
         context.close()


### PR DESCRIPTION
Closes #11320.

## Summary

Cleans up the `NoSuchBeanException` error message so it no longer wraps bean type names and class identifiers in `[…]`, and resolves generated proxy class names (`$Foo$Definition$Intercepted`) back to the user-facing simple type.

**Before:**
```
NoSuchBeanException: No bean of type [Foo] exists.
* [$FooImpl$Definition$Intercepted] a candidate of [Foo] is disabled because:
 - Class [Bar] is not present
```

**After:**
```
NoSuchBeanException: No bean of type Foo exists.
* FooImpl, a candidate of Foo, is disabled because:
 - Class Bar is not present
```

## Production changes

- `NoSuchBeanException` — drop the `[`/`]` characters from the message constants used in the top line.
- `DefaultBeanContext.resolveDisabledBeanMessage` and `DefaultApplicationContext.appendEachPropertyMissingBeanMessage` / `appendMissingEachBeanMessage`:
  - Strip the `[`/`]` decoration around bean type names.
  - Render the candidate label using `beanDefinition.getBeanType().getSimpleName()` instead of `beanDefinition.asArgument().getTypeString(true)`, so intercepted/AOP-proxied beans show up as the user-facing type (`FooImpl`) rather than the generated proxy class name (`$FooImpl$Definition$Intercepted`).
  - Use commas around `, a candidate of <type>,` so the line reads naturally.
- The recursive parser that walks transitive `No bean of type … present within context` failures is updated to match the new bracketless format, so the nested-failure tree still works.
- Conditions that emit failure reasons containing a single identifier drop the `[]` decoration: `MatchesPresenceOfClassesCondition`, `MatchesAbsenceOfClassesCondition`, `MatchesAbsenceOfClassNamesCondition`, `MatchesPresenceOfBeansCondition`, `MatchesAbsenceOfBeansCondition`.

### Scope note

Other condition classes that embed *values* (not just identifiers) in their failure reasons — `MatchesPropertyCondition`, `MatchesConfigurationCondition`, `MatchesEnvironmentCondition`, `MatchesCurrentOsCondition`, `MatchesSdkCondition`, etc. — keep their bracket formatting in this PR. The brackets there serve as light value delimiters (`Property [foo] with value [bar baz]`), so the trade-off is different from a single class name. Happy to extend the cleanup in a follow-up if maintainers prefer.

## Tests

- New focused spec `NoSuchBeanMessageFormatSpec` (tagged with `@Issue` for #11320) that asserts the issue scenario directly:
  - top line has no surrounding brackets
  - candidate label has no `[]`, no `$Definition`, no `$Intercepted`
  - `Class … is not present` condition reason has no `[]`
- Existing tests across `inject`, `inject-java`, `inject-groovy`, `inject-kotlin`, and `test-inject-kotlin2-ksp2` that asserted on the old bracket-decorated message format are updated to the new format. The semantic content of the assertions is unchanged — only the bracket / generated-name decoration was updated.

## Test plan

- [x] `./gradlew :micronaut-inject:test` — all green (212 tests, including the new spec)
- [x] `./gradlew :micronaut-inject-java:test` — all green (4760 tests)
- [x] `./gradlew :micronaut-inject-groovy:test` — all green
- [x] `./gradlew :micronaut-inject-kotlin:test` — all green
- [x] Repo-wide grep confirms no remaining occurrences of `No bean of type [`, `a candidate of [`, `requires the presence of a bean of type [`, `Class [.] is not present`, `Class [.] is not absent`, `No bean of type [.] present within context`, `Existing bean [`, or `Configuration requires entries under the prefix: [` outside of the new spec's negative-assertion lines

## Branch

Targeting `4.10.x` per CONTRIBUTING.md. Code is identical on `master` so a forward-port is mechanical; happy to do it if maintainers prefer.
