### PR TITLE
Restore private nested client lookup

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -2421,9 +2421,9 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
                     collectExposedTypes(exposedTypeNames, beanTypeElement.getFirstTypeArgument()
                         .orElseThrow(() -> new IllegalStateException("No type argument found for array type: " + beanTypeElement.getType())));
                 }
-                collectExposedTypes(exposedTypeNames, beanTypeElement);
+                collectBeanTypeAndExposedTypes(exposedTypeNames, beanTypeElement);
             } else {
-                collectExposedTypes(exposedTypeNames, beanTypeElement);
+                collectBeanTypeAndExposedTypes(exposedTypeNames, beanTypeElement);
             }
         }
         if (exposedTypeNames.isEmpty()) {
@@ -2548,14 +2548,22 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     }
 
     private void collectExposedTypes(Set<String> exposedTypeNames, ClassElement element) {
-        if (isAccessibleFromBeanDefinition(element)) {
+        collectExposedTypes(exposedTypeNames, element, true);
+    }
+
+    private void collectExposedTypes(Set<String> exposedTypeNames, ClassElement element, boolean rootType) {
+        if (rootType || isAccessibleFromBeanDefinition(element)) {
             String className = getClassName(element);
             if (!exposedTypeNames.add(className) || IGNORED_EXPOSED_INTERFACES.contains(className)) {
                 return;
             }
         }
-        element.getSuperType().ifPresent(superType -> collectExposedTypes(exposedTypeNames, superType));
-        element.getInterfaces().forEach(iface -> collectExposedTypes(exposedTypeNames, iface));
+        element.getSuperType().ifPresent(superType -> collectExposedTypes(exposedTypeNames, superType, false));
+        element.getInterfaces().forEach(iface -> collectExposedTypes(exposedTypeNames, iface, false));
+    }
+
+    private void collectBeanTypeAndExposedTypes(Set<String> exposedTypeNames, ClassElement element) {
+        collectExposedTypes(exposedTypeNames, element);
     }
 
     private boolean isAccessibleFromBeanDefinition(ClassElement element) {

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
@@ -45,6 +45,14 @@ class ClientIntroductionAdviceSpec extends Specification {
         myService.index() == 'success'
     }
 
+    void "test implement private nested HTTP client"() {
+        given:
+        PrivateNestedClient client = server.applicationContext.getBean(PrivateNestedClient)
+
+        expect:
+        client.index() == 'success'
+    }
+
     void "test accept type defaults to json"() {
         given:
         AcceptTypeClient client = server.applicationContext.getBean(AcceptTypeClient)
@@ -448,6 +456,11 @@ class ClientIntroductionAdviceSpec extends Specification {
     @Requires(property = 'spec.name', value = 'ClientIntroductionAdviceSpec')
     @Client('/aop')
     static interface MyClient extends MyApi {
+    }
+
+    @Requires(property = 'spec.name', value = 'ClientIntroductionAdviceSpec')
+    @Client('/aop')
+    private static interface PrivateNestedClient extends MyApi {
     }
 
     @Client('/accept')


### PR DESCRIPTION
## Summary
- restore exact bean lookup for private nested declarative HTTP client interfaces
- keep recursive exposed-type filtering for inaccessible supertypes/interfaces
- add regression coverage for a private nested @Client interface

## Testing
- ./gradlew :micronaut-http-client:test --tests 'io.micronaut.http.client.ClientIntroductionAdviceSpec.test implement private nested HTTP client' --stacktrace --no-daemon --no-build-cache
- ./gradlew :micronaut-inject-java:test --tests 'io.micronaut.inject.beans.BeanDefinitionSpec.test exposed types omit package-private supertypes from another package' --stacktrace --no-daemon --no-build-cache
- ./gradlew :micronaut-core-processor:compileJava --stacktrace --no-daemon --no-build-cache