### PR TITLE
Handle health status for endpoint base paths

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/health/filter/HealthResultFilter.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/health/filter/HealthResultFilter.java
@@ -18,17 +18,14 @@ package io.micronaut.management.endpoint.health.filter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.health.HealthStatus;
-import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpResponse;
-import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.annotation.ServerFilter;
+import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.management.endpoint.EndpointDefaultConfiguration;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthResult;
-import io.micronaut.web.router.MethodBasedRouteMatch;
-import io.micronaut.web.router.RouteAttributes;
 
 /**
  * A filter that matches the {@link HealthEndpoint}
@@ -37,7 +34,11 @@ import io.micronaut.web.router.RouteAttributes;
  * @author graemerocher
  * @since 1.0
  */
-@ServerFilter(Filter.MATCH_ALL_PATTERN)
+@ServerFilter(
+    value = {HealthResultFilter.DEFAULT_MAPPING,
+        HealthResultFilter.LIVENESS_PROBE_MAPPING,
+        HealthResultFilter.READINESS_PROBE_MAPPING},
+    patternStyle = FilterPatternStyle.REGEX)
 @Requires(beans = HealthEndpoint.class)
 @Internal
 public class HealthResultFilter {
@@ -46,11 +47,11 @@ public class HealthResultFilter {
      * Configurable default mapping for filter.
      */
     public static final String DEFAULT_MAPPING =
-        "${" + EndpointDefaultConfiguration.PREFIX + ".path:" +
-            EndpointDefaultConfiguration.DEFAULT_ENDPOINT_BASE_PATH + "}${" +
+        "/?${" + EndpointDefaultConfiguration.PREFIX + ".path:" +
+            EndpointDefaultConfiguration.DEFAULT_ENDPOINT_BASE_PATH + "}/?${" +
             HealthEndpoint.PREFIX + ".id:health}";
-    public static final String LIVENESS_PROBE_MAPPING = DEFAULT_MAPPING + "/liveness";
-    public static final String READINESS_PROBE_MAPPING = DEFAULT_MAPPING + "/readiness";
+    public static final String LIVENESS_PROBE_MAPPING = DEFAULT_MAPPING + "/?liveness";
+    public static final String READINESS_PROBE_MAPPING = DEFAULT_MAPPING + "/?readiness";
 
     private final HealthEndpoint healthEndpoint;
 
@@ -66,16 +67,10 @@ public class HealthResultFilter {
     /**
      * Set response status by health result.
      *
-     * @param request http request
      * @param response http response
      */
     @ResponseFilter
-    public void doFilter(HttpRequest<?> request, MutableHttpResponse<?> response) {
-        if (!(RouteAttributes.getRouteMatch(request).orElse(null) instanceof MethodBasedRouteMatch<?, ?> routeMatch)
-            || !HealthEndpoint.class.isAssignableFrom(routeMatch.getDeclaringType())) {
-            return;
-        }
-
+    public void doFilter(MutableHttpResponse<?> response) {
         Object body = response.body();
         if (body instanceof HealthResult healthResult) {
             HealthStatus status = healthResult.getStatus();

--- a/management/src/main/java/io/micronaut/management/endpoint/health/filter/HealthResultFilter.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/health/filter/HealthResultFilter.java
@@ -18,13 +18,17 @@ package io.micronaut.management.endpoint.health.filter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.health.HealthStatus;
+import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.management.endpoint.EndpointDefaultConfiguration;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthResult;
+import io.micronaut.web.router.MethodBasedRouteMatch;
+import io.micronaut.web.router.RouteAttributes;
 
 /**
  * A filter that matches the {@link HealthEndpoint}
@@ -33,11 +37,7 @@ import io.micronaut.management.health.indicator.HealthResult;
  * @author graemerocher
  * @since 1.0
  */
-@ServerFilter({
-    HealthResultFilter.DEFAULT_MAPPING,
-    HealthResultFilter.LIVENESS_PROBE_MAPPING,
-    HealthResultFilter.READINESS_PROBE_MAPPING
-})
+@ServerFilter(Filter.MATCH_ALL_PATTERN)
 @Requires(beans = HealthEndpoint.class)
 @Internal
 public class HealthResultFilter {
@@ -66,10 +66,16 @@ public class HealthResultFilter {
     /**
      * Set response status by health result.
      *
+     * @param request http request
      * @param response http response
      */
     @ResponseFilter
-    public void doFilter(MutableHttpResponse<?> response) {
+    public void doFilter(HttpRequest<?> request, MutableHttpResponse<?> response) {
+        if (!(RouteAttributes.getRouteMatch(request).orElse(null) instanceof MethodBasedRouteMatch<?, ?> routeMatch)
+            || !HealthEndpoint.class.isAssignableFrom(routeMatch.getDeclaringType())) {
+            return;
+        }
+
         Object body = response.body();
         if (body instanceof HealthResult healthResult) {
             HealthStatus status = healthResult.getStatus();

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsBasePathSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsBasePathSpec.groovy
@@ -25,6 +25,7 @@ import io.micronaut.management.endpoint.annotation.Read
 import io.micronaut.management.endpoint.annotation.Selector
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class EndpointsBasePathSpec extends Specification {
 
@@ -58,6 +59,36 @@ class EndpointsBasePathSpec extends Specification {
         cleanup:
         rxClient.close()
         server.close()
+    }
+
+    @Unroll
+    void "health status filter works with endpoint base path '#path'"() {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': getClass().simpleName,
+                'endpoints.all.path': path,
+                'endpoints.health.sensitive': false,
+                'endpoints.health.disk-space.threshold': '9999GB'
+        ])
+        HttpClient client = server.applicationContext.createBean(HttpClient.class, server.getURL())
+
+        when:
+        client.toBlocking().exchange('/admin/health')
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.SERVICE_UNAVAILABLE
+
+        cleanup:
+        client.close()
+        server.close()
+
+        where:
+        path << [
+                '/admin',
+                'admin/',
+                'admin'
+        ]
     }
 
     void "test routes with a server context path"() {

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsBasePathSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsBasePathSpec.groovy
@@ -85,6 +85,7 @@ class EndpointsBasePathSpec extends Specification {
 
         where:
         path << [
+                '/admin/',
                 '/admin',
                 'admin/',
                 'admin'


### PR DESCRIPTION
## Summary

- Match health responses using the resolved endpoint route instead of constructing the filter path from configuration.
- Ensure DOWN health responses return the configured HTTP status when `endpoints.all.path` omits a leading or trailing slash.
- Add regression coverage for the affected path variants.

## Testing

- `./gradlew :micronaut-management:test --tests "io.micronaut.management.endpoint.EndpointsBasePathSpec"`
- `./gradlew :micronaut-management:check spotlessCheck`

Fixes #12637