### PR TITLE
Fix CorsFilter reference equality for CORS wildcard checks

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -419,11 +419,11 @@ public class CorsFilter implements Ordered, ConditionalFilter {
     }
 
     private static boolean isAny(List<String> values) {
-        return values == CorsOriginConfiguration.ANY;
+        return values != null && values.size() == 1 && "*".equals(values.get(0));
     }
 
     private static boolean isAnyMethod(List<HttpMethod> allowedMethods) {
-        return allowedMethods == CorsOriginConfiguration.ANY_METHOD;
+        return allowedMethods == null || allowedMethods.isEmpty();
     }
 
     private boolean methodAllowed(CorsOriginConfiguration config,


### PR DESCRIPTION
## Summary

Fixes #12626

`CorsFilter.isAny()` and `isAnyMethod()` used reference equality (`==`) to compare against the sentinel constants `CorsOriginConfiguration.ANY` (`Collections.singletonList("*")`) and `ANY_METHOD` (`Collections.emptyList()`). When CORS configuration is loaded from `application.yml`, deserialization produces new `List` instances that are never reference-equal to these constants, so wildcard CORS checks silently fail.

## Changes

- `isAny(values)`: replaced `== ANY` with a value check for a single-element list containing `"*"`
- `isAnyMethod(allowedMethods)`: replaced `== ANY_METHOD` with a null/empty check

## Test plan

- [ ] Existing `CorsFilterSpec` tests pass
- [ ] CORS preflight requests succeed when `allowed-headers: ["*"]` is set in `application.yml`
- [ ] CORS wildcard behaviour is unchanged when configuration is provided programmatically

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD7pn95JrzaHu5gzQTfvFT)_