### PR TITLE
Fix generic candidate matching for intercepted beans

### DIFF
--- a/core-processor/src/main/java/io/micronaut/aop/writer/ProxyingBeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/ProxyingBeanDefinitionWriter.java
@@ -112,6 +112,7 @@ public abstract class ProxyingBeanDefinitionWriter implements ProxyingBeanDefini
         this.interceptorBinding = toInterceptorBindingMap(interceptorBinding);
         this.visitorContext = visitorContext;
         this.proxyBeanDefinitionWriter = createAdviceProxyBeanDefinitionWriter(suffix);
+        proxyBeanDefinitionWriter.visitTypeArguments(targetType.getAllTypeArguments());
         proxyBeanDefinitionWriter.setRequiresMethodProcessing(parent.requiresMethodProcessing());
         proxyBeanDefinitionWriter.setInterceptedType(targetType.getName());
     }
@@ -167,6 +168,7 @@ public abstract class ProxyingBeanDefinitionWriter implements ProxyingBeanDefini
         this.isIntroduction = true;
         this.visitorContext = visitorContext;
         this.proxyBeanDefinitionWriter = createIntroductionProxyBeanDefinitionWriter(suffix);
+        proxyBeanDefinitionWriter.visitTypeArguments(targetType.getAllTypeArguments());
         if (targetType.isInterface()) {
             if (implementInterface) {
                 proxyBeanDefinitionWriter.setInterceptedType(targetType.getName());

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/Bear.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/Bear.java
@@ -1,0 +1,88 @@
+package io.micronaut.inject.generics;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+public interface Bear<T> {
+    String name();
+}
+
+interface Habitat {
+}
+
+class Arctic implements Habitat {
+}
+
+class Forest implements Habitat {
+}
+
+@Requires(property = "spec.name", value = "GenericInjectionSpec")
+@Singleton
+@InterceptedBear
+class WhiteBear implements Bear<Arctic> {
+    @Override
+    public String name() {
+        return "white";
+    }
+}
+
+@Requires(property = "spec.name", value = "GenericInjectionSpec")
+@Singleton
+class BrownBear implements Bear<Forest> {
+    @Override
+    public String name() {
+        return "brown";
+    }
+}
+
+@Requires(property = "spec.name", value = "GenericInjectionSpec")
+@Singleton
+class ForestDen {
+    private final Bear<Forest> bear;
+
+    @Inject
+    Bear<Forest> fieldBear;
+
+    @Inject
+    List<Bear<Forest>> bears;
+
+    @Inject
+    Provider<Bear<Forest>> bearProvider;
+
+    ForestDen(Bear<Forest> bear) {
+        this.bear = bear;
+    }
+
+    Bear<Forest> getBear() {
+        return bear;
+    }
+}
+
+@Around
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@interface InterceptedBear {
+}
+
+@Requires(property = "spec.name", value = "GenericInjectionSpec")
+@Singleton
+@InterceptorBean(InterceptedBear.class)
+class InterceptedBearInterceptor implements MethodInterceptor<Object, Object> {
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/GenericInjectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/GenericInjectionSpec.groovy
@@ -10,7 +10,7 @@ import spock.lang.Specification
 import java.util.stream.Collectors
 
 class GenericInjectionSpec extends Specification {
-    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run(["spec.name": GenericInjectionSpec.simpleName])
 
     void "test narrow injection by generic type"() {
         when:
@@ -49,5 +49,28 @@ class GenericInjectionSpec extends Specification {
         then:
         !bean.is(another)
 
+    }
+
+    void "test narrow injection by generic type with intercepted candidate"() {
+        when:
+        def forestBear = Argument.of(Bear, Forest)
+        def den = context.getBean(ForestDen)
+        def brownBearDefinition = context.getBeanDefinition(BrownBear)
+        def whiteBearDefinition = context.getBeanDefinition(WhiteBear)
+
+        then:
+        den.bear instanceof BrownBear
+        den.fieldBear instanceof BrownBear
+        den.bears*.class == [BrownBear]
+        den.bearProvider.get() instanceof BrownBear
+        context.getBean(forestBear) instanceof BrownBear
+        context.getBeanDefinition(forestBear).beanType == BrownBear
+        context.getBeansOfType(forestBear).toList()*.class == [BrownBear]
+
+        and:
+        brownBearDefinition.isCandidateBean(forestBear)
+        !whiteBearDefinition.isCandidateBean(forestBear)
+        brownBearDefinition.getTypeArguments(Bear)[0].type == Forest
+        whiteBearDefinition.getTypeArguments(Bear)[0].type == Arctic
     }
 }


### PR DESCRIPTION
## Summary
- Propagate target generic type arguments to generated proxy bean definitions so intercepted beans keep generic-aware candidate matching.
- Preserve the raw candidate fast path for non-generic proxy definitions, which avoids processing intercepted controller definitions as separate controller route definitions.
- Add regression coverage for an intercepted generic implementation competing with a plain generic implementation.

## Reproducer
Given two implementations of the same generic bean type:

```java
interface Bear<T> {}
class Arctic {}
class Forest {}

@Singleton
@InterceptedBear
class WhiteBear implements Bear<Arctic> {}

@Singleton
class BrownBear implements Bear<Forest> {}
```

And an injection point or lookup narrowed by the generic type:

```java
@Inject Bear<Forest> bear;
context.getBean(Argument.of(Bear.class, Forest.class));
```

Expected behavior: only `BrownBear` is a candidate for `Bear<Forest>`.

Previous behavior: the generated intercepted definition for `WhiteBear` did not carry the target generic type metadata, so it generated raw candidate matching and `Bear<Forest>` could also match `WhiteBear`, resulting in multiple candidate errors such as:

```text
Multiple possible bean candidates found: [$WhiteBear$Definition$Intercepted, BrownBear]
```

This PR propagates the target type arguments into proxy bean definitions. Generic intercepted definitions therefore avoid the raw candidate fast path and delegate to the generic-aware parent definition, while non-generic intercepted definitions keep the existing raw fast path.

## Testing
- ./gradlew :micronaut-inject-java:test --tests io.micronaut.inject.generics.GenericInjectionSpec
- ./gradlew :test-suite-http-server-tck-netty:test
- ./gradlew :test-suite-http2-server-tck-netty:test