### PR TITLE
fix(multipart): case-insensitive Content-Type/Content-Length header matching in FormDemuxer

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/FormDemuxer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/FormDemuxer.java
@@ -333,9 +333,9 @@ public final class FormDemuxer implements BufferConsumer {
                 ParsedHeaderValue parsedHeaderValue = decoder.parsedHeaderValue();
                 if (parsedHeaderValue instanceof ContentDisposition cd) {
                     this.disposition = cd;
-                } else if (HttpHeaderNames.CONTENT_TYPE.contentEquals(decoder.headerName())) {
+                } else if (HttpHeaderNames.CONTENT_TYPE.contentEqualsIgnoreCase(decoder.headerName())) {
                     this.mediaType = MediaType.of(decoder.headerValue());
-                } else if (HttpHeaderNames.CONTENT_LENGTH.contentEquals(decoder.headerName())) {
+                } else if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(decoder.headerName())) {
                     this.contentLength = Long.parseLong(decoder.headerValue());
                 }
             } else if (event == PostBodyDecoder.Event.HEADERS_COMPLETE) {

--- a/http-server-netty/src/test/java/io/micronaut/http/server/netty/multipart/FormDemuxerTest.java
+++ b/http-server-netty/src/test/java/io/micronaut/http/server/netty/multipart/FormDemuxerTest.java
@@ -1,6 +1,7 @@
 package io.micronaut.http.server.netty.multipart;
 
 import io.micronaut.core.io.buffer.ReadBuffer;
+import io.micronaut.http.MediaType;
 import io.micronaut.http.body.ByteBody;
 import io.micronaut.http.body.ByteBodyFactory;
 import io.micronaut.http.body.CloseableByteBody;
@@ -44,6 +45,10 @@ public class FormDemuxerTest {
         return new FormDemuxer(PostBodyDecoder.builder().forUrlEncodedData(), channel, BodySizeLimits.UNLIMITED, BodySizeLimits.UNLIMITED, body);
     }
 
+    private FormDemuxer createMultipart(ByteBody body, String boundary) {
+        return new FormDemuxer(PostBodyDecoder.builder().forMultipartBoundary(boundary), channel, BodySizeLimits.UNLIMITED, BodySizeLimits.UNLIMITED, body);
+    }
+
     private static <T> Queue<T> toQueue(Flux<T> flux) {
         QueueSubscriber<T> subscriber = new QueueSubscriber<>();
         subscriber.noBackpressure();
@@ -72,6 +77,47 @@ public class FormDemuxerTest {
         QueueSubscriber<String> data = content(field.byteBody()).noBackpressure();
         assertEquals("bar", data.queue.poll());
         assertTrue(data.complete);
+    }
+
+    @Test
+    public void multipartContentTypeMixedCase() {
+        // Regression test: real clients (curl, browsers, MultipartBody) send the conventional
+        // mixed-case "Content-Type" header on multipart parts. This must be recognized.
+        String boundary = "boundary1234";
+        String body = "--" + boundary + "\r\n" +
+            "Content-Disposition: form-data; name=\"file\"; filename=\"test.pdf\"\r\n" +
+            "Content-Type: application/pdf\r\n" +
+            "\r\n" +
+            "file content\r\n" +
+            "--" + boundary + "--\r\n";
+
+        Queue<RawFormField> fields = toQueue(createMultipart(byteBodyFactory.copyOf(body, StandardCharsets.UTF_8), boundary).fields());
+
+        RawFormField field = fields.remove();
+        assertEquals("file", field.metadata().name());
+        assertEquals("test.pdf", field.metadata().fileName());
+        assertEquals(MediaType.of("application/pdf"), field.metadata().mediaType());
+        content(field.byteBody()).noBackpressure();
+    }
+
+    @Test
+    public void multipartContentTypeLowerCase() {
+        // lower-case header names must also be recognized, since HTTP header names are
+        // case-insensitive per RFC 7230 section 3.2.
+        String boundary = "boundary1234";
+        String body = "--" + boundary + "\r\n" +
+            "content-disposition: form-data; name=\"file\"; filename=\"test.pdf\"\r\n" +
+            "content-type: application/pdf\r\n" +
+            "\r\n" +
+            "file content\r\n" +
+            "--" + boundary + "--\r\n";
+
+        Queue<RawFormField> fields = toQueue(createMultipart(byteBodyFactory.copyOf(body, StandardCharsets.UTF_8), boundary).fields());
+
+        RawFormField field = fields.remove();
+        assertEquals("file", field.metadata().name());
+        assertEquals(MediaType.of("application/pdf"), field.metadata().mediaType());
+        content(field.byteBody()).noBackpressure();
     }
 
     @Test


### PR DESCRIPTION
## Problem

`CompletedFileUpload#getContentType()` always returns `Optional.empty()` for multipart file parts — even when the client sends a perfectly normal `Content-Type` header on the part. This is a regression from the 5.0 rewrite of multipart
parsing on top of `io.netty.contrib:netty-codec-multipart-core`.

```
$ curl -F "file=@test.pdf;type=application/pdf" http://localhost:8080/upload
```

- **Expected:** `Optional[application/pdf]`
- **Actual:** `Optional.empty`

## Root cause

`FormDemuxer.Headers#accept()` matches the part's `Content-Type` / `Content-Length` headers with a case-sensitive
comparison:

```java
}else if(HttpHeaderNames.CONTENT_TYPE.contentEquals(decoder.headerName())){
```

- `HttpHeaderNames.CONTENT_TYPE` / `CONTENT_LENGTH` are Netty constants, defined **lowercase** (`"content-type"`,
  `"content-length"`).
- `AsciiString#contentEquals(CharSequence)` is **case-sensitive**.
- `decoder.headerName()` (`io.netty.contrib.multipart.MultipartDecoder`) returns the raw header name exactly as seen on the wire — no case normalization.

Virtually every real client (curl, browsers, Micronaut's own `MultipartBody`, Postman, ...) writes the conventional
mixed-case `Content-Type:` / `Content-Length:`, so the comparison never matches in practice, and `mediaType` /
`contentLength` are never populated.

`Content-Disposition` is unaffected — it's parsed into a structured `ContentDisposition` object case-insensitively
rather than going through this raw string comparison.