### PR TITLE
Fix Jackson introspection for generated property names

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -201,11 +201,12 @@ public final class AstBeanPropertiesUtils {
                 }
                 continue;
             }
-            String propertyName = fieldElement.getSimpleName();
-            boolean isPropertyField = propertyFields.contains(propertyName);
+            String fieldPropertyName = fieldElement.getSimpleName();
+            String propertyName = resolvePropertyNameForField(props, fieldPropertyName);
+            boolean isPropertyField = propertyFields.contains(fieldPropertyName);
             boolean hasConstructorWriteAccess = isIntrospectedPropertyField
                 && isWriteOnlyIntrospectedProperty(fieldElement)
-                && hasConstructorWriteAccess(classElement, propertyName, fieldElement.getGenericType());
+                && hasConstructorWriteAccess(classElement, propertyName, fieldPropertyName, fieldElement.getGenericType());
             boolean canUseFieldForAccess = canFieldBeUsedForAccess(fieldElement, effectiveAccessKinds, visibility, configuration) ||
                 canNativePropertyFieldBeUsedForAccess(isPropertyField, fieldElement, effectiveAccessKinds, visibility) ||
                 canIntrospectedPropertyFieldBeUsedForAccess(fieldElement, visibility);
@@ -291,6 +292,19 @@ public final class AstBeanPropertiesUtils {
             }
         }
         return beanProperties;
+    }
+
+    private static String resolvePropertyNameForField(Map<String, BeanPropertyData> props, String fieldPropertyName) {
+        if (props.containsKey(fieldPropertyName)) {
+            return fieldPropertyName;
+        }
+        if (fieldPropertyName.length() > 1 && fieldPropertyName.charAt(0) == '$') {
+            String accessorPropertyName = "$" + Character.toUpperCase(fieldPropertyName.charAt(1)) + fieldPropertyName.substring(2);
+            if (props.containsKey(accessorPropertyName)) {
+                return accessorPropertyName;
+            }
+        }
+        return fieldPropertyName;
     }
 
     private static boolean isIntrospectedPropertyReader(MethodElement methodElement, BeanProperties.Visibility visibility) {
@@ -473,6 +487,14 @@ public final class AstBeanPropertiesUtils {
             }
         }
         return false;
