### PR TITLE
Update brotli4j for Netty compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 awaitility = "4.3.0"
 bcpkix = "1.84"
 blaze = "1.6.18"
-brotli4j = "1.18.0"
+brotli4j = "1.23.0"
 bytebuddy = "1.18.10"
 caffeine = "2.9.3"
 classgraph = "4.8.184"


### PR DESCRIPTION
## Summary
- update managed brotli4j to 1.23.0
- align with Netty BrotliDecoder's DecoderJNI.Wrapper.pull(int) API usage

## Verification
- Parsed gradle/libs.versions.toml with Python tomllib and confirmed brotli4j = 1.23.0
- Ran ./gradlew -q help