### PR TITLE
Fix introspection for generated Jackson models

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -304,7 +304,31 @@ public final class AstBeanPropertiesUtils {
                 return accessorPropertyName;
             }
         }
+        if (isBooleanAccessorPropertyFieldName(fieldPropertyName)) {
+            String accessorPropertyName = NameUtils.decapitalize(fieldPropertyName.substring(2));
+            if (props.containsKey(accessorPropertyName)) {
+                return accessorPropertyName;
+            }
+        }
+        if (isAcronymPropertyFieldName(fieldPropertyName)) {
+            String accessorPropertyName = Character.toUpperCase(fieldPropertyName.charAt(0)) + fieldPropertyName.substring(1);
+            if (props.containsKey(accessorPropertyName)) {
+                return accessorPropertyName;
+            }
+        }
         return fieldPropertyName;
+    }
+
+    private static boolean isBooleanAccessorPropertyFieldName(String fieldPropertyName) {
+        return fieldPropertyName.length() > 2 &&
+            fieldPropertyName.startsWith("is") &&
+            Character.isUpperCase(fieldPropertyName.charAt(2));
+    }
+
+    private static boolean isAcronymPropertyFieldName(String fieldPropertyName) {
+        return fieldPropertyName.length() > 1 &&
+            Character.isLowerCase(fieldPropertyName.charAt(0)) &&
+            Character.isUpperCase(fieldPropertyName.charAt(1));
     }
 
     private static boolean isIntrospectedPropertyReader(MethodElement methodElement, BeanProperties.Visibility visibility) {

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -202,7 +202,7 @@ public final class AstBeanPropertiesUtils {
                 continue;
             }
             String fieldPropertyName = fieldElement.getSimpleName();
-            String propertyName = resolvePropertyNameForField(props, fieldPropertyName);
+            String propertyName = resolvePropertyNameForField(props, fieldPropertyName, isIntrospectedPropertyField);
             boolean isPropertyField = propertyFields.contains(fieldPropertyName);
             boolean hasConstructorWriteAccess = isIntrospectedPropertyField
                 && isWriteOnlyIntrospectedProperty(fieldElement)
@@ -294,7 +294,9 @@ public final class AstBeanPropertiesUtils {
         return beanProperties;
     }
 
-    private static String resolvePropertyNameForField(Map<String, BeanPropertyData> props, String fieldPropertyName) {
+    private static String resolvePropertyNameForField(Map<String, BeanPropertyData> props,
+                                                      String fieldPropertyName,
+                                                      boolean isIntrospectedPropertyField) {
         if (props.containsKey(fieldPropertyName)) {
             return fieldPropertyName;
         }
@@ -304,16 +306,18 @@ public final class AstBeanPropertiesUtils {
                 return accessorPropertyName;
             }
         }
-        if (isBooleanAccessorPropertyFieldName(fieldPropertyName)) {
-            String accessorPropertyName = NameUtils.decapitalize(fieldPropertyName.substring(2));
-            if (props.containsKey(accessorPropertyName)) {
-                return accessorPropertyName;
+        if (isIntrospectedPropertyField) {
+            if (isBooleanAccessorPropertyFieldName(fieldPropertyName)) {
+                String accessorPropertyName = NameUtils.decapitalize(fieldPropertyName.substring(2));
+                if (props.containsKey(accessorPropertyName)) {
+                    return accessorPropertyName;
+                }
             }
-        }
-        if (isAcronymPropertyFieldName(fieldPropertyName)) {
-            String accessorPropertyName = Character.toUpperCase(fieldPropertyName.charAt(0)) + fieldPropertyName.substring(1);
-            if (props.containsKey(accessorPropertyName)) {
-                return accessorPropertyName;
+            if (isAcronymPropertyFieldName(fieldPropertyName)) {
+                String accessorPropertyName = Character.toUpperCase(fieldPropertyName.charAt(0)) + fieldPropertyName.substring(1);
+                if (props.containsKey(accessorPropertyName)) {
+                    return accessorPropertyName;
+                }
             }
         }
         return fieldPropertyName;

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/AbstractJsonPOJOBuilderAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/AbstractJsonPOJOBuilderAnnotationMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor;
+
+import io.micronaut.core.annotation.AccessorsStyle;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+abstract class AbstractJsonPOJOBuilderAnnotationMapper implements NamedAnnotationMapper {
+
+    private static final String MEMBER_WITH_PREFIX = "withPrefix";
+
+    @Override
+    public final List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return List.of(
+            AnnotationValue.builder(AccessorsStyle.class)
+                .member("writePrefixes", annotation.stringValue(MEMBER_WITH_PREFIX).orElse("with"))
+                .build()
+        );
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPOJOBuilderAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPOJOBuilderAnnotationMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor;
+
+import io.micronaut.core.annotation.AccessorsStyle;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * Makes Jackson builder methods visible to bean property resolution.
+ *
+ * @author Denis Stepanov
+ * @since 5.1.4
+ */
+@Internal
+public final class JsonPOJOBuilderAnnotationMapper implements NamedAnnotationMapper {
+
+    private static final String MEMBER_WITH_PREFIX = "withPrefix";
+
+    @Override
+    public String getName() {
+        return "com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return List.of(
+            AnnotationValue.builder(AccessorsStyle.class)
+                .member("writePrefixes", annotation.stringValue(MEMBER_WITH_PREFIX).orElse("with"))
+                .build()
+        );
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPOJOBuilderAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/JsonPOJOBuilderAnnotationMapper.java
@@ -15,14 +15,7 @@
  */
 package io.micronaut.inject.beans.visitor;
 
-import io.micronaut.core.annotation.AccessorsStyle;
-import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.inject.annotation.NamedAnnotationMapper;
-import io.micronaut.inject.visitor.VisitorContext;
-
-import java.lang.annotation.Annotation;
-import java.util.List;
 
 /**
  * Makes Jackson builder methods visible to bean property resolution.
@@ -31,21 +24,10 @@ import java.util.List;
  * @since 5.1.4
  */
 @Internal
-public final class JsonPOJOBuilderAnnotationMapper implements NamedAnnotationMapper {
-
-    private static final String MEMBER_WITH_PREFIX = "withPrefix";
+public final class JsonPOJOBuilderAnnotationMapper extends AbstractJsonPOJOBuilderAnnotationMapper {
 
     @Override
     public String getName() {
         return "com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder";
-    }
-
-    @Override
-    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
-        return List.of(
-            AnnotationValue.builder(AccessorsStyle.class)
-                .member("writePrefixes", annotation.stringValue(MEMBER_WITH_PREFIX).orElse("with"))
-                .build()
-        );
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/ToolsJsonPOJOBuilderAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/ToolsJsonPOJOBuilderAnnotationMapper.java
@@ -15,14 +15,7 @@
  */
 package io.micronaut.inject.beans.visitor;
 
-import io.micronaut.core.annotation.AccessorsStyle;
-import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.inject.annotation.NamedAnnotationMapper;
-import io.micronaut.inject.visitor.VisitorContext;
-
-import java.lang.annotation.Annotation;
-import java.util.List;
 
 /**
  * Makes Jackson builder methods visible to bean property resolution.
@@ -31,21 +24,10 @@ import java.util.List;
  * @since 5.1.4
  */
 @Internal
-public final class ToolsJsonPOJOBuilderAnnotationMapper implements NamedAnnotationMapper {
-
-    private static final String MEMBER_WITH_PREFIX = "withPrefix";
+public final class ToolsJsonPOJOBuilderAnnotationMapper extends AbstractJsonPOJOBuilderAnnotationMapper {
 
     @Override
     public String getName() {
         return "tools.jackson.databind.annotation.JsonPOJOBuilder";
-    }
-
-    @Override
-    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
-        return List.of(
-            AnnotationValue.builder(AccessorsStyle.class)
-                .member("writePrefixes", annotation.stringValue(MEMBER_WITH_PREFIX).orElse("with"))
-                .build()
-        );
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/ToolsJsonPOJOBuilderAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/ToolsJsonPOJOBuilderAnnotationMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor;
+
+import io.micronaut.core.annotation.AccessorsStyle;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * Makes Jackson builder methods visible to bean property resolution.
+ *
+ * @author Denis Stepanov
+ * @since 5.1.4
+ */
+@Internal
+public final class ToolsJsonPOJOBuilderAnnotationMapper implements NamedAnnotationMapper {
+
+    private static final String MEMBER_WITH_PREFIX = "withPrefix";
+
+    @Override
+    public String getName() {
+        return "tools.jackson.databind.annotation.JsonPOJOBuilder";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return List.of(
+            AnnotationValue.builder(AccessorsStyle.class)
+                .member("writePrefixes", annotation.stringValue(MEMBER_WITH_PREFIX).orElse("with"))
+                .build()
+        );
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -639,6 +639,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     private final String beanFullClassName;
     private final String beanDefinitionName;
+    private final String beanDefinitionPackageName;
     private final TypeDef beanTypeDef;
     private final Map<String, MethodDef> loadTypeMethods = new LinkedHashMap<>();
     private final ClassTypeDef beanDefinitionTypeDef;
@@ -798,6 +799,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
         this.isConfigurationProperties = isConfigurationProperties(this.annotationMetadata);
         validateExposedTypes(this.annotationMetadata, visitorContext);
         this.beanDefinitionName = beanDefinitionName;
+        this.beanDefinitionPackageName = NameUtils.getPackageName(beanDefinitionName);
         this.visitorContext = visitorContext;
         this.evaluatedExpressionProcessor = new EvaluatedExpressionProcessor(visitorContext, getOriginatingElement());
         evaluatedExpressionProcessor.processEvaluatedExpressions(this.annotationMetadata,
@@ -2561,7 +2563,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
             return isAccessibleFromBeanDefinition(element.fromArray());
         }
         return element.isPublic() ||
-            (!element.isPrivate() && element.getPackageName().equals(NameUtils.getPackageName(beanDefinitionName)));
+            (!element.isPrivate() && element.getPackageName().equals(beanDefinitionPackageName));
     }
 
     private String getClassName(ClassElement element) {

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -1969,7 +1969,17 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
             classDefBuilder.addField(injectionMethodsField);
             initStatements.add(beanDefinitionTypeDef.getStaticField(injectionMethodsField)
                 .put(methodReferenceArray.instantiate(allMethods.stream()
-                    .map(md -> getNewMethodReference(md.methodElement().getDeclaringType(), md.methodElement(), md.annotationMetadata(), postConstructMethods.contains(md), preDestroyMethods.contains(md)))
+                    .map(md -> {
+                        boolean postConstructMethod = postConstructMethods.contains(md);
+                        boolean preDestroyMethod = preDestroyMethods.contains(md);
+                        return getNewMethodReference(
+                            getMethodReferenceDeclaringType(md.methodElement(), postConstructMethod, preDestroyMethod),
+                            md.methodElement(),
+                            md.annotationMetadata(),
+                            postConstructMethod,
+                            preDestroyMethod
+                        );
+                    })
                     .toList())));
             failStatements.add(beanDefinitionTypeDef.getStaticField(injectionMethodsField).put(ExpressionDef.nullValue()));
         }
@@ -2536,12 +2546,22 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     }
 
     private void collectExposedTypes(Set<String> exposedTypeNames, ClassElement element) {
-        String className = getClassName(element);
-        if (!exposedTypeNames.add(className) || IGNORED_EXPOSED_INTERFACES.contains(className)) {
-            return;
+        if (isAccessibleFromBeanDefinition(element)) {
+            String className = getClassName(element);
+            if (!exposedTypeNames.add(className) || IGNORED_EXPOSED_INTERFACES.contains(className)) {
+                return;
+            }
         }
         element.getSuperType().ifPresent(superType -> collectExposedTypes(exposedTypeNames, superType));
         element.getInterfaces().forEach(iface -> collectExposedTypes(exposedTypeNames, iface));
+    }
+
+    private boolean isAccessibleFromBeanDefinition(ClassElement element) {
+        if (element.isArray()) {
+            return isAccessibleFromBeanDefinition(element.fromArray());
+        }
+        return element.isPublic() ||
+            (!element.isPrivate() && element.getPackageName().equals(NameUtils.getPackageName(beanDefinitionName)));
     }
 
     private String getClassName(ClassElement element) {
@@ -4140,6 +4160,18 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
                     METHOD_REFERENCE_CONSTRUCTOR, values
                 );
         }
+    }
+
+    private ClassElement getMethodReferenceDeclaringType(MethodElement methodElement,
+                                                        boolean isPostConstructMethod,
+                                                        boolean isPreDestroyMethod) {
+        ClassElement declaringType = methodElement.getDeclaringType();
+        if ((isPostConstructMethod || isPreDestroyMethod) &&
+            methodElement.isPublic() &&
+            !isAccessibleFromBeanDefinition(declaringType)) {
+            return beanTypeElement;
+        }
+        return declaringType;
     }
 
     private ExpressionDef getNewFieldReference(TypedElement declaringType, FieldElement fieldElement) {

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -7,8 +7,10 @@ io.micronaut.inject.beans.visitor.MappedSuperClassIntrospectionMapper
 io.micronaut.inject.beans.visitor.JsonCreatorAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonAutoDetectAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonGetterAnnotationMapper
+io.micronaut.inject.beans.visitor.JsonPOJOBuilderAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonPropertyAnnotationMapper
 io.micronaut.inject.beans.visitor.JsonSetterAnnotationMapper
+io.micronaut.inject.beans.visitor.ToolsJsonPOJOBuilderAnnotationMapper
 io.micronaut.inject.beans.visitor.persistence.JakartaEntityIntrospectedAnnotationMapper
 io.micronaut.inject.beans.visitor.persistence.JakartaMappedSuperClassIntrospectionMapper
 io.micronaut.inject.beans.visitor.MapperAnnotationMapper

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMapperSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMapperSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.inject.annotation
 
 import org.jspecify.annotations.NonNull
 import io.micronaut.context.annotation.ConfigurationInject
+import io.micronaut.core.annotation.AccessorsStyle
 import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.core.annotation.Creator
 import io.micronaut.core.bind.annotation.Bindable
@@ -11,6 +12,8 @@ import io.micronaut.http.annotation.Header
 import io.micronaut.http.annotation.HttpMethodMapping
 import io.micronaut.http.annotation.QueryValue
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.beans.visitor.JsonPOJOBuilderAnnotationMapper
+import io.micronaut.inject.beans.visitor.ToolsJsonPOJOBuilderAnnotationMapper
 import io.micronaut.inject.visitor.VisitorContext
 
 import java.lang.annotation.Annotation
@@ -98,6 +101,32 @@ class Test {
         def annotations = metadata.getAnnotationTypesByStereotype(HttpMethodMapping)
         annotations.size() == 1
         annotations[0] == Get
+    }
+
+    void "test jackson pojo builder annotation mapper maps withPrefix to accessors style"() {
+        given:
+        def annotationBuilder = AnnotationValue.builder(annotationName)
+        if (withPrefix != null) {
+            annotationBuilder.member("withPrefix", withPrefix)
+        }
+
+        when:
+        def mappedAnnotations = mapper.map(annotationBuilder.build(), null)
+        def accessorsStyle = mappedAnnotations[0]
+
+        then:
+        mapper.name == annotationName
+        mappedAnnotations.size() == 1
+        accessorsStyle.annotationName == AccessorsStyle.name
+        accessorsStyle.stringValues("writePrefixes").toList() == [expectedPrefix]
+        accessorsStyle.stringValues("readPrefixes").length == 0
+
+        where:
+        mapper                                      | annotationName                                              | withPrefix | expectedPrefix
+        new JsonPOJOBuilderAnnotationMapper()      | "com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder" | ""         | ""
+        new JsonPOJOBuilderAnnotationMapper()      | "com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder" | null       | "with"
+        new ToolsJsonPOJOBuilderAnnotationMapper() | "tools.jackson.databind.annotation.JsonPOJOBuilder"         | ""         | ""
+        new ToolsJsonPOJOBuilderAnnotationMapper() | "tools.jackson.databind.annotation.JsonPOJOBuilder"         | null       | "with"
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -102,6 +102,29 @@ class Test implements Runnable {
         reference.exposedTypes == [Runnable] as Set
     }
 
+    void "test exposed types omit package-private supertypes from another package"() {
+        given:
+        def reference = buildBeanDefinitionReference('limittypes.Test', '''
+package limittypes;
+
+import jakarta.inject.Singleton;
+import test.exposedtypes.internal.PublicExposedType;
+
+@Singleton
+class Test extends PublicExposedType {
+}
+
+''')
+
+        when:
+        def exposedTypeNames = reference.exposedTypes*.name as Set
+
+        then:
+        exposedTypeNames.contains('limittypes.Test')
+        exposedTypeNames.contains('test.exposedtypes.internal.PublicExposedType')
+        !exposedTypeNames.contains('test.exposedtypes.internal.HiddenExposedType')
+    }
+
     void "test fail compilation on invalid exposed bean type"() {
         when:
         buildBeanDefinition('limittypes.Test', '''

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/lifecycle/PreDestroyOnBeanAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/lifecycle/PreDestroyOnBeanAnnotationSpec.groovy
@@ -50,7 +50,7 @@ class Foo {}
         bean != null
 
         when:
-        context.destroyBean(bean.getClass())
+        context.destroyBean(bean)
 
         then:
         bean.closed
@@ -131,7 +131,7 @@ class TestFactory {
         bean != null
 
         when:
-        context.destroyBean(bean.getClass())
+        context.destroyBean(bean)
 
         then:
         bean.closed

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/lifecycle/PreDestroyOnBeanAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/lifecycle/PreDestroyOnBeanAnnotationSpec.groovy
@@ -104,6 +104,43 @@ class AbstractTest implements AutoCloseable {
         bean != context.getBean(beanType)
     }
 
+    void "test pre destroy with bean method on package-private parent class from another package"() {
+        given:
+        ApplicationContext context = buildContext('test.TestFactory$TestBean', '''\
+package test;
+
+import io.micronaut.context.annotation.*;
+import test.exposedtypes.internal.PublicExposedType;
+
+@Factory
+class TestFactory {
+
+    @Bean(preDestroy="close")
+    @jakarta.inject.Singleton
+    PublicExposedType testBean() {
+        return new PublicExposedType();
+    }
+}
+
+''')
+
+        when:
+        def bean = context.getBean(Class.forName('test.exposedtypes.internal.PublicExposedType'))
+
+        then:
+        bean != null
+
+        when:
+        context.destroyBean(bean.getClass())
+
+        then:
+        bean.closed
+        bean != context.getBean(bean.getClass())
+
+        cleanup:
+        context.close()
+    }
+
     void "test pre destroy with bean method on parent interface"() {
         given:
         ApplicationContext context = buildContext('test.TestFactory$TestBean', '''\

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
@@ -719,6 +719,36 @@ class JacksonPropertyAccessBean {
         setterOnly.isWriteOnly()
     }
 
+    void "test jackson pojo builder empty prefix uses fluent writers for json property fields"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonFluentBuilderBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+
+@Introspected
+@JsonPOJOBuilder(withPrefix = "")
+class JacksonFluentBuilderBean {
+    @JsonProperty("json_code")
+    private String code;
+
+    public JacksonFluentBuilderBean code(String code) {
+        this.code = code;
+        return this;
+    }
+}
+''')
+        def code = introspection.beanProperties.find { it.name == 'code' }
+
+        expect:
+        code != null
+        !code.isReadOnly()
+        code.isWriteOnly()
+        code.stringValue(Introspected.Property, "name").get() == 'json_code'
+    }
+
     void "test jackson property on generated dollar prefixed private field uses public accessors"() {
         given:
         def introspection = buildBeanIntrospection('test.JacksonDollarPrefixedFieldBean', '''
@@ -781,6 +811,62 @@ class JacksonUnderscorePrefixedFieldBean {
 
         expect:
         property.stringValue(Introspected.Property, "name").orElseThrow() == 'default'
+    }
+
+    void "test jackson property on generated boolean is prefixed private field uses public accessor"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonBooleanIsPrefixedFieldBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class JacksonBooleanIsPrefixedFieldBean {
+    @JsonProperty("default")
+    private final Boolean isDefault;
+
+    JacksonBooleanIsPrefixedFieldBean(Boolean isDefault) {
+        this.isDefault = isDefault;
+    }
+
+    public Boolean isDefault() {
+        return isDefault;
+    }
+}
+''')
+        def property = introspection.getRequiredProperty('default', Boolean)
+
+        expect:
+        property.stringValue(Introspected.Property, "name").orElseThrow() == 'default'
+    }
+
+    void "test jackson property on generated acronym private field uses public accessor"() {
+        given:
+        def introspection = buildBeanIntrospection('test.JacksonAcronymFieldBean', '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class JacksonAcronymFieldBean {
+    @JsonProperty("CACertChain")
+    private final String cACertChain;
+
+    JacksonAcronymFieldBean(String cACertChain) {
+        this.cACertChain = cACertChain;
+    }
+
+    public String getCACertChain() {
+        return cACertChain;
+    }
+}
+''')
+        def property = introspection.getRequiredProperty('CACertChain', String)
+
+        expect:
+        property.stringValue(Introspected.Property, "name").orElseThrow() == 'CACertChain'
     }
 
     void "test jackson write only final dollar prefixed field resolves as constructor property"() {

--- a/inject-java/src/test/java/test/exposedtypes/internal/HiddenExposedType.java
+++ b/inject-java/src/test/java/test/exposedtypes/internal/HiddenExposedType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.exposedtypes.internal;
+
+abstract class HiddenExposedType implements AutoCloseable {
+
+    boolean closed;
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+}

--- a/inject-java/src/test/java/test/exposedtypes/internal/PublicExposedType.java
+++ b/inject-java/src/test/java/test/exposedtypes/internal/PublicExposedType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.exposedtypes.internal;
+
+public class PublicExposedType extends HiddenExposedType implements Runnable {
+
+    @Override
+    public void run() {
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+}


### PR DESCRIPTION
Map Jackson JsonPOJOBuilder withPrefix values to AccessorsStyle for both Jackson annotation packages.

Merge generated JSON property fields with public accessors for boolean and acronym property names.

Avoid emitting inaccessible package-private supertypes in bean definition exposed types and lifecycle method references.