### PR TITLE
sonar: Suppress false stream warning in StreamPair

### DIFF
--- a/http/src/main/java/io/micronaut/http/body/stream/StreamPair.java
+++ b/http/src/main/java/io/micronaut/http/body/stream/StreamPair.java
@@ -89,6 +89,7 @@ final class StreamPair {
         return (old & mask) != mask && ((old | flag) & mask) == mask;
     }
 
+    @SuppressWarnings("java:S2095") // streams are returned to the caller through Pair
     static Pair createStreamPair(ExtendedInputStream upstream, ByteBody.SplitBackpressureMode backpressureMode) {
         StreamPair pair = new StreamPair(upstream);
         return switch (backpressureMode) {


### PR DESCRIPTION
Add a targeted suppression for the resource-close warning in createStreamPair. The streams created there are intentionally returned to the caller through Pair, so they should not be closed inside the factory method.

We cannot use try-with-resources here, because it would close the streams before the caller can use them.