### PR TITLE
Forward-port #12692: fix IllegalArgumentException synthesizing bootstrap-loaded annotations

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -473,7 +473,14 @@ public final class AnnotationMetadataSupport {
     @SuppressWarnings("unchecked")
     static Optional<Constructor<InvocationHandler>> getProxyClass(Class<? extends Annotation> annotation) {
         return ANNOTATION_PROXY_CACHE.computeIfAbsent(annotation, aClass -> {
-            Class proxyClass = Proxy.getProxyClass(annotation.getClassLoader(), annotation, AnnotationValueProvider.class);
+            // Annotations loaded by the bootstrap or platform classloader (e.g. java.lang.Deprecated)
+            // cannot see Micronaut's AnnotationValueProvider; in that case fall back to the loader of
+            // AnnotationValueProvider, which still resolves the JDK annotation via parent delegation.
+            ClassLoader annotationLoader = annotation.getClassLoader();
+            ClassLoader proxyLoader = (annotationLoader == null || annotationLoader == ClassLoader.getPlatformClassLoader())
+                ? AnnotationValueProvider.class.getClassLoader()
+                : annotationLoader;
+            Class proxyClass = Proxy.getProxyClass(proxyLoader, annotation, AnnotationValueProvider.class);
             return ReflectionUtils.findConstructor(proxyClass, InvocationHandler.class);
         });
     }

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
@@ -47,6 +47,20 @@ class AnnotationMetadataSpec extends Specification {
         noExceptionThrown()
     }
 
+    void "test buildAnnotation works for bootstrap-loaded JDK annotations"() {
+        // Regression test for https://github.com/micronaut-projects/micronaut-jaxrs/issues/640
+        // java.lang.Deprecated is loaded by the bootstrap classloader (getClassLoader() == null).
+        // The proxy must implement both the annotation type and AnnotationValueProvider, so the
+        // chosen classloader has to be able to see AnnotationValueProvider.
+        when:
+        Deprecated deprecated = AnnotationMetadataSupport.buildAnnotation(Deprecated, null)
+
+        then:
+        noExceptionThrown()
+        deprecated != null
+        deprecated.annotationType() == Deprecated
+    }
+
     AnnotationMetadata newMetadata(AnnotationValueBuilder... builders) {
 
         def values = builders.collect({ it.build() })


### PR DESCRIPTION
Forward-port of #12692 (merged into `4.10.x` yesterday) onto `5.1.x`.

## Summary

Same fix as #12692 — the buggy code in `AnnotationMetadataSupport.getProxyClass` exists verbatim on `5.1.x`, so the same `IllegalArgumentException: AnnotationValueProvider referenced from a method is not visible from class loader: null` reproduces on `5.1.x` for any annotation loaded by the bootstrap classloader (e.g. `java.lang.Deprecated`).

Fall back to `AnnotationValueProvider.class.getClassLoader()` when the annotation's loader is the bootstrap (or platform) loader; that loader sees Micronaut classes and still resolves the JDK annotation via parent delegation.

## Diff

Two files, +22 / −1:
- `inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java` — same fix as #12692
- `inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy` — same regression test as #12692

## Test plan

- [x] On `4.10.x` (which has the identical buggy code), verified locally with JDK 21:
  - `:micronaut-inject:test` — green (212 tests, including the new regression spec)
  - Sanity-revert check: without the fix, the new test fails with the exact `IllegalArgumentException` from the bug report; with the fix, it passes.
- [ ] Local `5.1.x` build not attempted because the branch's build now requires JDK 25 preview features (`ScopedValue` etc.) which isn't installed on my machine. The patch is byte-identical to the merged 4.10.x version, so CI on this PR should validate.
- Original reproducer (a runnable Micronaut JAX-RS app pinned to versions that hit the bug): https://github.com/szabelin/micronaut-jaxrs-deprecated-repro

Closes part of the work in https://github.com/micronaut-projects/micronaut-jaxrs/issues/640.
