### PR TITLE
Ensure ByteBuf release during writes

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/body/NettyByteBufMessageBodyHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/NettyByteBufMessageBodyHandler.java
@@ -85,10 +85,8 @@ public final class NettyByteBufMessageBodyHandler implements TypedMessageBodyHan
 
     @Override
     public void writeTo(Argument<ByteBuf> type, MediaType mediaType, ByteBuf object, MutableHeaders outgoingHeaders, OutputStream outputStream) throws CodecException {
-        try {
-            new ByteBufInputStream(object).transferTo(outputStream);
-            // ByteBufInputStream#close doesn't release properly
-            object.release();
+        try (ByteBufInputStream inputStream = new ByteBufInputStream(object, true)) {
+            inputStream.transferTo(outputStream);
         } catch (IOException e) {
             throw new CodecException("Failed to transfer byte buffer", e);
         }


### PR DESCRIPTION
Use ByteBufInputStream with releaseOnClose in a try-with-resources block when writing Netty ByteBuf bodies. This guarantees the buffer is released when the stream closes, including when transferTo throws, and removes the manual release call.