### PR TITLE
Honor configuration loading strategy during bootstrap

### DIFF
--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfigurationDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfigurationDelegate.java
@@ -19,6 +19,7 @@ import io.micronaut.context.env.EnvironmentNamesDeducer;
 import io.micronaut.context.env.EnvironmentPackagesDeducer;
 import io.micronaut.context.env.PropertySourcesLocator;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.ResourceLoadStrategy;
 import io.micronaut.inject.BeanConfiguration;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.convert.MutableConversionService;
@@ -138,6 +139,11 @@ class ApplicationContextConfigurationDelegate implements ApplicationContextConfi
     @Override
     public Collection<PropertySourcesLocator> getPropertySourcesLocators() {
         return delegate.getPropertySourcesLocators();
+    }
+
+    @Override
+    public ResourceLoadStrategy getConfigurationLoadingStrategy() {
+        return delegate.getConfigurationLoadingStrategy();
     }
 
     @Override

--- a/test-suite-property-source/src/test/groovy/io/micronaut/context/env/ConfigurationLoadStrategySpec.groovy
+++ b/test-suite-property-source/src/test/groovy/io/micronaut/context/env/ConfigurationLoadStrategySpec.groovy
@@ -4,10 +4,9 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.exceptions.ConfigurationException
 import io.micronaut.core.io.ResourceLoadStrategy
 import io.micronaut.core.io.ResourceLoadStrategyType
+import spock.lang.Issue
 import spock.lang.Specification
 
-import java.net.URL
-import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
@@ -89,6 +88,41 @@ class ConfigurationLoadStrategySpec extends Specification {
               ApplicationContext ctx = ApplicationContext.builder(cl)
                      .configurationLoadingStrategy(ResourceLoadStrategy.builder()
                          .type(ResourceLoadStrategyType.MERGE_ALL))
+                     .start()) {
+            props = [
+                    foo: ctx.environment.getProperty("foo", String).orElse(null),
+                    appOnly: ctx.environment.getProperty("appOnly", String).orElse(null),
+                    libOnly: ctx.environment.getProperty("libOnly", String).orElse(null)
+            ]
+        }
+
+        then:
+        props.foo == "lib"
+        props.appOnly == "yes"
+        props.libOnly == "yes"
+
+        cleanup:
+        deleteDirectory(result.dir)
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/12786")
+    void "MERGE_ALL is honored when bootstrap environment wraps configuration"() {
+        given:
+        def result = duplicateJars(
+                "app-1.0.jar",
+                "lib-1.0.jar",
+                "application.properties",
+                "foo=app\nappOnly=yes\n",
+                "foo=lib\nlibOnly=yes\n"
+        )
+
+        when:
+        Map<String, Object> props
+        try (URLClassLoader cl = new URLClassLoader(result.jars*.toUri()*.toURL() as URL[], getClass().classLoader)
+             ApplicationContext ctx = ApplicationContext.builder(cl)
+                     .bootstrapEnvironment(true)
+                     .configurationLoadingStrategy(ResourceLoadStrategy.builder()
+                             .type(ResourceLoadStrategyType.MERGE_ALL))
                      .start()) {
             props = [
                     foo: ctx.environment.getProperty("foo", String).orElse(null),


### PR DESCRIPTION
## Summary

- forward `getConfigurationLoadingStrategy()` from `ApplicationContextConfigurationDelegate`
- add a regression test that enables the bootstrap environment and verifies `MERGE_ALL` still merges duplicate configuration resources

## Root cause

When bootstrap configuration wraps the original `ApplicationContextConfiguration`, the wrapper did not forward the configured resource loading strategy. `DefaultEnvironment` then read the interface default strategy, which falls back to `FAIL_ON_DUPLICATE`.

Fixes #12786

## Validation

```bash
./gradlew :test-suite-property-source:test --tests io.micronaut.context.env.ConfigurationLoadStrategySpec."MERGE_ALL is honored when bootstrap environment wraps configuration"
```
