### PR TITLE
fix: encode illegal characters in UriBuilder path

### DIFF
--- a/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
+++ b/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
@@ -341,6 +341,8 @@ class DefaultUriBuilder implements UriBuilder {
             String pathStr = path.toString();
             if (isTemplate(pathStr, values)) {
                 pathStr = UriTemplate.of(pathStr).expand(values);
+            } else {
+                pathStr = encodePath(pathStr);
             }
 
             builder.append(pathStr);
@@ -405,5 +407,54 @@ class DefaultUriBuilder implements UriBuilder {
 
     private String encode(String userInfo) {
         return URLEncoder.encode(userInfo, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Percent-encode characters that are illegal in a URI path, leaving valid {@code %XX}
+     * sequences untouched so already-encoded paths are not double-encoded.
+     */
+    private static String encodePath(String path) {
+        StringBuilder sb = null;
+        for (int i = 0; i < path.length();) {
+            char c = path.charAt(i);
+            if (c == '%' && i + 2 < path.length() && isHexDigit(path.charAt(i + 1)) && isHexDigit(path.charAt(i + 2))) {
+                if (sb != null) {
+                    sb.append(path, i, i + 3);
+                }
+                i += 3;
+                continue;
+            }
+            int cp = path.codePointAt(i);
+            int len = Character.charCount(cp);
+            if (isAllowedPathChar(cp)) {
+                if (sb != null) {
+                    sb.appendCodePoint(cp);
+                }
+            } else {
+                if (sb == null) {
+                    sb = new StringBuilder(path.length() + 8);
+                    sb.append(path, 0, i);
+                }
+                sb.append(URLEncoder.encode(path.substring(i, i + len), StandardCharsets.UTF_8).replace("+", "%20"));
+            }
+            i += len;
+        }
+        return sb == null ? path : sb.toString();
+    }
+
+    private static boolean isAllowedPathChar(int c) {
+        return (c >= 'a' && c <= 'z')
+            || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9')
+            || switch (c) {
+                case '-', '.', '_', '~',
+                     '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=',
+                     ':', '@', '/' -> true;
+                default -> false;
+            };
+    }
+
+    private static boolean isHexDigit(char c) {
+        return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
     }
 }

--- a/http/src/main/java/io/micronaut/http/uri/UriBuilder.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriBuilder.java
@@ -106,7 +106,8 @@ public interface UriBuilder {
     UriBuilder replaceQueryParam(String name, Object... values);
 
     /**
-     * The constructed URI.
+     * The constructed URI. Illegal path characters are percent-encoded; existing valid
+     * percent-encoded sequences are preserved.
      *
      * @return Build the URI
      * @throws io.micronaut.http.exceptions.UriSyntaxException if the URI to be constructed is invalid

--- a/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
@@ -196,4 +196,42 @@ class UriBuilderSpec extends Specification {
         then:
         builder.build().toString() == "https://google.com/search?q1=v1&q2=v2"
     }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/12578")
+    void "test path with curly braces is encoded on build"() {
+        given:
+        String url = 'https://abc.com/XXX/YYY;abcd=${ABCD};ab_cd=1'
+
+        when:
+        URI uri = UriBuilder.of(url).build()
+
+        then:
+        uri.toString() == 'https://abc.com/XXX/YYY;abcd=$%7BABCD%7D;ab_cd=1'
+        !uri.rawPath.contains('{')
+        !uri.rawPath.contains('}')
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/7288")
+    void "test path with spaces is encoded on build"() {
+        expect:
+        UriBuilder.of("").path("this has a space in it").build().toString() ==
+                "/this%20has%20a%20space%20in%20it"
+        UriBuilder.of("https://example.com").path("foo bar").build().toString() ==
+                "https://example.com/foo%20bar"
+    }
+
+    void "test already percent-encoded path is not double encoded"() {
+        expect:
+        UriBuilder.of("").path("this%20has%20a%20space%20in%20it").build().toString() ==
+                "/this%20has%20a%20space%20in%20it"
+        UriBuilder.of("https://example.com/foo%20bar").build().toString() ==
+                "https://example.com/foo%20bar"
+        UriBuilder.of("https://example.com/foo%2Fbar").build().toString() ==
+                "https://example.com/foo%2Fbar"
+    }
+
+    void "test path with unicode is utf8 percent encoded"() {
+        expect:
+        UriBuilder.of("").path("café").build().toString() == "/caf%C3%A9"
+    }
 }


### PR DESCRIPTION
Fixes #12578

### Problem

`UriBuilder.of(url).build()` throws `UriSyntaxException` when the path contains characters that are illegal in a URI path, for example curly braces:

```java
UriBuilder.of("https://abc.com/XXX/YYY;abcd=${ABCD};ab_cd=1").build();
// Illegal character in path ... ${ABCD}
```

`build()` was reconstructing the URI string and handing it to `new URI(String)` without encoding the path. Query params were already encoded; the path was not (unless you went through `expand()` with a template).

### Fix

When the path is not treated as a URI template, percent-encode illegal path characters on build. Valid `%XX` sequences are left as-is so already-encoded paths are not double-encoded (that was the concern that blocked #7302).

```java
UriBuilder.of("https://abc.com/XXX/YYY;abcd=${ABCD};ab_cd=1").build().toString()
// https://abc.com/XXX/YYY;abcd=$%7BABCD%7D;ab_cd=1
```

Also covers spaces and other non-pchar characters. URI template expansion via `expand()` is unchanged.

### Tests

- #12578 repro (`${...}` in matrix-style path)
- spaces in path
- already percent-encoded path not double-encoded
- unicode path segments

```bash
./gradlew :micronaut-http:test --tests 'io.micronaut.http.uri.UriBuilderSpec'
```