### PR TITLE
Add RFC 10008 support (QUERY Method)

### DIFF
--- a/core/src/main/java/io/micronaut/core/naming/conventions/MethodConvention.java
+++ b/core/src/main/java/io/micronaut/core/naming/conventions/MethodConvention.java
@@ -71,7 +71,7 @@ public enum MethodConvention {
 
     /**
      * The default query method of controllers.
-     * @since 5.1.4
+     * @since 5.2.0
      */
     QUERY("");
 

--- a/core/src/main/java/io/micronaut/core/naming/conventions/MethodConvention.java
+++ b/core/src/main/java/io/micronaut/core/naming/conventions/MethodConvention.java
@@ -67,7 +67,13 @@ public enum MethodConvention {
     /**
      * The default trace method of controllers.
      */
-    TRACE("");
+    TRACE(""),
+
+    /**
+     * The default query method of controllers.
+     * @since 5.1.4
+     */
+    QUERY("");
 
     /**
      * Path for the id.

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
@@ -1230,7 +1230,7 @@ final class NettyHttpClient implements
     }
 
     private static boolean requiresRequestBody(HttpMethod method) {
-        return method != null && (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT) || method.equals(HttpMethod.PATCH));
+        return method != null && (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT) || method.equals(HttpMethod.PATCH) || method.equals(HttpMethod.QUERY));
     }
 
     private static boolean permitsRequestBody(HttpMethod method) {
@@ -1486,7 +1486,10 @@ final class NettyHttpClient implements
                     String location = nettyHeaders.get(HttpHeaderNames.LOCATION);
 
                     MutableHttpRequest<Object> redirectRequest;
-                    if (code == 307 || code == 308) {
+                    boolean isRedirectWithBody = code == 307 || code == 308;
+                    boolean isQueryRedirect = (code == 301 || code == 302) && request.getMethod() == io.micronaut.http.HttpMethod.QUERY;
+                    boolean preserveBody = isRedirectWithBody || isQueryRedirect;
+                    if (preserveBody) {
                         redirectRequest = io.micronaut.http.HttpRequest.create(request.getMethod(), location);
                         request.getBody().ifPresent(redirectRequest::body);
                     } else {
@@ -1499,7 +1502,7 @@ final class NettyHttpClient implements
                     redirectRequest.setAttribute(REDIRECT_COUNT, redirectCount);
                     return resolveRedirectURI(request, redirectRequest)
                         .flatMap(uri -> {
-                            setRedirectHeaders(request, redirectRequest.uri(uri), code == 307 || code == 308);
+                            setRedirectHeaders(request, redirectRequest.uri(uri), preserveBody);
                             return sendRequestWithRedirects(propagatedContext, blockHint, redirectRequest.uri(uri), readResponse);
                         });
                 } else {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/QueryMethodSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/QueryMethodSpec.groovy
@@ -1,0 +1,116 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.*
+import io.micronaut.http.annotation.*
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.web.router.DefaultRouteBuilder
+import io.micronaut.web.router.Router
+import io.micronaut.web.router.RouteBuilder.UriNamingStrategy
+import io.micronaut.context.ExecutionHandleLocator
+import io.micronaut.context.annotation.Executable
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import jakarta.inject.Singleton
+
+class QueryMethodSpec extends Specification {
+
+    @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': 'QueryMethodSpec'])
+    @Shared HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
+    @Shared QueryClient queryClient = embeddedServer.applicationContext.getBean(QueryClient)
+    @Shared Router router = embeddedServer.applicationContext.getBean(Router)
+
+    void "test query method route and declarative client"() {
+        when:
+        HttpResponse<String> resp = client.toBlocking().exchange(
+                HttpRequest.QUERY("/query-test/search", "my-query"), String
+        )
+
+        then:
+        resp.status() == HttpStatus.OK
+        resp.body() == 'received: my-query'
+        resp.header(HttpHeaders.ACCEPT_QUERY) == 'application/x-www-form-urlencoded, application/json'
+
+        when:
+        String result = queryClient.search("other-query")
+
+        then:
+        result == 'received: other-query'
+
+        when:
+        HttpResponse<String> resp2 = client.toBlocking().exchange(
+                HttpRequest.QUERY("/query-test", "convention-query"), String
+        )
+
+        then:
+        resp2.status() == HttpStatus.OK
+        resp2.body() == 'convention: convention-query'
+
+        when:
+        HttpResponse<String> resp3 = client.toBlocking().exchange(
+                HttpRequest.QUERY("/query-test/redirect-301", "redirect-query-1"), String
+        )
+
+        then:
+        resp3.status() == HttpStatus.OK
+        resp3.body() == 'received: redirect-query-1'
+
+        when:
+        HttpResponse<String> resp4 = client.toBlocking().exchange(
+                HttpRequest.QUERY("/query-test/redirect-302", "redirect-query-2"), String
+        )
+
+        then:
+        resp4.status() == HttpStatus.OK
+        resp4.body() == 'received: redirect-query-2'
+    }
+
+    @Requires(property = 'spec.name', value = 'QueryMethodSpec')
+    @Controller("/query-test")
+    static class QueryController {
+
+        @Query("/search")
+        HttpResponse<String> search(@Body String query) {
+            return HttpResponse.ok("received: " + query)
+                    .header(HttpHeaders.ACCEPT_QUERY, "application/x-www-form-urlencoded, application/json")
+        }
+
+        // Mapping by naming convention (method name is 'query')
+        @Executable
+        HttpResponse<String> query(@Body String body) {
+            return HttpResponse.ok("convention: " + body)
+        }
+
+        @Query("/redirect-301")
+        HttpResponse<?> redirect301() {
+            return HttpResponse.status(HttpStatus.MOVED_PERMANENTLY)
+                    .header(HttpHeaders.LOCATION, "/query-test/search")
+        }
+
+        @Query("/redirect-302")
+        HttpResponse<?> redirect302() {
+            return HttpResponse.status(HttpStatus.FOUND)
+                    .header(HttpHeaders.LOCATION, "/query-test/search")
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'QueryMethodSpec')
+    @Client("/query-test")
+    static interface QueryClient {
+        @Query("/search")
+        String search(@Body String query)
+    }
+
+    @Requires(property = 'spec.name', value = 'QueryMethodSpec')
+    @Singleton
+    static class QueryRouteBuilder extends DefaultRouteBuilder {
+        QueryRouteBuilder(ExecutionHandleLocator executionHandleLocator, UriNamingStrategy uriNamingStrategy) {
+            super(executionHandleLocator, uriNamingStrategy)
+            QUERY("/query-test", QueryController, "query", String)
+        }
+    }
+}

--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -83,7 +83,7 @@ public interface HttpHeaders extends Headers {
 
     /**
      * {@code "Accept-Query"}.
-     * @since 5.1.4
+     * @since 5.2.0
      */
     String ACCEPT_QUERY = "Accept-Query";
 

--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -82,6 +82,12 @@ public interface HttpHeaders extends Headers {
     String ACCEPT_PATCH = "Accept-Patch";
 
     /**
+     * {@code "Accept-Query"}.
+     * @since 5.1.4
+     */
+    String ACCEPT_QUERY = "Accept-Query";
+
+    /**
      * {@code "Access-Control-Allow-Credentials"}.
      */
     String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";

--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -539,6 +539,7 @@ public interface HttpHeaders extends Headers {
         ACCEPT_LANGUAGE,
         ACCEPT_RANGES,
         ACCEPT_PATCH,
+        ACCEPT_QUERY,
         ACCESS_CONTROL_ALLOW_CREDENTIALS,
         ACCESS_CONTROL_ALLOW_HEADERS,
         ACCESS_CONTROL_ALLOW_METHODS,

--- a/http/src/main/java/io/micronaut/http/HttpMethod.java
+++ b/http/src/main/java/io/micronaut/http/HttpMethod.java
@@ -71,6 +71,12 @@ import org.jspecify.annotations.Nullable;
     PATCH(true, true),
 
     /**
+     * See https://www.rfc-editor.org/rfc/rfc10008.txt.
+     * @since 5.1.4
+     */
+    QUERY(true, true),
+
+    /**
      * A custom non-standard HTTP method.
      */
     CUSTOM(false, true);
@@ -135,7 +141,7 @@ import org.jspecify.annotations.Nullable;
      * @return True if it does
      */
     public static boolean requiresRequestBody(HttpMethod method) {
-        return method != null && (method.equals(POST) || method.equals(PUT) || method.equals(PATCH));
+        return method != null && (method.equals(POST) || method.equals(PUT) || method.equals(PATCH) || method.equals(QUERY));
     }
 
     /**
@@ -199,6 +205,9 @@ import org.jspecify.annotations.Nullable;
             case "PATCH":
             case "patch":
                 return PATCH;
+            case "QUERY":
+            case "query":
+                return QUERY;
             default:
                 return null;
         }

--- a/http/src/main/java/io/micronaut/http/HttpMethod.java
+++ b/http/src/main/java/io/micronaut/http/HttpMethod.java
@@ -72,7 +72,7 @@ import org.jspecify.annotations.Nullable;
 
     /**
      * See https://www.rfc-editor.org/rfc/rfc10008.txt.
-     * @since 5.1.4
+     * @since 5.2.0
      */
     QUERY(true, true),
 

--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -384,7 +384,7 @@ public interface HttpRequest<B> extends HttpMessage<B> {
      * Return a {@link MutableHttpRequest} that executes an {@link HttpMethod#QUERY} request for the given URI.
      *
      * @param uri  The URI
-     * @param body The body of the request (content type defaults to {@link MediaType#APPLICATION_JSON}
+     * @param body The body of the request (content type defaults to {@link MediaType#APPLICATION_JSON})
      * @param <T>  The body type
      * @return The {@link MutableHttpRequest} instance
      * @see HttpRequestFactory
@@ -398,7 +398,7 @@ public interface HttpRequest<B> extends HttpMessage<B> {
      * Return a {@link MutableHttpRequest} that executes an {@link HttpMethod#QUERY} request for the given URI.
      *
      * @param uri  The URI
-     * @param body The body of the request (content type defaults to {@link MediaType#APPLICATION_JSON}
+     * @param body The body of the request (content type defaults to {@link MediaType#APPLICATION_JSON})
      * @param <T>  The body type
      * @return The {@link MutableHttpRequest} instance
      * @see HttpRequestFactory

--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -388,7 +388,7 @@ public interface HttpRequest<B> extends HttpMessage<B> {
      * @param <T>  The body type
      * @return The {@link MutableHttpRequest} instance
      * @see HttpRequestFactory
-     * @since 5.1.4
+     * @since 5.2.0
      */
     static <T> MutableHttpRequest<T> QUERY(URI uri, T body) {
         return QUERY(uri.toString(), body);
@@ -402,7 +402,7 @@ public interface HttpRequest<B> extends HttpMessage<B> {
      * @param <T>  The body type
      * @return The {@link MutableHttpRequest} instance
      * @see HttpRequestFactory
-     * @since 5.1.4
+     * @since 5.2.0
      */
     static <T> MutableHttpRequest<T> QUERY(String uri, T body) {
         Objects.requireNonNull(uri, "Argument [uri] is required");

--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -381,6 +381,35 @@ public interface HttpRequest<B> extends HttpMessage<B> {
     }
 
     /**
+     * Return a {@link MutableHttpRequest} that executes an {@link HttpMethod#QUERY} request for the given URI.
+     *
+     * @param uri  The URI
+     * @param body The body of the request (content type defaults to {@link MediaType#APPLICATION_JSON}
+     * @param <T>  The body type
+     * @return The {@link MutableHttpRequest} instance
+     * @see HttpRequestFactory
+     * @since 5.1.4
+     */
+    static <T> MutableHttpRequest<T> QUERY(URI uri, T body) {
+        return QUERY(uri.toString(), body);
+    }
+
+    /**
+     * Return a {@link MutableHttpRequest} that executes an {@link HttpMethod#QUERY} request for the given URI.
+     *
+     * @param uri  The URI
+     * @param body The body of the request (content type defaults to {@link MediaType#APPLICATION_JSON}
+     * @param <T>  The body type
+     * @return The {@link MutableHttpRequest} instance
+     * @see HttpRequestFactory
+     * @since 5.1.4
+     */
+    static <T> MutableHttpRequest<T> QUERY(String uri, T body) {
+        Objects.requireNonNull(uri, "Argument [uri] is required");
+        return HttpRequestFactory.INSTANCE.query(uri, body);
+    }
+
+    /**
      * Return a {@link MutableHttpRequest} that executes an {@link HttpMethod#DELETE} request for the given URI.
      *
      * @param uri  The URI

--- a/http/src/main/java/io/micronaut/http/HttpRequestFactory.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequestFactory.java
@@ -76,7 +76,7 @@ import org.jspecify.annotations.Nullable;
      * @param body The body
      * @param <T>  The body type
      * @return The {@link MutableHttpRequest} instance
-     * @since 5.1.4
+     * @since 5.2.0
      */
     default <T> MutableHttpRequest<T> query(String uri, T body) {
         return create(HttpMethod.QUERY, uri).body(body);

--- a/http/src/main/java/io/micronaut/http/HttpRequestFactory.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequestFactory.java
@@ -70,6 +70,19 @@ import org.jspecify.annotations.Nullable;
     <T> MutableHttpRequest<T> patch(String uri, T body);
 
     /**
+     * Return a {@link MutableHttpRequest} that executes an {@link HttpMethod#QUERY} request for the given URI.
+     *
+     * @param uri  The URI
+     * @param body The body
+     * @param <T>  The body type
+     * @return The {@link MutableHttpRequest} instance
+     * @since 5.1.4
+     */
+    default <T> MutableHttpRequest<T> query(String uri, T body) {
+        return create(HttpMethod.QUERY, uri).body(body);
+    }
+
+    /**
      * Return a {@link MutableHttpRequest} that executes an {@link HttpMethod#HEAD} request for the given URI.
      *
      * @param uri The URI

--- a/http/src/main/java/io/micronaut/http/annotation/Query.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Query.java
@@ -30,7 +30,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Annotation that can be applied to method to signify the method receives a {@link io.micronaut.http.HttpMethod#QUERY}.
  *
  * @author Graeme Rocher
- * @since 5.1.4
+ * @since 5.2.0
  */
 @Documented
 @Retention(RUNTIME)

--- a/http/src/main/java/io/micronaut/http/annotation/Query.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Query.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.annotation;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.core.async.annotation.SingleResult;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation that can be applied to method to signify the method receives a {@link io.micronaut.http.HttpMethod#QUERY}.
+ *
+ * @author Graeme Rocher
+ * @since 5.1.4
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+@HttpMethodMapping
+@Inherited
+public @interface Query {
+
+    /**
+     * @return The URI of the QUERY route
+     */
+    @AliasFor(annotation = HttpMethodMapping.class, member = "value")
+    @AliasFor(annotation = UriMapping.class, member = "value")
+    String value() default UriMapping.DEFAULT_URI;
+
+    /**
+     * @return The URI of the QUERY route
+     */
+    @AliasFor(annotation = HttpMethodMapping.class, member = "value")
+    @AliasFor(annotation = UriMapping.class, member = "value")
+    String uri() default UriMapping.DEFAULT_URI;
+
+    /**
+     * Only to be used in the context of a server.
+     *
+     * @return The URIs of the QUERY route
+     */
+    @AliasFor(annotation = HttpMethodMapping.class, member = "uris")
+    @AliasFor(annotation = UriMapping.class, member = "uris")
+    String[] uris() default {UriMapping.DEFAULT_URI};
+
+    /**
+     * @return The default consumes, otherwise override from controller
+     */
+    @AliasFor(annotation = Consumes.class, member = "value")
+    String[] consumes() default {};
+
+    /**
+     * @return The default produces, otherwise override from controller
+     */
+    @AliasFor(annotation = Produces.class, member = "value")
+    String[] produces() default {};
+
+    /**
+     * Shortcut that allows setting both the {@link #consumes()} and {@link #produces()} settings to the same media type.
+     *
+     * @return The media type this method processes
+     */
+    @AliasFor(annotation = Produces.class, member = "value")
+    @AliasFor(annotation = Consumes.class, member = "value")
+    String[] processes() default {};
+
+    /**
+     * Shortcut that allows setting both the {@link Consumes} and {@link Produces} single settings.
+     *
+     * @return Whether a single or multiple items are produced/consumed
+     */
+    @AliasFor(annotation = Produces.class, member = "single")
+    @AliasFor(annotation = Consumes.class, member = "single")
+    @AliasFor(annotation = SingleResult.class, member = "value")
+    boolean single() default false;
+
+}

--- a/http/src/test/groovy/io/micronaut/http/HttpHeadersSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/HttpHeadersSpec.groovy
@@ -62,6 +62,7 @@ class HttpHeadersSpec extends Specification {
         HttpHeaders.ACCEPT_LANGUAGE,
         HttpHeaders.ACCEPT_RANGES,
         HttpHeaders.ACCEPT_PATCH,
+        HttpHeaders.ACCEPT_QUERY,
         HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
         HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
         HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,

--- a/router/src/main/java/io/micronaut/web/router/AnnotatedMethodRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/AnnotatedMethodRouteBuilder.java
@@ -39,6 +39,7 @@ import io.micronaut.http.annotation.Patch;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.Query;
 import io.micronaut.http.annotation.Trace;
 import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.http.uri.UriTemplate;
@@ -186,6 +187,29 @@ public class AnnotatedMethodRouteBuilder extends DefaultRouteBuilder implements 
                 MediaType[] consumes = resolveConsumes(method);
                 MediaType[] produces = resolveProduces(method);
                 UriRoute route = PATCH(resolveUri(bean, uri,
+                        method,
+                        uriNamingStrategy),
+                        bean,
+                        method);
+                route = route.consumes(consumes).produces(produces);
+                if (definition.port > -1) {
+                    route.exposedPort(definition.port);
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Created Route: {}", route);
+                }
+            }
+        });
+
+        httpMethodsHandlers.put(Query.class, (RouteDefinition definition) -> {
+            final ExecutableMethod method = definition.executableMethod;
+            final BeanDefinition bean = definition.beanDefinition;
+
+            Set<String> uris = this.resolveUrisMapping(Query.class, method);
+            for (String uri: uris) {
+                MediaType[] consumes = resolveConsumes(method);
+                MediaType[] produces = resolveProduces(method);
+                UriRoute route = QUERY(resolveUri(bean, uri,
                         method,
                         uriNamingStrategy),
                         bean,

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
@@ -283,6 +283,16 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
     }
 
     @Override
+    public UriRoute QUERY(String uri, Object target, String method, Class<?>... parameterTypes) {
+        return buildRoute(HttpMethod.QUERY, uri, target.getClass(), method, parameterTypes);
+    }
+
+    @Override
+    public UriRoute QUERY(String uri, Class<?> type, String method, Class<?>... parameterTypes) {
+        return buildRoute(HttpMethod.QUERY, uri, type, method, parameterTypes);
+    }
+
+    @Override
     public UriRoute DELETE(String uri, Object target, String method, Class<?>... parameterTypes) {
         return buildRoute(HttpMethod.DELETE, uri, target.getClass(), method, parameterTypes);
     }
@@ -340,6 +350,11 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
     @Override
     public UriRoute PATCH(String uri, BeanDefinition<?> beanDefinition, ExecutableMethod<?, ?> method) {
         return buildBeanRoute(HttpMethod.PATCH, uri, beanDefinition, method);
+    }
+
+    @Override
+    public UriRoute QUERY(String uri, BeanDefinition<?> beanDefinition, ExecutableMethod<?, ?> method) {
+        return buildBeanRoute(HttpMethod.QUERY, uri, beanDefinition, method);
     }
 
     @Override

--- a/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
@@ -703,6 +703,124 @@ public interface RouteBuilder {
     UriRoute PATCH(String uri, Class<?> type, String method, Class<?>... parameterTypes);
 
     /**
+     * Route the specified URI to the specified target for an HTTP QUERY. Since the method to execute is not
+     * specified "query" is used by default.
+     *
+     * @param uri    The URI
+     * @param target The target object
+     * @return The route
+     * @since 5.1.4
+     */
+    default UriRoute QUERY(String uri, Object target) {
+        return QUERY(uri, target, MethodConvention.QUERY.methodName());
+    }
+
+    /**
+     * <p>Route to the specified object. The URI route is built by the configured {@link UriNamingStrategy}.</p>
+     *
+     * @param target The object
+     * @return The route
+     * @since 5.1.4
+     */
+    default UriRoute QUERY(Object target) {
+        Class<?> type = target.getClass();
+        return QUERY(getUriNamingStrategy().resolveUri(type), target);
+    }
+
+    /**
+     * <p>Route to the specified object and ID. The URI route is built by the configured {@link UriNamingStrategy}.</p>
+     *
+     * @param target The object
+     * @param id     The route id
+     * @return The route
+     * @since 5.1.4
+     */
+    default UriRoute QUERY(Object target, PropertyConvention id) {
+        Class<?> type = target.getClass();
+        return QUERY(getUriNamingStrategy().resolveUri(type, id), target, MethodConvention.QUERY.methodName());
+    }
+
+    /**
+     * <p>Route to the specified class. The URI route is built by the configured {@link UriNamingStrategy}.</p>
+     *
+     * @param type The class
+     * @return The route
+     * @since 5.1.4
+     */
+    default UriRoute QUERY(Class<?> type) {
+        return QUERY(getUriNamingStrategy().resolveUri(type), type, MethodConvention.QUERY.methodName());
+    }
+
+    /**
+     * <p>Route to the specified class and ID. The URI route is built by the configured {@link UriNamingStrategy}.</p>
+     *
+     * @param type The class
+     * @param id   The route id
+     * @return The route
+     * @since 5.1.4
+     */
+    default UriRoute QUERY(Class<?> type, PropertyConvention id) {
+        return QUERY(getUriNamingStrategy().resolveUri(type, id), type, MethodConvention.QUERY.methodName());
+    }
+
+    /**
+     * <p>Route the specified URI template to the specified target.</p>
+     *
+     * <p>The number of variables in the template should match the number of method arguments</p>
+     *
+     * @param uri    The URI
+     * @param method The method
+     * @return The route
+     * @since 5.1.4
+     */
+    default UriRoute QUERY(String uri, ExecutableMethod<?, ?> method) {
+        return QUERY(uri, method.getDeclaringType(), method.getMethodName(), method.getArgumentTypes());
+    }
+
+    /**
+     * <p>Route the specified URI template to the specified target.</p>
+     *
+     * <p>The number of variables in the template should match the number of method arguments</p>
+     *
+     * @param beanDefinition The bean definition
+     * @param uri            The URI
+     * @param method         The method
+     * @return The route
+     * @since 5.1.4
+     */
+    default UriRoute QUERY(String uri, BeanDefinition<?> beanDefinition, ExecutableMethod<?, ?> method) {
+        return QUERY(uri, beanDefinition.getBeanType(), method.getMethodName(), method.getArgumentTypes());
+    }
+
+    /**
+     * <p>Route the specified URI template to the specified target.</p>
+     *
+     * <p>The number of variables in the template should match the number of method arguments</p>
+     *
+     * @param uri            The URI
+     * @param target         The target
+     * @param method         The method
+     * @param parameterTypes The parameter types for the target method
+     * @return The route
+     * @since 5.1.4
+     */
+    UriRoute QUERY(String uri, Object target, String method, Class<?>... parameterTypes);
+
+    /**
+     * <p>Route the specified URI template to the specified target.</p>
+     *
+     * <p>The number of variables in the template should match the number of method arguments</p>
+     *
+     * @param uri            The URI
+     * @param type           The type
+     * @param method         The method
+     * @param parameterTypes The parameter types for the target method
+     * @return The route
+     * @since 5.1.4
+     */
+    UriRoute QUERY(String uri, Class<?> type, String method, Class<?>... parameterTypes);
+
+    /**
      * Route the specified URI to the specified target for an HTTP DELETE. Since the method to execute is not
      * specified "index" is used by default.
      *

--- a/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
@@ -709,7 +709,7 @@ public interface RouteBuilder {
      * @param uri    The URI
      * @param target The target object
      * @return The route
-     * @since 5.1.4
+     * @since 5.2.0
      */
     default UriRoute QUERY(String uri, Object target) {
         return QUERY(uri, target, MethodConvention.QUERY.methodName());
@@ -720,7 +720,7 @@ public interface RouteBuilder {
      *
      * @param target The object
      * @return The route
-     * @since 5.1.4
+     * @since 5.2.0
      */
     default UriRoute QUERY(Object target) {
         Class<?> type = target.getClass();
@@ -733,7 +733,7 @@ public interface RouteBuilder {
      * @param target The object
      * @param id     The route id
      * @return The route
-     * @since 5.1.4
+     * @since 5.2.0
      */
     default UriRoute QUERY(Object target, PropertyConvention id) {
         Class<?> type = target.getClass();
@@ -745,7 +745,7 @@ public interface RouteBuilder {
      *
      * @param type The class
      * @return The route
-     * @since 5.1.4
+     * @since 5.2.0
      */
     default UriRoute QUERY(Class<?> type) {
         return QUERY(getUriNamingStrategy().resolveUri(type), type, MethodConvention.QUERY.methodName());
@@ -757,7 +757,7 @@ public interface RouteBuilder {
      * @param type The class
      * @param id   The route id
      * @return The route
-     * @since 5.1.4
+     * @since 5.2.0
      */
     default UriRoute QUERY(Class<?> type, PropertyConvention id) {
         return QUERY(getUriNamingStrategy().resolveUri(type, id), type, MethodConvention.QUERY.methodName());
@@ -771,7 +771,7 @@ public interface RouteBuilder {
      * @param uri    The URI
      * @param method The method
      * @return The route
-     * @since 5.1.4
+     * @since 5.2.0
      */
     default UriRoute QUERY(String uri, ExecutableMethod<?, ?> method) {
         return QUERY(uri, method.getDeclaringType(), method.getMethodName(), method.getArgumentTypes());
@@ -786,7 +786,7 @@ public interface RouteBuilder {
      * @param uri            The URI
      * @param method         The method
      * @return The route
-     * @since 5.1.4
+     * @since 5.2.0
      */
     default UriRoute QUERY(String uri, BeanDefinition<?> beanDefinition, ExecutableMethod<?, ?> method) {
         return QUERY(uri, beanDefinition.getBeanType(), method.getMethodName(), method.getArgumentTypes());
@@ -802,7 +802,7 @@ public interface RouteBuilder {
      * @param method         The method
      * @param parameterTypes The parameter types for the target method
      * @return The route
-     * @since 5.1.4
+     * @since 5.2.0
      */
     UriRoute QUERY(String uri, Object target, String method, Class<?>... parameterTypes);
 
@@ -816,7 +816,7 @@ public interface RouteBuilder {
      * @param method         The method
      * @param parameterTypes The parameter types for the target method
      * @return The route
-     * @since 5.1.4
+     * @since 5.2.0
      */
     UriRoute QUERY(String uri, Class<?> type, String method, Class<?>... parameterTypes);
 

--- a/router/src/main/java/io/micronaut/web/router/Router.java
+++ b/router/src/main/java/io/micronaut/web/router/Router.java
@@ -384,6 +384,19 @@ public interface Router {
     }
 
     /**
+     * Find the first {@link RouteMatch} route for an {@link HttpMethod#QUERY} method and the given URI.
+     *
+     * @param uri The URI
+     * @param <T> The target type
+     * @param <R> The return type
+     * @return An {@link Optional} of {@link RouteMatch}
+     * @since 5.1.4
+     */
+    default <T, R> Optional<UriRouteMatch<T, R>> QUERY(CharSequence uri) {
+        return route(HttpMethod.QUERY, uri);
+    }
+
+    /**
      * Find the first {@link RouteMatch} route for an {@link HttpMethod#DELETE} method and the given URI.
      *
      * @param uri The URI

--- a/router/src/main/java/io/micronaut/web/router/Router.java
+++ b/router/src/main/java/io/micronaut/web/router/Router.java
@@ -390,7 +390,7 @@ public interface Router {
      * @param <T> The target type
      * @param <R> The return type
      * @return An {@link Optional} of {@link RouteMatch}
-     * @since 5.1.4
+     * @since 5.2.0
      */
     default <T, R> Optional<UriRouteMatch<T, R>> QUERY(CharSequence uri) {
         return route(HttpMethod.QUERY, uri);


### PR DESCRIPTION
Fixes #12772 

This change adds support for RFC 10008, the HTTP QUERY Method.

I took a shortcut and made a default method in HttpRequestFactory, please tell me if you want me to move the implementation elsewhere