### PR TITLE
Remove deprecated --enable-http/--enable-https native image options

### DIFF
--- a/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
+++ b/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-Args=--enable-http \
-       --enable-https \
-       --initialize-at-build-time=io.micronaut.context.annotation \
+Args=--initialize-at-build-time=io.micronaut.context.annotation \
        --initialize-at-build-time=io.micronaut.inject.annotation \
        --initialize-at-build-time=io.micronaut.runtime.converters.time \
        --initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer$1 \


### PR DESCRIPTION
GraalVM for JDK 25.1 deprecates the `--enable-http` and `--enable-https` native image options. Building a native image currently emits a warning for each, originating from `micronaut-inject`'s `native-image.properties`:

```
Warning: Using a deprecated option --enable-http from
'META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties'.
Use reachability metadata instead. ...
Warning: Using a deprecated option --enable-https from
'META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties'.
Use reachability metadata instead. ...
```

The reachability metadata these options are replaced by is already present in `micronaut-inject/reachability-metadata.json` — the `sun.net.www.protocol.http.Handler` and `sun.net.www.protocol.https.Handler` reflection entries. With that metadata in place the two options in `native-image.properties` are redundant and only produce the deprecation warnings.

This removes the two deprecated options; the `http`/`https` URL protocol handlers stay registered through the existing reachability metadata.

The `--install-exit-handlers` warning also mentioned in the issue is no longer present on `5.2.x`.

Fixes #12807
