### PR TITLE
Update Micronaut 4 to netty to v4.2.15.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,8 +81,9 @@ managed-kotlin = "1.9.25"
 managed-kotlin2 = "2.1.21"
 managed-kotlin-coroutines = "1.8.1"
 managed-methvin-directory-watcher = "0.19.1"
-managed-netty = "4.2.13.Final"
-managed-netty-tcnative = "2.0.75.Final"
+
+managed-netty = "4.2.15.Final"
+managed-netty-tcnative = "2.0.77.Final"
 managed-netty-contrib-multipart = "1.0.0.Final"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -522,8 +522,9 @@ public final class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> imple
                 if (authority.isEmpty()) {
                     outboundHeaders.authority("");
                 } else {
+                    int start = authority.indexOf('@') + 1;
                     if (start == authority.length()) {
-                        throw new IllegalArgumentException("Invalid authority: missing host");
+                        throw new IllegalArgumentException("authority: " + authority);
                     }
                     outboundHeaders.authority(authority.subSequence(start, authority.length()));
                 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -522,9 +522,8 @@ public final class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> imple
                 if (authority.isEmpty()) {
                     outboundHeaders.authority("");
                 } else {
-                    int start = authority.indexOf('@') + 1;
                     if (start == authority.length()) {
-                        throw new IllegalArgumentException("authority: " + authority);
+                        throw new IllegalArgumentException("Invalid authority: missing host");
                     }
                     outboundHeaders.authority(authority.subSequence(start, authority.length()));
                 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -79,6 +79,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.DefaultHttp2PushPromiseFrame;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2FrameCodec;
@@ -482,11 +483,10 @@ public final class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> imple
                 throw new IllegalArgumentException("Request must have an absolute path");
             }
             String query = configuredUri.getQuery();
-            String fragment = configuredUri.getFragment();
 
-            URI fixedUri;
+            URI pathUri;
             try {
-                fixedUri = new URI(scheme, authority, path, query, fragment);
+                pathUri = new URI(null, null, path, query, null);
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException("Illegal URI", e);
             }
@@ -514,13 +514,22 @@ public final class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> imple
             }
 
             // request used to compute the headers for the PUSH_PROMISE frame
-            io.netty.handler.codec.http.HttpRequest outboundRequest = new DefaultHttpRequest(
-                inboundRequest.protocolVersion(),
-                inboundRequest.method(),
-                fixedUri.toString(),
-                inboundRequest.headers()
-            );
-            Http2Headers outboundHeaders = HttpConversionUtil.toHttp2Headers(outboundRequest, false);
+            Http2Headers outboundHeaders = new DefaultHttp2Headers(true, inboundRequest.headers().size() + 4);
+            outboundHeaders.method(inboundRequest.method().asciiName());
+            outboundHeaders.scheme(scheme);
+            outboundHeaders.path(pathUri.toString());
+            if (authority != null) {
+                if (authority.isEmpty()) {
+                    outboundHeaders.authority("");
+                } else {
+                    int start = authority.indexOf('@') + 1;
+                    if (start == authority.length()) {
+                        throw new IllegalArgumentException("authority: " + authority);
+                    }
+                    outboundHeaders.authority(authority.subSequence(start, authority.length()));
+                }
+            }
+            HttpConversionUtil.toHttp2Headers(inboundRequest.headers(), outboundHeaders);
 
             if (channelHandlerContext.channel() instanceof Http2StreamChannel streamChannel) {
                 int ourStream = streamChannel.stream().id();

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2ServerPushSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2ServerPushSpec.groovy
@@ -116,6 +116,43 @@ class Http2ServerPushSpec extends Specification {
         runner.responses.forEach(FullHttpResponse::release)
     }
 
+    def 'push promise path includes query string'() {
+        given:
+        def runner = new Runner()
+        runner.run(true, '/serverPush/query', new DefaultHttpHeaders(), 2)
+
+        expect:
+        runner.responses.size() == 2
+
+        runner.pushPromiseHeaders.any {
+            it.scheme() == 'https' &&
+                    it.path() == '/serverPush/resource1?foo=bar&baz=qux'
+        }
+        runner.responses.any { it.content().toString(StandardCharsets.UTF_8) == 'bar' }
+
+        cleanup:
+        runner.responses.forEach(FullHttpResponse::release)
+    }
+
+    def 'push promise authority strips userinfo'() {
+        given:
+        def runner = new Runner()
+        runner.run(true, '/serverPush/userinfoAuthority', new DefaultHttpHeaders(), 2)
+
+        expect:
+        runner.responses.size() == 2
+
+        runner.pushPromiseHeaders.any {
+            it.scheme() == 'https' &&
+                    it.authority() == "${embeddedServer.host}:${embeddedServer.port}" &&
+                    it.path() == '/serverPush/resource1'
+        }
+        runner.responses.any { it.content().toString(StandardCharsets.UTF_8) == 'bar' }
+
+        cleanup:
+        runner.responses.forEach(FullHttpResponse::release)
+    }
+
     def 'with push disabled'() {
         given:
         def runner = new Runner()
@@ -135,8 +172,8 @@ class Http2ServerPushSpec extends Specification {
         def pushPromiseHeaders = new ArrayList<Http2Headers>()
         int expectedResponses
 
-        def run(boolean pushEnabled, String path, HttpHeaders headers = new DefaultHttpHeaders()) {
-            expectedResponses = pushEnabled ? 3 : 1
+        def run(boolean pushEnabled, String path, HttpHeaders headers = new DefaultHttpHeaders(), int expectedResponses = pushEnabled ? 3 : 1) {
+            this.expectedResponses = expectedResponses
             def sslContext = SslContextBuilder.forClient()
                     .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
@@ -241,6 +278,22 @@ class Http2ServerPushSpec extends Specification {
             if (request.isServerPushSupported()) {
                 request.serverPush(HttpRequest.GET('/serverPush/resource1').header("Referer", "abc").header("Authorization", "bla"))
                 request.serverPush(HttpRequest.GET('/serverPush/resource2'))
+            }
+            return HttpResponse.ok('push supported: ' + request.isServerPushSupported())
+        }
+
+        @Get("/query")
+        HttpResponse<String> query(PushCapableHttpRequest<?> request) {
+            if (request.isServerPushSupported()) {
+                request.serverPush(HttpRequest.GET('/serverPush/resource1?foo=bar&baz=qux'))
+            }
+            return HttpResponse.ok('push supported: ' + request.isServerPushSupported())
+        }
+
+        @Get("/userinfoAuthority")
+        HttpResponse<String> userinfoAuthority(PushCapableHttpRequest<?> request) {
+            if (request.isServerPushSupported()) {
+                request.serverPush(HttpRequest.GET("https://user:pass@${embeddedServer.host}:${embeddedServer.port}/serverPush/resource1"))
             }
             return HttpResponse.ok('push supported: ' + request.isServerPushSupported())
         }


### PR DESCRIPTION
see: http://netty.io/news/2026/06/01/4-2-15-Final.html

* Fix HTTP/2 push promise path conversion
* Add HTTP/2 server push promise regression tests

Build HTTP/2 push promise headers directly so the path remains origin-form with Netty 4.2.15 while preserving validated pseudo-header construction.

Cover pushed request query strings and userinfo authority normalization in Http2ServerPushSpec.