### PR TITLE
Add shared trailing slash trimming utility

### DIFF
--- a/core/src/main/java/io/micronaut/core/util/StringUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/StringUtils.java
@@ -249,6 +249,41 @@ public final class StringUtils {
     }
 
     /**
+     * Returns a new string without a trailing character that matches the supplied character.
+     *
+     * @param str The string
+     * @param c   The character to remove
+     * @return The string without a trailing character matching the supplied character, or {@code null} when the input is {@code null}.
+     * @since 5.1.6
+     */
+    @Nullable
+    public static String trimTrailingCharacter(@Nullable String str, char c) {
+        if (isEmpty(str)) {
+            return str;
+        }
+        int length = str.length();
+        if (str.charAt(length - 1) == c) {
+            return str.substring(0, length - 1);
+        }
+        return str;
+    }
+
+    /**
+     * Returns a new string without a trailing slash character, unless the string is a single slash.
+     *
+     * @param str The string
+     * @return The string without a trailing slash character, or {@code null} when the input is {@code null}.
+     * @since 5.1.6
+     */
+    @Nullable
+    public static String trimTrailingSlashExceptRoot(@Nullable String str) {
+        if (isEmpty(str)) {
+            return str;
+        }
+        return str.length() > 1 ? trimTrailingCharacter(str, '/') : str;
+    }
+
+    /**
      * Returns a new string without any leading characters that match the supplied predicate.
      *
      * @param str       The string

--- a/core/src/main/java/io/micronaut/core/util/StringUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/StringUtils.java
@@ -269,7 +269,7 @@ public final class StringUtils {
     }
 
     /**
-     * Returns a new string without a trailing slash character, unless the string is a single slash.
+     * Returns a new string without a single trailing slash character, unless the string is a single slash.
      *
      * @param str The string
      * @return The string without a trailing slash character, or {@code null} when the input is {@code null}.

--- a/core/src/main/java/io/micronaut/core/util/StringUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/StringUtils.java
@@ -249,7 +249,7 @@ public final class StringUtils {
     }
 
     /**
-     * Returns a new string without a trailing character that matches the supplied character.
+     * Returns a new string without a single trailing character that matches the supplied character.
      *
      * @param str The string
      * @param c   The character to remove

--- a/core/src/test/java/io/micronaut/core/util/StringUtilsTest.java
+++ b/core/src/test/java/io/micronaut/core/util/StringUtilsTest.java
@@ -30,7 +30,7 @@ class StringUtilsTest {
         return Stream.of(
             Arguments.of("abc", 'c', "ab"),
             Arguments.of("abc", 'd', "abc"),
-            Arguments.of("abc   ", ' ', "abc"),
+            Arguments.of("abc ", ' ', "abc"),
             Arguments.of("aa", 'a', "a"),
             Arguments.of("", 'a', ""),
             Arguments.of(null, 'a', null)

--- a/core/src/test/java/io/micronaut/core/util/StringUtilsTest.java
+++ b/core/src/test/java/io/micronaut/core/util/StringUtilsTest.java
@@ -1,7 +1,13 @@
 package io.micronaut.core.util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class StringUtilsTest {
@@ -12,5 +18,39 @@ class StringUtilsTest {
             sb.append('a');
         }
         assertEquals(4096, StringUtils.utf8Bytes(sb.toString()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("trimTrailingCharacterArguments")
+    void trimTrailingCharacter(String input, char character, String expected) {
+        assertEquals(expected, StringUtils.trimTrailingCharacter(input, character));
+    }
+
+    private static Stream<Arguments> trimTrailingCharacterArguments() {
+        return Stream.of(
+            Arguments.of("abc", 'c', "ab"),
+            Arguments.of("abc", 'd', "abc"),
+            Arguments.of("abc   ", ' ', "abc"),
+            Arguments.of("aa", 'a', "a"),
+            Arguments.of("", 'a', ""),
+            Arguments.of(null, 'a', null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("trimTrailingSlashExceptRootArguments")
+    void trimTrailingSlashExceptRoot(String input, String expected) {
+        assertEquals(expected, StringUtils.trimTrailingSlashExceptRoot(input));
+    }
+
+    private static Stream<Arguments> trimTrailingSlashExceptRootArguments() {
+        return Stream.of(
+            Arguments.of("/admin/secret/", "/admin/secret"),
+            Arguments.of("/admin/secret", "/admin/secret"),
+            Arguments.of("path/", "path"),
+            Arguments.of("path//", "path/"),
+            Arguments.of("/", "/"),
+            Arguments.of(null, null)
+        );
     }
 }

--- a/http/src/main/java/io/micronaut/http/uri/UriMatchTemplate.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriMatchTemplate.java
@@ -173,9 +173,7 @@ public class UriMatchTemplate extends UriTemplate implements UriMatcher {
             throw new IllegalArgumentException("Argument 'uri' cannot be null");
         }
         int length = uri.length();
-        if (length > 1 && uri.charAt(length - 1) == '/') {
-            uri = uri.substring(0, length - 1);
-        }
+        uri = StringUtils.trimTrailingSlashExceptRoot(uri);
 
         if (isRoot && (length == 0 || (length == 1 && uri.charAt(0) == '/'))) {
             if (rootMatchInfo == null) {
@@ -188,9 +186,7 @@ public class UriMatchTemplate extends UriTemplate implements UriMatcher {
         if (parameterIndex > -1) {
             uri = uri.substring(0, parameterIndex);
         }
-        if (uri.endsWith("/")) {
-            uri = uri.substring(0, uri.length() - 1);
-        }
+        uri = StringUtils.trimTrailingSlashExceptRoot(uri);
         if (exactMatch) {
             if (uri.equals(templateString)) {
                 if (exactMatchInfo == null) {

--- a/http/src/main/java/io/micronaut/http/uri/UriMatchTemplate.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriMatchTemplate.java
@@ -186,7 +186,7 @@ public class UriMatchTemplate extends UriTemplate implements UriMatcher {
         if (parameterIndex > -1) {
             uri = uri.substring(0, parameterIndex);
         }
-        uri = StringUtils.trimTrailingSlashExceptRoot(uri);
+        uri = StringUtils.trimTrailingCharacter(uri, '/');
         if (exactMatch) {
             if (uri.equals(templateString)) {
                 if (exactMatchInfo == null) {

--- a/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
@@ -1232,9 +1232,7 @@ public interface RouteBuilder {
                 if (len > 0 && uri.charAt(0) != '/') {
                     uri = '/' + uri;
                 }
-                if (len > 1 && uri.charAt(uri.length() - 1) == '/') {
-                    uri = uri.substring(0, uri.length() - 1);
-                }
+                uri = StringUtils.trimTrailingSlashExceptRoot(uri);
                 if (len > 0) {
                     return uri;
                 }

--- a/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
@@ -1220,7 +1220,7 @@ public interface RouteBuilder {
          * Normalizes a URI.
          * <p>
          * Ensures the string:
-         * 1) Does not end with a /
+         * 1) Does not end with a / (except for the root path "/", which is preserved as-is)
          * 2) Starts with a /
          *
          * @param uri The URI

--- a/router/src/main/java/io/micronaut/web/router/naming/HyphenatedUriNamingStrategy.java
+++ b/router/src/main/java/io/micronaut/web/router/naming/HyphenatedUriNamingStrategy.java
@@ -27,6 +27,8 @@ import io.micronaut.web.router.RouteBuilder;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+import java.util.Objects;
+
 /**
  * The default {@link io.micronaut.web.router.RouteBuilder.UriNamingStrategy} if none is provided by the application.
  *
@@ -86,9 +88,7 @@ public class HyphenatedUriNamingStrategy implements RouteBuilder.UriNamingStrate
             if (contextPath.charAt(0) != '/') {
                 contextPath = '/' + contextPath;
             }
-            if (contextPath.charAt(contextPath.length() - 1) == '/') {
-                contextPath = contextPath.substring(0, contextPath.length() - 1);
-            }
+            contextPath = Objects.requireNonNull(StringUtils.trimTrailingSlashExceptRoot(contextPath));
         }
         return contextPath;
     }

--- a/router/src/main/java/io/micronaut/web/router/naming/HyphenatedUriNamingStrategy.java
+++ b/router/src/main/java/io/micronaut/web/router/naming/HyphenatedUriNamingStrategy.java
@@ -27,6 +27,8 @@ import io.micronaut.web.router.RouteBuilder;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+import java.util.Objects;
+
 /**
  * The default {@link io.micronaut.web.router.RouteBuilder.UriNamingStrategy} if none is provided by the application.
  *
@@ -86,7 +88,7 @@ public class HyphenatedUriNamingStrategy implements RouteBuilder.UriNamingStrate
             if (contextPath.charAt(0) != '/') {
                 contextPath = '/' + contextPath;
             }
-            contextPath = StringUtils.trimTrailingCharacter(contextPath, '/');
+            contextPath = Objects.requireNonNull(StringUtils.trimTrailingCharacter(contextPath, '/'));
         }
         return contextPath;
     }

--- a/router/src/main/java/io/micronaut/web/router/naming/HyphenatedUriNamingStrategy.java
+++ b/router/src/main/java/io/micronaut/web/router/naming/HyphenatedUriNamingStrategy.java
@@ -27,8 +27,6 @@ import io.micronaut.web.router.RouteBuilder;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
-import java.util.Objects;
-
 /**
  * The default {@link io.micronaut.web.router.RouteBuilder.UriNamingStrategy} if none is provided by the application.
  *

--- a/router/src/main/java/io/micronaut/web/router/naming/HyphenatedUriNamingStrategy.java
+++ b/router/src/main/java/io/micronaut/web/router/naming/HyphenatedUriNamingStrategy.java
@@ -88,7 +88,7 @@ public class HyphenatedUriNamingStrategy implements RouteBuilder.UriNamingStrate
             if (contextPath.charAt(0) != '/') {
                 contextPath = '/' + contextPath;
             }
-            contextPath = Objects.requireNonNull(StringUtils.trimTrailingSlashExceptRoot(contextPath));
+            contextPath = StringUtils.trimTrailingCharacter(contextPath, '/');
         }
         return contextPath;
     }


### PR DESCRIPTION
Introduce StringUtils helpers for removing a single trailing character and trimming trailing slashes while preserving the root path.

Use the shared trailing slash utility in URI matching, route building, and hyphenated URI naming to keep normalization consistent, and add parameterized tests for the new string utility behavior.