### PR TITLE
Cache successful message lookups in ResourceBundleMessageSource

### DIFF
--- a/inject/src/main/java/io/micronaut/context/i18n/ResourceBundleMessageSource.java
+++ b/inject/src/main/java/io/micronaut/context/i18n/ResourceBundleMessageSource.java
@@ -112,9 +112,9 @@ public class ResourceBundleMessageSource extends AbstractMessageSource {
             try {
                 final Optional<ResourceBundle> bundle = resolveBundle(locale);
                 if (bundle.isPresent()) {
-                    return bundle.map(b -> b.getString(code));
+                    opt = bundle.map(b -> b.getString(code));
                 } else {
-                    return resolveDefault(code);
+                    opt = resolveDefault(code);
                 }
             } catch (MissingResourceException e) {
                 opt = resolveDefault(code);

--- a/inject/src/test/groovy/io/micronaut/context/i18n/ResourceBundleMessageSourceSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/i18n/ResourceBundleMessageSourceSpec.groovy
@@ -3,6 +3,8 @@ package io.micronaut.context.i18n
 import io.micronaut.context.MessageSource
 import spock.lang.Specification
 
+import java.lang.reflect.Field
+
 class ResourceBundleMessageSourceSpec extends Specification {
 
     void "test resource bundle message source"() {
@@ -49,5 +51,39 @@ class ResourceBundleMessageSourceSpec extends Specification {
         "test {0} ''{1} {2}"     | "test A 'B C"
         "test {{{x}}}"           | "test D}}"
         "test {abcd"             | "test {abcd"
+    }
+
+    void "successful message lookups are cached"() {
+        given:
+        ResourceBundleMessageSource ms = new ResourceBundleMessageSource("io.micronaut.context.i18n.Test")
+
+        when: "a message that resolves successfully is looked up"
+        Optional<String> result = ms.getRawMessage("hello.message", MessageSource.MessageContext.of(Locale.ENGLISH))
+
+        then: "it resolves and the successful resolution is stored in the message cache"
+        result.get() == 'Hello'
+        messageCache(ms).size() == 1
+        messageCache(ms).values().first().get() == 'Hello'
+    }
+
+    void "missing bundle lookups are cached"() {
+        given:
+        ResourceBundleMessageSource ms = new ResourceBundleMessageSource("io.micronaut.context.i18n.DoesNotExist")
+
+        when: "a code is looked up but no bundle can be resolved"
+        Optional<String> result = ms.getRawMessage("any.code", MessageSource.MessageContext.of(Locale.ENGLISH))
+
+        then: "the empty result is cached too"
+        !result.present
+        messageCache(ms).size() == 1
+        !messageCache(ms).values().first().present
+    }
+
+    private static Map<?, Optional<String>> messageCache(ResourceBundleMessageSource ms) {
+        // The cache is private; read it via reflection, mirroring test-suite's
+        // ResourceBundleMessageSourceTest which reflects into bundleCache.
+        Field field = ResourceBundleMessageSource.getDeclaredField("messageCache")
+        field.setAccessible(true)
+        return (Map<?, Optional<String>>) field.get(ms)
     }
 }


### PR DESCRIPTION
## Problem

`ResourceBundleMessageSource.getRawMessage()` has a `messageCache`, but the two
success paths — a message found in the locale-specific bundle, and one resolved
from the default bundle — return before `messageCache.put(...)`. Only the
`MissingResourceException` fallback populates the cache, so successful lookups are
resolved on every call and never cached.

## Fix

Assign the resolved value to `opt` in both success paths so control falls through
to `messageCache.put(messageKey, opt)` before returning. Behaviour for callers is
unchanged; successful lookups (and empty results from an unresolvable bundle) are
now cached, consistent with the existing `MissingResourceException` fallback.

## Tests

Adds two Spock cases to `ResourceBundleMessageSourceSpec`: a successful lookup is
stored in `messageCache`, and an unresolvable-bundle lookup caches the empty
result. (The existing "repeated to exercise cache" assertions pass whether or not
the value is cached, so they didn't catch this.) The cache is read via reflection,
mirroring `test-suite`'s `ResourceBundleMessageSourceTest`.

`:micronaut-inject:check` and the `test-suite` `ResourceBundleMessageSourceTest`
pass.

Closes #12832
