### PR TITLE
Handle invalid locale conversion

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -811,7 +811,14 @@ public class DefaultMutableConversionService implements MutableConversionService
         });
 
         // String -> Locale
-        addInternalConverter(CharSequence.class, Locale.class, object -> StringUtils.parseLocale(object.toString()));
+        addInternalConverter(CharSequence.class, Locale.class, (CharSequence object, Class<Locale> targetType, ConversionContext context) -> {
+            try {
+                return Optional.ofNullable(StringUtils.parseLocale(object.toString()));
+            } catch (IllegalArgumentException e) {
+                context.reject(object, e);
+                return Optional.empty();
+            }
+        });
 
         // String -> UUID
         addInternalConverter(CharSequence.class, UUID.class, (CharSequence object, Class<UUID> targetType, ConversionContext context) -> {

--- a/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
@@ -94,6 +94,27 @@ class DefaultConversionServiceSpec extends Specification {
         targetType << [File, Date, Integer, BigInteger, Float, Double, Long, Short, Byte, BigDecimal, URL, URI, Locale, UUID, Currency, TimeZone, Charset, Status]
     }
 
+    void "test invalid locale conversion"() {
+        given:
+        ConversionService conversionService = new DefaultMutableConversionService()
+
+        expect:
+        !conversionService.convert("?/", Locale).isPresent()
+    }
+
+    void "test invalid locale convert required"() {
+        given:
+        ConversionService conversionService = new DefaultMutableConversionService()
+
+        when:
+        conversionService.convertRequired("?/", Locale)
+
+        then:
+        def e = thrown(ConversionErrorException)
+        e.conversionError.originalValue.get() == "?/"
+        e.message.contains('Locale part "?/" contains invalid characters')
+    }
+
     void "test convert required"() {
         given:
         ConversionService conversionService = new DefaultMutableConversionService()


### PR DESCRIPTION
## Summary

Fixes an OSS-Fuzz crash where invalid locale text could escape `ConversionService.convert(..., Locale.class)` as an uncaught `IllegalArgumentException`.

The `CharSequence -> Locale` converter now treats invalid locale syntax like other parsing converters in `DefaultMutableConversionService`: it rejects the value through the `ConversionContext` and returns `Optional.empty()` instead of leaking the parser exception.

## Details

- Keeps `StringUtils.parseLocale` strict for direct callers.
- Catches only `IllegalArgumentException` at the conversion boundary.
- Preserves conversion error details for `convertRequired(...)`.
- Adds regression coverage for both optional and required Locale conversions using the OSS-Fuzz-style invalid input `?/`.

## Verification

- `./gradlew :micronaut-core:test --tests io.micronaut.core.convert.DefaultConversionServiceSpec -q`

OSS-Fuzz testcase: 6287336563605504
