### PR TITLE
Fix regression @Replaces matching for proxied default implementations

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultReplacesDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultReplacesDefinition.java
@@ -20,10 +20,12 @@ import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
-import org.jspecify.annotations.Nullable;
+import io.micronaut.inject.AdvisedBeanType;
 import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ProxyBeanDefinition;
 import io.micronaut.inject.ReplacesDefinition;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
@@ -47,6 +49,7 @@ public record DefaultReplacesDefinition<T>(Class<T> beanType,
                                            @Nullable Class<?> factoryClass) implements ReplacesDefinition<T> {
 
 
+    @SuppressWarnings("unchecked")
     public DefaultReplacesDefinition(Class<T> beanType, AnnotationValue<Replaces> replacesAnnotation) {
         this(
             beanType,
@@ -119,7 +122,7 @@ public record DefaultReplacesDefinition<T>(Class<T> beanType,
 
     private boolean checkIfTypeMatches(BeanDefinition<T> definitionToBeReplaced,
                                        Class<T> beanTypeToReplace) {
-        Class<T> bt = definitionToBeReplaced.getBeanType();
+        Class<?> bt = getCanonicalBeanType(definitionToBeReplaced);
         Class<?> defaultImplementation = definitionToBeReplaced.getDefaultImplementation();
         if (defaultImplementation != null) {
             if (defaultImplementation == bt) {
@@ -129,5 +132,15 @@ public record DefaultReplacesDefinition<T>(Class<T> beanType,
             }
         }
         return beanTypeToReplace != Object.class && beanTypeToReplace.isAssignableFrom(bt);
+    }
+
+    private Class<?> getCanonicalBeanType(BeanDefinition<T> beanDefinition) {
+        if (beanDefinition instanceof AdvisedBeanType<?> advisedBeanType) {
+            return advisedBeanType.getInterceptedType();
+        }
+        if (beanDefinition instanceof ProxyBeanDefinition<?> proxyBeanDefinition) {
+            return proxyBeanDefinition.getTargetType();
+        }
+        return beanDefinition.getBeanType();
     }
 }

--- a/test-suite/src/test/java/io/micronaut/context/annotation/ReplacesProxiedDefaultImplementationTest.java
+++ b/test-suite/src/test/java/io/micronaut/context/annotation/ReplacesProxiedDefaultImplementationTest.java
@@ -1,0 +1,50 @@
+package io.micronaut.context.annotation;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.scheduling.annotation.Async;
+import jakarta.inject.Singleton;
+
+import java.util.Map;
+
+class ReplacesProxiedDefaultImplementationTest {
+    @Test
+    void replacingAnInterfaceWithDefaultImplementationWorksWhenDefaultBeanIsProxied() {
+        Map<String, Object> config = Map.of("spec.name", "ReplacesProxiedDefaultImplementationTest");
+        try (ApplicationContext ctx = ApplicationContext.run(config)) {
+            assertInstanceOf(GreeterReplacement.class, ctx.getBean(Greeter.class));
+        }
+    }
+
+    @DefaultImplementation(DefaultGreeter.class)
+    public interface Greeter {
+        String greet(String name);
+    }
+
+    @Requires(property = "spec.name", value = "ReplacesProxiedDefaultImplementationTest")
+    @Singleton
+    static class DefaultGreeter implements Greeter {
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+
+        @Async // any AOP advice: this makes the bean definition an intercepted proxy
+        public void warmUp() {
+        }
+    }
+
+    @Requires(property = "spec.name", value = "ReplacesProxiedDefaultImplementationTest")
+    @Singleton
+    @Replaces(Greeter.class)
+    static class GreeterReplacement implements Greeter {
+        @Override
+        public String greet(String name) {
+            return "Hola " + name;
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/context/annotation/ReplacesProxiedDefaultImplementationTest.java
+++ b/test-suite/src/test/java/io/micronaut/context/annotation/ReplacesProxiedDefaultImplementationTest.java
@@ -1,15 +1,13 @@
 package io.micronaut.context.annotation;
 
 import io.micronaut.context.ApplicationContext;
-import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import io.micronaut.context.annotation.DefaultImplementation;
-import io.micronaut.context.annotation.Replaces;
 import io.micronaut.scheduling.annotation.Async;
 import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class ReplacesProxiedDefaultImplementationTest {
     @Test


### PR DESCRIPTION
Fix @Replaces matching for proxied default implementations

Canonicalize the bean type used by DefaultReplacesDefinition before checking replacement matches.

When a @DefaultImplementation bean is AOP-proxied, getBeanType() returns the generated proxy type, which prevents @Replaces(SomeInterface.class) from matching the declared default implementation. Use the intercepted/target type for advised and proxy bean definitions so proxied default implementations can be replaced correctly.

Fixes [#12794](https://github.com/micronaut-projects/micronaut-core/issues/12794). 

[This is a regression, it was working in Micronaut 4](https://github.com/micronaut-projects/micronaut-core/pull/12795).