### PR TITLE
Remove deprecated RouteVersionFilter constructor

### DIFF
--- a/router/src/main/java/io/micronaut/web/router/version/RouteVersionFilter.java
+++ b/router/src/main/java/io/micronaut/web/router/version/RouteVersionFilter.java
@@ -25,7 +25,6 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.web.router.UriRouteMatch;
 import io.micronaut.web.router.version.resolution.HeaderVersionResolverConfiguration;
 import io.micronaut.web.router.version.resolution.RequestVersionResolver;
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,23 +62,9 @@ public class RouteVersionFilter implements VersionRouteMatchFilter {
      *
      * @param resolvingStrategies A list of {@link RequestVersionResolver} beans to extract version from HTTP request
      * @param defaultVersionProvider The Default Version Provider
-     * @deprecated Use {@link #RouteVersionFilter(List, DefaultVersionProvider, RoutesVersioningConfiguration, HeaderVersionResolverConfiguration)} instead.
-     */
-    @Deprecated
-    public RouteVersionFilter(List<RequestVersionResolver> resolvingStrategies,
-                              @Nullable DefaultVersionProvider defaultVersionProvider) {
-        this(resolvingStrategies, defaultVersionProvider, null, null);
-    }
-
-    /**
-     * Creates a {@link RouteVersionFilter} with a collection of {@link RequestVersionResolver}.
-     *
-     * @param resolvingStrategies A list of {@link RequestVersionResolver} beans to extract version from HTTP request
-     * @param defaultVersionProvider The Default Version Provider
      * @param routesVersioningConfiguration Configuration for routes versioning
      * @param headerVersionResolverConfiguration Configuration for Header Version resolution
      */
-    @Inject
     public RouteVersionFilter(List<RequestVersionResolver> resolvingStrategies,
                                          @Nullable DefaultVersionProvider defaultVersionProvider,
                                          @Nullable RoutesVersioningConfiguration routesVersioningConfiguration,

--- a/router/src/main/java/io/micronaut/web/router/version/RouteVersionFilter.java
+++ b/router/src/main/java/io/micronaut/web/router/version/RouteVersionFilter.java
@@ -25,6 +25,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.web.router.UriRouteMatch;
 import io.micronaut.web.router.version.resolution.HeaderVersionResolverConfiguration;
 import io.micronaut.web.router.version.resolution.RequestVersionResolver;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,6 +79,7 @@ public class RouteVersionFilter implements VersionRouteMatchFilter {
      * @param routesVersioningConfiguration Configuration for routes versioning
      * @param headerVersionResolverConfiguration Configuration for Header Version resolution
      */
+    @Inject
     public RouteVersionFilter(List<RequestVersionResolver> resolvingStrategies,
                                          @Nullable DefaultVersionProvider defaultVersionProvider,
                                          @Nullable RoutesVersioningConfiguration routesVersioningConfiguration,


### PR DESCRIPTION
## Summary
- remove the deprecated 2-arg `RouteVersionFilter` constructor reintroduced by the merge
- restore the 5.0.x constructor shape so Micronaut uses the full versioning-aware constructor
- fix the 5.0.x -> 5.1.x merge regression that made versioned CORS preflight requests bypass version matching

## Verification
- `./gradlew --no-daemon --no-build-cache --no-parallel -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process :micronaut-http-server-netty:test --tests "io.micronaut.http.server.netty.cors.CorsVersionSpec"`
- `./gradlew --no-daemon --no-build-cache --no-parallel -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process :micronaut-http-server-tck:test --tests "io.micronaut.http.tck.tests.cors.CrossOriginTest"` *(module resolved to `test NO-SOURCE` in this layout)*