### PR TITLE
Fix Groovy JsonProperty introspection access

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -54,7 +54,6 @@ import java.util.function.Supplier;
 public final class AstBeanPropertiesUtils {
 
     private static final String ANN_INTROSPECTED_PROPERTY = Introspected.Property.class.getName();
-    private static final String ANN_JAKARTA_ACCESS = "jakarta.persistence.Access";
     private static final String MEMBER_IGNORE_OTHER_ACCESSORS = "ignoreOtherAccessors";
 
     private AstBeanPropertiesUtils() {
@@ -90,7 +89,7 @@ public final class AstBeanPropertiesUtils {
         String[] readPrefixes = configuration.getReadPrefixes();
         String[] writePrefixes = configuration.getWritePrefixes();
         var isRecord = classElement.isRecord();
-        Set<BeanProperties.AccessKind> effectiveAccessKinds = resolveAccessKinds(configuration, classElement);
+        Set<BeanProperties.AccessKind> effectiveAccessKinds = configuration.getAccessKinds();
 
         var props = new LinkedHashMap<String, BeanPropertyData>();
         for (MethodElement methodElement : methodsSupplier.get()) {
@@ -186,12 +185,13 @@ public final class AstBeanPropertiesUtils {
                 continue;
             }
             String propertyName = fieldElement.getSimpleName();
-            boolean isAccessor = propertyFields.contains(propertyName) ||
-                isIntrospectedPropertyField ||
-                canFieldBeUsedForAccess(fieldElement, effectiveAccessKinds, visibility, configuration);
+            boolean isPropertyField = propertyFields.contains(propertyName);
+            boolean canUseFieldForAccess = canFieldBeUsedForAccess(fieldElement, effectiveAccessKinds, visibility, configuration) ||
+                canIntrospectedPropertyFieldBeUsedForAccess(fieldElement, visibility);
+            boolean isAccessor = isPropertyField || canUseFieldForAccess;
             if (!isAccessor && !props.containsKey(propertyName)) {
                 if (isIntrospectedPropertyField) {
-                    validateIntrospectedPropertyField(fieldElement, visibility, null);
+                    validateIntrospectedPropertyField(fieldElement, visibility, null, false);
                 }
                 continue;
             }
@@ -200,7 +200,7 @@ public final class AstBeanPropertiesUtils {
             resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
             resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
             if (isIntrospectedPropertyField) {
-                validateIntrospectedPropertyField(fieldElement, visibility, beanPropertyData);
+                validateIntrospectedPropertyField(fieldElement, visibility, beanPropertyData, isPropertyField);
             }
             registerIntrospectedPropertyAccess(beanPropertyData, fieldElement);
         }
@@ -266,19 +266,6 @@ public final class AstBeanPropertiesUtils {
             }
         }
         return beanProperties;
-    }
-
-    private static Set<BeanProperties.AccessKind> resolveAccessKinds(PropertyElementQuery configuration,
-                                                                     ClassElement classElement) {
-        Optional<String> accessType = classElement.stringValue(ANN_JAKARTA_ACCESS);
-        if (accessType.isEmpty()) {
-            return configuration.getAccessKinds();
-        }
-        return switch (accessType.get()) {
-            case "FIELD" -> EnumSet.of(BeanProperties.AccessKind.FIELD);
-            case "PROPERTY" -> EnumSet.of(BeanProperties.AccessKind.METHOD);
-            default -> configuration.getAccessKinds();
-        };
     }
 
     private static boolean isIntrospectedPropertyReader(MethodElement methodElement, BeanProperties.Visibility visibility) {
@@ -355,6 +342,13 @@ public final class AstBeanPropertiesUtils {
         return fieldElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
     }
 
+    private static boolean canIntrospectedPropertyFieldBeUsedForAccess(FieldElement fieldElement,
+                                                                       BeanProperties.Visibility visibility) {
+        return isIntrospectedPropertyField(fieldElement) &&
+            isAccessible(fieldElement, visibility) &&
+            !fieldElement.getOwningType().isRecord();
+    }
+
     private static boolean isIntrospectedPropertyMethod(MethodElement methodElement) {
         return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
     }
@@ -402,9 +396,10 @@ public final class AstBeanPropertiesUtils {
 
     private static void validateIntrospectedPropertyField(FieldElement fieldElement,
                                                           BeanProperties.Visibility visibility,
-                                                          @Nullable BeanPropertyData beanPropertyData) {
+                                                          @Nullable BeanPropertyData beanPropertyData,
+                                                          boolean isPropertyField) {
         EnumSet<Introspected.Property.Access> accessKinds = resolveIntrospectedPropertyAccess(fieldElement);
-        boolean canReadField = isAccessible(fieldElement, visibility) && !fieldElement.getOwningType().isRecord();
+        boolean canReadField = (isPropertyField || isAccessible(fieldElement, visibility)) && !fieldElement.getOwningType().isRecord();
         boolean canWriteField = canReadField && !fieldElement.isFinal();
         boolean canRead = canReadField || hasMethodReadAccess(beanPropertyData);
         boolean canWrite = canWriteField || hasMethodWriteAccess(beanPropertyData);

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -54,7 +54,6 @@ import java.util.function.Supplier;
 public final class AstBeanPropertiesUtils {
 
     private static final String ANN_INTROSPECTED_PROPERTY = Introspected.Property.class.getName();
-    private static final String ANN_GROOVY_PACKAGE_SCOPE = "groovy.transform.PackageScope";
     private static final String MEMBER_IGNORE_OTHER_ACCESSORS = "ignoreOtherAccessors";
 
     private AstBeanPropertiesUtils() {
@@ -766,15 +765,11 @@ public final class AstBeanPropertiesUtils {
     private static boolean isAccessible(MemberElement memberElement, BeanProperties.Visibility visibility) {
         return switch (visibility) {
             case DEFAULT ->
-                isGroovyPackageScope(memberElement) ||
-                    (!memberElement.isPrivate() && (memberElement.isAccessible() || memberElement.getDeclaringType().hasDeclaredStereotype(BeanProperties.class)));
+                (!memberElement.isPrivate() || memberElement.isPackagePrivate()) &&
+                    (memberElement.isAccessible() || memberElement.getDeclaringType().hasDeclaredStereotype(BeanProperties.class));
             case PUBLIC -> memberElement.isPublic();
             case ANY -> true;
         };
-    }
-
-    private static boolean isGroovyPackageScope(MemberElement memberElement) {
-        return memberElement.hasAnnotation(ANN_GROOVY_PACKAGE_SCOPE);
     }
 
     private static boolean shouldExclude(Set<String> includes, Set<String> excludes, String propertyName) {

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -54,6 +54,7 @@ import java.util.function.Supplier;
 public final class AstBeanPropertiesUtils {
 
     private static final String ANN_INTROSPECTED_PROPERTY = Introspected.Property.class.getName();
+    private static final String ANN_GROOVY_PACKAGE_SCOPE = "groovy.transform.PackageScope";
     private static final String MEMBER_IGNORE_OTHER_ACCESSORS = "ignoreOtherAccessors";
 
     private AstBeanPropertiesUtils() {
@@ -187,9 +188,9 @@ public final class AstBeanPropertiesUtils {
             String propertyName = fieldElement.getSimpleName();
             boolean isPropertyField = propertyFields.contains(propertyName);
             boolean canUseFieldForAccess = canFieldBeUsedForAccess(fieldElement, effectiveAccessKinds, visibility, configuration) ||
+                canNativePropertyFieldBeUsedForAccess(isPropertyField, fieldElement, effectiveAccessKinds, visibility) ||
                 canIntrospectedPropertyFieldBeUsedForAccess(fieldElement, visibility);
-            boolean isAccessor = isPropertyField || canUseFieldForAccess;
-            if (!isAccessor && !props.containsKey(propertyName)) {
+            if (!isPropertyField && !canUseFieldForAccess && !props.containsKey(propertyName)) {
                 if (isIntrospectedPropertyField) {
                     validateIntrospectedPropertyField(fieldElement, visibility, null, false);
                 }
@@ -197,10 +198,12 @@ public final class AstBeanPropertiesUtils {
             }
             BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
             boolean ignoreOtherAccessors = ignoresOtherAccessors(fieldElement);
-            resolveReadAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
-            resolveWriteAccessForField(fieldElement, isAccessor, beanPropertyData, ignoreOtherAccessors);
+            boolean hasGeneratedPropertyAccessors = isPropertyField && !ignoreOtherAccessors;
+            beanPropertyData.hasGeneratedPropertyAccessors |= hasGeneratedPropertyAccessors;
+            resolveReadAccessForField(fieldElement, canUseFieldForAccess, beanPropertyData, ignoreOtherAccessors);
+            resolveWriteAccessForField(fieldElement, canUseFieldForAccess, beanPropertyData, ignoreOtherAccessors);
             if (isIntrospectedPropertyField) {
-                validateIntrospectedPropertyField(fieldElement, visibility, beanPropertyData, isPropertyField);
+                validateIntrospectedPropertyField(fieldElement, visibility, beanPropertyData, hasGeneratedPropertyAccessors);
             }
             registerIntrospectedPropertyAccess(beanPropertyData, fieldElement);
         }
@@ -254,10 +257,10 @@ public final class AstBeanPropertiesUtils {
                 && hasMoreAnnotations(value.getter.getGenericReturnType(), value.type)) {
                 value.type = value.getter.getGenericReturnType();
             }
-            if (value.readAccessKind != null || value.writeAccessKind != null) {
+            if (value.hasGeneratedPropertyAccessors || value.readAccessKind != null || value.writeAccessKind != null) {
                 value.isExcluded = shouldExclude(includes, excludes, propertyName)
                     || isExcludedByAnnotations(configuration, value)
-                    || isExcludedBecauseOfMissingAccess(value);
+                    || (!value.hasGeneratedPropertyAccessors && isExcludedBecauseOfMissingAccess(value));
 
                 PropertyElement propertyElement = propertyCreator.apply(value);
                 if (propertyElement != null) {
@@ -349,6 +352,20 @@ public final class AstBeanPropertiesUtils {
             !fieldElement.getOwningType().isRecord();
     }
 
+    private static boolean canNativePropertyFieldBeUsedForAccess(boolean isPropertyField,
+                                                                 FieldElement fieldElement,
+                                                                 Set<BeanProperties.AccessKind> accessKinds,
+                                                                 BeanProperties.Visibility visibility) {
+        if (!isPropertyField || fieldElement.getOwningType().isRecord() || !accessKinds.contains(BeanProperties.AccessKind.FIELD)) {
+            return false;
+        }
+        return switch (visibility) {
+            case DEFAULT -> !fieldElement.isPrivate() || fieldElement.isPackagePrivate();
+            case PUBLIC -> fieldElement.isPublic();
+            case ANY -> true;
+        };
+    }
+
     private static boolean isIntrospectedPropertyMethod(MethodElement methodElement) {
         return methodElement.hasAnnotation(ANN_INTROSPECTED_PROPERTY);
     }
@@ -397,12 +414,12 @@ public final class AstBeanPropertiesUtils {
     private static void validateIntrospectedPropertyField(FieldElement fieldElement,
                                                           BeanProperties.Visibility visibility,
                                                           @Nullable BeanPropertyData beanPropertyData,
-                                                          boolean isPropertyField) {
+                                                          boolean hasGeneratedPropertyAccessors) {
         EnumSet<Introspected.Property.Access> accessKinds = resolveIntrospectedPropertyAccess(fieldElement);
-        boolean canReadField = (isPropertyField || isAccessible(fieldElement, visibility)) && !fieldElement.getOwningType().isRecord();
+        boolean canReadField = isAccessible(fieldElement, visibility) && !fieldElement.getOwningType().isRecord();
         boolean canWriteField = canReadField && !fieldElement.isFinal();
-        boolean canRead = canReadField || hasMethodReadAccess(beanPropertyData);
-        boolean canWrite = canWriteField || hasMethodWriteAccess(beanPropertyData);
+        boolean canRead = canReadField || hasGeneratedPropertyAccessors || hasMethodReadAccess(beanPropertyData);
+        boolean canWrite = canWriteField || (hasGeneratedPropertyAccessors && !fieldElement.isFinal()) || hasMethodWriteAccess(beanPropertyData);
         boolean hasReadAccess = accessKinds.contains(Introspected.Property.Access.READ);
         boolean hasWriteAccess = accessKinds.contains(Introspected.Property.Access.WRITE);
         if ((hasReadAccess && canRead) || (hasWriteAccess && canWrite)) {
@@ -676,7 +693,9 @@ public final class AstBeanPropertiesUtils {
         }
         if (ignoreOtherAccessors) {
             beanPropertyData.field = fieldElement;
-            beanPropertyData.writeAccessKind = BeanProperties.AccessKind.FIELD;
+            if (isAccessor) {
+                beanPropertyData.writeAccessKind = BeanProperties.AccessKind.FIELD;
+            }
             beanPropertyData.type = fieldElement.getGenericType();
             return;
         }
@@ -701,7 +720,9 @@ public final class AstBeanPropertiesUtils {
                                                   boolean ignoreOtherAccessors) {
         if (ignoreOtherAccessors) {
             beanPropertyData.field = fieldElement;
-            beanPropertyData.readAccessKind = BeanProperties.AccessKind.FIELD;
+            if (isAccessor) {
+                beanPropertyData.readAccessKind = BeanProperties.AccessKind.FIELD;
+            }
             beanPropertyData.type = fieldElement.getGenericType();
             return;
         }
@@ -745,10 +766,15 @@ public final class AstBeanPropertiesUtils {
     private static boolean isAccessible(MemberElement memberElement, BeanProperties.Visibility visibility) {
         return switch (visibility) {
             case DEFAULT ->
-                !memberElement.isPrivate() && (memberElement.isAccessible() || memberElement.getDeclaringType().hasDeclaredStereotype(BeanProperties.class));
+                isGroovyPackageScope(memberElement) ||
+                    (!memberElement.isPrivate() && (memberElement.isAccessible() || memberElement.getDeclaringType().hasDeclaredStereotype(BeanProperties.class)));
             case PUBLIC -> memberElement.isPublic();
             case ANY -> true;
         };
+    }
+
+    private static boolean isGroovyPackageScope(MemberElement memberElement) {
+        return memberElement.hasAnnotation(ANN_GROOVY_PACKAGE_SCOPE);
     }
 
     private static boolean shouldExclude(Set<String> includes, Set<String> excludes, String propertyName) {
@@ -775,6 +801,7 @@ public final class AstBeanPropertiesUtils {
         public MemberElement propertyAccessMember;
         public boolean ignoreReadAccessors;
         public boolean ignoreWriteAccessors;
+        public boolean hasGeneratedPropertyAccessors;
 
         public BeanPropertyData(String propertyName) {
             this.propertyName = propertyName;

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyFieldElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyFieldElement.java
@@ -147,7 +147,8 @@ public class GroovyFieldElement extends AbstractGroovyElement implements FieldEl
 
     @Override
     public boolean isPackagePrivate() {
-        return !Modifier.isPublic(fieldNode.getModifiers()) && !Modifier.isProtected(fieldNode.getModifiers()) && !Modifier.isPrivate(fieldNode.getModifiers());
+        return super.isPackagePrivate() ||
+            (!Modifier.isPublic(fieldNode.getModifiers()) && !Modifier.isProtected(fieldNode.getModifiers()) && !Modifier.isPrivate(fieldNode.getModifiers()));
     }
 
     @Override

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.inject.visitor
 
 import com.blazebit.persistence.impl.function.entity.ValuesEntity
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.micronaut.ast.groovy.TypeElementVisitorStart
 import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 import io.micronaut.context.annotation.Executable
@@ -25,6 +26,41 @@ class BeanIntrospectionSpec extends AbstractBeanDefinitionSpec {
 
     def setup() {
         System.setProperty(TypeElementVisitorStart.ELEMENT_VISITORS_PROPERTY, IntrospectedTypeElementVisitor.name)
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/12727")
+    void "test json property on groovy property is not treated as inaccessible field"() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('test.CustomErrorResponse', '''
+package test
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class CustomErrorResponse {
+    String error
+
+    @JsonProperty("error_description")
+    String errorDescription
+
+    @JsonProperty("error_uri")
+    String errorUri
+}
+''')
+        BeanProperty errorDescription = introspection.getRequiredProperty("errorDescription", String)
+        BeanProperty errorUri = introspection.getRequiredProperty("errorUri", String)
+        def bean = introspection.instantiate()
+
+        when:
+        errorDescription.set(bean, "invalid")
+        errorUri.set(bean, "https://example.com/errors/invalid")
+
+        then:
+        errorDescription.get(bean) == "invalid"
+        errorDescription.stringValue(JsonProperty).get() == "error_description"
+        errorUri.get(bean) == "https://example.com/errors/invalid"
+        errorUri.stringValue(JsonProperty).get() == "error_uri"
     }
 
     void "test annotations"() {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
@@ -1022,6 +1022,52 @@ class Pet {
             packPrvFields.stream().map(FieldElement::getName).toList() == ["packprivme", "PACK_PRV_CONST"]
     }
 
+    void "test groovy package scope field visibility selection"() {
+        given:
+            ClassElement classElement = buildClassElement('test.GroovyFieldVisibility', '''
+package test
+
+import groovy.transform.PackageScope
+
+class GroovyFieldVisibility {
+    String propertyField
+
+    @PackageScope
+    String packageField
+
+    @PackageScope
+    static String packageStaticField
+}
+
+''')
+
+        when:
+            List<FieldElement> fields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS)
+            FieldElement propertyField = fields.find { it.name == 'propertyField' }
+            FieldElement packageField = fields.find { it.name == 'packageField' }
+            FieldElement packageStaticField = fields.find { it.name == 'packageStaticField' }
+
+        then:
+            propertyField.isPrivate()
+            !propertyField.isPackagePrivate()
+            packageField.isPackagePrivate()
+            !packageField.isPrivate()
+            packageStaticField.isPackagePrivate()
+            packageStaticField.isStatic()
+
+        when:
+            List<FieldElement> packagePrivateFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.filter(e -> e.isPackagePrivate()))
+
+        then:
+            packagePrivateFields*.name as Set == ['packageField', 'packageStaticField'] as Set
+
+        when:
+            List<FieldElement> accessibleFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.onlyAccessible())
+
+        then:
+            accessibleFields*.name as Set == ['packageField', 'packageStaticField'] as Set
+    }
+
     void "test annotations on generic type"() {
         given:
             ClassElement classElement = buildClassElement('test.PetOperations', '''

--- a/src/main/docs/guide/ioc/introspection/introspectedProperty.adoc
+++ b/src/main/docs/guide/ioc/introspection/introspectedProperty.adoc
@@ -50,9 +50,3 @@ For `JsonProperty`, Micronaut also maps Jackson's `access` member:
 * `JsonProperty.Access.AUTO` and `JsonProperty.Access.READ_WRITE` map to both read and write access.
 
 Because `accessKind` is property-level, multiple Jackson annotations that map to the same bean property must agree on the mapped access.
-
-== Jakarta Persistence
-
-Micronaut also maps `jakarta.persistence.Access` on a field or method to ann:core.annotation.Introspected.Property[] with `ignoreOtherAccessors` enabled.
-This allows explicit Jakarta Persistence field-access and property-access attributes to be treated as introspected bean properties.
-When `@Access(AccessType.FIELD)` is declared on a field that also has getter or setter methods, Micronaut uses the field directly for bean property reads and writes.


### PR DESCRIPTION
Only treat @Introspected.Property fields as direct field accessors when they are actually accessible, while allowing native Groovy properties to validate against generated accessors.

Remove the jakarta.persistence.Access introspection mapping and docs introduced by PR #12636.