### PR TITLE
Use configuration properties for logger levels

### DIFF
--- a/context/src/main/java/io/micronaut/logging/LoggingConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/logging/LoggingConverterRegistrar.java
@@ -16,9 +16,12 @@
 package io.micronaut.logging;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.CharSequenceToEnumConverter;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.micronaut.core.util.StringUtils;
+
+import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Logging converters.
@@ -31,7 +34,17 @@ public final class LoggingConverterRegistrar implements TypeConverterRegistrar {
 
     @Override
     public void register(MutableConversionService conversionService) {
-        conversionService.addConverter(CharSequence.class, LogLevel.class, new CharSequenceToEnumConverter<>());
+        conversionService.addConverter(CharSequence.class, LogLevel.class, (object, targetType, context) -> {
+            if (StringUtils.isEmpty(object)) {
+                return Optional.of(LogLevel.NOT_SPECIFIED);
+            }
+            try {
+                return Optional.of(Enum.valueOf(LogLevel.class, object.toString().toUpperCase(Locale.ENGLISH)));
+            } catch (IllegalArgumentException e) {
+                context.reject(object, e);
+                return Optional.empty();
+            }
+        });
         conversionService.addConverter(Boolean.class, LogLevel.class, value -> value ? null : LogLevel.OFF);
     }
 }

--- a/context/src/main/java/io/micronaut/logging/LoggingConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/logging/LoggingConverterRegistrar.java
@@ -32,5 +32,6 @@ public final class LoggingConverterRegistrar implements TypeConverterRegistrar {
     @Override
     public void register(MutableConversionService conversionService) {
         conversionService.addConverter(CharSequence.class, LogLevel.class, new CharSequenceToEnumConverter<>());
+        conversionService.addConverter(Boolean.class, LogLevel.class, value -> value ? null : LogLevel.OFF);
     }
 }

