### PR TITLE
Add public-only method visibility option for @Around AOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ If you wish to contribute to the development of Micronaut Framework please read 
 ## Versioning
 
 Micronaut Framework uses Semantic Versioning 2.0.0. To understand what that means, please see the specification [documentation](https://semver.org/). Exclusions to Micronaut Framework's public API include any classes annotated with `@Experimental` or `@Internal`, which reside in the `io.micronaut.core.annotation` package.
+
+## Fork publish
+
+./gradlew -PpistolMavenPublishing=true -PprojectVersion=5.1.0-aop-public-only-SNAPSHOT publishAllPublicationsToPistolRepository

--- a/aop/src/main/java/io/micronaut/aop/Around.java
+++ b/aop/src/main/java/io/micronaut/aop/Around.java
@@ -91,6 +91,21 @@ public @interface Around {
     boolean cacheableLazyTarget() default false;
 
     /**
+     * Controls which methods inherit type-level around advice.
+     *
+     * <p>{@link MethodVisibility#DEFAULT} preserves the default method selection behavior. {@link MethodVisibility#PUBLIC_ONLY}
+     * applies type-level around advice only to public methods. Method-level around advice is still applied to methods that can
+     * be proxied.</p>
+     *
+     * <p>This selector does not change the existing method selection behavior for beans produced by
+     * {@link io.micronaut.context.annotation.Factory} methods.</p>
+     *
+     * @return The method visibility policy.
+     * @since 5.1.0
+     */
+    MethodVisibility methodVisibility() default MethodVisibility.DEFAULT;
+
+    /**
      * Sets the {@link io.micronaut.aop.Around.ProxyTargetConstructorMode}. See the
      * javadoc for {@link io.micronaut.aop.Around.ProxyTargetConstructorMode} for more information.
      *
@@ -99,6 +114,22 @@ public @interface Around {
      * @since 3.0.0
      */
     ProxyTargetConstructorMode proxyTargetMode() default ProxyTargetConstructorMode.ERROR;
+
+    /**
+     * The method visibility policy for type-level around advice.
+     *
+     * @since 5.1.0
+     */
+    enum MethodVisibility {
+        /**
+         * Use the default method selection behavior.
+         */
+        DEFAULT,
+        /**
+         * Apply type-level around advice only to public methods.
+         */
+        PUBLIC_ONLY
+    }
 
     /**
      * When using {@link #proxyTarget()} on a {@link io.micronaut.context.annotation.Factory} method if the

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
@@ -42,6 +42,9 @@ import java.util.concurrent.Future;
  */
 @Internal
 public final class InterceptedMethodUtil {
+    private static final String METHOD_VISIBILITY = "methodVisibility";
+    private static final String METHOD_VISIBILITY_PUBLIC_ONLY = "PUBLIC_ONLY";
+
     private InterceptedMethodUtil() {
     }
 
@@ -141,6 +144,18 @@ public final class InterceptedMethodUtil {
             true,
             Around.class,
             InterceptorKind.AROUND);
+    }
+
+    /**
+     * Does the given around advice metadata request public methods only.
+     *
+     * @param annotationMetadata The annotation metadata
+     * @return True if type-level around advice should apply only to public methods
+     */
+    public static boolean hasPublicOnlyAroundMethodVisibility(@Nullable AnnotationMetadata annotationMetadata) {
+        return annotationMetadata != null && annotationMetadata.stringValue(AnnotationUtil.ANN_AROUND, METHOD_VISIBILITY)
+            .map(METHOD_VISIBILITY_PUBLIC_ONLY::equals)
+            .orElse(false);
     }
 
     private static boolean hasInterceptorBinding(AnnotationMetadata annotationMetadata,

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,28 @@ repositories {
     mavenCentral()
 }
 
+def pistolMavenPublishing = providers.gradleProperty("pistolMavenPublishing")
+    .map { it.toBoolean() }
+    .orElse(false)
+
+if (pistolMavenPublishing.get()) {
+    allprojects {
+        plugins.withId("maven-publish") {
+            publishing {
+                repositories {
+                    maven {
+                        name = "Pistol"
+                        url = uri("s3://pistol-maven/maven2")
+                        authentication {
+                            create("awsIm", org.gradle.authentication.aws.AwsImAuthentication)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 tasks.named("updateVersionCatalogs") {
     // we set the list to empty because we accept upgrades which improve the status
     rejectedQualifiers = []

--- a/core-processor/src/main/java/io/micronaut/aop/writer/ProxyingBeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/ProxyingBeanDefinitionWriter.java
@@ -309,6 +309,7 @@ public abstract class ProxyingBeanDefinitionWriter implements ElementProxyBuilde
 
     protected final void processAlreadyVisitedMethods(BeanDefinitionWriter parent) {
         parent.getPostConstructMethods().forEach(proxyBeanDefinitionWriter::addPostConstruct);
+        parent.getPreDestroyMethods().forEach(proxyBeanDefinitionWriter::addPreDestroy);
     }
 
     @Override

--- a/core-processor/src/main/java/io/micronaut/inject/processing/AbstractBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/AbstractBeanElementCreator.java
@@ -76,11 +76,13 @@ abstract class AbstractBeanElementCreator<R> implements BeanDefinitionCreator<R>
     protected boolean visitIntrospectedMethod(ElementProxyBuilder<R> proxyBuilder, MethodElement methodElement) {
 
         final AnnotationMetadata resolvedTypeMetadata = classElement.getAnnotationMetadata();
-        final boolean resolvedTypeMetadataIsAopProxyType = InterceptedMethodUtil.hasDeclaredAroundAdvice(resolvedTypeMetadata);
+        final boolean methodHasDeclaredAroundAdvice = InterceptedMethodUtil.hasDeclaredAroundAdvice(methodElement.getMethodAnnotationMetadata());
+        final boolean resolvedTypeMetadataIsAopProxyType = InterceptedMethodUtil.hasDeclaredAroundAdvice(resolvedTypeMetadata)
+            && (!InterceptedMethodUtil.hasPublicOnlyAroundMethodVisibility(resolvedTypeMetadata) || methodElement.isPublic());
 
         if (methodElement.isAbstract()
             || resolvedTypeMetadataIsAopProxyType
-            || InterceptedMethodUtil.hasDeclaredAroundAdvice(methodElement.getAnnotationMetadata())) {
+            || methodHasDeclaredAroundAdvice) {
             proxyBuilder.addProxyMethod(methodElement);
             return true;
         } else if (methodElement.hasDeclaredStereotype(Executable.class)) {

--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -403,15 +403,17 @@ sealed class DeclaredBeanElementCreator<R> extends AbstractBeanElementCreator<R>
      * @return true if processed
      */
     protected boolean visitAopMethod(ElementBeanDefinitionBuilder<R> beanDefinitionBuilder, MethodElement methodElement) {
+        AnnotationMetadata methodAnnotationMetadata = methodElement.getMethodAnnotationMetadata();
+        boolean methodHasDeclaredAroundAdvice = InterceptedMethodUtil.hasDeclaredAroundAdvice(methodAnnotationMetadata);
+        boolean publicOnlyAroundAdvice = InterceptedMethodUtil.hasPublicOnlyAroundMethodVisibility(classElement.getAnnotationMetadata());
         boolean aopDefinedOnClassAndPublicMethod = isAopProxy
             && !methodElement.isStatic()
-            && (methodElement.isPublic() || methodElement.isPackagePrivate());
-        AnnotationMetadata methodAnnotationMetadata = methodElement.getMethodAnnotationMetadata();
+            && (methodElement.isPublic() || (!publicOnlyAroundAdvice && methodElement.isPackagePrivate()));
         if (aopDefinedOnClassAndPublicMethod ||
-            !isAopProxy && InterceptedMethodUtil.hasAroundStereotype(methodAnnotationMetadata) ||
-            InterceptedMethodUtil.hasDeclaredAroundAdvice(methodAnnotationMetadata) && !classElement.isAbstract()) {
+            (!isAopProxy && InterceptedMethodUtil.hasAroundStereotype(methodAnnotationMetadata)) ||
+            (methodHasDeclaredAroundAdvice && !classElement.isAbstract())) {
             if (methodElement.isFinal()) {
-                if (InterceptedMethodUtil.hasDeclaredAroundAdvice(methodAnnotationMetadata)) {
+                if (methodHasDeclaredAroundAdvice) {
                     throw new ProcessingException(methodElement, "Method defines AOP advice but is declared final. Change the method to be non-final in order for AOP advice to be applied.");
                 } else if (!methodElement.isSynthetic() && aopDefinedOnClassAndPublicMethod && isDeclaredInThisClass(methodElement)) {
                     throw new ProcessingException(methodElement, "Public method inherits AOP advice but is declared final. Either make the method non-public or apply AOP advice only to public methods declared on the class.");

--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.writer;
 
+import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Value;
@@ -523,6 +524,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
         }
 
         if (this.intercepted) {
+            boolean publicOnly = InterceptedMethodUtil.hasPublicOnlyAroundMethodVisibility(getAnnotationMetadata());
             beanClass.getEnclosedElements(
                 ElementQuery.ALL_METHODS
                     .onlyInstance()
@@ -532,7 +534,8 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
                     method,
                     true
                 );
-                if (!interceptedMethods.contains(ibem)) {
+                if (!interceptedMethods.contains(ibem)
+                    && (!publicOnly || method.isPublic() || InterceptedMethodUtil.hasDeclaredAroundAdvice(method.getMethodAnnotationMetadata()))) {
                     addProxyMethod(proxyBuilder, ibem);
                 }
             });

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -1049,6 +1049,15 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     }
 
     /**
+     * Returns the pre destroy method definitions scheduled for invocation.
+     *
+     * @return The pre destroy method definitions scheduled for invocation
+     */
+    public List<MethodDefinition<ClassElement, MethodElement>> getPreDestroyMethods() {
+        return preDestroyMethods;
+    }
+
+    /**
      * @return Is interface
      */
     public boolean isInterface() {

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundCompileSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundCompileSpec.groovy
@@ -1005,6 +1005,279 @@ class MyBean {
         t.message.contains 'Method annotated as executable but is declared private'
     }
 
+    void 'test class level public only around advice'() {
+        given:
+        ApplicationContext context = buildContext('''
+package publiconlyaround;
+
+import java.lang.annotation.*;
+import java.util.*;
+import io.micronaut.aop.*;
+import jakarta.inject.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Singleton
+@TestAnn
+class PublicOnlyBean {
+    public boolean constructorHelperInvoked;
+
+    PublicOnlyBean() {
+        packageHelper("ctor");
+    }
+
+    public String publicMethod(String value) {
+        return value;
+    }
+
+    public String callPackageHelper(String value) {
+        return packageHelper(value);
+    }
+
+    public String callProtectedHelper(String value) {
+        return protectedHelper(value);
+    }
+
+    public String callMethodLevelPackageHelper(String value) {
+        return methodLevelPackageHelper(value);
+    }
+
+    String packageHelper(String value) {
+        constructorHelperInvoked = true;
+        return "package " + value;
+    }
+
+    protected String protectedHelper(String value) {
+        return "protected " + value;
+    }
+
+    @TestAnn
+    String methodLevelPackageHelper(String value) {
+        return "method " + value;
+    }
+}
+
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Around(methodVisibility = Around.MethodVisibility.PUBLIC_ONLY)
+@interface TestAnn {
+}
+
+@InterceptorBean(TestAnn.class)
+class TestInterceptor implements MethodInterceptor<Object, Object> {
+    public int invoked;
+    public final List<String> methods = new ArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        invoked++;
+        methods.add(context.getMethodName());
+        return context.proceed();
+    }
+}
+''')
+        def bean = getBean(context, 'publiconlyaround.PublicOnlyBean')
+        def interceptor = getBean(context, 'publiconlyaround.TestInterceptor')
+
+        expect:
+        bean.constructorHelperInvoked
+        interceptor.methods.isEmpty()
+
+        when:
+        def publicResult = bean.publicMethod('one')
+        def packageResult = bean.callPackageHelper('two')
+        def protectedResult = bean.callProtectedHelper('three')
+        def methodLevelResult = bean.callMethodLevelPackageHelper('four')
+        def interceptedMethodNames = ((Intercepted) bean).interceptedMethods()*.methodName
+
+        then:
+        publicResult == 'one'
+        packageResult == 'package two'
+        protectedResult == 'protected three'
+        methodLevelResult == 'method four'
+        interceptor.methods == [
+                'publicMethod',
+                'callPackageHelper',
+                'callProtectedHelper',
+                'callMethodLevelPackageHelper',
+                'methodLevelPackageHelper'
+        ]
+        interceptedMethodNames.containsAll([
+                'publicMethod',
+                'callPackageHelper',
+                'callProtectedHelper',
+                'callMethodLevelPackageHelper',
+                'methodLevelPackageHelper'
+        ])
+        !interceptedMethodNames.contains('packageHelper')
+        !interceptedMethodNames.contains('protectedHelper')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test default class level around advice still intercepts package private methods'() {
+        given:
+        ApplicationContext context = buildContext('''
+package defaultaroundvisibility;
+
+import java.lang.annotation.*;
+import java.util.*;
+import io.micronaut.aop.*;
+import jakarta.inject.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Singleton
+@TestAnn
+class DefaultVisibilityBean {
+    public String callPackageHelper(String value) {
+        return packageHelper(value);
+    }
+
+    String packageHelper(String value) {
+        return "package " + value;
+    }
+}
+
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Around
+@interface TestAnn {
+}
+
+@InterceptorBean(TestAnn.class)
+class TestInterceptor implements MethodInterceptor<Object, Object> {
+    public final List<String> methods = new ArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        methods.add(context.getMethodName());
+        return context.proceed();
+    }
+}
+''')
+        def bean = getBean(context, 'defaultaroundvisibility.DefaultVisibilityBean')
+        def interceptor = getBean(context, 'defaultaroundvisibility.TestInterceptor')
+
+        when:
+        def result = bean.callPackageHelper('one')
+        def interceptedMethodNames = ((Intercepted) bean).interceptedMethods()*.methodName
+
+        then:
+        result == 'package one'
+        interceptor.methods == ['callPackageHelper', 'packageHelper']
+        interceptedMethodNames.contains('callPackageHelper')
+        interceptedMethodNames.contains('packageHelper')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test factory produced class level around advice remains public only'() {
+        given:
+        ApplicationContext context = buildContext('''
+package factoryaroundvisibility;
+
+import java.lang.annotation.*;
+import java.util.*;
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.*;
+import jakarta.inject.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+class DefaultProduct {
+    public String callPackageHelper(String value) {
+        return packageHelper(value);
+    }
+
+    String packageHelper(String value) {
+        return "default " + value;
+    }
+}
+
+class PublicOnlyProduct {
+    public String callPackageHelper(String value) {
+        return packageHelper(value);
+    }
+
+    String packageHelper(String value) {
+        return "public only " + value;
+    }
+}
+
+@Factory
+class ProductFactory {
+    @Singleton
+    @DefaultAnn
+    DefaultProduct defaultProduct() {
+        return new DefaultProduct();
+    }
+
+    @Singleton
+    @PublicOnlyAnn
+    PublicOnlyProduct publicOnlyProduct() {
+        return new PublicOnlyProduct();
+    }
+}
+
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Around
+@interface DefaultAnn {
+}
+
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Around(methodVisibility = Around.MethodVisibility.PUBLIC_ONLY)
+@interface PublicOnlyAnn {
+}
+
+@InterceptorBean(DefaultAnn.class)
+class DefaultInterceptor implements MethodInterceptor<Object, Object> {
+    public final List<String> methods = new ArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        methods.add(context.getMethodName());
+        return context.proceed();
+    }
+}
+
+@InterceptorBean(PublicOnlyAnn.class)
+class PublicOnlyInterceptor implements MethodInterceptor<Object, Object> {
+    public final List<String> methods = new ArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        methods.add(context.getMethodName());
+        return context.proceed();
+    }
+}
+''')
+        def defaultBean = getBean(context, 'factoryaroundvisibility.DefaultProduct')
+        def publicOnlyBean = getBean(context, 'factoryaroundvisibility.PublicOnlyProduct')
+        def defaultInterceptor = getBean(context, 'factoryaroundvisibility.DefaultInterceptor')
+        def publicOnlyInterceptor = getBean(context, 'factoryaroundvisibility.PublicOnlyInterceptor')
+
+        when:
+        def defaultResult = defaultBean.callPackageHelper('one')
+        def publicOnlyResult = publicOnlyBean.callPackageHelper('two')
+        def defaultInterceptedMethodNames = ((Intercepted) defaultBean).interceptedMethods()*.methodName
+        def publicOnlyInterceptedMethodNames = ((Intercepted) publicOnlyBean).interceptedMethods()*.methodName
+
+        then:
+        defaultResult == 'default one'
+        publicOnlyResult == 'public only two'
+        defaultInterceptor.methods == ['callPackageHelper']
+        publicOnlyInterceptor.methods == ['callPackageHelper']
+        defaultInterceptedMethodNames.contains('callPackageHelper')
+        publicOnlyInterceptedMethodNames.contains('callPackageHelper')
+        !defaultInterceptedMethodNames.contains('packageHelper')
+        !publicOnlyInterceptedMethodNames.contains('packageHelper')
+
+        cleanup:
+        context.close()
+    }
+
     void 'test byte[] return compile'() {
         given:
         ApplicationContext context = buildContext('''

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -243,7 +243,7 @@ public final class AnnotationMetadataSupport {
         );
         coreAnnotationsDefaults.put(
             "io.micronaut.aop.Around",
-            Map.of("cacheableLazyTarget", false, "hotswap", false, "lazy", false, "proxyTarget", false, "proxyTargetMode", "ERROR")
+            Map.of("cacheableLazyTarget", false, "hotswap", false, "lazy", false, "methodVisibility", "DEFAULT", "proxyTarget", false, "proxyTargetMode", "ERROR")
         );
         coreAnnotationsDefaults.put(
             "io.micronaut.aop.Introduction",


### PR DESCRIPTION
Introduce Around.methodVisibility() with a PUBLIC_ONLY option for class-level AOP, preserving existing behavior by default. Apply the selector during compile-time proxy method selection so public-only class advice skips non-public helper methods unless the method has explicit advice.

Add compile-time coverage for public-only interception, constructor helper safety, method-level advice precedence, default behavior, and unchanged factory-produced bean selection.

### Use Case

 Class-level `@Around` advice can currently cause Micronaut to generate intercepted overrides for non-public methods that are still overridable by the generated subclass, such as package-private and protected methods.

  This can be problematic when an advised class calls one of those helper methods from its constructor. Java virtual dispatch can enter the generated AOP override before the generated subclass has finished initializing its interceptor state, which can fail during bean construction.

  `methodVisibility = PUBLIC_ONLY` lets applications apply class-level AOP to the bean’s public API while leaving non-public helper methods unproxied. This is useful for constructor helpers, internal decomposition methods, and package-private/protected test seams that should not become part of the AOP interception surface.
  
  Checking `Modifier.isPublic(context.getTargetMethod().getModifiers())` inside an interceptor is too late for this problem. That check can decide whether the interceptor should apply its behavior, but it does not prevent Micronaut from generating an AOP override for the non-public method. If a constructor calls that helper, Java virtual dispatch still enters the generated override first, before the generated subclass has finished initializing its interceptor/proxy method state. `PUBLIC_ONLY` fixes this at compile time by not generating the override or AOP dispatch entry for inherited non-public helper methods in the first place.