+    }
+
+    private static boolean hasConstructorWriteAccess(ClassElement classElement,
+                                                     String propertyName,
+                                                     String fieldPropertyName,
+                                                     @Nullable ClassElement type) {
+        return hasConstructorWriteAccess(classElement, propertyName, type) ||
+            (!fieldPropertyName.equals(propertyName) && hasConstructorWriteAccess(classElement, fieldPropertyName, type));
     }
 
     private static void validateIntrospectedPropertyField(FieldElement fieldElement,

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -1142,12 +1142,13 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
             for (int i = 0; i < parameters.length; i++) {
                 ParameterElement parameter = parameters[i];
                 String parameterName = parameter.getName();
+                String propertyName = resolvePropertyNameForConstructorArgument(parameterName);
 
                 BeanPropertyData prop = beanProperties.stream()
-                    .filter(bp -> bp.name.equals(parameterName))
+                    .filter(bp -> bp.name.equals(propertyName))
                     .findAny().orElse(null);
 
-                Integer propertyIndex = propertyNames.get(parameterName);
+                Integer propertyIndex = propertyNames.get(propertyName);
                 if (propertyIndex != null && propertyNames.size() == 1) {
                     newValueArguments[i] = true;
                     if (prop != null) {
@@ -1197,7 +1198,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
                         ParameterElement parameter = parameters[i];
                         Object constructorArgument = constructorArguments[i];
 
-                        Integer propertyIndex = propertyNames.get(parameter.getName());
+                        Integer propertyIndex = propertyNames.get(resolvePropertyNameForConstructorArgument(parameter.getName()));
                         ExpressionDef paramExp;
                         if (newValueArguments[i]) {
                             paramExp = value.cast(TypeDef.erasure(parameter.getType()));
@@ -1311,6 +1312,24 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
         @Override
         public TypedElement getDeclaringType() {
             return constructor.getDeclaringType();
+        }
+
+        private String resolvePropertyNameForConstructorArgument(String parameterName) {
+            if (hasBeanProperty(parameterName)) {
+                return parameterName;
+            }
+            if (parameterName.length() > 1 && parameterName.charAt(0) == '$') {
+                String accessorPropertyName = "$" + Character.toUpperCase(parameterName.charAt(1)) + parameterName.substring(2);
+                if (hasBeanProperty(accessorPropertyName)) {
+                    return accessorPropertyName;
+                }
+            }
+            return parameterName;
+        }
+
+        private boolean hasBeanProperty(String propertyName) {
+            return propertyNames.containsKey(propertyName) ||
+                beanProperties.stream().anyMatch(bp -> bp.name.equals(propertyName));
         }
 
     }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.visitors
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.Introspected
 import io.micronaut.http.annotation.Get
 import io.micronaut.inject.ast.ClassElement
 import jakarta.annotation.Nullable
@@ -716,6 +717,200 @@ class JacksonPropertyAccessBean {
         readOnly.isReadOnly()
         writeOnly.isWriteOnly()
         setterOnly.isWriteOnly()
+    }
+
+    void "test jackson property on generated dollar prefixed private field uses public accessors"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonDollarPrefixedFieldBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class JacksonDollarPrefixedFieldBean {
+    public static final String JSON_PROPERTY_$_REF = "$ref";
+
+    @JsonProperty(JSON_PROPERTY_$_REF)
+    @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+    private String $ref;
+
+    public String get$Ref() {
+        return $ref;
+    }
+
+    public void set$Ref(String $ref) {
+        this.$ref = $ref;
+    }
+}
+''')
+        def property = introspection.getRequiredProperty('$Ref', String)
+
+        expect:
+        property.stringValue(Introspected.Property, "name").orElseThrow() == '$ref'
+    }
+
+    void "test jackson property on generated underscore prefixed private field uses public accessors"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonUnderscorePrefixedFieldBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class JacksonUnderscorePrefixedFieldBean {
+    public static final String JSON_PROPERTY_DEFAULT = "default";
+
+    @JsonProperty(JSON_PROPERTY_DEFAULT)
+    @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
+    private String _default;
+
+    public String get_default() {
+        return _default;
+    }
+
+    public void set_default(String _default) {
+        this._default = _default;
+    }
+}
+''')
+        def property = introspection.getRequiredProperty('_default', String)
+
+        expect:
+        property.stringValue(Introspected.Property, "name").orElseThrow() == 'default'
+    }
+
+    void "test jackson write only final dollar prefixed field resolves as constructor property"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonWriteOnlyDollarConstructorGetterBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class JacksonWriteOnlyDollarConstructorGetterBean {
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private final String $ref;
+
+    @JsonCreator
+    JacksonWriteOnlyDollarConstructorGetterBean(@JsonProperty("$ref") String $ref) {
+        this.$ref = $ref;
+    }
+
+    public String get$Ref() {
+        return $ref;
+    }
+}
+''')
+        def property = introspection.getRequiredProperty('$Ref', String)
+        def writeProperty = introspection.getRequiredWriteProperty('$Ref', String)
+        def bean = introspection.instantiate('value')
+        def updated = writeProperty.withValue(bean, 'updated')
+
+        expect:
+        property.isWriteOnly()
+        !property.isReadOnly()
+        introspection.getReadProperty('$Ref').isEmpty()
+        introspection.getWriteProperty('$Ref').isPresent()
+        updated.get$Ref() == 'updated'
+    }
+
+    void "test jackson write only final underscore prefixed field resolves as constructor property"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonWriteOnlyUnderscoreConstructorGetterBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class JacksonWriteOnlyUnderscoreConstructorGetterBean {
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private final String _default;
+
+    @JsonCreator
+    JacksonWriteOnlyUnderscoreConstructorGetterBean(@JsonProperty("default") String _default) {
+        this._default = _default;
+    }
+
+    public String get_default() {
+        return _default;
+    }
+}
+''')
+        def property = introspection.getRequiredProperty('_default', String)
+        def writeProperty = introspection.getRequiredWriteProperty('_default', String)
+        def bean = introspection.instantiate('value')
+        def updated = writeProperty.withValue(bean, 'updated')
+
+        expect:
+        property.isWriteOnly()
+        !property.isReadOnly()
+        introspection.getReadProperty('_default').isEmpty()
+        introspection.getWriteProperty('_default').isPresent()
+        updated.get_default() == 'updated'
+    }
+
+    void "test jackson write only dollar prefixed record component resolves as constructor property"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonWriteOnlyDollarRecord', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+record JacksonWriteOnlyDollarRecord(
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    String $ref
+) {
+}
+''')
+        def property = introspection.getRequiredProperty('$ref', String)
+        def writeProperty = introspection.getRequiredWriteProperty('$ref', String)
+        def bean = introspection.instantiate('value')
+        def updated = writeProperty.withValue(bean, 'updated')
+
+        expect:
+        property.isWriteOnly()
+        !property.isReadOnly()
+        introspection.getReadProperty('$ref').isEmpty()
+        introspection.getWriteProperty('$ref').isPresent()
+        updated.$ref() == 'updated'
+    }
+
+    void "test jackson write only underscore prefixed record component resolves as constructor property"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonWriteOnlyUnderscoreRecord', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+record JacksonWriteOnlyUnderscoreRecord(
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    String _default
+) {
+}
+''')
+        def property = introspection.getRequiredProperty('_default', String)
+        def writeProperty = introspection.getRequiredWriteProperty('_default', String)
+        def bean = introspection.instantiate('value')
+        def updated = writeProperty.withValue(bean, 'updated')
+
+        expect:
+        property.isWriteOnly()
+        !property.isReadOnly()
+        introspection.getReadProperty('_default').isEmpty()
+        introspection.getWriteProperty('_default').isPresent()
+        updated._default() == 'updated'
     }
 
     void "test jackson write only record component resolves as write only constructor property"() {


### PR DESCRIPTION
Support generated dollar-prefixed fields whose JavaBean accessors use capitalized special-character names, including constructor-backed write properties and copy-constructor mutation.

Add regression coverage for dollar and underscore generated fields, final constructor properties, and records.