--- a/context/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
+++ b/context/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
@@ -151,6 +151,7 @@ final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListene
     @ConfigurationProperties(LOGGER_PROPERTY_PREFIX)
     @Internal
     static final class PropertiesLoggingLevelsConfiguration {
+        @MapFormat(keyFormat = StringConvention.RAW, transformation = MapFormat.MapTransformation.FLAT)
         private Map<String, LogLevel> levels = Map.of();
 
         /**
@@ -167,7 +168,7 @@ final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListene
          *
          * @param levels The log levels
          */
-        public void setLevels(@MapFormat(keyFormat = StringConvention.RAW) Map<String, LogLevel> levels) {
+        public void setLevels(@MapFormat(keyFormat = StringConvention.RAW, transformation = MapFormat.MapTransformation.FLAT) Map<String, LogLevel> levels) {
             this.levels = levels;
         }
     }

--- a/context/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
+++ b/context/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
@@ -16,13 +16,16 @@
 package io.micronaut.logging;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.conventions.StringConvention;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
 import jakarta.inject.Singleton;
@@ -49,23 +52,28 @@ import java.util.Map;
 @Requires(beans = Environment.class)
 @Requires(property = PropertiesLoggingLevelsConfigurer.LOGGER_PROPERTY_PREFIX)
 @Internal
-final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListener<RefreshEvent> {
+final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListener<RefreshEvent>, Ordered {
 
     static final String LOGGER_PROPERTY_PREFIX = "logger";
     static final String LOGGER_LEVELS_PROPERTY_PREFIX = LOGGER_PROPERTY_PREFIX + ".levels";
     private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesLoggingLevelsConfigurer.class);
 
     private final Environment environment;
+    private final PropertiesLoggingLevelsConfiguration configuration;
     private final List<LoggingSystem> loggingSystems;
 
     /**
      * Sets log level according to properties.
      *
-     * @param environment   The environment
+     * @param environment The environment
+     * @param configuration The logging levels configuration
      * @param loggingSystems The logging systems
      */
-    PropertiesLoggingLevelsConfigurer(Environment environment, List<LoggingSystem> loggingSystems) {
+    PropertiesLoggingLevelsConfigurer(Environment environment,
+                                      PropertiesLoggingLevelsConfiguration configuration,
+                                      List<LoggingSystem> loggingSystems) {
         this.environment = environment;
+        this.configuration = configuration;
         this.loggingSystems = loggingSystems;
         initLogging();
         configureLogLevels();
@@ -82,25 +90,31 @@ final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListene
         configureLogLevels();
     }
 
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
     private void initLogging() {
         this.loggingSystems.forEach(LoggingSystem::refresh);
     }
 
     private void configureLogLevels() {
-        // Using raw keys here allows configuring log levels for camelCase package names in application.yml
-        final Map<String, Object> rawProperties = environment.getProperties(LOGGER_LEVELS_PROPERTY_PREFIX, StringConvention.RAW);
         // Adding the generated properties allows environment variables and system properties to override names in application.yaml
         final Map<String, Object> generatedProperties = environment.getProperties(LOGGER_LEVELS_PROPERTY_PREFIX);
+        final Map<String, LogLevel> levels = configuration.getLevels();
 
-        final Map<String, Object> properties = new HashMap<>(generatedProperties.size() + rawProperties.size(), 1f);
-        properties.putAll(rawProperties);
+        final Map<String, Object> properties = new HashMap<>(generatedProperties.size() + levels.size(), 1f);
+        properties.putAll(levels);
         properties.putAll(generatedProperties);
         properties.forEach(this::configureLogLevelForPrefix);
     }
 
     private void configureLogLevelForPrefix(final String loggerPrefix, final Object levelValue) {
         final LogLevel newLevel;
-        if (levelValue instanceof Boolean boolean1 && !boolean1) {
+        if (levelValue instanceof LogLevel logLevel) {
+            newLevel = logLevel;
+        } else if (levelValue instanceof Boolean booleanValue && !booleanValue) {
             newLevel = LogLevel.OFF; // SnakeYAML converts OFF (without quotations) to a boolean false value, hence we need to handle that here...
         } else {
             newLevel = toLogLevel(levelValue.toString());
@@ -130,4 +144,31 @@ final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListene
         }
     }
 
+    /**
+     * Configuration for setting log levels from {@code logger.levels}.
+     */
+    @BootstrapContextCompatible
+    @ConfigurationProperties(LOGGER_PROPERTY_PREFIX)
+    @Internal
+    static final class PropertiesLoggingLevelsConfiguration {
+        private Map<String, LogLevel> levels = Map.of();
+
+        /**
+         * The configured log levels keyed by logger name.
+         *
+         * @return The log levels
+         */
+        public Map<String, LogLevel> getLevels() {
+            return levels;
+        }
+
+        /**
+         * Sets the configured log levels keyed by logger name.
+         *
+         * @param levels The log levels
+         */
+        public void setLevels(@MapFormat(keyFormat = StringConvention.RAW) Map<String, LogLevel> levels) {
+            this.levels = levels;
+        }
+    }
 }

--- a/context/src/test/groovy/io/micronaut/logging/PropertiesLoggingLevelsConfigurerSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/logging/PropertiesLoggingLevelsConfigurerSpec.groovy
@@ -15,7 +15,8 @@ class PropertiesLoggingLevelsConfigurerSpec extends Specification {
     Map<String, Object> config = [
             'logger.levels.com.foo.bar': 'info',
             'logger.levels.com.packass': 'DeBuG',
-            'logger.levels.my.warn': 'WARN'
+            'logger.levels.my.warn': 'WARN',
+            'logger.levels.my.off': false
     ]
     @Shared
     @AutoCleanup
@@ -28,7 +29,8 @@ class PropertiesLoggingLevelsConfigurerSpec extends Specification {
         given:
         def env = context.getEnvironment()
         def loggingSystem = new LogbackLoggingSystem(null, null)
-        def configurer = new PropertiesLoggingLevelsConfigurer(env, List.of(loggingSystem))
+        def configuration = context.getBean(PropertiesLoggingLevelsConfigurer.PropertiesLoggingLevelsConfiguration)
+        def configurer = new PropertiesLoggingLevelsConfigurer(env, configuration, List.of(loggingSystem))
 
         when:
         configurer.onApplicationEvent(null)
@@ -38,5 +40,16 @@ class PropertiesLoggingLevelsConfigurerSpec extends Specification {
         loggerContext.getLogger('com.foo.bar').level == Level.INFO
         loggerContext.getLogger('com.packass').level == Level.DEBUG
         loggerContext.getLogger('my.warn').level == Level.WARN
+        loggerContext.getLogger('my.off').level == Level.OFF
+    }
+
+    void "test configuration properties preserve raw logger names"() {
+        expect:
+        context.getBean(PropertiesLoggingLevelsConfigurer.PropertiesLoggingLevelsConfiguration).levels.keySet().containsAll([
+                'com.foo.bar',
+                'com.packass',
+                'my.warn',
+                'my.off'
+        ])
     }
 }


### PR DESCRIPTION
## Summary
- bind logger levels through a logger @ConfigurationProperties holder with raw map keys
- keep generated property fallback so env/system properties can override application configuration
- make the configurer highest precedence and preserve boolean false -> OFF conversion

## Tests
- git diff --check
- ./gradlew :context:test --tests io.micronaut.logging.PropertiesLoggingLevelsConfigurerSpec *(blocked: Gradle cannot resolve com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.3.9 from configured plugin repositories; retried outside sandbox with the same result)*