### PR TITLE
Fix RequestBean validation for computed properties

### DIFF
--- a/http-validation/src/main/java/io/micronaut/validation/routes/rules/RequestBeanParameterRule.java
+++ b/http-validation/src/main/java/io/micronaut/validation/routes/rules/RequestBeanParameterRule.java
@@ -66,6 +66,7 @@ public class RequestBeanParameterRule implements RouteValidationRule {
 
             // Check readonly bindable properties can be set via constructor
             beanProperties.stream()
+                    .filter(RequestBeanParameterRule::isBindable)
                     .filter(PropertyElement::isReadOnly)
                     .filter(p -> constructorParameters.stream().noneMatch(constructorProperty -> constructorProperty.getName().equals(p.getName())))
                     .forEach(p -> errors.add(
@@ -77,12 +78,17 @@ public class RequestBeanParameterRule implements RouteValidationRule {
         } else {
             // Check readonly bindable properties
             beanProperties.stream()
+                    .filter(RequestBeanParameterRule::isBindable)
                     .filter(PropertyElement::isReadOnly)
                     .forEach(p -> errors.add("Bindable property [" + p.getName()  + "] for type [" + parameterElement.getType().getName() + "]"
                             + " is Read only and cannot be set during initialization.\n"
                             + "Add property setter or add @Creator constructor/method."));
         }
         return errors;
+    }
+
+    private static boolean isBindable(PropertyElement propertyElement) {
+        return propertyElement.hasStereotype(Bindable.class);
     }
 
 }

--- a/http-validation/src/test/groovy/io/micronaut/validation/routes/RequestBeanParameterRuleSpec.groovy
+++ b/http-validation/src/test/groovy/io/micronaut/validation/routes/RequestBeanParameterRuleSpec.groovy
@@ -208,6 +208,48 @@ class Foo {
             noExceptionThrown()
     }
 
+    void "test RequestBean compiles with computed getter property"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import org.jspecify.annotations.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/abc")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+
+    @Introspected
+    private static final class Bean {
+
+        @Nullable
+        @QueryValue
+        private final String abc;
+
+        public Bean(String abc) {
+            this.abc = abc;
+        }
+
+        public String getAbc() { return abc; }
+
+        public boolean isCheckEquality() { return true; }
+
+    }
+
+}
+
+""")
+        then:
+            noExceptionThrown()
+    }
+
     void "test RequestBean fails when read only property not settable"() {
         when:
             buildTypeElement("""


### PR DESCRIPTION
## Summary

Closes : #12706.

`RequestBeanParameterRule` was treating every read-only bean property on a `@RequestBean` type as a bindable request property. Kotlin/KSP exposes JavaBean-style computed validation getters such as `isCheckEquality()` as read-only bean properties, which caused route validation to require a matching constructor parameter even though the property is computed and not request-bindable.

This change restricts the read-only constructor/setter checks to properties with a `Bindable` stereotype, matching the behavior used by related route validation rules.

## Related downstream report

Originally identified via micronaut-validation issue:

- https://github.com/micronaut-projects/micronaut-validation/issues/620

## Validation performed

In micronaut-core:

```bash
./gradlew -q :micronaut-http-validation:compileTestJava :micronaut-http-validation:compileTestGroovy
./gradlew :micronaut-http-validation:test --tests 'io.micronaut.validation.routes.RequestBeanParameterRuleSpec'
```

Also validated against a local micronaut-validation reproducer:

1. Published fixed core snapshot locally with:

```bash
./gradlew -q :micronaut-core-bom:publishToMavenLocal :micronaut-http-validation:publishToMavenLocal -x javadoc
```

2. Pointed micronaut-validation at the local `5.0.3-SNAPSHOT` core artifacts and enabled `kspTest(mn.micronaut.http.validation)`.
3. Verified a Kotlin `@Introspected` `@RequestBean` DTO with `@AssertTrue fun isCheckEquality(): Boolean` no longer fails KSP and validates at runtime:

```bash
./gradlew :test-suite-kotlin:test --tests 'io.micronaut.docs.validation.Issue620RequestBeanSpec'
```
