### PR TITLE
Copy all HTTP client configuration fields

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -38,6 +38,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -310,7 +311,7 @@ public abstract class HttpClientConfiguration {
             this.threadFactory = copy.threadFactory;
             this.httpVersion = copy.httpVersion;
             this.plaintextMode = copy.plaintextMode;
-            this.alpnModes = copy.alpnModes;
+            this.alpnModes = new ArrayList<>(copy.alpnModes);
             this.allowBlockEventLoop = copy.allowBlockEventLoop;
             this.dnsResolutionMode = copy.dnsResolutionMode;
             this.addressResolverGroupName = copy.addressResolverGroupName;

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -282,6 +282,7 @@ public abstract class HttpClientConfiguration {
             this.connectTtl = copy.connectTtl;
             this.defaultCharset = copy.defaultCharset;
             this.exceptionOnErrorStatus = copy.exceptionOnErrorStatus;
+            this.decompressionEnabled = copy.decompressionEnabled;
             this.eventLoopGroup = copy.eventLoopGroup;
             this.followRedirects = copy.followRedirects;
             this.redirectAlwaysFilteredHeaders = copy.redirectAlwaysFilteredHeaders;
@@ -299,6 +300,7 @@ public abstract class HttpClientConfiguration {
             this.proxySelector = copy.proxySelector;
             this.proxyType = copy.proxyType;
             this.proxyUsername = copy.proxyUsername;
+            this.requestTimeout = copy.requestTimeout;
             this.readIdleTimeout = copy.readIdleTimeout;
             this.connectionPoolIdleTimeout = copy.connectionPoolIdleTimeout;
             this.readTimeout = copy.readTimeout;
@@ -307,6 +309,12 @@ public abstract class HttpClientConfiguration {
             this.sslConfiguration = copy.sslConfiguration;
             this.threadFactory = copy.threadFactory;
             this.httpVersion = copy.httpVersion;
+            this.plaintextMode = copy.plaintextMode;
+            this.alpnModes = copy.alpnModes;
+            this.allowBlockEventLoop = copy.allowBlockEventLoop;
+            this.dnsResolutionMode = copy.dnsResolutionMode;
+            this.addressResolverGroupName = copy.addressResolverGroupName;
+            this.pcapLoggingPathPattern = copy.pcapLoggingPathPattern;
         }
     }
 

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -310,7 +310,7 @@ public abstract class HttpClientConfiguration {
             this.sslConfiguration = copy.sslConfiguration;
             this.threadFactory = copy.threadFactory;
             this.httpVersion = copy.httpVersion;
-            // these two have non-null defaults, so only overwrite them when the source
+            // these have non-null defaults, so only overwrite them when the source
             // actually carries a value
             if (copy.plaintextMode != null) {
                 this.plaintextMode = copy.plaintextMode;
@@ -319,7 +319,9 @@ public abstract class HttpClientConfiguration {
                 this.alpnModes = new ArrayList<>(copy.alpnModes);
             }
             this.allowBlockEventLoop = copy.allowBlockEventLoop;
-            this.dnsResolutionMode = copy.dnsResolutionMode;
+            if (copy.dnsResolutionMode != null) {
+                this.dnsResolutionMode = copy.dnsResolutionMode;
+            }
             this.addressResolverGroupName = copy.addressResolverGroupName;
             this.pcapLoggingPathPattern = copy.pcapLoggingPathPattern;
         }

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -310,8 +310,14 @@ public abstract class HttpClientConfiguration {
             this.sslConfiguration = copy.sslConfiguration;
             this.threadFactory = copy.threadFactory;
             this.httpVersion = copy.httpVersion;
-            this.plaintextMode = copy.plaintextMode;
-            this.alpnModes = new ArrayList<>(copy.alpnModes);
+            // these two have non-null defaults, so only overwrite them when the source
+            // actually carries a value
+            if (copy.plaintextMode != null) {
+                this.plaintextMode = copy.plaintextMode;
+            }
+            if (copy.alpnModes != null) {
+                this.alpnModes = new ArrayList<>(copy.alpnModes);
+            }
             this.allowBlockEventLoop = copy.allowBlockEventLoop;
             this.dnsResolutionMode = copy.dnsResolutionMode;
             this.addressResolverGroupName = copy.addressResolverGroupName;

--- a/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.http.HttpVersion
 import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.HttpClientConfiguration
 import io.micronaut.http.client.HttpVersionSelection
+import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Issue
 import spock.lang.Specification
 
@@ -158,6 +159,24 @@ class DefaultHttpClientConfigurationSpec extends Specification {
 
         expect:
         cfg.connectionPoolIdleTimeout.empty
+    }
+
+    void "service client configuration inherits pcap logging path pattern"() {
+        given:
+        def pcapLoggingPathPattern = '/tmp/{localAddress}-{remoteAddress}-{qualifier}-{random}-{timestamp}.pcap'
+        def ctx = ApplicationContext.run(
+                'micronaut.http.client.pcap-logging-path-pattern': pcapLoggingPathPattern,
+                'micronaut.http.services.foo.url': 'http://localhost'
+        )
+
+        when:
+        def config = ctx.getBean(HttpClientConfiguration, Qualifiers.byName('foo'))
+
+        then:
+        config.pcapLoggingPathPattern == pcapLoggingPathPattern
+
+        cleanup:
+        ctx.close()
     }
 
     void "copy constructor copies top-level HTTP client settings"() {

--- a/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
@@ -181,11 +181,18 @@ class DefaultHttpClientConfigurationSpec extends Specification {
         !copy.decompressionEnabled
         copy.plaintextMode == HttpVersionSelection.PlaintextMode.H2C
         copy.alpnModes == [HttpVersionSelection.ALPN_HTTP_1]
+        !copy.alpnModes.is(cfg.alpnModes)
         copy.allowBlockEventLoop
         copy.dnsResolutionMode == HttpClientConfiguration.DnsResolutionMode.NOOP
         copy.addressResolverGroupName == 'custom-resolver'
         copy.pcapLoggingPathPattern == '/tmp/client.pcap'
         copy.httpVersion == HttpVersion.HTTP_2_0
+
+        when:
+        cfg.alpnModes << HttpVersionSelection.ALPN_HTTP_2
+
+        then:
+        copy.alpnModes == [HttpVersionSelection.ALPN_HTTP_1]
     }
 
     static final class TestHttpClientConfiguration extends HttpClientConfiguration {

--- a/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
@@ -1,8 +1,10 @@
 package io.micronaut.http.client.config
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpVersion
 import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.HttpClientConfiguration
+import io.micronaut.http.client.HttpVersionSelection
 import spock.lang.Issue
 import spock.lang.Specification
 
@@ -156,5 +158,49 @@ class DefaultHttpClientConfigurationSpec extends Specification {
 
         expect:
         cfg.connectionPoolIdleTimeout.empty
+    }
+
+    void "copy constructor copies top-level HTTP client settings"() {
+        given:
+        def cfg = new TestHttpClientConfiguration()
+        cfg.requestTimeout = Duration.ofSeconds(2)
+        cfg.decompressionEnabled = false
+        cfg.plaintextMode = HttpVersionSelection.PlaintextMode.H2C
+        cfg.alpnModes = [HttpVersionSelection.ALPN_HTTP_1]
+        cfg.allowBlockEventLoop = true
+        cfg.dnsResolutionMode = HttpClientConfiguration.DnsResolutionMode.NOOP
+        cfg.addressResolverGroupName = 'custom-resolver'
+        cfg.pcapLoggingPathPattern = '/tmp/client.pcap'
+        cfg.httpVersion = HttpVersion.HTTP_2_0
+
+        when:
+        def copy = new TestHttpClientConfiguration(cfg)
+
+        then:
+        copy.requestTimeout == Duration.ofSeconds(2)
+        !copy.decompressionEnabled
+        copy.plaintextMode == HttpVersionSelection.PlaintextMode.H2C
+        copy.alpnModes == [HttpVersionSelection.ALPN_HTTP_1]
+        copy.allowBlockEventLoop
+        copy.dnsResolutionMode == HttpClientConfiguration.DnsResolutionMode.NOOP
+        copy.addressResolverGroupName == 'custom-resolver'
+        copy.pcapLoggingPathPattern == '/tmp/client.pcap'
+        copy.httpVersion == HttpVersion.HTTP_2_0
+    }
+
+    static final class TestHttpClientConfiguration extends HttpClientConfiguration {
+        private final ConnectionPoolConfiguration connectionPoolConfiguration = new ConnectionPoolConfiguration()
+
+        TestHttpClientConfiguration() {
+        }
+
+        TestHttpClientConfiguration(HttpClientConfiguration copy) {
+            super(copy)
+        }
+
+        @Override
+        ConnectionPoolConfiguration getConnectionPoolConfiguration() {
+            connectionPoolConfiguration
+        }
     }
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
@@ -214,6 +214,19 @@ class DefaultHttpClientConfigurationSpec extends Specification {
         copy.alpnModes == [HttpVersionSelection.ALPN_HTTP_1]
     }
 
+    void "copy constructor keeps non-null defaults when the source has none"() {
+        given: "a source whose fields are all null, as a mock or partially built config is"
+        def source = Mock(HttpClientConfiguration)
+
+        when:
+        def copy = new TestHttpClientConfiguration(source)
+
+        then: "the defaults survive rather than being overwritten with null"
+        copy.plaintextMode == HttpVersionSelection.PlaintextMode.HTTP_1
+        copy.alpnModes == [HttpVersionSelection.ALPN_HTTP_2, HttpVersionSelection.ALPN_HTTP_1]
+        copy.dnsResolutionMode == HttpClientConfiguration.DEFAULT_DNS_RESOLUTION_MODE
+    }
+
     static final class TestHttpClientConfiguration extends HttpClientConfiguration {
         private final ConnectionPoolConfiguration connectionPoolConfiguration = new ConnectionPoolConfiguration()
 


### PR DESCRIPTION
## Summary
- Copy newer top-level `HttpClientConfiguration` fields in the copy constructor
- Preserve protocol selection fields such as `alpnModes` and `plaintextMode`
- Preserve `pcapLoggingPathPattern` for named service client configurations
- Add regression coverage for copied HTTP client settings and named service pcap inheritance

## Verification
- `./gradlew :micronaut-http-client:test --tests io.micronaut.http.client.config.DefaultHttpClientConfigurationSpec --rerun-tasks -q` (26 tests, 0 failures; warnings only)
- `./gradlew :micronaut-http-client-core:check -q -x japiCmp -x checkVersionCatalogCompatibility` (passed)
- `git diff --check` (passed)