### PR TITLE
Enable SSL by default for per-service client SSL configuration

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
@@ -331,6 +331,11 @@ public class ServiceHttpClientConfiguration extends HttpClientConfiguration impl
     @ConfigurationProperties("ssl")
     public static class ServiceSslClientConfiguration extends AbstractClientSslConfiguration {
 
+        public ServiceSslClientConfiguration() {
+            // Enable by default, like ClientSslConfiguration; otherwise a per-service ssl block leaves SSL disabled.
+            setEnabled(true);
+        }
+
         /**
          * Sets the key configuration.
          *

--- a/http-client/src/test/groovy/io/micronaut/http/client/ServiceSslConfigurationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ServiceSslConfigurationSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue("https://github.com/micronaut-projects/micronaut-core/issues/12757")
+class ServiceSslConfigurationSpec extends Specification {
+
+    void "a per-service ssl block is enabled by default but can still be disabled explicitly"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run([
+                'micronaut.http.services.myservice.url'                                : 'https://example.com',
+                'micronaut.http.services.myservice.ssl.insecure-trust-all-certificates': true,
+                'micronaut.http.services.disabled.url'                                 : 'https://example.com',
+                'micronaut.http.services.disabled.ssl.enabled'                         : false,
+        ])
+
+        expect: 'declaring a per-service ssl block enables SSL by default (otherwise HTTPS silently breaks)'
+        ctx.getBean(ServiceHttpClientConfiguration, Qualifiers.byName('myservice')).sslConfiguration.enabled
+
+        and: 'an explicit ssl.enabled=false still wins'
+        !ctx.getBean(ServiceHttpClientConfiguration, Qualifiers.byName('disabled')).sslConfiguration.enabled
+
+        cleanup:
+        ctx.close()
+    }
+}


### PR DESCRIPTION
Fixes #12757

Declaring any property under `micronaut.http.services.<name>.ssl` binds a `ServiceHttpClientConfiguration.ServiceSslClientConfiguration`, which takes over from the global client SSL configuration for that service. Unlike the global `ClientSslConfiguration` — whose constructors call `setEnabled(true)` — the per-service config never enabled SSL, so it fell back to `SslConfiguration.DEFAULT_ENABLED` (`false`).

`ConnectionManager` only builds the SSL context when `getSslConfiguration().isEnabled()` is true, so a per-service `ssl` block left SSL disabled for that service. On the Netty client this surfaced as the channel being closed during initialization, before the TLS handshake or even a TCP connection — an HTTPS request through a `@Client(id = "...")` failed with `Connect Error: null` wrapping a `StacklessClosedChannelException`. The `insecure-trust-all-certificates` flag in the original report was incidental; any property under the service's `ssl` namespace triggered it.

As discussed on #12757, per-service SSL is a self-contained configuration, consistent with how the JDK client treats it (#12473). The fix mirrors `ClientSslConfiguration` and enables SSL by default in the constructor.
