### PR TITLE
Inherit HTTP/2 settings for service clients

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -1453,6 +1453,26 @@ public abstract class HttpClientConfiguration {
         private int maxHeaderListSize = DEFAULT_MAX_HEADER_LIST_SIZE;
 
         /**
+         * Default constructor.
+         */
+        public Http2ClientConfiguration() {
+        }
+
+        /**
+         * Copy constructor.
+         *
+         * @param copy The HTTP/2 configuration to copy
+         */
+        protected Http2ClientConfiguration(@Nullable Http2ClientConfiguration copy) {
+            if (copy != null) {
+                this.pingIntervalRead = copy.pingIntervalRead;
+                this.pingIntervalWrite = copy.pingIntervalWrite;
+                this.pingIntervalIdle = copy.pingIntervalIdle;
+                this.maxHeaderListSize = copy.maxHeaderListSize;
+            }
+        }
+
+        /**
          * For HTTP/2 connections, the interval from the last inbound message to when an automated ping
          * should be sent. This can be used to keep low-traffic connections alive.
          *

--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
@@ -140,7 +140,7 @@ public class ServiceHttpClientConfiguration extends HttpClientConfiguration impl
         @Nullable ServiceWebSocketCompressionConfiguration webSocketCompressionConfiguration,
         @Nullable ServiceSslClientConfiguration sslConfiguration,
         HttpClientConfiguration defaultHttpClientConfiguration) {
-        this(serviceId, connectionPoolConfiguration, webSocketCompressionConfiguration, new ServiceHttp2ClientConfiguration(), sslConfiguration, defaultHttpClientConfiguration);
+        this(serviceId, connectionPoolConfiguration, webSocketCompressionConfiguration, null, sslConfiguration, defaultHttpClientConfiguration);
     }
 
     /**
@@ -168,7 +168,8 @@ public class ServiceHttpClientConfiguration extends HttpClientConfiguration impl
         }
         this.connectionPoolConfiguration = Objects.requireNonNullElseGet(connectionPoolConfiguration, ServiceConnectionPoolConfiguration::new);
         this.webSocketCompressionConfiguration = Objects.requireNonNullElseGet(webSocketCompressionConfiguration, ServiceWebSocketCompressionConfiguration::new);
-        this.http2Configuration = Objects.requireNonNullElseGet(http2Configuration, ServiceHttp2ClientConfiguration::new);
+        this.http2Configuration = http2Configuration == null ?
+                new ServiceHttp2ClientConfiguration(defaultHttpClientConfiguration) : http2Configuration;
     }
 
     /**
@@ -323,6 +324,21 @@ public class ServiceHttpClientConfiguration extends HttpClientConfiguration impl
      */
     @ConfigurationProperties(Http2ClientConfiguration.PREFIX)
     public static class ServiceHttp2ClientConfiguration extends Http2ClientConfiguration {
+        /**
+         * Default constructor.
+         */
+        public ServiceHttp2ClientConfiguration() {
+        }
+
+        /**
+         * Creates a service configuration initialized from the default HTTP client configuration.
+         *
+         * @param defaultConfiguration The default HTTP client configuration
+         */
+        @Inject
+        public ServiceHttp2ClientConfiguration(HttpClientConfiguration defaultConfiguration) {
+            super(defaultConfiguration.getHttp2Configuration());
+        }
     }
 
     /**

--- a/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
@@ -176,6 +176,36 @@ class ManualHttpServiceDefinitionSpec extends Specification {
         ctx.close()
     }
 
+    void 'test service HTTP/2 configuration inherits global values and allows overrides'() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(
+                'micronaut.http.client.http2.max-header-list-size': 32768,
+                'micronaut.http.client.http2.ping-interval-read': '30s',
+                'micronaut.http.client.http2.ping-interval-write': '40s',
+                'micronaut.http.client.http2.ping-interval-idle': '50s',
+                'micronaut.http.services.foo.url': 'http://localhost',
+                'micronaut.http.services.bar.url': 'http://localhost',
+                'micronaut.http.services.bar.http2.max-header-list-size': 65536,
+                'micronaut.http.services.bar.http2.ping-interval-write': '60s',
+        )
+
+        ServiceHttpClientConfiguration foo = ctx.getBean(ServiceHttpClientConfiguration, Qualifiers.byName("foo"))
+        ServiceHttpClientConfiguration bar = ctx.getBean(ServiceHttpClientConfiguration, Qualifiers.byName("bar"))
+
+        expect:
+        foo.http2Configuration.maxHeaderListSize == 32768
+        foo.http2Configuration.pingIntervalRead == Duration.ofSeconds(30)
+        foo.http2Configuration.pingIntervalWrite == Duration.ofSeconds(40)
+        foo.http2Configuration.pingIntervalIdle == Duration.ofSeconds(50)
+        bar.http2Configuration.maxHeaderListSize == 65536
+        bar.http2Configuration.pingIntervalRead == Duration.ofSeconds(30)
+        bar.http2Configuration.pingIntervalWrite == Duration.ofSeconds(60)
+        bar.http2Configuration.pingIntervalIdle == Duration.ofSeconds(50)
+
+        cleanup:
+        ctx.close()
+    }
+
     void "test that manually defining an HTTP client without URL doesn't create bean"() {
         given:
         ApplicationContext clientApp = ApplicationContext.run(


### PR DESCRIPTION
Closes #12791

A service-scoped HTTP client currently falls back to a new `Http2ClientConfiguration` when no service-specific `http2.*` property is present. That skips the global HTTP/2 settings, so values such as `micronaut.http.client.http2.max-header-list-size` are lost for named clients.

This change copies the global HTTP/2 configuration into the service configuration first, then lets service-specific properties override individual values. It covers both paths: when a nested service HTTP/2 bean exists and when the outer configuration has to create the fallback.

Tests cover inheriting all four global HTTP/2 values and overriding only selected values for one service.

Validation:
- `ManualHttpServiceDefinitionSpec`: 6 tests passed
- Spotless and Checkstyle passed
- `japiCmp` passed

I also ran both HTTP client module checks. The affected tests passed; four existing external-network tests timed out (two public WebSocket echo tests and two SSL/redirect tests), including on focused reruns, so they are not related to this configuration change.
