### PR TITLE
Fix RequestBean binding without query values

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/RequestBeanSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/RequestBeanSpec.groovy
@@ -136,6 +136,16 @@ class RequestBeanSpec extends Specification {
         client.requestBeanNull(null) == "null"
     }
 
+    void "test request bean with only nullable values is instantiated when no input is provided"() {
+        expect:
+        client.allNullableBean() == "null:null"
+    }
+
+    void "test request bean with only nullable setter values is instantiated when no input is provided"() {
+        expect:
+        client.allNullableSetterBean() == "null:null"
+    }
+
     void "test nullable request bean with only context properties returns null"() {
         expect:
         client.contextOnlyBean() == null
@@ -242,6 +252,16 @@ class RequestBeanSpec extends Specification {
             return bean == null ? "null" : "not-null"
         }
 
+        @Get("/all-nullable")
+        String allNullableBean(@RequestBean AllNullableBean bean) {
+            return "$bean.name:$bean.age"
+        }
+
+        @Get("/all-nullable-setter")
+        String allNullableSetterBean(@RequestBean AllNullableSetterBean bean) {
+            return "$bean.name:$bean.age"
+        }
+
         @Get("/context-only")
         ContextOnlyBean contextOnly(@Nullable @RequestBean ContextOnlyBean bean) {
             return bean
@@ -299,6 +319,12 @@ class RequestBeanSpec extends Specification {
 
         @Get("/request-bean-nullable")
         String requestBeanNull(@RequestBean @Nullable EmptyBean bean)
+
+        @Get("/all-nullable")
+        String allNullableBean()
+
+        @Get("/all-nullable-setter")
+        String allNullableSetterBean()
 
         @Get("/context-only")
         ContextOnlyBean contextOnlyBean()
@@ -409,6 +435,35 @@ class RequestBeanSpec extends Specification {
     @Introspected
     static class EmptyBean {
         @Nullable String value
+    }
+
+    @Introspected
+    static class AllNullableBean {
+
+        @Nullable
+        @QueryValue
+        final String name
+
+        @Nullable
+        @QueryValue
+        final Integer age
+
+        AllNullableBean(String name, Integer age) {
+            this.name = name
+            this.age = age
+        }
+    }
+
+    @Introspected
+    static class AllNullableSetterBean {
+
+        @Nullable
+        @QueryValue
+        String name
+
+        @Nullable
+        @QueryValue
+        Integer age
     }
 
     @Introspected

--- a/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
@@ -100,7 +100,7 @@ public class RequestBeanAnnotationBinder<T> implements AnnotatedRequestArgumentB
                     }
                     argumentValues[i] = constructorArgument.isOptional() ? bindableResult : bindableResult.orElse(null);
                 }
-                if (!bindingFound) {
+                if (!bindingFound && argument.isNullable()) {
                     return BindingResult.empty();
                 }
                 return () -> Optional.of(introspection.instantiate(false, argumentValues));
@@ -115,7 +115,7 @@ public class RequestBeanAnnotationBinder<T> implements AnnotatedRequestArgumentB
                         bindingFound = true;
                     }
                 }
-                if (!bindingFound) {
+                if (!bindingFound && argument.isNullable()) {
                     return BindingResult.empty();
                 }
 


### PR DESCRIPTION
## Summary
- restore non-null @RequestBean instantiation when no request values are present but the request bean parameter itself is not nullable
- keep @RequestBean @Nullable behavior returning null when no request values are present
- add constructor and setter regression coverage for all-nullable request bean properties

## Verification
- ./gradlew :micronaut-http-client:test --tests io.micronaut.http.client.aop.RequestBeanSpec -q -x japiCmp -x checkVersionCatalogCompatibility
- ./gradlew :micronaut-http:check -q -x japiCmp -x checkVersionCatalogCompatibility
- git diff --check

Bisect identified 939478a5d302bc1a7d76a70c9bbffa74549e0b4c (#12632) as the upstream regression source.

Resolves #12738