### PR TITLE
Add SCIM JSON media type support

### DIFF
--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -254,6 +254,16 @@ public class MediaType implements CharSequence {
     public static final MediaType APPLICATION_JSON_SCHEMA_TYPE = new MediaType(MediaType.APPLICATION_JSON_SCHEMA);
 
     /**
+     * JSON Schema: application/scim+json.
+     */
+    public static final String APPLICATION_SCIM_JSON = "application/scim+json";
+
+    /**
+     * JSON Schema: application/scim+json.
+     */
+    public static final MediaType APPLICATION_SCIM_JSON_TYPE = new MediaType(MediaType.APPLICATION_SCIM_JSON);
+
+    /**
      * JSON: application/json.
      */
     public static final String APPLICATION_JSON = "application/json";
@@ -933,6 +943,7 @@ public class MediaType implements CharSequence {
             case APPLICATION_JSON_MERGE_PATCH -> APPLICATION_JSON_MERGE_PATCH_TYPE;
             case APPLICATION_JSON_PROBLEM -> APPLICATION_JSON_PROBLEM_TYPE;
             case APPLICATION_JSON_SCHEMA -> APPLICATION_JSON_SCHEMA_TYPE;
+            case APPLICATION_SCIM_JSON -> APPLICATION_SCIM_JSON_TYPE;
             case APPLICATION_YAML -> APPLICATION_YAML_TYPE;
             case APPLICATION_HAL_JSON -> APPLICATION_HAL_JSON_TYPE;
             case APPLICATION_HAL_XML -> APPLICATION_HAL_XML_TYPE;

--- a/http/src/test/java/io/micronaut/http/MediaTypeTest.java
+++ b/http/src/test/java/io/micronaut/http/MediaTypeTest.java
@@ -99,6 +99,7 @@ class MediaTypeTest {
             APPLICATION_JSON_PATCH_TYPE,
             APPLICATION_JSON_MERGE_PATCH_TYPE,
             APPLICATION_JSON_SCHEMA_TYPE,
+            APPLICATION_SCIM_JSON_TYPE,
             APPLICATION_VND_ERROR_TYPE
          );
     }

--- a/json-core/src/main/java/io/micronaut/json/body/JsonMessageHandler.java
+++ b/json-core/src/main/java/io/micronaut/json/body/JsonMessageHandler.java
@@ -179,7 +179,8 @@ public final class JsonMessageHandler<T> implements MessageBodyHandler<T>, Custo
         MediaType.APPLICATION_JSON_PROBLEM,
         MediaType.APPLICATION_JSON_PATCH,
         MediaType.APPLICATION_JSON_MERGE_PATCH,
-        MediaType.APPLICATION_JSON_SCHEMA
+        MediaType.APPLICATION_JSON_SCHEMA,
+        MediaType.APPLICATION_SCIM_JSON
     })
     public @interface ProducesJson {
     }
@@ -200,7 +201,8 @@ public final class JsonMessageHandler<T> implements MessageBodyHandler<T>, Custo
         MediaType.APPLICATION_JSON_PROBLEM,
         MediaType.APPLICATION_JSON_PATCH,
         MediaType.APPLICATION_JSON_MERGE_PATCH,
-        MediaType.APPLICATION_JSON_SCHEMA
+        MediaType.APPLICATION_JSON_SCHEMA,
+        MediaType.APPLICATION_SCIM_JSON
     })
     public @interface ConsumesJson {
     }

--- a/json-core/src/main/java/io/micronaut/json/codec/JsonMediaTypeCodec.java
+++ b/json-core/src/main/java/io/micronaut/json/codec/JsonMediaTypeCodec.java
@@ -54,6 +54,7 @@ public class JsonMediaTypeCodec extends MapperMediaTypeCodec {
         MediaType.APPLICATION_JSON_PATCH_TYPE,
         MediaType.APPLICATION_JSON_MERGE_PATCH_TYPE,
         MediaType.APPLICATION_JSON_PROBLEM_TYPE,
+        MediaType.APPLICATION_SCIM_JSON_TYPE,
         MediaType.APPLICATION_JSON_SCHEMA_TYPE
     );
 


### PR DESCRIPTION
Introduce the application/scim+json media type and register it with Micronaut's JSON message handlers and codec. Extend media type coverage tests to verify the new type.

https://datatracker.ietf.org/doc/html/rfc7644#section-8.1