### PR TITLE
Fix byte range handling for File responses

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
@@ -109,9 +109,15 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         "bytes=0-9000" | 200            | null                                                     | tempFileContents
         "bytes=abc-10" | 200            | null                                                     | tempFileContents
         "bytes=0-def"  | 200            | null                                                     | tempFileContents
+        "bytes=-0"     | 200            | null                                                     | tempFileContents
+        "bytes=2-1"    | 200            | null                                                     | tempFileContents
         "bytes=0-"     | 206            | "bytes 0-${tempFile.length() - 1}/${tempFile.length()}"  | tempFileContents
+        "bytes=0-0"    | 206            | "bytes 0-0/${tempFile.length()}"                         | tempFileContents.substring(0, 1)
         "bytes=10-"    | 206            | "bytes 10-${tempFile.length() - 1}/${tempFile.length()}" | tempFileContents.substring(10)
         "bytes=1-2"    | 206            | "bytes 1-2/${tempFile.length()}"                         | tempFileContents.substring(1, 3)
+        "bytes=-1"     | 206            | "bytes ${tempFile.length() - 1}-${tempFile.length() - 1}/${tempFile.length()}" | tempFileContents.substring(tempFileContents.length() - 1)
+        "bytes=-10"    | 206            | "bytes ${tempFile.length() - 10}-${tempFile.length() - 1}/${tempFile.length()}" | tempFileContents.substring(tempFileContents.length() - 10)
+        "bytes=-9000"  | 206            | "bytes 0-${tempFile.length() - 1}/${tempFile.length()}"  | tempFileContents
     }
 
     void "test cache control can be overridden"() {

--- a/http-server/src/main/java/io/micronaut/http/server/body/SystemFileBodyWriter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/body/SystemFileBodyWriter.java
@@ -110,8 +110,8 @@ public final class SystemFileBodyWriter extends AbstractFileBodyWriter implement
                 ) {
                     IntRange range = parseRangeHeader(rangeHeader, fileLength);
                     if (range != null // A server that supports range requests MAY ignore or reject a Range header field that contains an invalid ranges-specifier (Section 14.1.1)
-                        && range.firstPos < range.lastPos // A server that supports range requests MAY ignore a Range header field when the selected representation has no content (i.e., the selected representation's data is of zero length).
-                        && range.firstPos < fileLength
+                        && range.firstPos <= range.lastPos
+                        && range.firstPos < fileLength // A server that supports range requests MAY ignore a Range header field when the selected representation has no content (i.e., the selected representation's data is of zero length).
                         && range.lastPos < fileLength
                     ) {
                         position = range.firstPos;
@@ -172,7 +172,14 @@ public final class SystemFileBodyWriter extends AbstractFileBodyWriter implement
         String from = value.substring(equalsIdx + 1, minusIdx).trim();
         String to = value.substring(minusIdx + 1).trim();
         try {
-            long fromPosition = from.isEmpty() ? 0 : Long.parseLong(from);
+            if (from.isEmpty()) {
+                long suffixLength = Long.parseLong(to);
+                if (suffixLength < 1 || contentLength < 1) {
+                    return null;
+                }
+                return new IntRange(Math.max(contentLength - suffixLength, 0), contentLength - 1);
+            }
+            long fromPosition = Long.parseLong(from);
             long toPosition = to.isEmpty() ? contentLength - 1 : Long.parseLong(to);
             return new IntRange(fromPosition, toPosition);
         } catch (NumberFormatException e) {


### PR DESCRIPTION
## Summary

Fixes #12731

Range handling for File/SystemFile responses had two small gaps from #8553:

- `Range: bytes=0-0` was ignored because single-byte ranges did not pass the range check.
- `Range: bytes=-10` returned bytes from the start of the file instead of the last 10 bytes.

Invalid and unsupported ranges still fall back the same way as before.

## Testing

- `./gradlew :micronaut-http-server-netty:test --tests io.micronaut.http.server.netty.types.FileTypeHandlerSpec`