### PR TITLE
Handle invalid zone id conversion

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -197,7 +197,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             try {
                 ZoneId result = ZoneId.of(object.toString());
                 return Optional.of(result);
-            } catch (DateTimeParseException e) {
+            } catch (DateTimeException e) {
                 context.reject(object, e);
                 return Optional.empty();
             }

--- a/context/src/test/groovy/io/micronaut/runtime/converters/time/ZoneIdConverterSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/runtime/converters/time/ZoneIdConverterSpec.groovy
@@ -1,0 +1,48 @@
+package io.micronaut.runtime.converters.time
+
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.convert.DefaultMutableConversionService
+import io.micronaut.core.convert.MutableConversionService
+import io.micronaut.core.convert.exceptions.ConversionErrorException
+import spock.lang.Specification
+
+import java.time.ZoneId
+
+class ZoneIdConverterSpec extends Specification {
+
+    private ConversionService conversionService() {
+        MutableConversionService conversionService = new DefaultMutableConversionService()
+        new TimeConverterRegistrar().register(conversionService)
+        conversionService
+    }
+
+    void "test invalid zone id '#value' converts to empty"() {
+        given:
+        ConversionService conversionService = conversionService()
+
+        expect:
+        !conversionService.convert(value, ZoneId).isPresent()
+
+        where:
+        value << ["foobar", "Europe/Foobar", "foo bar", "+25:00"]
+    }
+
+    void "test invalid zone id convert required throws conversion error"() {
+        given:
+        ConversionService conversionService = conversionService()
+
+        when:
+        conversionService.convertRequired("foobar", ZoneId)
+
+        then:
+        thrown(ConversionErrorException)
+    }
+
+    void "test valid zone id conversion"() {
+        given:
+        ConversionService conversionService = conversionService()
+
+        expect:
+        conversionService.convert("Europe/London", ZoneId).get() == ZoneId.of("Europe/London")
+    }
+}


### PR DESCRIPTION
the charsequence to zoneid converter in `TimeConverterRegistrar` only catches `DateTimeParseException`, but `ZoneId.of` throws `ZoneRulesException` for an unknown region and a plain `DateTimeException` for a malformed id, neither of which extends `DateTimeParseException`. a bound request value such as `?zone=foobar` therefore leaks the exception straight out of `ConversionService.convert` instead of being rejected, so a bad value turns into a 500 rather than a 400. widening the catch to `DateTimeException` routes every parse failure through `context.reject` and resolves the conversion to `Optional.empty`, the same broader type the temporal format converters in this class already catch.
