### PR TITLE
Fix KSP configuration interface inheritance

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -149,10 +149,10 @@ internal open class KotlinClassElement(
         while (clazz != null) {
             // We need to aggregate all the hierarchy properties because
             // getAllProperties doesn't return correct parent of the property
-            properties.addAll(clazz.getDeclaredSyntheticBeanProperties())
+            properties.addAll(clazz.getDeclaredSyntheticBeanProperties(this))
             clazz.interfaces.forEach {
                 if (it is KotlinClassElement) {
-                    properties.addAll(it.getDeclaredSyntheticBeanProperties())
+                    properties.addAll(it.getDeclaredSyntheticBeanProperties(this))
                 }
             }
 
@@ -338,7 +338,22 @@ internal open class KotlinClassElement(
 
     override fun getSyntheticBeanProperties() = nativeProperties
 
-    private fun getDeclaredSyntheticBeanProperties() = declaredNativeProperties
+    private fun getDeclaredSyntheticBeanProperties(owningType: KotlinClassElement): List<PropertyElement> {
+        if (owningType == this) {
+            return declaredNativeProperties
+        }
+        return declaration.getDeclaredProperties()
+            .filter { !it.isPrivate() && !hasAnnotation(it, JvmField::class.java) }
+            .map {
+                KotlinPropertyElement(
+                    owningType,
+                    it,
+                    elementAnnotationMetadataFactory,
+                    visitorContext
+                )
+            }
+            .toList()
+    }
 
     override fun getAccessibleStaticCreators(): List<MethodElement> {
         val staticCreators: MutableList<MethodElement> = mutableListOf()

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -150,6 +150,39 @@ interface ParentConfig {
 
     }
 
+    void "test inheritance from unannotated interface config props"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyConfig$Intercepted', '''
+package test
+
+import io.micronaut.context.annotation.ConfigurationProperties
+
+@ConfigurationProperties("foo")
+interface MyConfig : ParentConfig
+
+interface ParentConfig {
+    val host: String
+    val serverPort: Int
+}
+''')
+        then:
+        beanDefinition.getRequiredMethod("getHost")
+                .stringValue(Property, "name").get() == 'foo.host'
+        beanDefinition.getRequiredMethod("getServerPort")
+                .stringValue(Property, "name").get() == 'foo.server-port'
+
+        when:
+        def context = ApplicationContext.run('foo.host': 'test', 'foo.server-port': '9999')
+        def config = ((InstantiatableBeanDefinition) beanDefinition).instantiate(context)
+
+        then:
+        config.host == 'test'
+        config.serverPort == 9999
+
+        cleanup:
+        context.close()
+    }
+
     void "test nested interface config props"() {
 
         when:


### PR DESCRIPTION
Fixes #12051

Inherited Kotlin properties were created with the parent interface as their owning type when KSP collected synthetic bean properties. This prevented the generated configuration property metadata from being applied to the methods used by the introduction proxy.

Keep inherited synthetic properties associated with the configuration interface being processed, and add a regression test for properties inherited from an unannotated parent interface.

### Testing

- `./gradlew :micronaut-inject-kotlin:test --tests "io.micronaut.kotlin.processing.inject.configproperties.InterfaceConfigurationPropertiesSpec"`
- `./gradlew :micronaut-inject-kotlin:check`