### PR TITLE
Wrap Jackson JsonMapper exceptions

### DIFF
--- a/jackson-databind/src/main/java/io/micronaut/jackson/databind/DatabindPropertyBinderExceptionHandler.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/databind/DatabindPropertyBinderExceptionHandler.java
@@ -39,7 +39,8 @@ import java.util.Optional;
 final class DatabindPropertyBinderExceptionHandler implements JsonBeanPropertyBinderExceptionHandler {
     @Override
     public Optional<ConversionErrorException> toConversionError(@Nullable Object object, Exception e) {
-        if (e instanceof InvalidFormatException ife) {
+        InvalidFormatException ife = findInvalidFormatException(e);
+        if (ife != null) {
             Object originalValue = ife.getValue();
             var conversionError = new ConversionError() {
                 @Override
@@ -63,5 +64,13 @@ final class DatabindPropertyBinderExceptionHandler implements JsonBeanPropertyBi
             return Optional.of(new ConversionErrorException(Argument.of(ife.getTargetType(), name), conversionError));
         }
         return Optional.empty();
+    }
+
+    @Nullable
+    private static InvalidFormatException findInvalidFormatException(Exception e) {
+        if (e instanceof InvalidFormatException ife) {
+            return ife;
+        }
+        return e.getCause() instanceof InvalidFormatException ife ? ife : null;
     }
 }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
@@ -43,6 +43,7 @@ import jakarta.inject.Singleton;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonFactory;
@@ -194,21 +195,33 @@ public final class JacksonDatabindMapper implements JsonMapper {
     @Override
     @Nullable
     public <T> T readValueFromTree(JsonNode tree, Argument<T> type) throws IOException {
-        return createReader(type).readValue(treeAsTokens(tree));
+        try {
+            return createReader(type).readValue(treeAsTokens(tree));
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
+        }
     }
 
     @Override
     public JsonNode writeValueToTree(@Nullable Object value) throws IOException {
-        TreeGenerator treeGenerator = treeCodec.createTreeGenerator();
-        objectMapper.writeValue(treeGenerator, value);
-        return treeGenerator.getCompletedValue();
+        try {
+            TreeGenerator treeGenerator = treeCodec.createTreeGenerator();
+            objectMapper.writeValue(treeGenerator, value);
+            return treeGenerator.getCompletedValue();
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
+        }
     }
 
     @Override
     public <T> JsonNode writeValueToTree(Argument<T> type, @Nullable T value) throws IOException {
-        TreeGenerator treeGenerator = treeCodec.createTreeGenerator();
-        createWriter(type).writeValue(treeGenerator, value);
-        return treeGenerator.getCompletedValue();
+        try {
+            TreeGenerator treeGenerator = treeCodec.createTreeGenerator();
+            createWriter(type).writeValue(treeGenerator, value);
+            return treeGenerator.getCompletedValue();
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
+        }
     }
 
     @Override
@@ -216,8 +229,8 @@ public final class JacksonDatabindMapper implements JsonMapper {
     public <T> T readValue(InputStream inputStream, Argument<T> type) throws IOException {
         try {
             return createReader(type).readValue(inputStream);
-        } catch (StreamReadException pe) {
-            throw new JsonSyntaxException(pe);
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
         }
     }
 
@@ -226,8 +239,8 @@ public final class JacksonDatabindMapper implements JsonMapper {
     public <T> T readValue(byte[] byteArray, Argument<T> type) throws IOException {
         try {
             return createReader(type).readValue(byteArray);
-        } catch (StreamReadException pe) {
-            throw new JsonSyntaxException(pe);
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
         }
     }
 
@@ -236,8 +249,8 @@ public final class JacksonDatabindMapper implements JsonMapper {
     public <T> T readValue(ByteBuffer<?> byteBuffer, Argument<T> type) throws IOException {
         try (JsonParser parser = JacksonCoreParserFactory.createJsonParser((JsonFactory) objectMapper.tokenStreamFactory(), objectMapper._deserializationContext(), byteBuffer)) {
             return createReader(type).readValue(parser);
-        } catch (StreamReadException pe) {
-            throw new JsonSyntaxException(pe);
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
         }
     }
 
@@ -253,41 +266,61 @@ public final class JacksonDatabindMapper implements JsonMapper {
             }
 
             return reader.readValue(readBuffer.toInputStream());
-        } catch (StreamReadException pe) {
-            throw new JsonSyntaxException(pe);
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
         }
     }
 
     @Override
     public void writeValue(OutputStream outputStream, @Nullable Object object) throws IOException {
-        if (specializedWriter != null) {
-            specializedWriter.writeValue(outputStream, object);
-        } else {
-            objectMapper.writeValue(outputStream, object);
+        try {
+            if (specializedWriter != null) {
+                specializedWriter.writeValue(outputStream, object);
+            } else {
+                objectMapper.writeValue(outputStream, object);
+            }
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
         }
     }
 
     @Override
     public <T> void writeValue(OutputStream outputStream, Argument<T> type, @Nullable T object) throws IOException {
-        createWriter(type).writeValue(outputStream, object);
+        try {
+            createWriter(type).writeValue(outputStream, object);
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
+        }
     }
 
     @Override
     public byte[] writeValueAsBytes(@Nullable Object object) throws IOException {
-        if (specializedWriter != null) {
-            return specializedWriter.writeValueAsBytes(object);
+        try {
+            if (specializedWriter != null) {
+                return specializedWriter.writeValueAsBytes(object);
+            }
+            return objectMapper.writeValueAsBytes(object);
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
         }
-        return objectMapper.writeValueAsBytes(object);
     }
 
     @Override
     public <T> byte[] writeValueAsBytes(Argument<T> type, @Nullable T object) throws IOException {
-        return createWriter(type).writeValueAsBytes(object);
+        try {
+            return createWriter(type).writeValueAsBytes(object);
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
+        }
     }
 
     @Override
     public void updateValueFromTree(Object value, JsonNode tree) throws IOException {
-        objectMapper.readerForUpdating(value).readValue(treeAsTokens(tree));
+        try {
+            objectMapper.readerForUpdating(value).readValue(treeAsTokens(tree));
+        } catch (JacksonException e) {
+            throw wrapJacksonException(e);
+        }
     }
 
     @Override
@@ -337,6 +370,13 @@ public final class JacksonDatabindMapper implements JsonMapper {
     private JsonParser treeAsTokens(JsonNode tree) {
         DeserializationContext context = objectMapper._deserializationContext(); // Not supposed to be used technically
         return treeCodec.treeAsTokens(tree, context);
+    }
+
+    private static IOException wrapJacksonException(JacksonException e) {
+        if (e instanceof StreamReadException) {
+            return new JsonSyntaxException(e);
+        }
+        return new IOException(e);
     }
 
     private record TypeCache<T>(Argument<?> type, T cachedValue) {

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/databind/JacksonDatabindMapperSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/databind/JacksonDatabindMapperSpec.groovy
@@ -1,10 +1,13 @@
 package io.micronaut.jackson.databind
 
+import tools.jackson.core.JsonGenerator
 import tools.jackson.core.JsonParser
 import tools.jackson.core.JacksonException
 import tools.jackson.databind.DeserializationContext
-import tools.jackson.databind.ValueDeserializer
 import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.ValueSerializer
 import tools.jackson.databind.module.SimpleModule
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.type.Argument
@@ -53,6 +56,42 @@ class JacksonDatabindMapperSpec extends Specification {
         testBean.value == BigInteger.valueOf(42)
     }
 
+    def 'wraps JacksonException as IOException'() {
+        given:
+        def objectMapper = new ObjectMapper()
+        objectMapper = objectMapper.rebuild().addModule(new SimpleModule() {
+            {
+                addDeserializer(TestBean, new FailingDeserializer())
+            }
+        }).build()
+        def jsonMapper = new JacksonDatabindMapper(objectMapper)
+
+        when:
+        jsonMapper.readValue('42', TestBean)
+
+        then:
+        def e = thrown(IOException)
+        e.cause instanceof TestJacksonException
+    }
+
+    def 'wraps JacksonException from write as IOException'() {
+        given:
+        def objectMapper = new ObjectMapper()
+        objectMapper = objectMapper.rebuild().addModule(new SimpleModule() {
+            {
+                addSerializer(TestBean, new FailingSerializer())
+            }
+        }).build()
+        def jsonMapper = new JacksonDatabindMapper(objectMapper)
+
+        when:
+        jsonMapper.writeValueAsBytes(new TestBean())
+
+        then:
+        def e = thrown(IOException)
+        e.cause instanceof TestJacksonException
+    }
+
     private static final class TestBean {
         BigInteger value
     }
@@ -67,6 +106,26 @@ class JacksonDatabindMapperSpec extends Specification {
         TestBean deserialize(JsonParser p, DeserializationContext ctxt, TestBean intoValue) throws IOException {
             intoValue.value = p.objectReadContext().readValue(p, BigInteger)
             return intoValue
+        }
+    }
+
+    private static final class FailingDeserializer extends ValueDeserializer<TestBean> {
+        @Override
+        TestBean deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+            throw new TestJacksonException()
+        }
+    }
+
+    private static final class FailingSerializer extends ValueSerializer<TestBean> {
+        @Override
+        void serialize(TestBean value, JsonGenerator gen, SerializationContext serializers) {
+            throw new TestJacksonException()
+        }
+    }
+
+    private static final class TestJacksonException extends JacksonException {
+        TestJacksonException() {
+            super('test')
         }
     }
 }

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/serialize/ConvertibleValuesDeserializerSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/serialize/ConvertibleValuesDeserializerSpec.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.jackson.serialize
 
+import java.io.IOException
+
 import tools.jackson.databind.exc.MismatchedInputException
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.convert.value.ConvertibleValues
@@ -49,7 +51,8 @@ class ConvertibleValuesDeserializerSpec extends Specification {
         when:
         mapper.readValue('[{"foo":"4","fizz":5},4]', Argument.of(ConvertibleValues))
         then:
-        thrown MismatchedInputException
+        def e = thrown IOException
+        e.cause instanceof MismatchedInputException
 
         cleanup:
         ctx.close()


### PR DESCRIPTION
## Summary
- Wrap Jackson 3 `JacksonException` from `JacksonDatabindMapper` as `IOException` while preserving `JsonSyntaxException` for stream read syntax errors
- Add read/write regression coverage for the JsonMapper exception contract
- Preserve databind binder metadata when Jackson invalid-format exceptions are wrapped

## Verification
- `./gradlew :micronaut-jackson-databind:test --tests io.micronaut.jackson.databind.JacksonDatabindMapperSpec -q`
- `./gradlew :micronaut-jackson-databind:check -q -x japiCmp -x checkVersionCatalogCompatibility`
- `git diff --check`

Resolves #12749