### PR TITLE
Add shared GraalPy context execution APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,14 @@ tasks.named("updateVersionCatalogs") {
     ignoredModules.add("com.github.ben-manes.caffeine:caffeine")
 }
 
+def pythonProjects = [
+        ":micronaut-inject-python",
+        ":micronaut-inject-python-test",
+        ":micronaut-context-python",
+        ":micronaut-context-python-netty",
+        ":test-suite-python"
+]
+
 if (System.getenv("SONAR_TOKEN") != null) {
     // deprecated and compile time only classes excluded from analysis
     def analysisExcludes = [
@@ -59,24 +67,19 @@ if (System.getenv("SONAR_TOKEN") != null) {
         "**/DirectoryClassWriterOutputVisitor.java",
         "**/GroovyClassWriterOutputVisitor.java",
         "**/MutableHttpRequestWrapper.java",
-        "**/context/python/GraalPyContextCustomizer.java",
-        "**/context/python/GraalPyContextFactory.java",
-        "**/context/python/PythonContextExecutor.java",
-        "**/context/python/PythonContextRuntime.java",
-        "**/context/python/PythonPool.java",
         "**/tck/**",
         "**/test/support/**",
         "**/micronaut/annotation/processing/test/**"
     ]
     // Python module tests run in a separate CI workflow without Sonar coverage collection.
-    def coverageExcludes = [
-        "inject-python/src/main/java/**"
-    ]
+    def pythonCoverageExcludes = pythonProjects.collect {
+        "${project(it).projectDir.name}/**/*"
+    }
     sonarqube {
         skipProject = project.name.contains("test")
         properties {
             property "sonar.exclusions", analysisExcludes.join(",")
-            property "sonar.coverage.exclusions", coverageExcludes.join(",")
+            property "sonar.coverage.exclusions", pythonCoverageExcludes.join(",")
         }
     }
 }
@@ -88,15 +91,6 @@ configurations.javadocAggregatorBase.dependencies.removeIf {
     it instanceof ProjectDependency && it.path.startsWith(":test-")
 }
 
-def pythonProjects = [
-        ":micronaut-inject-python",
-        ":micronaut-inject-python-test",
-        ":micronaut-context-python",
-        ":micronaut-context-python-netty",
-        ":test-suite-python"
-]
-
-// Python tests are also required when collecting coverage for SonarCloud.
 if (!providers.gradleProperty("python-ci").isPresent()) {
     subprojects { project ->
         if (project.path in pythonProjects) {

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,11 @@ if (System.getenv("SONAR_TOKEN") != null) {
         "**/DirectoryClassWriterOutputVisitor.java",
         "**/GroovyClassWriterOutputVisitor.java",
         "**/MutableHttpRequestWrapper.java",
+        "**/context/python/GraalPyContextCustomizer.java",
+        "**/context/python/GraalPyContextFactory.java",
+        "**/context/python/PythonContextExecutor.java",
+        "**/context/python/PythonContextRuntime.java",
+        "**/context/python/PythonPool.java",
         "**/tck/**",
         "**/test/support/**",
         "**/micronaut/annotation/processing/test/**"
@@ -91,6 +96,7 @@ def pythonProjects = [
         ":test-suite-python"
 ]
 
+// Python tests are also required when collecting coverage for SonarCloud.
 if (!providers.gradleProperty("python-ci").isPresent()) {
     subprojects { project ->
         if (project.path in pythonProjects) {

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyContextConfiguration.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyContextConfiguration.java
@@ -57,7 +57,9 @@ public final class GraalPyContextConfiguration {
         "hostClassLoader",
         "apply"
     })
-    Context.Builder builder = Context.newBuilder();
+    Context.Builder builder = Context.newBuilder(
+        GraalPyContextCustomizers.languages(GraalPyContextCustomizers.currentClassLoader())
+    );
     private Map<String, String> options = Map.of();
 
     GraalPyContextConfiguration() {

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyContextCustomizer.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyContextCustomizer.java
@@ -19,6 +19,8 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.order.Ordered;
 import org.graalvm.polyglot.Context;
 
+import java.util.Set;
+
 /**
  * Customizes every GraalPy context builder created by Micronaut.
  *
@@ -40,6 +42,18 @@ public interface GraalPyContextCustomizer extends Ordered {
      * @param builder The builder to customize
      */
     void customize(Context.Builder builder);
+
+    /**
+     * Returns additional guest languages that must be enabled in the shared engine and contexts.
+     *
+     * <p>Python is always enabled. Implementations should return only languages they require and
+     * must ensure the corresponding language distribution is present at runtime.</p>
+     *
+     * @return The additional Polyglot language identifiers
+     */
+    default Set<String> getAdditionalLanguages() {
+        return Set.of();
+    }
 
     @Override
     default int getOrder() {

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyContextCustomizer.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyContextCustomizer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.python;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.order.Ordered;
+import org.graalvm.polyglot.Context;
+
+/**
+ * Customizes every GraalPy context builder created by Micronaut.
+ *
+ * <p>Implementations are loaded with {@link java.util.ServiceLoader} semantics and invoked in
+ * {@link #getOrder() order}. A customizer must not build or retain the supplied builder.</p>
+ *
+ * @author Micronaut Team
+ * @since 5.2.0
+ */
+@Experimental
+@FunctionalInterface
+public interface GraalPyContextCustomizer extends Ordered {
+
+    /**
+     * Customize a context builder before its context is created.
+     *
+     * @param builder The builder to customize
+     */
+    void customize(Context.Builder builder);
+
+    @Override
+    default int getOrder() {
+        return 0;
+    }
+}

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyContextCustomizer.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyContextCustomizer.java
@@ -23,7 +23,9 @@ import org.graalvm.polyglot.Context;
  * Customizes every GraalPy context builder created by Micronaut.
  *
  * <p>Implementations are loaded with {@link java.util.ServiceLoader} semantics and invoked in
- * {@link #getOrder() order}. A customizer must not build or retain the supplied builder.</p>
+ * {@link #getOrder() order} each time a context is built. Implementations may therefore be
+ * invoked multiple times and should be idempotent. A customizer must not build or retain the
+ * supplied builder.</p>
  *
  * @author Micronaut Team
  * @since 5.2.0

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyContextCustomizers.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyContextCustomizers.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.python;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.service.SoftServiceLoader;
+
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+@Internal
+final class GraalPyContextCustomizers {
+    private GraalPyContextCustomizers() {
+    }
+
+    static List<GraalPyContextCustomizer> load(ClassLoader classLoader) {
+        List<GraalPyContextCustomizer> customizers = SoftServiceLoader
+            .load(GraalPyContextCustomizer.class, classLoader)
+            .collectAll();
+        customizers.sort(Comparator.comparingInt(GraalPyContextCustomizer::getOrder));
+        return customizers;
+    }
+
+    static String[] languages(ClassLoader classLoader) {
+        LinkedHashSet<String> languages = new LinkedHashSet<>();
+        languages.add(GraalPyRuntimeUtil.PYTHON);
+        for (GraalPyContextCustomizer customizer : load(classLoader)) {
+            languages.addAll(customizer.getAdditionalLanguages());
+        }
+        return languages.toArray(String[]::new);
+    }
+
+    static ClassLoader currentClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? GraalPyContextCustomizers.class.getClassLoader() : classLoader;
+    }
+}

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyContextFactory.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyContextFactory.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -190,10 +191,10 @@ public class GraalPyContextFactory implements BeanDestroyedEventListener<org.gra
         return buildContext(hostAccess, engine, classLoader, new GraalPyContextConfiguration());
     }
 
-    private static Context buildContext(HostAccess hostAccess,
-                                        Engine engine,
-                                        ClassLoader classLoader,
-                                        GraalPyContextConfiguration contextConfiguration) throws IOException {
+    static Context buildContext(HostAccess hostAccess,
+                                Engine engine,
+                                ClassLoader classLoader,
+                                GraalPyContextConfiguration contextConfiguration) throws IOException {
         return buildContext(hostAccess, engine, classLoader, contextConfiguration, APPLICATION_MAIN);
     }
 
@@ -224,6 +225,11 @@ public class GraalPyContextFactory implements BeanDestroyedEventListener<org.gra
             .allowHostClassLookup(_ -> true);
         resolveVirtualEnvExecutable(System.getenv())
             .ifPresent(executable -> builder.option("python.Executable", executable.toString()));
+        List<GraalPyContextCustomizer> customizers = SoftServiceLoader
+            .load(GraalPyContextCustomizer.class, classLoader)
+            .collectAll();
+        customizers.sort(Comparator.comparingInt(GraalPyContextCustomizer::getOrder));
+        customizers.forEach(customizer -> customizer.customize(builder));
 
         LOG.debug("Configured GraalPy Context.Builder in {}ms", System.currentTimeMillis() - now);
 

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyContextFactory.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyContextFactory.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -225,11 +224,8 @@ public class GraalPyContextFactory implements BeanDestroyedEventListener<org.gra
             .allowHostClassLookup(_ -> true);
         resolveVirtualEnvExecutable(System.getenv())
             .ifPresent(executable -> builder.option("python.Executable", executable.toString()));
-        List<GraalPyContextCustomizer> customizers = SoftServiceLoader
-            .load(GraalPyContextCustomizer.class, classLoader)
-            .collectAll();
-        customizers.sort(Comparator.comparingInt(GraalPyContextCustomizer::getOrder));
-        customizers.forEach(customizer -> customizer.customize(builder));
+        GraalPyContextCustomizers.load(classLoader)
+            .forEach(customizer -> customizer.customize(builder));
 
         LOG.debug("Configured GraalPy Context.Builder in {}ms", System.currentTimeMillis() - now);
 

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyEngineFactory.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyEngineFactory.java
@@ -139,8 +139,14 @@ final class GraalPyEngineFactory implements BeanDestroyedEventListener<Engine> {
         Engine.Builder builder = Engine.newBuilder();
 
         GraalPyEngineConfiguration() {
-            // currently GraalPy spawns too many compiler threads by default. limit to 1 for now.
-            builder.options(Map.of("engine.CompilerThreads", "1"));
+            // The fallback Truffle runtime has no compiler and therefore does not expose this
+            // option. This runtime is useful when several guest languages are embedded in a
+            // native executable whose application class path is not compatible with Truffle's
+            // runtime compiler.
+            if (!Boolean.getBoolean("truffle.UseFallbackRuntime")) {
+                // currently GraalPy spawns too many compiler threads by default. limit to 1 for now.
+                builder.options(Map.of("engine.CompilerThreads", "1"));
+            }
         }
 
         /**

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyEngineFactory.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyEngineFactory.java
@@ -136,17 +136,13 @@ final class GraalPyEngineFactory implements BeanDestroyedEventListener<Engine> {
         public static final String PREFIX = "graalpy.engine";
 
         @ConfigurationBuilder(prefixes = "", excludes = {"out", "in", "err", "exceptionHandler", "messageTransport"})
-        Engine.Builder builder = Engine.newBuilder();
+        Engine.Builder builder = Engine.newBuilder(
+            GraalPyContextCustomizers.languages(GraalPyContextCustomizers.currentClassLoader())
+        );
 
         GraalPyEngineConfiguration() {
-            // The fallback Truffle runtime has no compiler and therefore does not expose this
-            // option. This runtime is useful when several guest languages are embedded in a
-            // native executable whose application class path is not compatible with Truffle's
-            // runtime compiler.
-            if (!Boolean.getBoolean("truffle.UseFallbackRuntime")) {
-                // currently GraalPy spawns too many compiler threads by default. limit to 1 for now.
-                builder.options(Map.of("engine.CompilerThreads", "1"));
-            }
+            // currently GraalPy spawns too many compiler threads by default. limit to 1 for now.
+            builder.options(Map.of("engine.CompilerThreads", "1"));
         }
 
         /**

--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextExecutor.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextExecutor.java
@@ -17,6 +17,7 @@ package io.micronaut.context.python;
 
 import io.micronaut.core.annotation.Experimental;
 import org.graalvm.polyglot.Context;
+import org.jspecify.annotations.Nullable;
 
 import java.util.function.Function;
 
@@ -38,7 +39,7 @@ public interface PythonContextExecutor {
      *
      * @param callback The callback
      * @param <T> The callback result type
-     * @return The callback result
+     * @return The callback result, possibly {@code null}
      */
-    <T> T withContext(Function<Context, T> callback);
+    <T extends @Nullable Object> T withContext(Function<Context, T> callback);
 }

--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextExecutor.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextExecutor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.python;
+
+import io.micronaut.core.annotation.Experimental;
+import org.graalvm.polyglot.Context;
+
+import java.util.function.Function;
+
+/**
+ * Executes a callback with exclusive access to a Python-owned polyglot context.
+ *
+ * <p>The context, and any context-owned {@code Value}, is valid only for the duration of the
+ * callback and must not be retained by the callback or its result.</p>
+ *
+ * @author Micronaut Team
+ * @since 5.2.0
+ */
+@Experimental
+@FunctionalInterface
+public interface PythonContextExecutor {
+
+    /**
+     * Execute a callback using an exclusively owned Python context.
+     *
+     * @param callback The callback
+     * @param <T> The callback result type
+     * @return The callback result
+     */
+    <T> T withContext(Function<Context, T> callback);
+}

--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.micronaut.context.python.GraalPyRuntimeUtil.PYTHON;
@@ -1267,7 +1268,7 @@ public final class PythonContextRuntime {
         }
     }
 
-    static <T> T withPrimaryContext(java.util.function.Function<Context, T> callback) {
+    static <T extends @Nullable Object> T withPrimaryContext(Function<Context, T> callback) {
         Context primary = getContext();
         return withContextLock(primary,
             () -> withExecutionFrame(primary, () -> callback.apply(primary)));

--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
@@ -615,7 +615,7 @@ public final class PythonContextRuntime {
             return offloadPooledExecution(() -> withPooled(classReference, fn));
         }
         if (isReuseContext() || pythonPool == null) {
-            return fn.apply(findClass(classReference));
+            return withPrimaryContext(context -> fn.apply(findClass(classReference, context)));
         }
         PythonEventLoop eventLoop = PythonAsyncioRuntime.currentEventLoopForContext();
         if (eventLoop != null) {
@@ -674,7 +674,7 @@ public final class PythonContextRuntime {
             return offloadPooledExecution(() -> withPooledScript(packageName, scriptName, fn));
         }
         if (isReuseContext() || pythonPool == null) {
-            return fn.apply(findScript(packageName, scriptName));
+            return withPrimaryContext(context -> fn.apply(findScript(packageName, scriptName, context)));
         }
         PythonEventLoop eventLoop = PythonAsyncioRuntime.currentEventLoopForContext();
         if (eventLoop != null) {
@@ -713,9 +713,7 @@ public final class PythonContextRuntime {
             return offloadPooledExecution(() -> withPooledValue(expression, fn));
         }
         if (isReuseContext() || pythonPool == null) {
-            Context context = getContext();
-            Value value = getOrCreateValue(context, expression);
-            return fn.apply(value);
+            return withPrimaryContext(context -> fn.apply(getOrCreateValue(context, expression)));
         }
         PythonEventLoop eventLoop = PythonAsyncioRuntime.currentEventLoopForContext();
         if (eventLoop != null) {
@@ -1267,6 +1265,12 @@ public final class PythonContextRuntime {
         synchronized (contextState(context).lock) {
             return action.get();
         }
+    }
+
+    static <T> T withPrimaryContext(java.util.function.Function<Context, T> callback) {
+        Context primary = getContext();
+        return withContextLock(primary,
+            () -> withExecutionFrame(primary, () -> callback.apply(primary)));
     }
 
     /**

--- a/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import static io.micronaut.context.python.GraalPyRuntimeUtil.PYTHON;
 
@@ -202,7 +203,7 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
     }
 
     @Override
-    public <T> T withContext(java.util.function.Function<Context, T> callback) {
+    public <T extends @Nullable Object> T withContext(Function<Context, T> callback) {
         Objects.requireNonNull(callback, "callback");
         if (PythonContextRuntime.isReuseContext() || targetSize <= 0) {
             return PythonContextRuntime.withPrimaryContext(callback);

--- a/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
@@ -60,11 +60,12 @@ import static io.micronaut.context.python.GraalPyRuntimeUtil.PYTHON;
 @Singleton
 @io.micronaut.context.annotation.Context
 @Internal
-final class PythonPool implements BeanDestroyedEventListener<Context>, GracefulShutdownCapable, Ordered {
+final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListener<Context>, GracefulShutdownCapable, Ordered {
     private static final Logger LOG = LoggerFactory.getLogger(PythonPool.class);
     private final Engine engine;
     private final HostAccess hostAccess;
     private final ApplicationContext applicationContext;
+    private final GraalPyContextConfiguration contextConfiguration;
     private final long warnThresholdMs;
 
     private final Context primaryContext;
@@ -98,11 +99,13 @@ final class PythonPool implements BeanDestroyedEventListener<Context>, GracefulS
                @Named(GraalPyRuntimeUtil.PYTHON) HostAccess hostAccess,
                @Named(GraalPyRuntimeUtil.PYTHON) Context primaryContext,
                ApplicationContext applicationContext,
+               GraalPyContextConfiguration contextConfiguration,
                PythonPoolConfiguration configuration) {
         this.engine = engine;
         this.primaryContext = primaryContext;
         this.hostAccess = hostAccess;
         this.applicationContext = applicationContext;
+        this.contextConfiguration = contextConfiguration;
         int configuredPoolSize = configuration.size();
         this.warnThresholdMs = configuration.warnWaitMs();
         this.targetSize = configuration.enabled() ? (configuredPoolSize > 0 ? configuredPoolSize : computeDefaultSize()) : 0;
@@ -196,6 +199,26 @@ final class PythonPool implements BeanDestroyedEventListener<Context>, GracefulS
 
     int availableContextCount() {
         return pooledQueue.size();
+    }
+
+    @Override
+    public <T> T withContext(java.util.function.Function<Context, T> callback) {
+        Objects.requireNonNull(callback, "callback");
+        if (PythonContextRuntime.isReuseContext() || targetSize <= 0) {
+            return PythonContextRuntime.withPrimaryContext(callback);
+        }
+        PythonEventLoop eventLoop = PythonAsyncioRuntime.currentEventLoopForContext();
+        if (eventLoop != null) {
+            Context eventLoopContext = getEventLoopContext(eventLoop);
+            return PythonContextRuntime.withContextLock(eventLoopContext,
+                () -> PythonContextRuntime.withExecutionFrame(eventLoopContext, () -> callback.apply(eventLoopContext)));
+        }
+        Context borrowed = borrow();
+        try {
+            return PythonContextRuntime.withExecutionFrame(borrowed, () -> callback.apply(borrowed));
+        } finally {
+            release(borrowed);
+        }
     }
 
     /**
@@ -452,7 +475,8 @@ final class PythonPool implements BeanDestroyedEventListener<Context>, GracefulS
             return GraalPyContextFactory.buildContext(
                 hostAccess,
                 engine,
-                applicationContext.getClassLoader()
+                applicationContext.getClassLoader(),
+                contextConfiguration
             );
         } catch (IOException e) {
             throw new ApplicationStartupException("Failed to create Python context: " + e.getMessage(), e);

--- a/context-python/src/test/java/io/micronaut/context/python/FirstGraalPyContextCustomizer.java
+++ b/context-python/src/test/java/io/micronaut/context/python/FirstGraalPyContextCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.python;
+
+import org.graalvm.polyglot.Context;
+
+public final class FirstGraalPyContextCustomizer implements GraalPyContextCustomizer {
+    static final String OPTION = "python.WarnExperimentalFeatures";
+
+    @Override
+    public void customize(Context.Builder builder) {
+        if (!GraalPyContextCustomizerTest.ENABLED) {
+            return;
+        }
+        GraalPyContextCustomizerTest.INVOCATIONS.add("first");
+        builder.option(OPTION, "true");
+    }
+
+    @Override
+    public int getOrder() {
+        return 100;
+    }
+}

--- a/context-python/src/test/java/io/micronaut/context/python/GraalPyContextCustomizerTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/GraalPyContextCustomizerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.python;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.HostAccess;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class GraalPyContextCustomizerTest {
+    static boolean ENABLED;
+    static final List<String> INVOCATIONS = new ArrayList<>();
+
+    @Test
+    void discoversCustomizersInOrderAndAppliesThemToBuiltContexts() throws IOException {
+        INVOCATIONS.clear();
+        ENABLED = true;
+        try {
+            try (Engine engine = GraalPyEngineFactory.buildPythonEngine();
+                 Context context = GraalPyContextFactory.buildContext(
+                     HostAccess.ALL,
+                     engine,
+                     GraalPyContextCustomizerTest.class.getClassLoader())) {
+                assertEquals(List.of("second", "first"), INVOCATIONS);
+            }
+        } finally {
+            ENABLED = false;
+        }
+    }
+}

--- a/context-python/src/test/java/io/micronaut/context/python/SecondGraalPyContextCustomizer.java
+++ b/context-python/src/test/java/io/micronaut/context/python/SecondGraalPyContextCustomizer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.python;
+
+import org.graalvm.polyglot.Context;
+
+public final class SecondGraalPyContextCustomizer implements GraalPyContextCustomizer {
+    @Override
+    public void customize(Context.Builder builder) {
+        if (!GraalPyContextCustomizerTest.ENABLED) {
+            return;
+        }
+        GraalPyContextCustomizerTest.INVOCATIONS.add("second");
+        builder.option(FirstGraalPyContextCustomizer.OPTION, "true");
+    }
+
+    @Override
+    public int getOrder() {
+        return -100;
+    }
+}

--- a/context-python/src/test/resources/META-INF/services/io.micronaut.context.python.GraalPyContextCustomizer
+++ b/context-python/src/test/resources/META-INF/services/io.micronaut.context.python.GraalPyContextCustomizer
@@ -1,0 +1,2 @@
+io.micronaut.context.python.SecondGraalPyContextCustomizer
+io.micronaut.context.python.FirstGraalPyContextCustomizer

--- a/test-suite-python/src/test/python/micronaut/docs/asyncio/PythonAsyncioSpec.py
+++ b/test-suite-python/src/test/python/micronaut/docs/asyncio/PythonAsyncioSpec.py
@@ -17,6 +17,7 @@ AsyncioConcurrentClientRunner = java.type("micronaut.docs.asyncio.AsyncioConcurr
 @Property(name="micronaut.netty.event-loops.client.num-threads", value="1")
 @Property(name="micronaut.http.client.event-loop-group", value="client")
 @Property(name="micronaut.http.client.pool.max-pending-connections", value="64")
+@Property(name="micronaut.http.client.read-timeout", value="30s")
 @Property(name="micronaut.python.pool.enabled", value="true")
 @MicronautTest
 class PythonAsyncioSpec:


### PR DESCRIPTION
## Summary

- add the experimental ordered `GraalPyContextCustomizer` service-loaded SPI
- apply common context configuration and customizers to primary, pooled, asyncio, and reusable contexts
- add experimental callback-scoped `PythonContextExecutor` leasing with reusable-context serialization and execution tracking

## Compatibility

Existing bootstrap APIs and Python-only behavior remain unchanged. Callers must not retain a leased `Context` or context-owned `Value` beyond the callback.

## Verification

- `./gradlew :micronaut-context-python:compileJava`
- `./gradlew :micronaut-context-python:test` — build succeeds; test execution is skipped when GraalPy test environment variables are absent