### PR TITLE
Make error body buffering for streaming clients configurable

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -131,6 +131,11 @@ public abstract class HttpClientConfiguration {
     /**
      * The default value.
      */
+    public static final boolean DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING = false;
+
+    /**
+     * The default value.
+     */
     @SuppressWarnings("WeakerAccess")
     public static final boolean DEFAULT_ALLOW_BLOCK_EVENT_LOOP = false;
 
@@ -221,6 +226,7 @@ public abstract class HttpClientConfiguration {
     private int maxRedirects = DEFAULT_MAX_REDIRECTS;
 
     private boolean exceptionOnErrorStatus = DEFAULT_EXCEPTION_ON_ERROR_STATUS;
+    private boolean bufferErrorBodyForStreaming = DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING;
     private boolean decompressionEnabled = true;
 
     private SslConfiguration sslConfiguration = new ClientSslConfiguration();
@@ -280,6 +286,7 @@ public abstract class HttpClientConfiguration {
             this.numOfThreads = copy.numOfThreads;
             this.connectTimeout = copy.connectTimeout;
             this.connectTtl = copy.connectTtl;
+            this.bufferErrorBodyForStreaming = copy.bufferErrorBodyForStreaming;
             this.defaultCharset = copy.defaultCharset;
             this.exceptionOnErrorStatus = copy.exceptionOnErrorStatus;
             this.eventLoopGroup = copy.eventLoopGroup;
@@ -404,6 +411,23 @@ public abstract class HttpClientConfiguration {
     @Nullable
     public WebSocketCompressionConfiguration getWebSocketCompressionConfiguration() {
         return null;
+    }
+
+    /**
+     * @return Whether the error response body should be buffered and parsed for streaming clients.
+     */
+    public boolean isBufferErrorBodyForStreaming() {
+        return bufferErrorBodyForStreaming;
+    }
+
+    /**
+     * Sets whether the error response body should be buffered and parsed for streaming clients, so that
+     * {@code getResponse().getBody(..)} is populated on error. Default value ({@link io.micronaut.http.client.HttpClientConfiguration#DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING})
+     *
+     * @param bufferErrorBodyForStreaming Whether
+     */
+    public void setBufferErrorBodyForStreaming(boolean bufferErrorBodyForStreaming) {
+        this.bufferErrorBodyForStreaming = bufferErrorBodyForStreaming;
     }
 
     /**

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
@@ -1247,7 +1247,7 @@ final class NettyHttpClient implements
     }
 
     private ExecutionFlow<HttpResponse<?>> readBodyOnError(@Nullable Argument<?> errorType, ExecutionFlow<HttpResponse<?>> publisher) {
-        if (errorType != null && errorType != HttpClient.DEFAULT_ERROR_TYPE) {
+        if (errorType != null && (errorType != HttpClient.DEFAULT_ERROR_TYPE || configuration.isBufferErrorBodyForStreaming())) {
             return publisher.onErrorResume(clientException -> {
                 if (clientException instanceof HttpClientResponseException exception) {
                     final HttpResponse<?> response = exception.getResponse();

--- a/http-client/src/test/groovy/io/micronaut/http/client/stream/ClientStreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/stream/ClientStreamSpec.groovy
@@ -74,6 +74,25 @@ class ClientStreamSpec extends Specification {
         !ex.response.getBody(Map).isPresent()
     }
 
+    void "test a stream error body is buffered when buffer-error-body-for-streaming is enabled"() {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.http.client.buffer-error-body-for-streaming': true
+        ])
+        def client = server.applicationContext.getBean(BookClientNoErrorType)
+
+        when:
+        Flux.from(client.errorStream()).blockFirst()
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.response.getBody(Map).isPresent()
+        ex.response.getBody(Map).get().get("error") == "from server"
+
+        cleanup:
+        server.close()
+    }
+
     void "test a stream that returns an error response"() {
         when:
         Flux.from(bookClient.errorStream2()).blockFirst()


### PR DESCRIPTION
Fixes #12771

Streaming clients (`SseClient`, `ReactorSseClient`, `dataStream`, `jsonStream`) drop the error response body when no explicit `errorType` is given, so `getResponse().getBody(..)` is empty on an HTTP error. `readBodyOnError` in `NettyHttpClient` only buffers the body when `errorType != DEFAULT_ERROR_TYPE`, which is never true for the default overloads.

Adds `micronaut.http.client.buffer error body for streaming` on `HttpClientConfiguration` to control this, per @graemerocher's comment that the default should be configurable.

The default is `false`, preserving current behaviour: buffering an arbitrarily large error body for every streaming client is a memory tradeoff worth opting into, and the existing behaviour is asserted by `ClientStreamSpec` ("test a stream that produces an error without an error type"). Happy to flip the default to `true` if you would prefer the bug fixed out of the box.

Adds a test that mirrors that existing one with the flag enabled, asserting the body is present.