### PR TITLE
Derive configuration metadata documentation from Kotlin KDoc

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
@@ -181,12 +181,20 @@ internal abstract class AbstractKotlinElement<T : KotlinNativeElement>(
         return super.getModifiers()
     }
 
-    override fun getDocumentation(parse: Boolean): Optional<String> {
-        return if (annotatedInfo is KSDeclaration) {
-            Optional.ofNullable(annotatedInfo.docString)
-        } else {
-            Optional.empty()
+    override fun getDocumentation(parse: Boolean): Optional<String> =
+        documentationText((annotatedInfo as? KSDeclaration)?.docString, parse)
+
+    /**
+     * Turns a raw KDoc string into element documentation: the verbatim string when [parse] is
+     * false, otherwise the prose description with block tags parsed out (empty description → absent).
+     */
+    protected fun documentationText(docString: String?, parse: Boolean): Optional<String> {
+        val raw = docString ?: return Optional.empty()
+        if (!parse) {
+            return Optional.of(raw)
         }
+        val description = parseKDoc(raw).description
+        return if (description.isEmpty()) Optional.empty() else Optional.of(description)
     }
 
     protected fun resolveDeclaringType(

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinPropertyElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinPropertyElement.kt
@@ -81,9 +81,8 @@ internal abstract class AbstractKotlinPropertyElement<T : KotlinNativeElement>(
         return false
     }
 
-    override fun getDocumentation(parse: Boolean): Optional<String> {
-        return Optional.ofNullable(declaration.docString)
-    }
+    override fun getDocumentation(parse: Boolean): Optional<String> =
+        documentationText(declaration.docString, parse)
 
     override fun getWriteTypeAnnotationMetadata(): Optional<AnnotationMetadata> {
         return Optional.of(annotationMetadata.writeAnnotationMetadata)

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KDocParser.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KDocParser.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.processing.visitor
+
+/**
+ * A single KDoc/Javadoc block tag, e.g. `@property percentage the VAT rate`.
+ *
+ * @property tag the tag keyword without the leading `@` (`"property"`, `"param"`, `"return"`, ...)
+ * @property name the tag's target name for tags that document a named element
+ *                (`@param`/`@property`), otherwise `null`
+ * @property content the remaining tag text, with any continuation lines joined by a single space
+ */
+internal data class BlockTag(val tag: String, val name: String?, val content: String)
+
+/**
+ * A KDoc string split into its leading prose [description] and its trailing [blockTags].
+ *
+ * @property description the prose preceding the first block tag, trimmed (empty when the doc opens with a tag)
+ * @property blockTags the block tags in declaration order
+ */
+internal data class ParsedKDoc(val description: String, val blockTags: List<BlockTag>) {
+
+    /**
+     * Returns the documentation for the constructor parameter [name].
+     *
+     * @return the matching tag content, or `null` if no `@property`/`@param` tag documents [name]
+     */
+    fun parameterDoc(name: String): String? =
+        tagContent("property", name) ?: tagContent("param", name)
+
+    private fun tagContent(tag: String, name: String): String? =
+        blockTags.firstOrNull { it.tag == tag && it.name == name && it.content.isNotBlank() }?.content
+}
+
+// A block tag opens on a line whose first non-blank character is '@'; group 1 is the tag
+// keyword, group 2 the rest of that line. Everything before the first such line is prose.
+private val TAG_LINE = Regex("""^\s*@(\w+)\s*(.*)$""")
+
+// Tags whose first token after the keyword is the name of the element they document.
+private val NAMED_TAGS = setOf("param", "property")
+
+/**
+ * Parses a raw KDoc string — as returned by [com.google.devtools.ksp.symbol.KSDeclaration.docString] —
+ * into a [ParsedKDoc]. Content is taken verbatim: no markdown, `[links]`, or inline tags are resolved.
+ *
+ * ```
+ * val parsed = parseKDoc(
+ *     "Configures the VAT rate.\n\n @property percentage the VAT percentage\n"
+ * )
+ * parsed.description                 // "Configures the VAT rate."
+ * parsed.parameterDoc("percentage")  // "the VAT percentage"
+ * ```
+ */
+internal fun parseKDoc(docString: String): ParsedKDoc {
+    val descriptionLines = mutableListOf<String>()
+    val blockTags = mutableListOf<BlockTag>()
+
+    // The tag currently being accumulated, if any. A tag stays "open" across the lines that
+    // follow it until the next tag line, so continuation lines append to its content.
+    var openTag: String? = null
+    var openName: String? = null
+    val openContent = StringBuilder()
+
+    fun commitOpenTag() {
+        val tag = openTag ?: return
+        blockTags += BlockTag(tag, openName, openContent.toString().trim())
+        openContent.setLength(0)
+    }
+
+    for (line in docString.split("\n")) {
+        val match = TAG_LINE.matchEntire(line)
+        when {
+            // A new block tag begins: close the previous one, then split off its name if named.
+            match != null -> {
+                commitOpenTag()
+                openTag = match.groupValues[1]
+                openName = null
+                var rest = match.groupValues[2].trim()
+                if (openTag in NAMED_TAGS && rest.isNotEmpty()) {
+                    val separator = rest.indexOfFirst { it.isWhitespace() }
+                    if (separator >= 0) {
+                        openName = rest.substring(0, separator)
+                        rest = rest.substring(separator + 1).trim()
+                    } else {
+                        openName = rest
+                        rest = ""
+                    }
+                }
+                openContent.append(rest)
+            }
+            // A continuation line for the open tag: join to its content with a single space.
+            openTag != null -> {
+                if (line.isNotBlank()) {
+                    if (openContent.isNotEmpty()) {
+                        openContent.append(" ")
+                    }
+                    openContent.append(line.trim())
+                }
+            }
+            // Still before the first tag: this line is part of the prose description.
+            // Trim per line to drop the leading space KSP leaves after stripping ` * `,
+            // while keeping blank lines so paragraph breaks survive.
+            else -> descriptionLines += line.trim()
+        }
+    }
+    commitOpenTag()
+
+    return ParsedKDoc(descriptionLines.joinToString("\n").trim(), blockTags)
+}

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -90,6 +90,10 @@ internal open class KotlinClassElement(
         nativeType.declaration
     }
 
+    internal val parsedKDoc: ParsedKDoc by lazy {
+        parseKDoc(declaration.docString ?: "")
+    }
+
     val kotlinType: KSType by lazy {
         definedType ?: declaration.asStarProjectedType()
     }

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinParameterElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinParameterElement.kt
@@ -19,8 +19,10 @@ import com.google.devtools.ksp.symbol.KSValueParameter
 import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.inject.ast.ArrayableClassElement
 import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ConstructorElement
 import io.micronaut.inject.ast.ParameterElement
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory
+import java.util.Optional
 
 internal class KotlinParameterElement(
     private val presetType: ClassElement?,
@@ -78,6 +80,15 @@ internal class KotlinParameterElement(
     override fun getMethodElement() = methodElement
 
     override fun getName() = internalName
+
+    override fun getDocumentation(parse: Boolean): Optional<String> {
+        // A KSValueParameter is not a KSDeclaration and carries no docString of its own; a Kotlin
+        // constructor parameter is documented by the owning class KDoc's @property/@param tag.
+        if (!parse || methodElement !is ConstructorElement) {
+            return Optional.empty()
+        }
+        return Optional.ofNullable(methodElement.getOwningType().parsedKDoc.parameterDoc(internalName))
+    }
 
     override fun withAnnotationMetadata(annotationMetadata: AnnotationMetadata) =
         super<AbstractKotlinElement>.withAnnotationMetadata(annotationMetadata) as ParameterElement

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/KotlinParameterElementDocumentationSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/KotlinParameterElementDocumentationSpec.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.processing.inject.ast
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ElementQuery
+
+class KotlinParameterElementDocumentationSpec extends AbstractKotlinCompilerSpec {
+
+    void "class-level KDoc documents constructor parameters, not regular method parameters"() {
+        expect:
+        buildClassElement('test.Test', '''
+package test
+
+/**
+ * Test class.
+ *
+ * @property percentage the class-level percentage doc
+ */
+class Test(val percentage: Int) {
+
+    fun updatePercentage(percentage: Int) {
+    }
+}
+''') { ClassElement ce ->
+            def constructorParam = ce.primaryConstructor.get().parameters[0]
+            def methodParam = ce.getEnclosedElements(ElementQuery.ALL_METHODS)
+                .find { it.name == 'updatePercentage' }.parameters[0]
+
+            // The class @property tag documents the constructor parameter of the same name...
+            assert constructorParam.getDocumentation(true).get() == 'the class-level percentage doc'
+            // ...but must not bleed onto an unrelated method parameter that happens to share the name.
+            assert !methodParam.getDocumentation(true).isPresent()
+        }
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/configproperties/ConfigurationMetadataSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/configproperties/ConfigurationMetadataSpec.groovy
@@ -1,0 +1,128 @@
+package io.micronaut.kotlin.processing.inject.configproperties
+
+import io.micronaut.annotation.processing.test.KotlinCompiler
+import io.micronaut.core.io.IOUtils
+import spock.lang.Specification
+
+class ConfigurationMetadataSpec extends Specification {
+
+    void "test data class config metadata includes per-property descriptions"() {
+        when:
+        String json = metadataJson('test.VatConfig', '''
+package test
+
+import io.micronaut.context.annotation.ConfigurationProperties
+import java.math.BigDecimal
+
+/**
+ * VAT configuration.
+ *
+ * @property percentage the percentage description text
+ * @param region the region description text
+ */
+@ConfigurationProperties("vat")
+data class VatConfig(val percentage: BigDecimal, val region: String)
+''')
+
+        then:
+        json.contains('"name":"vat.percentage"')
+        json.contains('"description":"the percentage description text"')
+        json.contains('"description":"the region description text"')
+    }
+
+    void "test @ConfigurationInject class config metadata includes per-property descriptions"() {
+        when:
+        String json = metadataJson('test.ServerConfig', '''
+package test
+
+import io.micronaut.context.annotation.ConfigurationInject
+import io.micronaut.context.annotation.ConfigurationProperties
+
+/**
+ * Server configuration.
+ *
+ * @param host the host description text
+ * @param port the port description text
+ */
+@ConfigurationProperties("server")
+class ServerConfig @ConfigurationInject constructor(val host: String, val port: Int)
+''')
+
+        then:
+        json.contains('"name":"server.host"')
+        json.contains('"description":"the host description text"')
+        json.contains('"description":"the port description text"')
+    }
+
+    void "test data class group description is clean prose without leaked KDoc tags"() {
+        when:
+        String json = metadataJson('test.VatConfig', '''
+package test
+
+import io.micronaut.context.annotation.ConfigurationProperties
+import java.math.BigDecimal
+
+/**
+ * VAT configuration.
+ *
+ * @property percentage the percentage description text
+ * @param region the region description text
+ */
+@ConfigurationProperties("vat")
+data class VatConfig(val percentage: BigDecimal, val region: String)
+''')
+
+        then:
+        json.contains('"description":"VAT configuration."')
+        !json.contains('@property')
+        !json.contains('@param')
+    }
+
+    void "test data class config metadata carries the Bindable default value of a constructor parameter"() {
+        when:
+        String json = metadataJson('test.VatConfig', '''
+package test
+
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.core.bind.annotation.Bindable
+import java.math.BigDecimal
+
+@ConfigurationProperties("vat")
+data class VatConfig(@Bindable(defaultValue = "20") val percentage: BigDecimal)
+''')
+
+        then:
+        json.contains('"name":"vat.percentage"')
+        json.contains('"defaultValue":"20"')
+    }
+
+    void "test property-based config metadata description strips KDoc block tags"() {
+        when:
+        String json = metadataJson('test.ServerConfig', '''
+package test
+
+import io.micronaut.context.annotation.ConfigurationProperties
+
+@ConfigurationProperties("server")
+class ServerConfig {
+    /**
+     * The host to connect to.
+     *
+     * @since 2.0
+     */
+    var host: String? = null
+}
+''')
+
+        then:
+        json.contains('"name":"server.host"')
+        json.contains('"description":"The host to connect to."')
+        !json.contains('@since')
+    }
+
+    private static String metadataJson(String name, String source) {
+        def classLoader = KotlinCompiler.buildClassLoader(name, source)
+        def resource = classLoader.getResources("META-INF/spring-configuration-metadata.json").toList().last()
+        return IOUtils.readText(new BufferedReader(new InputStreamReader(resource.openStream())))
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/KDocParserSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/KDocParserSpec.groovy
@@ -1,0 +1,99 @@
+package io.micronaut.kotlin.processing.visitor
+
+import spock.lang.Specification
+
+class KDocParserSpec extends Specification {
+
+    void "description is the prose before the first block tag"() {
+        expect:
+        KDocParserKt.parseKDoc('VAT configuration.\n\n @property percentage pct\n @param region reg\n').description == 'VAT configuration.'
+    }
+
+    void "description is empty when the doc is only block tags"() {
+        expect:
+        KDocParserKt.parseKDoc(' @param name only a tag\n').description == ''
+    }
+
+    void "parameterDoc returns the named property tag content"() {
+        expect:
+        KDocParserKt.parseKDoc('Doc.\n @property percentage the pct text\n').parameterDoc('percentage') == 'the pct text'
+    }
+
+    void "parameterDoc prefers property over param"() {
+        expect:
+        KDocParserKt.parseKDoc('Doc.\n @property region prop text\n @param region param text\n').parameterDoc('region') == 'prop text'
+    }
+
+    void "parameterDoc falls back to param and returns null when absent"() {
+        given:
+        def doc = 'Doc.\n @param region the region text\n'
+
+        expect:
+        KDocParserKt.parseKDoc(doc).parameterDoc('region') == 'the region text'
+        KDocParserKt.parseKDoc(doc).parameterDoc('missing') == null
+    }
+
+    void "block tag content spanning multiple lines is joined"() {
+        when:
+        def parsed = KDocParserKt.parseKDoc('Doc.\n @param name first line\n second line\n')
+
+        then:
+        parsed.description == 'Doc.'
+        parsed.blockTags.size() == 1
+        parsed.blockTags[0].tag == 'param'
+        parsed.blockTags[0].name == 'name'
+        parsed.blockTags[0].content == 'first line second line'
+    }
+
+    void "unknown tags are captured without a name"() {
+        when:
+        def parsed = KDocParserKt.parseKDoc('Doc.\n @return the result\n')
+
+        then:
+        parsed.blockTags[0].tag == 'return'
+        parsed.blockTags[0].name == null
+        parsed.blockTags[0].content == 'the result'
+    }
+
+    void "blank doc yields empty description and no tags"() {
+        when:
+        def parsed = KDocParserKt.parseKDoc('')
+
+        then:
+        parsed.description == ''
+        parsed.blockTags.isEmpty()
+    }
+
+    void "multi-line description keeps paragraph breaks and trims each line"() {
+        expect:
+        KDocParserKt.parseKDoc('First line.\n Second line.\n\n @param x y\n').description == 'First line.\nSecond line.'
+    }
+
+    void "a doc with no tags is entirely description"() {
+        when:
+        def parsed = KDocParserKt.parseKDoc('Just a description.\n with more.\n')
+
+        then:
+        parsed.description == 'Just a description.\nwith more.'
+        parsed.blockTags.isEmpty()
+    }
+
+    void "parameterDoc returns null when the tag has blank content"() {
+        expect:
+        KDocParserKt.parseKDoc('Doc.\n @property percentage\n').parameterDoc('percentage') == null
+    }
+
+    void "parameterDoc disambiguates tags of the same type by name"() {
+        given:
+        def doc = 'Doc.\n @param first the first\n @param second the second\n'
+
+        expect:
+        KDocParserKt.parseKDoc(doc).parameterDoc('first') == 'the first'
+        KDocParserKt.parseKDoc(doc).parameterDoc('second') == 'the second'
+    }
+
+    void "blank continuation lines within tag content are ignored"() {
+        expect:
+        KDocParserKt.parseKDoc('Doc.\n @param name line one\n\n line two\n').parameterDoc('name') == 'line one line two'
+    }
+}


### PR DESCRIPTION
Kotlin @ConfigurationProperties data classes and @ConfigurationInject classes now contribute per-property documentation to the generated configuration metadata. A constructor parameter's description is resolved from the class KDoc @property/@param tag of the same name, mirroring how Java records source descriptions from their @param tags.

Element documentation returns the prose description with block tags parsed out, so both group and property descriptions are clean text rather than raw KDoc.