### PR TITLE
Close InputStreamReader in readProcessStream

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironmentAndPackageDeducer.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironmentAndPackageDeducer.java
@@ -390,14 +390,15 @@ final class DefaultEnvironmentAndPackageDeducer implements EnvironmentNamesDeduc
         try {
             //Read out dir output
             InputStream is = process.getInputStream();
-            InputStreamReader isr = new InputStreamReader(is);
-            BufferedReader br = new BufferedReader(isr);
-            String line;
-            while ((line = br.readLine()) != null) {
-                stdout.append(line);
+            try (InputStreamReader isr = new InputStreamReader(is)) {
+                BufferedReader br = new BufferedReader(isr);
+                String line;
+                while ((line = br.readLine()) != null) {
+                    stdout.append(line);
+                }
+                } catch (IOException e) {
+                // ignore
             }
-        } catch (IOException e) {
-            // ignore
         }
 
         return stdout;


### PR DESCRIPTION
While tracing readProcessStream in inject/src/main/java/io/micronaut/context/env/DefaultEnvironmentAndPackageDeducer.java I noticed what might be an issue: The resource opened there can leak if readProcessStream exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Let me know if the approach doesn’t fit.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.