### PR TITLE
Fix KSP2 crash writing aggregating outputs

### DIFF
--- a/inject-kotlin-test/src/main/groovy/io/micronaut/annotation/processing/test/KotlinCompiler.java
+++ b/inject-kotlin-test/src/main/groovy/io/micronaut/annotation/processing/test/KotlinCompiler.java
@@ -99,6 +99,17 @@ public class KotlinCompiler {
         return toClassLoader(resultPair);
     }
 
+    /**
+     * Creates a Kotlin source file for use with {@link #compile(List, Consumer, List)}.
+     *
+     * @param name source file name
+     * @param source Kotlin source content
+     * @return Kotlin source file
+     */
+    public static SourceFile kotlinSource(String name, @Language("kotlin") String source) {
+        return SourceFile.Companion.kotlin(name, source, true);
+    }
+
     @NotNull
     private static URLClassLoader toClassLoader(Pair<Pair<KotlinCompilation, JvmCompilationResult>, Pair<KotlinCompilation, JvmCompilationResult>> resultPair) {
         try {
@@ -139,12 +150,28 @@ public class KotlinCompiler {
     }
 
     public static Pair<Pair<KotlinCompilation, JvmCompilationResult>, Pair<KotlinCompilation, JvmCompilationResult>> compile(String name, @Language("kotlin") String clazz, Consumer<ClassElement> classElements, List<SymbolProcessorProvider> extraSymbolProcessorProviders) {
+        return compile(
+            Collections.singletonList(SourceFile.Companion.kotlin(name + ".kt", clazz, true)),
+            classElements,
+            extraSymbolProcessorProviders
+        );
+    }
+
+    /**
+     * Compile Kotlin source files both directly and through KSP.
+     *
+     * @param sources Kotlin sources to compile
+     * @param classElements consumer for compiled class elements
+     * @param extraSymbolProcessorProviders additional KSP processors
+     * @return the direct and KSP compilation results
+     */
+    public static Pair<Pair<KotlinCompilation, JvmCompilationResult>, Pair<KotlinCompilation, JvmCompilationResult>> compile(List<SourceFile> sources, Consumer<ClassElement> classElements, List<SymbolProcessorProvider> extraSymbolProcessorProviders) {
         try {
             Files.deleteIfExists(KOTLIN_COMPILATION.getWorkingDir().toPath());
         } catch (IOException e) {
             // ignore
         }
-        KOTLIN_COMPILATION.setSources(Collections.singletonList(SourceFile.Companion.kotlin(name + ".kt", clazz, true)));
+        KOTLIN_COMPILATION.setSources(sources);
         JvmCompilationResult result = KOTLIN_COMPILATION.compile();
         if (result.getExitCode() != KotlinCompilation.ExitCode.OK) {
             throw new RuntimeException(result.getMessages());

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/KotlinOutputVisitor.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/KotlinOutputVisitor.kt
@@ -75,8 +75,11 @@ internal class KotlinOutputVisitor(private val environment: SymbolProcessorEnvir
     private fun normalizePath(path: String) = path.replace("\\\\", "/").split("/").toMutableList()
 
     private fun getNativeElements(fileName: String, originatingElements: Array<out Element>): Dependencies {
+        // Aggregating outputs are often written in finish(), when KSP2 may have already
+        // invalidated PSI. Avoid ALL_FILES / originating KSFiles here — empty sources +
+        // aggregating is enough (anyChangesWildcard). See #12677.
         if (context.aggregating) {
-            return Dependencies.ALL_FILES
+            return Dependencies(aggregating = true, sources = emptyArray())
         }
         val sources: Array<KSFile> = if (originatingElements.isNotEmpty()) {
             val originatingFiles: MutableList<KSFile> = ArrayList(originatingElements.size)
@@ -96,6 +99,6 @@ internal class KotlinOutputVisitor(private val environment: SymbolProcessorEnvir
             )
             emptyArray()
         }
-        return Dependencies(false, sources = sources)
+        return Dependencies(aggregating = false, sources = sources)
     }
 }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/configproperties/ConfigurationPropertiesSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/configproperties/ConfigurationPropertiesSpec.groovy
@@ -15,13 +15,49 @@
  */
 package io.micronaut.kotlin.processing.beans.configproperties
 
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import io.micronaut.annotation.processing.test.KotlinCompiler
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.PropertySource
+import io.micronaut.context.visitor.ConfigurationMetadataWriterVisitor
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.core.util.CollectionUtils
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.kotlin.processing.visitor.TypeElementSymbolProcessor
 import spock.lang.Specification
 
 class ConfigurationPropertiesSpec extends Specification {
+
+    void "test configuration metadata generation with an empty Kotlin source"() {
+        when:
+        KotlinCompiler.compile([
+            KotlinCompiler.kotlinSource('MyConfiguration.kt', '''
+                package test
+
+                import io.micronaut.context.annotation.ConfigurationProperties
+
+                @ConfigurationProperties("test")
+                class MyConfiguration
+            '''),
+            KotlinCompiler.kotlinSource('Empty.kt', '')
+        ], { ClassElement ignored -> }, [configurationMetadataProcessorProvider()])
+
+        then:
+        noExceptionThrown()
+    }
+
+    private static SymbolProcessorProvider configurationMetadataProcessorProvider() {
+        return { SymbolProcessorEnvironment environment ->
+            new TypeElementSymbolProcessor(environment) {
+                @Override
+                protected Collection<TypeElementVisitor<?, ?>> findTypeElementVisitors() {
+                    return [new ConfigurationMetadataWriterVisitor()]
+                }
+            }
+        } as SymbolProcessorProvider
+    }
 
     void "test submap with generics binding"() {
         given:


### PR DESCRIPTION
Fixes #12677

### Problem

Aggregating visitors (config metadata is the usual one) write META-INF files from `finish()`. We were passing `Dependencies.ALL_FILES` for those outputs.

With KSP2 + incremental processing that walks every `KSFile` and reads `filePath`. If PSI is already invalidated — empty `.kt` files are a reliable trigger — you get:

```
KaInvalidLifetimeOwnerAccessException: PSI has changed since creation
```

### Fix

Use `Dependencies(aggregating = true, sources = emptyArray())` instead of `ALL_FILES`.

Still aggregating (KSP dirties the output on any change via `anyChangesWildcard`), but we don't touch user source files after PSI may already be gone. Same idea as the no-originating-elements path in `visitGeneratedFile`.

Related: #12804 (same underlying issue, OpenAPI finish path).

### Verification

- #12677 reproducer (`@ConfigurationProperties` + empty `Empty.kt` + incremental KSP): fails stock, succeeds with this change
- `:micronaut-inject-kotlin:test` for beans / visitor / configproperties: 334 tests passed