### PR TITLE
Track JRT file system for cleanup

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/IOUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/IOUtils.java
@@ -187,6 +187,7 @@ public class IOUtils {
                 return Paths.get(uri).resolve(path);
             } else if ("jrt".equals(scheme)) {
                 FileSystem fs = FileSystems.newFileSystem(URI.create("jrt:/"), Map.of());
+                toClose.add(fs);
                 return fs.getPath(uri.getPath());
             } else {
                 // graal resource: case


### PR DESCRIPTION
Adds the newly created JRT file system to the close list in IOUtils so it is closed with the other resources managed by the method. This prevents the JRT file system handle from being leaked after resolving paths from the runtime image.