### PR TITLE
feat: add incremental Python and Java compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ tasks.named("updateVersionCatalogs") {
 }
 
 if (System.getenv("SONAR_TOKEN") != null) {
-    // deprecated and compile time only classes excluded from coverage
-    def coverageExcludes = [
+    // deprecated and compile time only classes excluded from analysis
+    def analysisExcludes = [
         "**/StreamSoftServiceLoader.java",
         "**/ServiceDescriptionProcessor.java",
         "**/GraalReflectionConfigurer.java",
@@ -63,10 +63,15 @@ if (System.getenv("SONAR_TOKEN") != null) {
         "**/test/support/**",
         "**/micronaut/annotation/processing/test/**"
     ]
+    // Python module tests run in a separate CI workflow without Sonar coverage collection.
+    def coverageExcludes = [
+        "inject-python/src/main/java/**"
+    ]
     sonarqube {
         skipProject = project.name.contains("test")
         properties {
-            property "sonar.exclusions", coverageExcludes.join(",")
+            property "sonar.exclusions", analysisExcludes.join(",")
+            property "sonar.coverage.exclusions", coverageExcludes.join(",")
         }
     }
 }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -1,0 +1,1192 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.version.VersionUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Plans and records an incremental {@link PyronautCompiler} disk compilation.
+ */
+@Internal
+final class IncrementalCompilation {
+    private static final String STATE_FILE = "state.properties";
+    private static final String STATE_VERSION = "5";
+    private static final String SOURCE_PREFIX = "source.";
+    private static final String VFS_SOURCE_PREFIX = "META-INF/GRAALPY-VFS/micronaut-application/src/";
+    private static final String VFS_ROOT = "META-INF/GRAALPY-VFS/micronaut-application";
+    private static final Pattern JAVA_PACKAGE = Pattern.compile("(?m)^\\s*package\\s+([\\w.]+)\\s*;");
+    private static final Pattern JAVA_TYPE = Pattern.compile("\\b(?:class|interface|record|enum|@interface)\\s+([A-Za-z_$][\\w$]*)");
+    private static final Pattern PYTHON_TYPE = Pattern.compile("(?m)^\\s*class\\s+([A-Za-z_]\\w*)\\b");
+    private static final Pattern IDENTIFIER = Pattern.compile("[A-Za-z_$][\\w$]*(?:\\.[A-Za-z_$][\\w$]*)*");
+    private static final Pattern PYTHON_IMPORT = Pattern.compile(
+        "(?m)^\\s*(?:from\\s+([\\w.]+)\\s+import|import\\s+([\\w.]+))"
+    );
+    private static final Pattern DYNAMIC_PYTHON_REFERENCE = Pattern.compile(
+        "\\b(?:__import__|import_module|getattr|globals|locals)\\s*\\(|@\\s*Mixin\\b"
+    );
+
+    private final Path javaRoot;
+    private final List<Path> pythonRoots;
+    private final String pythonCode;
+    private final String packageName;
+    private final String applicationClass;
+    private final Path targetDirectory;
+    private final Path cacheDirectory;
+    private final List<File> classpath;
+    private final List<File> bootclasspath;
+    private final List<File> annotationProcessorPath;
+    private final List<String> compilerOptions;
+    private final boolean compilePythonBytecode;
+    private final List<String> processorTypes;
+    private final String globalFingerprint;
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    IncrementalCompilation(String javaSrc,
+                           String pythonSrc,
+                           String pythonCode,
+                           String packageName,
+                           String applicationClass,
+                           File targetDirectory,
+                           File cacheDirectory,
+                           List<File> classpath,
+                           List<File> bootclasspath,
+                           List<File> annotationProcessorPath,
+                           List<String> compilerOptions,
+                           boolean compilePythonBytecode,
+                           Collection<?> annotationProcessors,
+                           Collection<?> pythonSourceVisitors) {
+        this.javaRoot = normalizeNullable(javaSrc);
+        this.pythonRoots = parseRoots(pythonSrc);
+        this.pythonCode = pythonCode;
+        this.packageName = packageName;
+        this.applicationClass = applicationClass;
+        this.targetDirectory = targetDirectory.toPath().toAbsolutePath().normalize();
+        this.cacheDirectory = cacheDirectory.toPath().toAbsolutePath().normalize();
+        this.classpath = copy(classpath);
+        this.bootclasspath = copy(bootclasspath);
+        this.annotationProcessorPath = copy(annotationProcessorPath);
+        this.compilerOptions = compilerOptions == null ? List.of() : List.copyOf(compilerOptions);
+        this.compilePythonBytecode = compilePythonBytecode;
+        this.processorTypes = Stream.concat(annotationProcessors.stream(), pythonSourceVisitors.stream())
+            .map(value -> value.getClass().getName())
+            .sorted()
+            .toList();
+        validateDirectories();
+        this.globalFingerprint = fingerprintGlobalInputs();
+    }
+
+    Plan plan(boolean hasAggregatingProcessors) {
+        Map<String, ScannedSource> scannedSources = scanSources();
+        Map<String, SourceState> currentSources = createSourceStates(scannedSources);
+        State previous = readState();
+        if (previous == null
+            || !globalFingerprint.equals(previous.globalFingerprint())
+            || !previous.processorCompatible()
+            || hasMissingOutputs(previous)) {
+            return new Plan(
+                false,
+                true,
+                Set.copyOf(currentSources.keySet()),
+                Set.copyOf(currentSources.keySet()),
+                currentSources,
+                previous,
+                hasAggregatingProcessors,
+                hasAggregatingProcessors
+            );
+        }
+
+        Set<String> changed = changedSources(previous.sources(), currentSources);
+        if (changed.isEmpty()) {
+            return new Plan(
+                true,
+                false,
+                Set.of(),
+                Set.of(),
+                currentSources,
+                previous,
+                false,
+                hasAggregatingProcessors
+            );
+        }
+
+        Set<String> affected = affectedSources(changed, previous.sources(), currentSources);
+        if (requiresConservativePythonProcessing(affected, scannedSources)
+            || containsDeletedPythonSource(affected, currentSources, previous.sources())) {
+            currentSources.values().stream()
+                .filter(source -> source.language() == Language.PYTHON)
+                .map(SourceState::key)
+                .forEach(affected::add);
+        }
+        addPythonPackageInitializers(affected, currentSources);
+        Set<String> isolatingAffected = Set.copyOf(affected);
+        boolean aggregating = hasAggregatingProcessors || previous.aggregatingProcessors();
+        if (aggregating) {
+            affected = new LinkedHashSet<>(currentSources.keySet());
+            affected.addAll(changed);
+        }
+        addApplicationSourceWhenPythonChanges(affected, isolatingAffected, currentSources, previous.sources());
+        return new Plan(
+            false,
+            false,
+            Set.copyOf(affected),
+            isolatingAffected,
+            currentSources,
+            previous,
+            aggregating,
+            hasAggregatingProcessors
+        );
+    }
+
+    void prepareOutput(Plan plan) {
+        try {
+            if (plan.fullRebuild()) {
+                deleteTree(targetDirectory);
+                Files.createDirectories(targetDirectory);
+                return;
+            }
+            State previous = plan.previous();
+            if (previous == null) {
+                Files.createDirectories(targetDirectory);
+                return;
+            }
+            Set<String> outputs = new LinkedHashSet<>();
+            for (String source : plan.isolatingAffectedSources()) {
+                SourceState sourceState = previous.sources().get(source);
+                if (sourceState != null) {
+                    outputs.addAll(sourceState.outputs());
+                }
+            }
+            if (plan.aggregating()) {
+                outputs.addAll(previous.aggregatingOutputs());
+            } else if (affectsPython(plan)) {
+                outputs.addAll(previous.pythonAggregatingOutputs());
+            }
+            for (String output : outputs) {
+                deleteManagedOutput(output);
+            }
+            Files.createDirectories(targetDirectory);
+        } catch (IOException e) {
+            throw new PyronautCompilerException("Failed to prepare incremental compilation output: " + e.getMessage());
+        }
+    }
+
+    void complete(Plan plan, IncrementalCompilationTrace compilationTrace) {
+        try {
+            rebuildPythonFilesList();
+            Map<String, SourceState> enrichedSources = mergeCompilationTrace(plan, compilationTrace);
+            Map<String, SourceState> sources = assignOutputs(
+                enrichedSources,
+                listOutputs(),
+                compilationTrace.outputs(),
+                compilationTrace.aggregatingOutputs(),
+                compilationTrace.pythonProcessorOutputs(),
+                compilationTrace.contractViolatingOutputs()
+            );
+            Set<String> assigned = new HashSet<>();
+            sources.values().forEach(source -> assigned.addAll(source.outputs()));
+            Set<String> aggregatingOutputs = new LinkedHashSet<>(listOutputs());
+            aggregatingOutputs.removeAll(assigned);
+            aggregatingOutputs.addAll(compilationTrace.aggregatingOutputs());
+            Set<String> pythonAggregatingOutputs = new LinkedHashSet<>(
+                compilationTrace.pythonProcessorOutputs()
+            );
+            pythonAggregatingOutputs.removeAll(assigned);
+            if (!runsPythonProcessing(plan) && plan.previous() != null) {
+                pythonAggregatingOutputs.addAll(plan.previous().pythonAggregatingOutputs());
+                pythonAggregatingOutputs.retainAll(aggregatingOutputs);
+            }
+            boolean detectedAggregation = plan.detectedAggregatingProcessors()
+                || !compilationTrace.aggregatingOutputs().isEmpty();
+            boolean processorCompatible = compilationTrace.processorCompatible()
+                && compilationTrace.contractViolatingOutputs().isEmpty()
+                && (detectedAggregation
+                    || aggregatingOutputs.stream().allMatch(output ->
+                        pythonAggregatingOutputs.contains(output)
+                            || isKnownCompilerSharedOutput(output)));
+            writeState(new State(
+                globalFingerprint,
+                sources,
+                detectedAggregation ? Set.copyOf(sources.keySet()) : Set.of(),
+                Set.copyOf(aggregatingOutputs),
+                Set.copyOf(pythonAggregatingOutputs),
+                detectedAggregation,
+                processorCompatible
+            ));
+        } catch (IOException e) {
+            invalidate();
+            throw new PyronautCompilerException("Failed to record incremental compilation state: " + e.getMessage());
+        }
+    }
+
+    private static Map<String, SourceState> mergeCompilationTrace(Plan plan,
+                                                                  IncrementalCompilationTrace compilationTrace) {
+        Map<String, SourceState> result = new LinkedHashMap<>();
+        for (SourceState source : plan.currentSources().values()) {
+            Set<String> dependencies = new LinkedHashSet<>(source.dependencies());
+            Set<String> types = new LinkedHashSet<>(source.types());
+            if (compilationTrace.analyzedSources().contains(source.key())) {
+                dependencies.addAll(compilationTrace.dependencies().getOrDefault(source.key(), Set.of()));
+                types.addAll(compilationTrace.declaredTypes().getOrDefault(source.key(), Set.of()));
+            } else if (plan.previous() != null) {
+                SourceState previous = plan.previous().sources().get(source.key());
+                if (previous != null && previous.hash().equals(source.hash())) {
+                    dependencies.addAll(previous.dependencies());
+                    types.addAll(previous.types());
+                }
+            }
+            result.put(source.key(), new SourceState(
+                source.key(),
+                source.language(),
+                source.relativePath(),
+                source.hash(),
+                Set.copyOf(dependencies),
+                Set.of(),
+                Set.copyOf(types)
+            ));
+        }
+        return result;
+    }
+
+    void invalidate() {
+        try {
+            Files.deleteIfExists(cacheDirectory.resolve(STATE_FILE));
+        } catch (IOException ignored) {
+            // A missing or unreadable state file causes a full rebuild on the next invocation.
+        }
+    }
+
+    private boolean affectsPython(Plan plan) {
+        return plan.isolatingAffectedSources().stream()
+            .map(key -> plan.currentSources().getOrDefault(
+                key,
+                plan.previous() == null ? null : plan.previous().sources().get(key)
+            ))
+            .anyMatch(source -> source != null && source.language() == Language.PYTHON);
+    }
+
+    private boolean runsPythonProcessing(Plan plan) {
+        if (plan.runsPythonProcessing() || applicationClass == null) {
+            return plan.runsPythonProcessing();
+        }
+        return plan.affectedSources().stream()
+            .map(plan.currentSources()::get)
+            .filter(source -> source != null && source.language() == Language.JAVA)
+            .anyMatch(source -> source.types().contains(applicationClass));
+    }
+
+    private void addApplicationSourceWhenPythonChanges(Set<String> affected,
+                                                       Set<String> isolatingAffected,
+                                                       Map<String, SourceState> currentSources,
+                                                       Map<String, SourceState> previousSources) {
+        boolean pythonChanged = isolatingAffected.stream()
+            .map(key -> {
+                SourceState source = currentSources.get(key);
+                return source == null ? previousSources.get(key) : source;
+            })
+            .anyMatch(source -> source != null && source.language() == Language.PYTHON);
+        if (!pythonChanged || applicationClass == null || applicationClass.isBlank()) {
+            return;
+        }
+        currentSources.values().stream()
+            .filter(source -> source.language() == Language.JAVA)
+            .filter(source -> source.types().contains(applicationClass))
+            .map(SourceState::key)
+            .forEach(affected::add);
+    }
+
+    private static boolean requiresConservativePythonProcessing(Set<String> affected,
+                                                                Map<String, ScannedSource> scannedSources) {
+        if (affected.isEmpty()) {
+            return false;
+        }
+        Set<String> pythonModules = scannedSources.values().stream()
+            .filter(source -> source.state().language() == Language.PYTHON)
+            .map(source -> pythonModule(source.state().relativePath()))
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        return scannedSources.values().stream()
+            .filter(source -> source.state().language() == Language.PYTHON)
+            .anyMatch(source -> hasDynamicOrUnresolvedPythonRelationship(source, pythonModules));
+    }
+
+    private static boolean hasDynamicOrUnresolvedPythonRelationship(ScannedSource source,
+                                                                    Set<String> pythonModules) {
+        if (DYNAMIC_PYTHON_REFERENCE.matcher(source.content()).find()
+            || source.content().matches("(?s).*\\bfrom\\s+[\\w.]+\\s+import\\s+\\*.*")) {
+            return true;
+        }
+        Matcher imports = PYTHON_IMPORT.matcher(source.content());
+        while (imports.find()) {
+            String module = imports.group(1) != null ? imports.group(1) : imports.group(2);
+            if (module.startsWith(".")) {
+                String resolved = resolveRelativePythonModule(source.state().relativePath(), module);
+                if (!pythonModules.contains(resolved) && !pythonModules.contains(resolved + ".__init__")) {
+                    return true;
+                }
+                continue;
+            }
+            int separator = module.indexOf('.');
+            String topLevelModule = separator == -1 ? module : module.substring(0, separator);
+            boolean localPackage = pythonModules.stream()
+                .anyMatch(candidate -> candidate.equals(topLevelModule)
+                    || candidate.startsWith(topLevelModule + '.'));
+            if (localPackage
+                && !pythonModules.contains(module)
+                && !pythonModules.contains(module + ".__init__")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String resolveRelativePythonModule(String relativePath, String module) {
+        String currentPackage = pythonPackage(relativePath);
+        int parentCount = 0;
+        while (parentCount < module.length() && module.charAt(parentCount) == '.') {
+            parentCount++;
+        }
+        String resolvedPackage = currentPackage;
+        for (int i = 1; i < parentCount; i++) {
+            int separator = resolvedPackage.lastIndexOf('.');
+            resolvedPackage = separator == -1 ? "" : resolvedPackage.substring(0, separator);
+        }
+        String suffix = module.substring(parentCount);
+        if (resolvedPackage.isEmpty()) {
+            return suffix;
+        }
+        return suffix.isEmpty() ? resolvedPackage : resolvedPackage + '.' + suffix;
+    }
+
+    private static boolean containsDeletedPythonSource(Set<String> affected,
+                                                       Map<String, SourceState> currentSources,
+                                                       Map<String, SourceState> previousSources) {
+        return affected.stream()
+            .filter(Predicate.not(currentSources::containsKey))
+            .map(previousSources::get)
+            .anyMatch(source -> source != null && source.language() == Language.PYTHON);
+    }
+
+    private static void addPythonPackageInitializers(Set<String> affected,
+                                                     Map<String, SourceState> currentSources) {
+        boolean affectsPython = affected.stream()
+            .map(currentSources::get)
+            .anyMatch(source -> source != null && source.language() == Language.PYTHON);
+        if (!affectsPython) {
+            return;
+        }
+        currentSources.values().stream()
+            .filter(source -> source.language() == Language.PYTHON)
+            .filter(source -> source.relativePath().endsWith("/__init__.py")
+                || source.relativePath().equals("__init__.py"))
+            .map(SourceState::key)
+            .forEach(affected::add);
+    }
+
+    private static Set<String> changedSources(Map<String, SourceState> previous,
+                                              Map<String, SourceState> current) {
+        Set<String> changed = new LinkedHashSet<>();
+        for (Map.Entry<String, SourceState> entry : current.entrySet()) {
+            SourceState old = previous.get(entry.getKey());
+            if (old == null || !old.hash().equals(entry.getValue().hash())) {
+                changed.add(entry.getKey());
+            }
+        }
+        for (String source : previous.keySet()) {
+            if (!current.containsKey(source)) {
+                changed.add(source);
+            }
+        }
+        return changed;
+    }
+
+    private static Set<String> affectedSources(Set<String> changed,
+                                               Map<String, SourceState> previous,
+                                               Map<String, SourceState> current) {
+        Map<String, Set<String>> dependents = new HashMap<>();
+        Stream.concat(previous.values().stream(), current.values().stream()).forEach(source -> {
+            for (String dependency : source.dependencies()) {
+                dependents.computeIfAbsent(dependency, ignored -> new LinkedHashSet<>()).add(source.key());
+            }
+        });
+        Set<String> affected = new LinkedHashSet<>(changed);
+        ArrayDeque<String> queue = new ArrayDeque<>(changed);
+        while (!queue.isEmpty()) {
+            String source = queue.removeFirst();
+            for (String dependent : dependents.getOrDefault(source, Set.of())) {
+                if (affected.add(dependent)) {
+                    queue.addLast(dependent);
+                }
+            }
+        }
+        return affected;
+    }
+
+    private Map<String, ScannedSource> scanSources() {
+        Map<String, ScannedSource> sources = new LinkedHashMap<>();
+        if (javaRoot != null && Files.isDirectory(javaRoot)) {
+            scanRoot(javaRoot, ".java", Language.JAVA, sources);
+        }
+        for (Path pythonRoot : pythonRoots) {
+            if (Files.isDirectory(pythonRoot)) {
+                scanRoot(pythonRoot, ".py", Language.PYTHON, sources);
+            }
+        }
+        return sources;
+    }
+
+    private static void scanRoot(Path root,
+                                 String extension,
+                                 Language language,
+                                 Map<String, ScannedSource> sources) {
+        try (Stream<Path> paths = Files.walk(root)) {
+            paths.filter(Files::isRegularFile)
+                .filter(path -> path.getFileName().toString().endsWith(extension))
+                .sorted()
+                .forEach(path -> {
+                    try {
+                        Path normalized = normalizeSourcePath(path);
+                        String content = Files.readString(normalized);
+                        String relative = root.relativize(normalized).toString().replace(File.separatorChar, '/');
+                        Set<String> types = language == Language.JAVA
+                            ? javaTypes(content)
+                            : pythonTypes(content, relative);
+                        SourceState state = new SourceState(
+                            normalized.toString(),
+                            language,
+                            relative,
+                            hash(content.getBytes(StandardCharsets.UTF_8)),
+                            Set.of(),
+                            Set.of(),
+                            types
+                        );
+                        sources.put(state.key(), new ScannedSource(state, content));
+                    } catch (IOException e) {
+                        throw new SourceScanException(e);
+                    }
+                });
+        } catch (SourceScanException e) {
+            throw new PyronautCompilerException("Failed to read source: " + e.getCause().getMessage());
+        } catch (IOException e) {
+            throw new PyronautCompilerException("Failed to scan source directory " + root + ": " + e.getMessage());
+        }
+    }
+
+    private static Map<String, SourceState> createSourceStates(Map<String, ScannedSource> sources) {
+        Map<String, Set<String>> typeOwners = new HashMap<>();
+        Map<String, String> pythonModules = new HashMap<>();
+        for (ScannedSource source : sources.values()) {
+            for (String type : source.state().types()) {
+                typeOwners.computeIfAbsent(type, ignored -> new LinkedHashSet<>()).add(source.state().key());
+                int packageSeparator = type.lastIndexOf('.');
+                String simpleName = packageSeparator == -1 ? type : type.substring(packageSeparator + 1);
+                typeOwners.computeIfAbsent(simpleName, ignored -> new LinkedHashSet<>()).add(source.state().key());
+            }
+            if (source.state().language() == Language.PYTHON) {
+                String module = pythonModule(source.state().relativePath());
+                pythonModules.put(module, source.state().key());
+            }
+        }
+
+        Map<String, SourceState> result = new LinkedHashMap<>();
+        for (ScannedSource source : sources.values()) {
+            Set<String> dependencies = new LinkedHashSet<>();
+            Matcher identifiers = IDENTIFIER.matcher(source.content());
+            while (identifiers.find()) {
+                String identifier = identifiers.group();
+                while (true) {
+                    for (String owner : typeOwners.getOrDefault(identifier, Set.of())) {
+                        if (!owner.equals(source.state().key())) {
+                            dependencies.add(owner);
+                        }
+                    }
+                    int separator = identifier.lastIndexOf('.');
+                    if (separator == -1) {
+                        break;
+                    }
+                    identifier = identifier.substring(0, separator);
+                }
+            }
+            if (source.state().language() == Language.PYTHON) {
+                Matcher imports = PYTHON_IMPORT.matcher(source.content());
+                while (imports.find()) {
+                    String module = imports.group(1) != null ? imports.group(1) : imports.group(2);
+                    if (module.startsWith(".")) {
+                        module = resolveRelativePythonModule(source.state().relativePath(), module);
+                    }
+                    String owner = pythonModules.get(module);
+                    if (owner == null) {
+                        owner = pythonModules.get(module + ".__init__");
+                    }
+                    if (owner != null && !owner.equals(source.state().key())) {
+                        dependencies.add(owner);
+                    }
+                }
+            }
+            SourceState state = source.state();
+            result.put(state.key(), new SourceState(
+                state.key(),
+                state.language(),
+                state.relativePath(),
+                state.hash(),
+                Set.copyOf(dependencies),
+                Set.of(),
+                state.types()
+            ));
+        }
+        return result;
+    }
+
+    private static String pythonModule(String relativePath) {
+        return relativePath.substring(0, relativePath.length() - ".py".length()).replace('/', '.');
+    }
+
+    private static Set<String> javaTypes(String content) {
+        String packageName = "";
+        Matcher packageMatcher = JAVA_PACKAGE.matcher(content);
+        if (packageMatcher.find()) {
+            packageName = packageMatcher.group(1);
+        }
+        Set<String> types = new LinkedHashSet<>();
+        Matcher typeMatcher = JAVA_TYPE.matcher(content);
+        while (typeMatcher.find()) {
+            String type = typeMatcher.group(1);
+            types.add(packageName.isEmpty() ? type : packageName + '.' + type);
+        }
+        return Set.copyOf(types);
+    }
+
+    private static Set<String> pythonTypes(String content, String relativePath) {
+        String packageName = pythonPackage(relativePath);
+        Set<String> types = new LinkedHashSet<>();
+        Matcher matcher = PYTHON_TYPE.matcher(content);
+        while (matcher.find()) {
+            types.add(packageName + '.' + matcher.group(1));
+        }
+        String fileName = Path.of(relativePath).getFileName().toString();
+        String scriptName = fileName.substring(0, fileName.length() - ".py".length());
+        types.add(packageName + '.' + capitalize(scriptName));
+        return Set.copyOf(types);
+    }
+
+    private static String pythonPackage(String relativePath) {
+        int separator = relativePath.lastIndexOf('/');
+        if (separator == -1) {
+            return "python";
+        }
+        return relativePath.substring(0, separator).replace('/', '.');
+    }
+
+    private static String capitalize(String value) {
+        if (value.isEmpty()) {
+            return value;
+        }
+        return Character.toUpperCase(value.charAt(0)) + value.substring(1);
+    }
+
+    private Map<String, SourceState> assignOutputs(Map<String, SourceState> sources,
+                                                   Set<String> outputs,
+                                                   Map<String, Set<String>> trackedOutputs,
+                                                   Set<String> trackedAggregatingOutputs,
+                                                   Set<String> pythonProcessorOutputs,
+                                                   Set<String> contractViolatingOutputs) {
+        Map<String, Set<String>> assigned = new LinkedHashMap<>();
+        sources.keySet().forEach(key -> assigned.put(key, new LinkedHashSet<>()));
+        for (String output : outputs) {
+            if (trackedAggregatingOutputs.contains(output)) {
+                continue;
+            }
+            String owner = outputOwner(output, sources);
+            if (owner != null) {
+                assigned.get(owner).add(output);
+            }
+        }
+        trackedOutputs.forEach((source, sourceOutputs) -> {
+            Set<String> assignedOutputs = assigned.get(source);
+            if (assignedOutputs != null) {
+                sourceOutputs.stream()
+                    .filter(outputs::contains)
+                    .filter(Predicate.not(contractViolatingOutputs::contains))
+                    .filter(Predicate.not(pythonProcessorOutputs::contains))
+                    .filter(output -> !isAttributedToPythonSource(output, source, assigned, sources))
+                    .forEach(assignedOutputs::add);
+            }
+        });
+        Map<String, SourceState> result = new LinkedHashMap<>();
+        sources.forEach((key, source) -> result.put(key, new SourceState(
+            source.key(),
+            source.language(),
+            source.relativePath(),
+            source.hash(),
+            source.dependencies(),
+            Set.copyOf(assigned.get(key)),
+            source.types()
+        )));
+        return result;
+    }
+
+    private static boolean isAttributedToPythonSource(String output,
+                                                      String trackedSource,
+                                                      Map<String, Set<String>> assigned,
+                                                      Map<String, SourceState> sources) {
+        SourceState tracked = sources.get(trackedSource);
+        if (tracked == null || tracked.language() != Language.JAVA) {
+            return false;
+        }
+        return assigned.entrySet().stream()
+            .filter(entry -> !entry.getKey().equals(trackedSource))
+            .filter(entry -> entry.getValue().contains(output))
+            .map(entry -> sources.get(entry.getKey()))
+            .anyMatch(source -> source != null && source.language() == Language.PYTHON);
+    }
+
+    private static String outputOwner(String output, Map<String, SourceState> sources) {
+        if (output.startsWith(VFS_SOURCE_PREFIX)) {
+            String relative = output.substring(VFS_SOURCE_PREFIX.length());
+            for (SourceState source : sources.values()) {
+                if (source.language() != Language.PYTHON) {
+                    continue;
+                }
+                if (source.relativePath().endsWith("/__init__.py")
+                    || source.relativePath().equals("__init__.py")) {
+                    continue;
+                }
+                if (relative.equals(source.relativePath()) || isPythonBytecode(relative, source.relativePath())) {
+                    return source.key();
+                }
+            }
+            // Package initializers, launchers, indexes, and Java bridge modules are shared
+            // Python runtime outputs and must not be attributed by their filename.
+            return null;
+        }
+        String typePath = outputTypePath(output);
+        if (typePath != null) {
+            for (SourceState source : sources.values()) {
+                for (String type : source.types()) {
+                    if (typePath.equals(type.replace('.', '/'))) {
+                        return source.key();
+                    }
+                }
+            }
+        }
+        String fileName = Path.of(output).getFileName().toString();
+        String owner = null;
+        for (SourceState source : sources.values()) {
+            if (matchesAnyType(fileName, source.types())) {
+                if (owner != null && !owner.equals(source.key())) {
+                    return null;
+                }
+                owner = source.key();
+            }
+        }
+        return owner;
+    }
+
+    private static String outputTypePath(String output) {
+        if (!output.endsWith(".class")) {
+            return null;
+        }
+        String typePath = output.substring(0, output.length() - ".class".length());
+        int nestedType = typePath.indexOf('$');
+        return nestedType == -1 ? typePath : typePath.substring(0, nestedType);
+    }
+
+    private boolean isKnownCompilerSharedOutput(String output) {
+        String generatedApplicationPath = packageName.replace('.', '/') + "/PyronautMain";
+        return output.startsWith(VFS_ROOT + '/')
+            || output.startsWith(generatedApplicationPath)
+            || output.startsWith("META-INF/pyronaut/")
+            || output.startsWith("META-INF/services/")
+            || output.startsWith("META-INF/native-image/");
+    }
+
+    private static boolean isPythonBytecode(String output, String source) {
+        int separator = source.lastIndexOf('/');
+        String parent = separator == -1 ? "" : source.substring(0, separator + 1);
+        String file = separator == -1 ? source : source.substring(separator + 1);
+        String stem = file.substring(0, file.length() - ".py".length());
+        return output.startsWith(parent + "__pycache__/" + stem + '.')
+            && output.endsWith(".pyc");
+    }
+
+    private static boolean matchesAnyType(String fileName, Set<String> types) {
+        for (String type : types) {
+            int separator = type.lastIndexOf('.');
+            String simpleName = separator == -1 ? type : type.substring(separator + 1);
+            int index = fileName.indexOf(simpleName);
+            while (index >= 0) {
+                boolean before = index == 0 || isTypeBoundary(fileName.charAt(index - 1));
+                int end = index + simpleName.length();
+                boolean after = end == fileName.length()
+                    || isTypeBoundary(fileName.charAt(end))
+                    || fileName.startsWith("TargetTypeMapping", end);
+                if (before && after) {
+                    return true;
+                }
+                index = fileName.indexOf(simpleName, index + 1);
+            }
+        }
+        return false;
+    }
+
+    private static boolean isTypeBoundary(char character) {
+        return !Character.isLetterOrDigit(character) && character != '_';
+    }
+
+    private Set<String> listOutputs() throws IOException {
+        if (!Files.isDirectory(targetDirectory)) {
+            return Set.of();
+        }
+        try (Stream<Path> paths = Files.walk(targetDirectory)) {
+            return paths.filter(Files::isRegularFile)
+                .map(targetDirectory::relativize)
+                .map(path -> path.toString().replace(File.separatorChar, '/'))
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        }
+    }
+
+    private boolean hasMissingOutputs(State state) {
+        return Stream.concat(
+                state.sources().values().stream().flatMap(source -> source.outputs().stream()),
+                state.aggregatingOutputs().stream()
+            )
+            .map(targetDirectory::resolve)
+            .anyMatch(Predicate.not(Files::isRegularFile));
+    }
+
+    private void rebuildPythonFilesList() throws IOException {
+        Path vfsRoot = targetDirectory.resolve(VFS_ROOT);
+        if (!Files.isDirectory(vfsRoot)) {
+            return;
+        }
+        Path filesList = vfsRoot.resolve("fileslist.txt");
+        List<String> entries;
+        try (Stream<Path> paths = Files.walk(vfsRoot)) {
+            entries = paths.filter(Files::isRegularFile)
+                .filter(Predicate.not(filesList::equals))
+                .map(targetDirectory::relativize)
+                .map(path -> "/META-INF/" + path.toString().replace(File.separatorChar, '/')
+                    .substring("META-INF/".length()))
+                .sorted()
+                .toList();
+        }
+        Files.createDirectories(filesList.getParent());
+        Files.writeString(filesList, String.join(System.lineSeparator(), entries) + System.lineSeparator());
+    }
+
+    private void deleteManagedOutput(String output) throws IOException {
+        Path resolved = targetDirectory.resolve(output).normalize();
+        if (!resolved.startsWith(targetDirectory)) {
+            throw new IOException("Incremental state contains an output outside the target directory: " + output);
+        }
+        Files.deleteIfExists(resolved);
+        Path parent = resolved.getParent();
+        while (parent != null && !parent.equals(targetDirectory)) {
+            try {
+                Files.delete(parent);
+            } catch (IOException e) {
+                break;
+            }
+            parent = parent.getParent();
+        }
+    }
+
+    private State readState() {
+        Path stateFile = cacheDirectory.resolve(STATE_FILE);
+        if (!Files.isRegularFile(stateFile)) {
+            return null;
+        }
+        Properties properties = new Properties();
+        try (InputStream input = Files.newInputStream(stateFile)) {
+            properties.load(input);
+            if (!STATE_VERSION.equals(properties.getProperty("version"))) {
+                return null;
+            }
+            String fingerprint = properties.getProperty("global");
+            if (fingerprint == null) {
+                return null;
+            }
+            Map<String, SourceState> sources = new LinkedHashMap<>();
+            for (String property : properties.stringPropertyNames()) {
+                if (!property.startsWith(SOURCE_PREFIX) || !property.endsWith(".language")) {
+                    continue;
+                }
+                String encodedKey = property.substring(SOURCE_PREFIX.length(), property.length() - ".language".length());
+                String prefix = SOURCE_PREFIX + encodedKey + '.';
+                String key = decode(encodedKey);
+                SourceState state = new SourceState(
+                    key,
+                    Language.valueOf(properties.getProperty(prefix + "language")),
+                    required(properties, prefix + "relative"),
+                    required(properties, prefix + "hash"),
+                    decodeList(properties.getProperty(prefix + "dependencies", "")),
+                    decodeList(properties.getProperty(prefix + "outputs", "")),
+                    decodeList(properties.getProperty(prefix + "types", ""))
+                );
+                sources.put(key, state);
+            }
+            State state = new State(
+                fingerprint,
+                Map.copyOf(sources),
+                decodeList(properties.getProperty("aggregating.inputs", "")),
+                decodeList(properties.getProperty("aggregating.outputs", "")),
+                decodeList(properties.getProperty("python.aggregating.outputs", "")),
+                Boolean.parseBoolean(properties.getProperty("aggregating.processors", "false")),
+                Boolean.parseBoolean(properties.getProperty("processor.compatible", "true"))
+            );
+            return isValidState(state) ? state : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private boolean isValidState(State state) {
+        boolean validOutputs = Stream.concat(
+                state.sources().values().stream().flatMap(source -> source.outputs().stream()),
+                state.aggregatingOutputs().stream()
+            )
+            .allMatch(this::isManagedOutputPath);
+        return validOutputs
+            && state.aggregatingOutputs().containsAll(state.pythonAggregatingOutputs());
+    }
+
+    private boolean isManagedOutputPath(String output) {
+        if (output == null || output.isBlank()) {
+            return false;
+        }
+        try {
+            Path path = Path.of(output);
+            if (path.isAbsolute()) {
+                return false;
+            }
+            Path resolved = targetDirectory.resolve(path).normalize();
+            return !resolved.equals(targetDirectory) && resolved.startsWith(targetDirectory);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void writeState(State state) throws IOException {
+        Properties properties = new Properties();
+        properties.setProperty("version", STATE_VERSION);
+        properties.setProperty("global", state.globalFingerprint());
+        properties.setProperty("aggregating.inputs", encodeList(state.aggregatingInputs()));
+        properties.setProperty("aggregating.outputs", encodeList(state.aggregatingOutputs()));
+        properties.setProperty("python.aggregating.outputs", encodeList(state.pythonAggregatingOutputs()));
+        properties.setProperty("aggregating.processors", Boolean.toString(state.aggregatingProcessors()));
+        properties.setProperty("processor.compatible", Boolean.toString(state.processorCompatible()));
+        for (SourceState source : state.sources().values()) {
+            String prefix = SOURCE_PREFIX + encode(source.key()) + '.';
+            properties.setProperty(prefix + "language", source.language().name());
+            properties.setProperty(prefix + "relative", source.relativePath());
+            properties.setProperty(prefix + "hash", source.hash());
+            properties.setProperty(prefix + "dependencies", encodeList(source.dependencies()));
+            properties.setProperty(prefix + "outputs", encodeList(source.outputs()));
+            properties.setProperty(prefix + "types", encodeList(source.types()));
+        }
+        Files.createDirectories(cacheDirectory);
+        Path temporary = Files.createTempFile(cacheDirectory, "state-", ".tmp");
+        try {
+            try (OutputStream output = Files.newOutputStream(temporary)) {
+                properties.store(output, "Pyronaut incremental compilation state");
+            }
+            try {
+                Files.move(temporary, cacheDirectory.resolve(STATE_FILE),
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(temporary, cacheDirectory.resolve(STATE_FILE),
+                    StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private String fingerprintGlobalInputs() {
+        MessageDigest digest = digest();
+        update(digest, "state-version=" + STATE_VERSION);
+        update(digest, "micronaut-version=" + VersionUtils.MICRONAUT_VERSION);
+        update(digest, "java-root=" + javaRoot);
+        pythonRoots.forEach(root -> update(digest, "python-root=" + root));
+        update(digest, "target-directory=" + targetDirectory);
+        update(digest, "python-code=" + pythonCode);
+        update(digest, "package-name=" + packageName);
+        update(digest, "application-class=" + applicationClass);
+        update(digest, "python-bytecode=" + compilePythonBytecode);
+        compilerOptions.forEach(option -> update(digest, "option=" + option));
+        processorTypes.forEach(type -> update(digest, "processor=" + type));
+        hashEntries(digest, "classpath", classpath);
+        hashEntries(digest, "bootclasspath", bootclasspath);
+        hashEntries(digest, "processor-path", annotationProcessorPath);
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static void hashEntries(MessageDigest digest, String group, List<File> entries) {
+        update(digest, group);
+        for (File entry : entries) {
+            Path path = entry.toPath().toAbsolutePath().normalize();
+            update(digest, path.toString());
+            if (!Files.exists(path)) {
+                update(digest, "missing");
+            } else if (Files.isRegularFile(path)) {
+                updateFile(digest, path);
+            } else if (Files.isDirectory(path)) {
+                try (Stream<Path> paths = Files.walk(path)) {
+                    paths.filter(Files::isRegularFile)
+                        .sorted()
+                        .forEach(file -> {
+                            update(digest, path.relativize(file).toString());
+                            updateFile(digest, file);
+                        });
+                } catch (IOException e) {
+                    throw new PyronautCompilerException("Failed to fingerprint classpath directory " + path + ": " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    private static void updateFile(MessageDigest digest, Path file) {
+        try {
+            digest.update(Files.readAllBytes(file));
+            digest.update((byte) 0);
+        } catch (IOException e) {
+            throw new PyronautCompilerException("Failed to fingerprint " + file + ": " + e.getMessage());
+        }
+    }
+
+    private void validateDirectories() {
+        if (cacheDirectory.startsWith(targetDirectory) || targetDirectory.startsWith(cacheDirectory)) {
+            throw new IllegalArgumentException(
+                "incrementalCacheDirectory and targetDir must not contain one another"
+            );
+        }
+    }
+
+    private static List<Path> parseRoots(String roots) {
+        if (roots == null || roots.isBlank()) {
+            return List.of();
+        }
+        List<Path> result = new ArrayList<>();
+        StringTokenizer tokenizer = new StringTokenizer(roots, ",");
+        while (tokenizer.hasMoreTokens()) {
+            result.add(normalizeRoot(Path.of(tokenizer.nextToken().trim())));
+        }
+        return List.copyOf(result);
+    }
+
+    private static Path normalizeNullable(String value) {
+        return value == null || value.isBlank() ? null : normalizeRoot(Path.of(value));
+    }
+
+    private static Path normalizeRoot(Path path) {
+        try {
+            return path.toRealPath().normalize();
+        } catch (IOException e) {
+            return path.toAbsolutePath().normalize();
+        }
+    }
+
+    private static Path normalizeSourcePath(Path path) throws IOException {
+        return path.toRealPath().normalize();
+    }
+
+    private static List<File> copy(List<File> files) {
+        return files == null ? List.of() : List.copyOf(files);
+    }
+
+    private static void deleteTree(Path directory) throws IOException {
+        if (!Files.exists(directory)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(directory)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(path);
+            }
+        }
+    }
+
+    private static String hash(byte[] content) {
+        return HexFormat.of().formatHex(digest().digest(content));
+    }
+
+    private static MessageDigest digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private static void update(MessageDigest digest, String value) {
+        digest.update(String.valueOf(value).getBytes(StandardCharsets.UTF_8));
+        digest.update((byte) 0);
+    }
+
+    private static String required(Properties properties, String key) {
+        String value = properties.getProperty(key);
+        if (value == null) {
+            throw new IllegalArgumentException("Missing property: " + key);
+        }
+        return value;
+    }
+
+    private static String encode(String value) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String decode(String value) {
+        return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+    }
+
+    private static String encodeList(Collection<String> values) {
+        return values.stream().sorted().map(IncrementalCompilation::encode)
+            .collect(java.util.stream.Collectors.joining(","));
+    }
+
+    private static Set<String> decodeList(String value) {
+        if (value == null || value.isEmpty()) {
+            return Set.of();
+        }
+        return Stream.of(value.split(","))
+            .map(IncrementalCompilation::decode)
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+
+    record Plan(boolean upToDate,
+                boolean fullRebuild,
+                Set<String> affectedSources,
+                Set<String> isolatingAffectedSources,
+                Map<String, SourceState> currentSources,
+                State previous,
+                boolean aggregating,
+                boolean detectedAggregatingProcessors) {
+
+        Set<Path> javaSources() {
+            return affectedSources.stream()
+                .map(currentSources::get)
+                .filter(source -> source != null && source.language() == Language.JAVA)
+                .map(SourceState::key)
+                .map(Path::of)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        }
+
+        Set<String> pythonSources() {
+            return isolatingAffectedSources.stream()
+                .map(currentSources::get)
+                .filter(source -> source != null && source.language() == Language.PYTHON)
+                .map(SourceState::key)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        }
+
+        Set<String> currentPythonSources() {
+            return currentSources.values().stream()
+                .filter(source -> source.language() == Language.PYTHON)
+                .map(SourceState::key)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        }
+
+        boolean processesAllPythonSources() {
+            long pythonSourceCount = currentSources.values().stream()
+                .filter(source -> source.language() == Language.PYTHON)
+                .count();
+            return pythonSources().size() == pythonSourceCount;
+        }
+
+        boolean needsCompilation(boolean generatedApplicationClass) {
+            return !javaSources().isEmpty() || (generatedApplicationClass && affectsPythonSources());
+        }
+
+        boolean affectsPythonSources() {
+            if (!pythonSources().isEmpty()) {
+                return true;
+            }
+            if (previous == null) {
+                return false;
+            }
+            return isolatingAffectedSources.stream()
+                .map(previous.sources()::get)
+                .anyMatch(source -> source != null && source.language() == Language.PYTHON);
+        }
+
+        boolean runsPythonProcessing() {
+            return fullRebuild()
+                || affectsPythonSources()
+                || (aggregating() && !currentPythonSources().isEmpty());
+        }
+    }
+
+    private record State(String globalFingerprint,
+                         Map<String, SourceState> sources,
+                         Set<String> aggregatingInputs,
+                         Set<String> aggregatingOutputs,
+                         Set<String> pythonAggregatingOutputs,
+                         boolean aggregatingProcessors,
+                         boolean processorCompatible) {
+    }
+
+    private record SourceState(String key,
+                               Language language,
+                               String relativePath,
+                               String hash,
+                               Set<String> dependencies,
+                               Set<String> outputs,
+                               Set<String> types) {
+    }
+
+    private record ScannedSource(SourceState state, String content) {
+    }
+
+    private enum Language {
+        JAVA,
+        PYTHON
+    }
+
+    private static final class SourceScanException extends RuntimeException {
+        private SourceScanException(IOException cause) {
+            super(cause);
+        }
+    }
+}

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -59,13 +59,14 @@ final class IncrementalCompilation {
     private static final String SOURCE_PREFIX = "source.";
     private static final String VFS_SOURCE_PREFIX = "META-INF/GRAALPY-VFS/micronaut-application/src/";
     private static final String VFS_ROOT = "META-INF/GRAALPY-VFS/micronaut-application";
+    private static final String PYTHON_INIT_MODULE_SUFFIX = ".__init__";
     private static final Pattern JAVA_PACKAGE = Pattern.compile("(?m)^\\s*package\\s+([\\w.]+)\\s*;");
     private static final Pattern JAVA_TYPE = Pattern.compile("\\b(?:class|interface|record|enum|@interface)\\s+([A-Za-z_$][\\w$]*)");
     private static final Pattern PYTHON_TYPE = Pattern.compile("(?m)^\\s*class\\s+([A-Za-z_]\\w*)\\b");
-    private static final Pattern IDENTIFIER = Pattern.compile("[A-Za-z_$][\\w$]*(?:\\.[A-Za-z_$][\\w$]*)*");
-    private static final Pattern PYTHON_IMPORT = Pattern.compile(
-        "(?m)^\\s*(?:from\\s+([\\w.]+)\\s+import|import\\s+([\\w.]+))"
-    );
+    private static final Pattern IDENTIFIER = Pattern.compile("[A-Za-z_$][\\w$]*");
+    private static final Pattern PYTHON_FROM_IMPORT = Pattern.compile("(?m)^\\s*from\\s+(\\S+)\\s+import\\s+");
+    private static final Pattern PYTHON_DIRECT_IMPORT = Pattern.compile("(?m)^\\s*import\\s+([\\w.]+)");
+    private static final Pattern PYTHON_STAR_IMPORT = Pattern.compile("(?m)^\\s*from\\s+\\S+\\s+import\\s+\\*");
     private static final Pattern DYNAMIC_PYTHON_REFERENCE = Pattern.compile(
         "\\b(?:__import__|import_module|getattr|globals|locals)\\s*\\(|@\\s*Mixin\\b"
     );
@@ -86,7 +87,7 @@ final class IncrementalCompilation {
     private final PythonIncrementalMode pythonIncrementalMode;
     private final String globalFingerprint;
 
-    @SuppressWarnings("checkstyle:ParameterNumber")
+    @SuppressWarnings({"checkstyle:ParameterNumber", "java:S107"})
     IncrementalCompilation(String javaSrc,
                            String pythonSrc,
                            String pythonCode,
@@ -364,31 +365,42 @@ final class IncrementalCompilation {
     private static boolean hasDynamicOrUnresolvedPythonRelationship(ScannedSource source,
                                                                     Set<String> pythonModules) {
         if (DYNAMIC_PYTHON_REFERENCE.matcher(source.content()).find()
-            || source.content().matches("(?s).*\\bfrom\\s+[\\w.]+\\s+import\\s+\\*.*")) {
+            || PYTHON_STAR_IMPORT.matcher(source.content()).find()) {
             return true;
         }
-        Matcher imports = PYTHON_IMPORT.matcher(source.content());
-        while (imports.find()) {
-            String module = imports.group(1) != null ? imports.group(1) : imports.group(2);
+        for (String module : pythonImports(source.content())) {
             if (module.startsWith(".")) {
                 String resolved = resolveRelativePythonModule(source.state().relativePath(), module);
-                if (!pythonModules.contains(resolved) && !pythonModules.contains(resolved + ".__init__")) {
+                if (!pythonModules.contains(resolved) && !pythonModules.contains(resolved + PYTHON_INIT_MODULE_SUFFIX)) {
                     return true;
                 }
-                continue;
-            }
-            int separator = module.indexOf('.');
-            String topLevelModule = separator == -1 ? module : module.substring(0, separator);
-            boolean localPackage = pythonModules.stream()
-                .anyMatch(candidate -> candidate.equals(topLevelModule)
-                    || candidate.startsWith(topLevelModule + '.'));
-            if (localPackage
-                && !pythonModules.contains(module)
-                && !pythonModules.contains(module + ".__init__")) {
-                return true;
+            } else {
+                int separator = module.indexOf('.');
+                String topLevelModule = separator == -1 ? module : module.substring(0, separator);
+                boolean localPackage = pythonModules.stream()
+                    .anyMatch(candidate -> candidate.equals(topLevelModule)
+                        || candidate.startsWith(topLevelModule + '.'));
+                if (localPackage
+                    && !pythonModules.contains(module)
+                    && !pythonModules.contains(module + PYTHON_INIT_MODULE_SUFFIX)) {
+                    return true;
+                }
             }
         }
         return false;
+    }
+
+    private static Set<String> pythonImports(String content) {
+        Set<String> modules = new LinkedHashSet<>();
+        Matcher fromImports = PYTHON_FROM_IMPORT.matcher(content);
+        while (fromImports.find()) {
+            modules.add(fromImports.group(1));
+        }
+        Matcher directImports = PYTHON_DIRECT_IMPORT.matcher(content);
+        while (directImports.find()) {
+            modules.add(directImports.group(1));
+        }
+        return modules;
     }
 
     private static String resolveRelativePythonModule(String relativePath, String module) {
@@ -545,29 +557,21 @@ final class IncrementalCompilation {
             Matcher identifiers = IDENTIFIER.matcher(source.content());
             while (identifiers.find()) {
                 String identifier = identifiers.group();
-                while (true) {
-                    for (String owner : typeOwners.getOrDefault(identifier, Set.of())) {
-                        if (!owner.equals(source.state().key())) {
-                            dependencies.add(owner);
-                        }
+                for (String owner : typeOwners.getOrDefault(identifier, Set.of())) {
+                    if (!owner.equals(source.state().key())) {
+                        dependencies.add(owner);
                     }
-                    int separator = identifier.lastIndexOf('.');
-                    if (separator == -1) {
-                        break;
-                    }
-                    identifier = identifier.substring(0, separator);
                 }
             }
             if (source.state().language() == Language.PYTHON) {
-                Matcher imports = PYTHON_IMPORT.matcher(source.content());
-                while (imports.find()) {
-                    String module = imports.group(1) != null ? imports.group(1) : imports.group(2);
+                for (String importedModule : pythonImports(source.content())) {
+                    String module = importedModule;
                     if (module.startsWith(".")) {
                         module = resolveRelativePythonModule(source.state().relativePath(), module);
                     }
                     String owner = pythonModules.get(module);
                     if (owner == null) {
-                        owner = pythonModules.get(module + ".__init__");
+                        owner = pythonModules.get(module + PYTHON_INIT_MODULE_SUFFIX);
                     }
                     if (owner != null && !owner.equals(source.state().key())) {
                         dependencies.add(owner);
@@ -695,14 +699,11 @@ final class IncrementalCompilation {
         if (output.startsWith(VFS_SOURCE_PREFIX)) {
             String relative = output.substring(VFS_SOURCE_PREFIX.length());
             for (SourceState source : sources.values()) {
-                if (source.language() != Language.PYTHON) {
-                    continue;
-                }
-                if (source.relativePath().endsWith("/__init__.py")
-                    || source.relativePath().equals("__init__.py")) {
-                    continue;
-                }
-                if (relative.equals(source.relativePath()) || isPythonBytecode(relative, source.relativePath())) {
+                boolean isolatingPythonSource = source.language() == Language.PYTHON
+                    && !source.relativePath().endsWith("/__init__.py")
+                    && !source.relativePath().equals("__init__.py");
+                if (isolatingPythonSource
+                    && (relative.equals(source.relativePath()) || isPythonBytecode(relative, source.relativePath()))) {
                     return source.key();
                 }
             }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -83,6 +83,7 @@ final class IncrementalCompilation {
     private final List<String> compilerOptions;
     private final boolean compilePythonBytecode;
     private final List<String> processorTypes;
+    private final PythonIncrementalMode pythonIncrementalMode;
     private final String globalFingerprint;
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -99,7 +100,8 @@ final class IncrementalCompilation {
                            List<String> compilerOptions,
                            boolean compilePythonBytecode,
                            Collection<?> annotationProcessors,
-                           Collection<?> pythonSourceVisitors) {
+                           Collection<?> pythonSourceVisitors,
+                           PythonIncrementalMode pythonIncrementalMode) {
         this.javaRoot = normalizeNullable(javaSrc);
         this.pythonRoots = parseRoots(pythonSrc);
         this.pythonCode = pythonCode;
@@ -112,6 +114,7 @@ final class IncrementalCompilation {
         this.annotationProcessorPath = copy(annotationProcessorPath);
         this.compilerOptions = compilerOptions == null ? List.of() : List.copyOf(compilerOptions);
         this.compilePythonBytecode = compilePythonBytecode;
+        this.pythonIncrementalMode = pythonIncrementalMode;
         this.processorTypes = Stream.concat(annotationProcessors.stream(), pythonSourceVisitors.stream())
             .map(value -> value.getClass().getName())
             .sorted()
@@ -155,7 +158,8 @@ final class IncrementalCompilation {
         }
 
         Set<String> affected = affectedSources(changed, previous.sources(), currentSources);
-        if (requiresConservativePythonProcessing(affected, scannedSources)
+        if ((pythonIncrementalMode == PythonIncrementalMode.CONSERVATIVE
+            && requiresConservativePythonProcessing(affected, scannedSources))
             || containsDeletedPythonSource(affected, currentSources, previous.sources())) {
             currentSources.values().stream()
                 .filter(source -> source.language() == Language.PYTHON)
@@ -341,7 +345,11 @@ final class IncrementalCompilation {
 
     private static boolean requiresConservativePythonProcessing(Set<String> affected,
                                                                 Map<String, ScannedSource> scannedSources) {
-        if (affected.isEmpty()) {
+        boolean affectsPython = affected.stream()
+            .map(scannedSources::get)
+            .filter(java.util.Objects::nonNull)
+            .anyMatch(source -> source.state().language() == Language.PYTHON);
+        if (!affectsPython) {
             return false;
         }
         Set<String> pythonModules = scannedSources.values().stream()
@@ -956,6 +964,7 @@ final class IncrementalCompilation {
         update(digest, "package-name=" + packageName);
         update(digest, "application-class=" + applicationClass);
         update(digest, "python-bytecode=" + compilePythonBytecode);
+        update(digest, "python-incremental-mode=" + pythonIncrementalMode);
         compilerOptions.forEach(option -> update(digest, "option=" + option));
         processorTypes.forEach(type -> update(digest, "processor=" + type));
         hashEntries(digest, "classpath", classpath);

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -55,7 +55,7 @@ import java.util.stream.Stream;
 @Internal
 final class IncrementalCompilation {
     private static final String STATE_FILE = "state.properties";
-    private static final String STATE_VERSION = "6";
+    private static final String STATE_VERSION = "7";
     private static final String SOURCE_PREFIX = "source.";
     private static final String VFS_SOURCE_PREFIX = "META-INF/GRAALPY-VFS/micronaut-application/src/";
     private static final String VFS_ROOT = "META-INF/GRAALPY-VFS/micronaut-application";
@@ -177,7 +177,8 @@ final class IncrementalCompilation {
         Set<String> isolatingAffected = Set.copyOf(affected);
         Set<String> aggregationTriggers = new LinkedHashSet<>(previous.aggregatingInputs());
         aggregationTriggers.addAll(currentAggregatingInputs);
-        boolean aggregating = affected.stream().anyMatch(aggregationTriggers::contains);
+        boolean aggregating = affected.stream().anyMatch(aggregationTriggers::contains)
+            || pythonSharedInputsChanged(changed, previous.sources(), currentSources);
         if (aggregating) {
             affected.addAll(currentAggregatingInputs);
         }
@@ -262,7 +263,7 @@ final class IncrementalCompilation {
                 Set<String> declaredPythonOutputs = compilationTrace.pythonProcessorOutputs();
                 plan.previous().pythonAggregatingOutputs().stream()
                     .filter(output -> isBytecodeForDeclaredPythonOutput(output, declaredPythonOutputs)
-                        || (!plan.aggregating() && !output.startsWith(VFS_ROOT + '/')))
+                        || !plan.aggregating())
                     .forEach(pythonAggregatingOutputs::add);
                 Set<String> stalePythonOutputs = new LinkedHashSet<>(
                     plan.previous().pythonAggregatingOutputs()
@@ -330,6 +331,7 @@ final class IncrementalCompilation {
                 source.language(),
                 source.relativePath(),
                 source.hash(),
+                source.pythonSharedFingerprint(),
                 Set.copyOf(dependencies),
                 Set.of(),
                 Set.copyOf(types)
@@ -495,6 +497,24 @@ final class IncrementalCompilation {
         return changed;
     }
 
+    private static boolean pythonSharedInputsChanged(Set<String> changed,
+                                                     Map<String, SourceState> previous,
+                                                     Map<String, SourceState> current) {
+        for (String key : changed) {
+            SourceState old = previous.get(key);
+            SourceState replacement = current.get(key);
+            SourceState source = replacement == null ? old : replacement;
+            if (source != null
+                && source.language() == Language.PYTHON
+                && (old == null
+                    || replacement == null
+                    || !old.pythonSharedFingerprint().equals(replacement.pythonSharedFingerprint()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static Set<String> affectedSources(Set<String> changed,
                                                Map<String, SourceState> previous,
                                                Map<String, SourceState> current) {
@@ -551,6 +571,7 @@ final class IncrementalCompilation {
                             language,
                             relative,
                             hash(content.getBytes(StandardCharsets.UTF_8)),
+                            language == Language.PYTHON ? pythonSharedFingerprint(content) : "",
                             Set.of(),
                             Set.of(),
                             types
@@ -616,6 +637,7 @@ final class IncrementalCompilation {
                 state.language(),
                 state.relativePath(),
                 state.hash(),
+                state.pythonSharedFingerprint(),
                 Set.copyOf(dependencies),
                 Set.of(),
                 state.types()
@@ -626,6 +648,44 @@ final class IncrementalCompilation {
 
     private static String pythonModule(String relativePath) {
         return relativePath.substring(0, relativePath.length() - ".py".length()).replace('/', '.');
+    }
+
+    private static String pythonSharedFingerprint(String content) {
+        MessageDigest digest = digest();
+        boolean continuation = false;
+        int bracketDepth = 0;
+        for (String line : content.lines().toList()) {
+            String stripped = line.stripLeading();
+            boolean sharedInput = continuation
+                || stripped.startsWith("@")
+                || stripped.startsWith("class ")
+                || stripped.startsWith("def ")
+                || stripped.startsWith("async def ")
+                || stripped.startsWith("import ")
+                || stripped.startsWith("from ");
+            if (!sharedInput) {
+                continue;
+            }
+            update(digest, stripped);
+            bracketDepth += bracketDelta(stripped);
+            continuation = bracketDepth > 0 || stripped.endsWith("\\");
+            if (!continuation) {
+                bracketDepth = 0;
+            }
+        }
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static int bracketDelta(String line) {
+        int delta = 0;
+        for (int i = 0; i < line.length(); i++) {
+            delta += switch (line.charAt(i)) {
+                case '(', '[', '{' -> 1;
+                case ')', ']', '}' -> -1;
+                default -> 0;
+            };
+        }
+        return delta;
     }
 
     private static Set<String> javaTypes(String content) {
@@ -705,6 +765,7 @@ final class IncrementalCompilation {
             source.language(),
             source.relativePath(),
             source.hash(),
+            source.pythonSharedFingerprint(),
             source.dependencies(),
             Set.copyOf(assigned.get(key)),
             source.types()
@@ -919,6 +980,7 @@ final class IncrementalCompilation {
                     Language.valueOf(properties.getProperty(prefix + "language")),
                     required(properties, prefix + "relative"),
                     required(properties, prefix + "hash"),
+                    required(properties, prefix + "python.shared"),
                     decodeList(properties.getProperty(prefix + "dependencies", "")),
                     decodeList(properties.getProperty(prefix + "outputs", "")),
                     decodeList(properties.getProperty(prefix + "types", ""))
@@ -984,6 +1046,7 @@ final class IncrementalCompilation {
             properties.setProperty(prefix + "language", source.language().name());
             properties.setProperty(prefix + "relative", source.relativePath());
             properties.setProperty(prefix + "hash", source.hash());
+            properties.setProperty(prefix + "python.shared", source.pythonSharedFingerprint());
             properties.setProperty(prefix + "dependencies", encodeList(source.dependencies()));
             properties.setProperty(prefix + "outputs", encodeList(source.outputs()));
             properties.setProperty(prefix + "types", encodeList(source.types()));
@@ -1244,6 +1307,7 @@ final class IncrementalCompilation {
                                Language language,
                                String relativePath,
                                String hash,
+                               String pythonSharedFingerprint,
                                Set<String> dependencies,
                                Set<String> outputs,
                                Set<String> types) {

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -55,7 +55,7 @@ import java.util.stream.Stream;
 @Internal
 final class IncrementalCompilation {
     private static final String STATE_FILE = "state.properties";
-    private static final String STATE_VERSION = "5";
+    private static final String STATE_VERSION = "6";
     private static final String SOURCE_PREFIX = "source.";
     private static final String VFS_SOURCE_PREFIX = "META-INF/GRAALPY-VFS/micronaut-application/src/";
     private static final String VFS_ROOT = "META-INF/GRAALPY-VFS/micronaut-application";
@@ -124,9 +124,13 @@ final class IncrementalCompilation {
         this.globalFingerprint = fingerprintGlobalInputs();
     }
 
-    Plan plan(boolean hasAggregatingProcessors) {
+    Plan plan(Set<String> detectedAggregatingInputs) {
         Map<String, ScannedSource> scannedSources = scanSources();
         Map<String, SourceState> currentSources = createSourceStates(scannedSources);
+        Set<String> currentAggregatingInputs = detectedAggregatingInputs.stream()
+            .filter(currentSources::containsKey)
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        boolean hasAggregatingProcessors = !currentAggregatingInputs.isEmpty();
         State previous = readState();
         if (previous == null
             || !globalFingerprint.equals(previous.globalFingerprint())
@@ -140,6 +144,7 @@ final class IncrementalCompilation {
                 currentSources,
                 previous,
                 hasAggregatingProcessors,
+                currentAggregatingInputs,
                 hasAggregatingProcessors
             );
         }
@@ -154,6 +159,7 @@ final class IncrementalCompilation {
                 currentSources,
                 previous,
                 false,
+                currentAggregatingInputs,
                 hasAggregatingProcessors
             );
         }
@@ -169,10 +175,11 @@ final class IncrementalCompilation {
         }
         addPythonPackageInitializers(affected, currentSources);
         Set<String> isolatingAffected = Set.copyOf(affected);
-        boolean aggregating = hasAggregatingProcessors || previous.aggregatingProcessors();
+        Set<String> aggregationTriggers = new LinkedHashSet<>(previous.aggregatingInputs());
+        aggregationTriggers.addAll(currentAggregatingInputs);
+        boolean aggregating = affected.stream().anyMatch(aggregationTriggers::contains);
         if (aggregating) {
-            affected = new LinkedHashSet<>(currentSources.keySet());
-            affected.addAll(changed);
+            affected.addAll(currentAggregatingInputs);
         }
         addApplicationSourceWhenPythonChanges(affected, isolatingAffected, currentSources, previous.sources());
         return new Plan(
@@ -183,8 +190,14 @@ final class IncrementalCompilation {
             currentSources,
             previous,
             aggregating,
+            currentAggregatingInputs,
             hasAggregatingProcessors
         );
+    }
+
+    Plan plan(boolean hasAggregatingProcessors) {
+        Map<String, ScannedSource> scannedSources = scanSources();
+        return plan(hasAggregatingProcessors ? scannedSources.keySet() : Set.of());
     }
 
     void prepareOutput(Plan plan) {
@@ -208,8 +221,7 @@ final class IncrementalCompilation {
             }
             if (plan.aggregating()) {
                 outputs.addAll(previous.aggregatingOutputs());
-            } else if (affectsPython(plan)) {
-                outputs.addAll(previous.pythonAggregatingOutputs());
+                outputs.removeAll(previous.pythonAggregatingOutputs());
             }
             for (String output : outputs) {
                 deleteManagedOutput(output);
@@ -224,9 +236,10 @@ final class IncrementalCompilation {
         try {
             rebuildPythonFilesList();
             Map<String, SourceState> enrichedSources = mergeCompilationTrace(plan, compilationTrace);
+            Set<String> outputFiles = listOutputs();
             Map<String, SourceState> sources = assignOutputs(
                 enrichedSources,
-                listOutputs(),
+                outputFiles,
                 compilationTrace.outputs(),
                 compilationTrace.aggregatingOutputs(),
                 compilationTrace.pythonProcessorOutputs(),
@@ -234,31 +247,59 @@ final class IncrementalCompilation {
             );
             Set<String> assigned = new HashSet<>();
             sources.values().forEach(source -> assigned.addAll(source.outputs()));
-            Set<String> aggregatingOutputs = new LinkedHashSet<>(listOutputs());
-            aggregatingOutputs.removeAll(assigned);
-            aggregatingOutputs.addAll(compilationTrace.aggregatingOutputs());
+            Set<String> aggregatingOutputs = new LinkedHashSet<>(compilationTrace.aggregatingOutputs());
+            if (!plan.aggregating() && plan.previous() != null) {
+                aggregatingOutputs.addAll(plan.previous().aggregatingOutputs());
+            }
+            aggregatingOutputs.retainAll(outputFiles);
             Set<String> pythonAggregatingOutputs = new LinkedHashSet<>(
                 compilationTrace.pythonProcessorOutputs()
             );
             pythonAggregatingOutputs.removeAll(assigned);
             if (!runsPythonProcessing(plan) && plan.previous() != null) {
                 pythonAggregatingOutputs.addAll(plan.previous().pythonAggregatingOutputs());
-                pythonAggregatingOutputs.retainAll(aggregatingOutputs);
+            } else if (plan.previous() != null) {
+                Set<String> declaredPythonOutputs = compilationTrace.pythonProcessorOutputs();
+                plan.previous().pythonAggregatingOutputs().stream()
+                    .filter(output -> isBytecodeForDeclaredPythonOutput(output, declaredPythonOutputs)
+                        || (!plan.aggregating() && !output.startsWith(VFS_ROOT + '/')))
+                    .forEach(pythonAggregatingOutputs::add);
+                Set<String> stalePythonOutputs = new LinkedHashSet<>(
+                    plan.previous().pythonAggregatingOutputs()
+                );
+                stalePythonOutputs.removeAll(pythonAggregatingOutputs);
+                for (String staleOutput : stalePythonOutputs) {
+                    deleteManagedOutput(staleOutput);
+                }
+                outputFiles = listOutputs();
             }
-            boolean detectedAggregation = plan.detectedAggregatingProcessors()
+            pythonAggregatingOutputs.retainAll(outputFiles);
+            Set<String> sharedOutputs = new LinkedHashSet<>(outputFiles);
+            sharedOutputs.removeAll(assigned);
+            sharedOutputs.removeAll(aggregatingOutputs);
+            sharedOutputs.removeAll(pythonAggregatingOutputs);
+            Set<String> aggregatingInputs = plan.aggregatingInputs();
+            if ((plan.fullRebuild() || plan.aggregating())
+                && !compilationTrace.aggregatingInputs().isEmpty()) {
+                aggregatingInputs = compilationTrace.aggregatingInputs();
+            } else if (!plan.aggregating() && plan.previous() != null) {
+                aggregatingInputs = plan.previous().aggregatingInputs();
+            }
+            if (aggregatingInputs.isEmpty() && !compilationTrace.aggregatingOutputs().isEmpty()) {
+                aggregatingInputs = Set.copyOf(sources.keySet());
+            }
+            boolean detectedAggregation = !aggregatingInputs.isEmpty()
                 || !compilationTrace.aggregatingOutputs().isEmpty();
             boolean processorCompatible = compilationTrace.processorCompatible()
                 && compilationTrace.contractViolatingOutputs().isEmpty()
-                && (detectedAggregation
-                    || aggregatingOutputs.stream().allMatch(output ->
-                        pythonAggregatingOutputs.contains(output)
-                            || isKnownCompilerSharedOutput(output)));
+                && sharedOutputs.stream().allMatch(this::isKnownCompilerSharedOutput);
             writeState(new State(
                 globalFingerprint,
                 sources,
-                detectedAggregation ? Set.copyOf(sources.keySet()) : Set.of(),
+                aggregatingInputs,
                 Set.copyOf(aggregatingOutputs),
                 Set.copyOf(pythonAggregatingOutputs),
+                Set.copyOf(sharedOutputs),
                 detectedAggregation,
                 processorCompatible
             ));
@@ -303,15 +344,6 @@ final class IncrementalCompilation {
         } catch (IOException ignored) {
             // A missing or unreadable state file causes a full rebuild on the next invocation.
         }
-    }
-
-    private boolean affectsPython(Plan plan) {
-        return plan.isolatingAffectedSources().stream()
-            .map(key -> plan.currentSources().getOrDefault(
-                key,
-                plan.previous() == null ? null : plan.previous().sources().get(key)
-            ))
-            .anyMatch(source -> source != null && source.language() == Language.PYTHON);
     }
 
     private boolean runsPythonProcessing(Plan plan) {
@@ -748,6 +780,7 @@ final class IncrementalCompilation {
         return output.startsWith(VFS_ROOT + '/')
             || output.startsWith(generatedApplicationPath)
             || output.startsWith("META-INF/pyronaut/")
+            || output.startsWith("META-INF/swagger/views/")
             || output.startsWith("META-INF/services/")
             || output.startsWith("META-INF/native-image/");
     }
@@ -759,6 +792,18 @@ final class IncrementalCompilation {
         String stem = file.substring(0, file.length() - ".py".length());
         return output.startsWith(parent + "__pycache__/" + stem + '.')
             && output.endsWith(".pyc");
+    }
+
+    private static boolean isBytecodeForDeclaredPythonOutput(String output,
+                                                             Set<String> declaredPythonOutputs) {
+        if (!output.startsWith(VFS_SOURCE_PREFIX) || !output.endsWith(".pyc")) {
+            return false;
+        }
+        String relativeOutput = output.substring(VFS_SOURCE_PREFIX.length());
+        return declaredPythonOutputs.stream()
+            .filter(candidate -> candidate.startsWith(VFS_SOURCE_PREFIX) && candidate.endsWith(".py"))
+            .map(candidate -> candidate.substring(VFS_SOURCE_PREFIX.length()))
+            .anyMatch(source -> isPythonBytecode(relativeOutput, source));
     }
 
     private static boolean matchesAnyType(String fileName, Set<String> types) {
@@ -798,10 +843,13 @@ final class IncrementalCompilation {
     }
 
     private boolean hasMissingOutputs(State state) {
-        return Stream.concat(
+        return Stream.of(
                 state.sources().values().stream().flatMap(source -> source.outputs().stream()),
-                state.aggregatingOutputs().stream()
+                state.aggregatingOutputs().stream(),
+                state.pythonAggregatingOutputs().stream(),
+                state.sharedOutputs().stream()
             )
+            .flatMap(Stream::sequential)
             .map(targetDirectory::resolve)
             .anyMatch(Predicate.not(Files::isRegularFile));
     }
@@ -883,6 +931,7 @@ final class IncrementalCompilation {
                 decodeList(properties.getProperty("aggregating.inputs", "")),
                 decodeList(properties.getProperty("aggregating.outputs", "")),
                 decodeList(properties.getProperty("python.aggregating.outputs", "")),
+                decodeList(properties.getProperty("shared.outputs", "")),
                 Boolean.parseBoolean(properties.getProperty("aggregating.processors", "false")),
                 Boolean.parseBoolean(properties.getProperty("processor.compatible", "true"))
             );
@@ -893,13 +942,15 @@ final class IncrementalCompilation {
     }
 
     private boolean isValidState(State state) {
-        boolean validOutputs = Stream.concat(
+        boolean validOutputs = Stream.of(
                 state.sources().values().stream().flatMap(source -> source.outputs().stream()),
-                state.aggregatingOutputs().stream()
+                state.aggregatingOutputs().stream(),
+                state.pythonAggregatingOutputs().stream(),
+                state.sharedOutputs().stream()
             )
+            .flatMap(Stream::sequential)
             .allMatch(this::isManagedOutputPath);
-        return validOutputs
-            && state.aggregatingOutputs().containsAll(state.pythonAggregatingOutputs());
+        return validOutputs;
     }
 
     private boolean isManagedOutputPath(String output) {
@@ -925,6 +976,7 @@ final class IncrementalCompilation {
         properties.setProperty("aggregating.inputs", encodeList(state.aggregatingInputs()));
         properties.setProperty("aggregating.outputs", encodeList(state.aggregatingOutputs()));
         properties.setProperty("python.aggregating.outputs", encodeList(state.pythonAggregatingOutputs()));
+        properties.setProperty("shared.outputs", encodeList(state.sharedOutputs()));
         properties.setProperty("aggregating.processors", Boolean.toString(state.aggregatingProcessors()));
         properties.setProperty("processor.compatible", Boolean.toString(state.processorCompatible()));
         for (SourceState source : state.sources().values()) {
@@ -1112,6 +1164,7 @@ final class IncrementalCompilation {
                 Map<String, SourceState> currentSources,
                 State previous,
                 boolean aggregating,
+                Set<String> aggregatingInputs,
                 boolean detectedAggregatingProcessors) {
 
         Set<Path> javaSources() {
@@ -1164,7 +1217,16 @@ final class IncrementalCompilation {
         boolean runsPythonProcessing() {
             return fullRebuild()
                 || affectsPythonSources()
-                || (aggregating() && !currentPythonSources().isEmpty());
+                || aggregatingAffectsPythonSources();
+        }
+
+        boolean aggregatingAffectsPythonSources() {
+            if (!aggregating()) {
+                return false;
+            }
+            return aggregatingInputs.stream()
+                .map(currentSources::get)
+                .anyMatch(source -> source != null && source.language() == Language.PYTHON);
         }
     }
 
@@ -1173,6 +1235,7 @@ final class IncrementalCompilation {
                          Set<String> aggregatingInputs,
                          Set<String> aggregatingOutputs,
                          Set<String> pythonAggregatingOutputs,
+                         Set<String> sharedOutputs,
                          boolean aggregatingProcessors,
                          boolean processorCompatible) {
     }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilationTrace.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilationTrace.java
@@ -27,6 +27,7 @@ import java.util.Set;
  * @param dependencies The resolved source dependency graph
  * @param declaredTypes The types declared by each source
  * @param outputs The isolating outputs attributed to each source
+ * @param aggregatingInputs The sources contributing to aggregating processor outputs
  * @param aggregatingOutputs The outputs created by aggregating processors
  * @param pythonProcessorOutputs The outputs created by Python processing
  * @param contractViolatingOutputs The outputs with invalid isolating origins
@@ -36,19 +37,23 @@ record IncrementalCompilationTrace(Set<String> analyzedSources,
                                    Map<String, Set<String>> dependencies,
                                    Map<String, Set<String>> declaredTypes,
                                    Map<String, Set<String>> outputs,
+                                   Set<String> aggregatingInputs,
                                    Set<String> aggregatingOutputs,
                                    Set<String> pythonProcessorOutputs,
                                    Set<String> contractViolatingOutputs,
                                    boolean processorCompatible) {
 
     private static final IncrementalCompilationTrace EMPTY =
-        new IncrementalCompilationTrace(Set.of(), Map.of(), Map.of(), Map.of(), Set.of(), Set.of(), Set.of(), true);
+        new IncrementalCompilationTrace(
+            Set.of(), Map.of(), Map.of(), Map.of(), Set.of(), Set.of(), Set.of(), Set.of(), true
+        );
 
     IncrementalCompilationTrace {
         analyzedSources = Set.copyOf(analyzedSources);
         dependencies = immutableCopy(dependencies);
         declaredTypes = immutableCopy(declaredTypes);
         outputs = immutableCopy(outputs);
+        aggregatingInputs = Set.copyOf(aggregatingInputs);
         aggregatingOutputs = Set.copyOf(aggregatingOutputs);
         pythonProcessorOutputs = Set.copyOf(pythonProcessorOutputs);
         contractViolatingOutputs = Set.copyOf(contractViolatingOutputs);

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilationTrace.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilationTrace.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Compiler facts collected while javac processes the selected source set.
+ *
+ * @param analyzedSources The sources analyzed by javac
+ * @param dependencies The resolved source dependency graph
+ * @param declaredTypes The types declared by each source
+ * @param outputs The isolating outputs attributed to each source
+ * @param aggregatingOutputs The outputs created by aggregating processors
+ * @param pythonProcessorOutputs The outputs created by Python processing
+ * @param contractViolatingOutputs The outputs with invalid isolating origins
+ * @param processorCompatible Whether every processor supports incremental processing
+ */
+record IncrementalCompilationTrace(Set<String> analyzedSources,
+                                   Map<String, Set<String>> dependencies,
+                                   Map<String, Set<String>> declaredTypes,
+                                   Map<String, Set<String>> outputs,
+                                   Set<String> aggregatingOutputs,
+                                   Set<String> pythonProcessorOutputs,
+                                   Set<String> contractViolatingOutputs,
+                                   boolean processorCompatible) {
+
+    private static final IncrementalCompilationTrace EMPTY =
+        new IncrementalCompilationTrace(Set.of(), Map.of(), Map.of(), Map.of(), Set.of(), Set.of(), Set.of(), true);
+
+    IncrementalCompilationTrace {
+        analyzedSources = Set.copyOf(analyzedSources);
+        dependencies = immutableCopy(dependencies);
+        declaredTypes = immutableCopy(declaredTypes);
+        outputs = immutableCopy(outputs);
+        aggregatingOutputs = Set.copyOf(aggregatingOutputs);
+        pythonProcessorOutputs = Set.copyOf(pythonProcessorOutputs);
+        contractViolatingOutputs = Set.copyOf(contractViolatingOutputs);
+    }
+
+    static IncrementalCompilationTrace empty() {
+        return EMPTY;
+    }
+
+    private static Map<String, Set<String>> immutableCopy(Map<String, Set<String>> values) {
+        Map<String, Set<String>> copy = new LinkedHashMap<>();
+        values.forEach((key, value) -> copy.put(key, Set.copyOf(new LinkedHashSet<>(value))));
+        return Map.copyOf(copy);
+    }
+}

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalProcessorTracker.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalProcessorTracker.java
@@ -59,6 +59,7 @@ final class IncrementalProcessorTracker {
     private final JavaCompilationTracker compilationTracker;
     private final Path targetDirectory;
     private final Map<String, Set<String>> isolatingOutputs = new LinkedHashMap<>();
+    private final Set<String> aggregatingInputs = new LinkedHashSet<>();
     private final Set<String> aggregatingOutputs = new LinkedHashSet<>();
     private final Set<String> pythonProcessorOutputs = new LinkedHashSet<>();
     private final Set<String> contractViolatingOutputs = new LinkedHashSet<>();
@@ -79,10 +80,21 @@ final class IncrementalProcessorTracker {
             wrapped.add(new TrackingProcessor(
                 processor,
                 kind,
-                processor instanceof PythonAnnotationProcessor
+                processor instanceof PythonAnnotationProcessor,
+                !isMicronautBuiltInProcessor(processor)
             ));
         }
         return wrapped;
+    }
+
+    private static boolean isMicronautBuiltInProcessor(Processor processor) {
+        return processor instanceof AggregatingTypeElementVisitorProcessor
+            || processor instanceof AggregatingPackageElementVisitorProcessor
+            || processor instanceof MixinVisitorProcessor
+            || processor instanceof PackageElementVisitorProcessor
+            || processor instanceof TypeElementVisitorProcessor
+            || processor instanceof BeanDefinitionInjectProcessor
+            || processor instanceof PythonAnnotationProcessor;
     }
 
     Map<String, Set<String>> isolatingOutputs() {
@@ -91,6 +103,10 @@ final class IncrementalProcessorTracker {
 
     Set<String> aggregatingOutputs() {
         return aggregatingOutputs;
+    }
+
+    Set<String> aggregatingInputs() {
+        return aggregatingInputs;
     }
 
     Set<String> pythonProcessorOutputs() {
@@ -138,13 +154,16 @@ final class IncrementalProcessorTracker {
         private final Processor delegate;
         private final ProcessorKind kind;
         private final boolean pythonProcessor;
+        private final boolean strictIsolating;
 
         private TrackingProcessor(Processor delegate,
                                   ProcessorKind kind,
-                                  boolean pythonProcessor) {
+                                  boolean pythonProcessor,
+                                  boolean strictIsolating) {
             this.delegate = delegate;
             this.kind = kind;
             this.pythonProcessor = pythonProcessor;
+            this.strictIsolating = strictIsolating;
         }
 
         @Override
@@ -166,7 +185,12 @@ final class IncrementalProcessorTracker {
         public void init(ProcessingEnvironment processingEnvironment) {
             delegate.init(new TrackingProcessingEnvironment(
                 processingEnvironment,
-                new TrackingFiler(processingEnvironment.getFiler(), kind, pythonProcessor)
+                new TrackingFiler(
+                    processingEnvironment.getFiler(),
+                    kind,
+                    pythonProcessor,
+                    strictIsolating
+                )
             ));
         }
 
@@ -190,13 +214,16 @@ final class IncrementalProcessorTracker {
         private final Filer delegate;
         private final ProcessorKind kind;
         private final boolean pythonProcessor;
+        private final boolean strictIsolating;
 
         private TrackingFiler(Filer delegate,
                               ProcessorKind kind,
-                              boolean pythonProcessor) {
+                              boolean pythonProcessor,
+                              boolean strictIsolating) {
             this.delegate = delegate;
             this.kind = kind;
             this.pythonProcessor = pythonProcessor;
+            this.strictIsolating = strictIsolating;
         }
 
         private void trackOutput(FileObject output, Element... originatingElements) {
@@ -210,12 +237,19 @@ final class IncrementalProcessorTracker {
             }
             if (kind != ProcessorKind.ISOLATING) {
                 aggregatingOutputs.add(relativeOutput);
+                for (Element originatingElement : originatingElements) {
+                    String source = compilationTracker.sourceKey(originatingElement);
+                    if (source != null) {
+                        aggregatingInputs.add(source);
+                    }
+                }
                 return;
             }
             if (originatingElements.length != 1) {
-                if (pythonProcessor) {
+                if (pythonProcessor
+                    || (!strictIsolating && relativeOutput.startsWith("META-INF/swagger/views/"))) {
                     // Python processing produces shared VFS indexes, package initializers, and bridge
-                    // modules. They are tracked separately and replaced whenever Python is processed.
+                    // modules. The OpenAPI visitor also copies immutable UI assets without origins.
                     return;
                 }
                 contractViolatingOutputs.add(relativeOutput);
@@ -278,7 +312,11 @@ final class IncrementalProcessorTracker {
         public FileObject getResource(JavaFileManager.Location location,
                                       CharSequence moduleAndPkg,
                                       CharSequence relativeName) throws IOException {
-            return delegate.getResource(location, moduleAndPkg, relativeName);
+            FileObject resource = delegate.getResource(location, moduleAndPkg, relativeName);
+            if (pythonProcessor) {
+                trackOutput(resource);
+            }
+            return resource;
         }
     }
 

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalProcessorTracker.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalProcessorTracker.java
@@ -126,56 +126,11 @@ final class IncrementalProcessorTracker {
         return ProcessorKind.UNKNOWN;
     }
 
-    private void record(FileObject output,
-                        ProcessorKind kind,
-                        boolean pythonProcessor,
-                        Element... originatingElements) {
-        String relativeOutput = relativeOutput(output);
-        if (relativeOutput == null) {
-            processorCompatible = false;
-            return;
-        }
-        if (pythonProcessor) {
-            pythonProcessorOutputs.add(relativeOutput);
-        }
-        if (kind != ProcessorKind.ISOLATING) {
-            aggregatingOutputs.add(relativeOutput);
-            return;
-        }
-        if (originatingElements.length != 1) {
-            if (pythonProcessor) {
-                // Python processing produces shared VFS indexes, package initializers, and bridge
-                // modules. They are tracked separately and replaced whenever Python is processed.
-                return;
-            }
-            contractViolatingOutputs.add(relativeOutput);
-            return;
-        }
-        String source = compilationTracker.sourceKey(originatingElements[0]);
-        if (source != null) {
-            isolatingOutputs.computeIfAbsent(source, ignored -> new LinkedHashSet<>())
-                .add(relativeOutput);
-        }
-    }
-
     private static Path normalizeDirectory(Path directory) {
         try {
             return directory.toRealPath().normalize();
         } catch (IOException e) {
             return directory.toAbsolutePath().normalize();
-        }
-    }
-
-    private String relativeOutput(FileObject output) {
-        try {
-            Path outputPath = Path.of(output.toUri()).toAbsolutePath().normalize();
-            if (!outputPath.startsWith(targetDirectory)) {
-                return null;
-            }
-            return targetDirectory.relativize(outputPath).toString()
-                .replace(outputPath.getFileSystem().getSeparator(), "/");
-        } catch (Exception e) {
-            return null;
         }
     }
 
@@ -244,6 +199,48 @@ final class IncrementalProcessorTracker {
             this.pythonProcessor = pythonProcessor;
         }
 
+        private void trackOutput(FileObject output, Element... originatingElements) {
+            String relativeOutput = relativeOutput(output);
+            if (relativeOutput == null) {
+                processorCompatible = false;
+                return;
+            }
+            if (pythonProcessor) {
+                pythonProcessorOutputs.add(relativeOutput);
+            }
+            if (kind != ProcessorKind.ISOLATING) {
+                aggregatingOutputs.add(relativeOutput);
+                return;
+            }
+            if (originatingElements.length != 1) {
+                if (pythonProcessor) {
+                    // Python processing produces shared VFS indexes, package initializers, and bridge
+                    // modules. They are tracked separately and replaced whenever Python is processed.
+                    return;
+                }
+                contractViolatingOutputs.add(relativeOutput);
+                return;
+            }
+            String source = compilationTracker.sourceKey(originatingElements[0]);
+            if (source != null) {
+                isolatingOutputs.computeIfAbsent(source, ignored -> new LinkedHashSet<>())
+                    .add(relativeOutput);
+            }
+        }
+
+        private String relativeOutput(FileObject output) {
+            try {
+                Path outputPath = Path.of(output.toUri()).toAbsolutePath().normalize();
+                if (!outputPath.startsWith(targetDirectory)) {
+                    return null;
+                }
+                return targetDirectory.relativize(outputPath).toString()
+                    .replace(outputPath.getFileSystem().getSeparator(), "/");
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
         @Override
         public JavaFileObject createSourceFile(CharSequence name,
                                                Element... originatingElements) throws IOException {
@@ -255,7 +252,7 @@ final class IncrementalProcessorTracker {
                     originatingElements
                 );
             }
-            record(output, kind, pythonProcessor, originatingElements);
+            trackOutput(output, originatingElements);
             return output;
         }
 
@@ -263,7 +260,7 @@ final class IncrementalProcessorTracker {
         public JavaFileObject createClassFile(CharSequence name,
                                               Element... originatingElements) throws IOException {
             JavaFileObject output = delegate.createClassFile(name, originatingElements);
-            record(output, kind, pythonProcessor, originatingElements);
+            trackOutput(output, originatingElements);
             return output;
         }
 
@@ -273,7 +270,7 @@ final class IncrementalProcessorTracker {
                                          CharSequence relativeName,
                                          Element... originatingElements) throws IOException {
             FileObject output = delegate.createResource(location, moduleAndPkg, relativeName, originatingElements);
-            record(output, kind, pythonProcessor, originatingElements);
+            trackOutput(output, originatingElements);
             return output;
         }
 

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalProcessorTracker.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalProcessorTracker.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import io.micronaut.annotation.processing.AggregatingPackageElementVisitorProcessor;
+import io.micronaut.annotation.processing.AggregatingTypeElementVisitorProcessor;
+import io.micronaut.annotation.processing.BeanDefinitionInjectProcessor;
+import io.micronaut.annotation.processing.MixinVisitorProcessor;
+import io.micronaut.annotation.processing.PackageElementVisitorProcessor;
+import io.micronaut.annotation.processing.TypeElementVisitorProcessor;
+import io.micronaut.python.processing.PythonAnnotationProcessor;
+
+import javax.annotation.processing.Completion;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Decorates annotation processors so their Filer outputs can be classified without Gradle.
+ */
+final class IncrementalProcessorTracker {
+    private static final String ISOLATING_MARKER = "org.gradle.annotation.processing.isolating";
+    private static final String AGGREGATING_MARKER = "org.gradle.annotation.processing.aggregating";
+
+    private final JavaCompilationTracker compilationTracker;
+    private final Path targetDirectory;
+    private final Map<String, Set<String>> isolatingOutputs = new LinkedHashMap<>();
+    private final Set<String> aggregatingOutputs = new LinkedHashSet<>();
+    private final Set<String> pythonProcessorOutputs = new LinkedHashSet<>();
+    private final Set<String> contractViolatingOutputs = new LinkedHashSet<>();
+    private boolean processorCompatible = true;
+
+    IncrementalProcessorTracker(JavaCompilationTracker compilationTracker, Path targetDirectory) {
+        this.compilationTracker = compilationTracker;
+        this.targetDirectory = normalizeDirectory(targetDirectory);
+    }
+
+    List<Processor> wrap(List<Processor> processors) {
+        List<Processor> wrapped = new ArrayList<>(processors.size());
+        for (Processor processor : processors) {
+            ProcessorKind kind = processorKind(processor);
+            if (kind == ProcessorKind.UNKNOWN) {
+                processorCompatible = false;
+            }
+            wrapped.add(new TrackingProcessor(
+                processor,
+                kind,
+                processor instanceof PythonAnnotationProcessor
+            ));
+        }
+        return wrapped;
+    }
+
+    Map<String, Set<String>> isolatingOutputs() {
+        return isolatingOutputs;
+    }
+
+    Set<String> aggregatingOutputs() {
+        return aggregatingOutputs;
+    }
+
+    Set<String> pythonProcessorOutputs() {
+        return pythonProcessorOutputs;
+    }
+
+    Set<String> contractViolatingOutputs() {
+        return contractViolatingOutputs;
+    }
+
+    boolean processorCompatible() {
+        return processorCompatible;
+    }
+
+    private static ProcessorKind processorKind(Processor processor) {
+        Set<String> options = processor.getSupportedOptions();
+        boolean isolating = options.contains(ISOLATING_MARKER);
+        boolean aggregating = options.contains(AGGREGATING_MARKER);
+        if (isolating != aggregating) {
+            return isolating ? ProcessorKind.ISOLATING : ProcessorKind.AGGREGATING;
+        }
+        if (processor instanceof AggregatingTypeElementVisitorProcessor
+            || processor instanceof AggregatingPackageElementVisitorProcessor) {
+            return ProcessorKind.AGGREGATING;
+        }
+        if (processor instanceof MixinVisitorProcessor
+            || processor instanceof PackageElementVisitorProcessor
+            || processor instanceof TypeElementVisitorProcessor
+            || processor instanceof BeanDefinitionInjectProcessor
+            || processor instanceof PythonAnnotationProcessor) {
+            return ProcessorKind.ISOLATING;
+        }
+        return ProcessorKind.UNKNOWN;
+    }
+
+    private void record(FileObject output,
+                        ProcessorKind kind,
+                        boolean pythonProcessor,
+                        Element... originatingElements) {
+        String relativeOutput = relativeOutput(output);
+        if (relativeOutput == null) {
+            processorCompatible = false;
+            return;
+        }
+        if (pythonProcessor) {
+            pythonProcessorOutputs.add(relativeOutput);
+        }
+        if (kind != ProcessorKind.ISOLATING) {
+            aggregatingOutputs.add(relativeOutput);
+            return;
+        }
+        if (originatingElements.length != 1) {
+            if (pythonProcessor) {
+                // Python processing produces shared VFS indexes, package initializers, and bridge
+                // modules. They are tracked separately and replaced whenever Python is processed.
+                return;
+            }
+            contractViolatingOutputs.add(relativeOutput);
+            return;
+        }
+        String source = compilationTracker.sourceKey(originatingElements[0]);
+        if (source != null) {
+            isolatingOutputs.computeIfAbsent(source, ignored -> new LinkedHashSet<>())
+                .add(relativeOutput);
+        }
+    }
+
+    private static Path normalizeDirectory(Path directory) {
+        try {
+            return directory.toRealPath().normalize();
+        } catch (IOException e) {
+            return directory.toAbsolutePath().normalize();
+        }
+    }
+
+    private String relativeOutput(FileObject output) {
+        try {
+            Path outputPath = Path.of(output.toUri()).toAbsolutePath().normalize();
+            if (!outputPath.startsWith(targetDirectory)) {
+                return null;
+            }
+            return targetDirectory.relativize(outputPath).toString()
+                .replace(outputPath.getFileSystem().getSeparator(), "/");
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private final class TrackingProcessor implements Processor {
+        private final Processor delegate;
+        private final ProcessorKind kind;
+        private final boolean pythonProcessor;
+
+        private TrackingProcessor(Processor delegate,
+                                  ProcessorKind kind,
+                                  boolean pythonProcessor) {
+            this.delegate = delegate;
+            this.kind = kind;
+            this.pythonProcessor = pythonProcessor;
+        }
+
+        @Override
+        public Set<String> getSupportedOptions() {
+            return delegate.getSupportedOptions();
+        }
+
+        @Override
+        public Set<String> getSupportedAnnotationTypes() {
+            return delegate.getSupportedAnnotationTypes();
+        }
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return delegate.getSupportedSourceVersion();
+        }
+
+        @Override
+        public void init(ProcessingEnvironment processingEnvironment) {
+            delegate.init(new TrackingProcessingEnvironment(
+                processingEnvironment,
+                new TrackingFiler(processingEnvironment.getFiler(), kind, pythonProcessor)
+            ));
+        }
+
+        @Override
+        @SuppressWarnings("DoNotClaimAnnotations")
+        public boolean process(Set<? extends TypeElement> annotations,
+                               RoundEnvironment roundEnvironment) {
+            return delegate.process(annotations, roundEnvironment);
+        }
+
+        @Override
+        public Iterable<? extends Completion> getCompletions(Element element,
+                                                             AnnotationMirror annotation,
+                                                             ExecutableElement member,
+                                                             String userText) {
+            return delegate.getCompletions(element, annotation, member, userText);
+        }
+    }
+
+    private final class TrackingFiler implements Filer {
+        private final Filer delegate;
+        private final ProcessorKind kind;
+        private final boolean pythonProcessor;
+
+        private TrackingFiler(Filer delegate,
+                              ProcessorKind kind,
+                              boolean pythonProcessor) {
+            this.delegate = delegate;
+            this.kind = kind;
+            this.pythonProcessor = pythonProcessor;
+        }
+
+        @Override
+        public JavaFileObject createSourceFile(CharSequence name,
+                                               Element... originatingElements) throws IOException {
+            JavaFileObject output = delegate.createSourceFile(name, originatingElements);
+            if (kind == ProcessorKind.ISOLATING) {
+                compilationTracker.recordGeneratedSource(
+                    output,
+                    pythonProcessor,
+                    originatingElements
+                );
+            }
+            record(output, kind, pythonProcessor, originatingElements);
+            return output;
+        }
+
+        @Override
+        public JavaFileObject createClassFile(CharSequence name,
+                                              Element... originatingElements) throws IOException {
+            JavaFileObject output = delegate.createClassFile(name, originatingElements);
+            record(output, kind, pythonProcessor, originatingElements);
+            return output;
+        }
+
+        @Override
+        public FileObject createResource(JavaFileManager.Location location,
+                                         CharSequence moduleAndPkg,
+                                         CharSequence relativeName,
+                                         Element... originatingElements) throws IOException {
+            FileObject output = delegate.createResource(location, moduleAndPkg, relativeName, originatingElements);
+            record(output, kind, pythonProcessor, originatingElements);
+            return output;
+        }
+
+        @Override
+        public FileObject getResource(JavaFileManager.Location location,
+                                      CharSequence moduleAndPkg,
+                                      CharSequence relativeName) throws IOException {
+            return delegate.getResource(location, moduleAndPkg, relativeName);
+        }
+    }
+
+    private record TrackingProcessingEnvironment(ProcessingEnvironment delegate,
+                                                 Filer filer) implements ProcessingEnvironment {
+        @Override
+        public Map<String, String> getOptions() {
+            return delegate.getOptions();
+        }
+
+        @Override
+        public Messager getMessager() {
+            return delegate.getMessager();
+        }
+
+        @Override
+        public Filer getFiler() {
+            return filer;
+        }
+
+        @Override
+        public Elements getElementUtils() {
+            return delegate.getElementUtils();
+        }
+
+        @Override
+        public Types getTypeUtils() {
+            return delegate.getTypeUtils();
+        }
+
+        @Override
+        public SourceVersion getSourceVersion() {
+            return delegate.getSourceVersion();
+        }
+
+        @Override
+        public Locale getLocale() {
+            return delegate.getLocale();
+        }
+
+        @Override
+        public boolean isPreviewEnabled() {
+            return delegate.isPreviewEnabled();
+        }
+    }
+
+    private enum ProcessorKind {
+        ISOLATING,
+        AGGREGATING,
+        UNKNOWN
+    }
+}

--- a/inject-python/src/main/java/io/micronaut/python/compiler/JavaCompilationTracker.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/JavaCompilationTracker.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.JavaFileObject;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Records resolved source dependencies from the javac attribution phase.
+ */
+final class JavaCompilationTracker implements TaskListener {
+    private final Trees trees;
+    private final Set<String> analyzedSources = new LinkedHashSet<>();
+    private final Map<String, Set<String>> dependencies = new LinkedHashMap<>();
+    private final Map<String, Set<String>> declaredTypes = new LinkedHashMap<>();
+    private final Map<String, String> generatedSourceOrigins = new LinkedHashMap<>();
+    private final Set<String> pythonGeneratedSources = new LinkedHashSet<>();
+
+    JavaCompilationTracker(JavacTask task) {
+        this.trees = Trees.instance(task);
+    }
+
+    @Override
+    public void finished(TaskEvent event) {
+        if (event.getKind() != TaskEvent.Kind.ANALYZE || event.getCompilationUnit() == null) {
+            return;
+        }
+        CompilationUnitTree compilationUnit = event.getCompilationUnit();
+        String source = sourceKey(compilationUnit.getSourceFile());
+        if (source == null) {
+            return;
+        }
+        analyzedSources.add(source);
+        dependencies.computeIfAbsent(source, ignored -> new LinkedHashSet<>());
+        declaredTypes.computeIfAbsent(source, ignored -> new LinkedHashSet<>());
+        new ReferenceScanner(source).scan(compilationUnit, null);
+    }
+
+    IncrementalCompilationTrace trace(Map<String, Set<String>> outputs) {
+        return new IncrementalCompilationTrace(
+            analyzedSources,
+            dependencies,
+            declaredTypes,
+            outputs,
+            Set.of(),
+            Set.of(),
+            Set.of(),
+            true
+        );
+    }
+
+    String sourceKey(Element element) {
+        TypeElement owner = enclosingType(element);
+        if (owner == null) {
+            return null;
+        }
+        TreePath ownerPath = trees.getPath(owner);
+        return ownerPath == null
+            ? null
+            : sourceKey(ownerPath.getCompilationUnit().getSourceFile());
+    }
+
+    String sourceKey(JavaFileObject source) {
+        String key = fileSourceKey(source);
+        if (key == null) {
+            return null;
+        }
+        return generatedSourceOrigins.getOrDefault(key, key);
+    }
+
+    void recordGeneratedSource(JavaFileObject generatedSource,
+                               boolean pythonProcessor,
+                               Element... originatingElements) {
+        if (originatingElements.length != 1) {
+            return;
+        }
+        String generated = fileSourceKey(generatedSource);
+        String origin = sourceKey(originatingElements[0]);
+        if (generated != null && origin != null) {
+            generatedSourceOrigins.put(generated, origin);
+            if (pythonProcessor) {
+                pythonGeneratedSources.add(generated);
+            }
+        }
+    }
+
+    boolean isPythonGeneratedSource(JavaFileObject source) {
+        String key = fileSourceKey(source);
+        return key != null && pythonGeneratedSources.contains(key);
+    }
+
+    private static TypeElement enclosingType(Element element) {
+        Element current = element;
+        while (current != null && !(current instanceof TypeElement)) {
+            current = current.getEnclosingElement();
+        }
+        return current instanceof TypeElement typeElement ? typeElement : null;
+    }
+
+    private static String fileSourceKey(JavaFileObject source) {
+        if (source == null) {
+            return null;
+        }
+        try {
+            URI uri = source.toUri();
+            if (!"file".equalsIgnoreCase(uri.getScheme())) {
+                return null;
+            }
+            Path path = Path.of(uri);
+            return Files.exists(path)
+                ? path.toRealPath().normalize().toString()
+                : path.toAbsolutePath().normalize().toString();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private final class ReferenceScanner extends TreePathScanner<Void, Void> {
+        private final String source;
+
+        private ReferenceScanner(String source) {
+            this.source = source;
+        }
+
+        @Override
+        public Void visitClass(com.sun.source.tree.ClassTree node, Void unused) {
+            Element element = trees.getElement(getCurrentPath());
+            if (element instanceof TypeElement typeElement) {
+                declaredTypes.get(source).add(typeElement.getQualifiedName().toString());
+            }
+            return super.visitClass(node, null);
+        }
+
+        @Override
+        public Void visitIdentifier(IdentifierTree node, Void unused) {
+            recordReference(getCurrentPath());
+            return super.visitIdentifier(node, null);
+        }
+
+        @Override
+        public Void visitMemberSelect(MemberSelectTree node, Void unused) {
+            recordReference(getCurrentPath());
+            return super.visitMemberSelect(node, null);
+        }
+
+        @Override
+        public Void visitMemberReference(MemberReferenceTree node, Void unused) {
+            recordReference(getCurrentPath());
+            return super.visitMemberReference(node, null);
+        }
+
+        private void recordReference(TreePath path) {
+            Element element = trees.getElement(path);
+            String dependency = sourceKey(element);
+            if (dependency != null && !source.equals(dependency)) {
+                dependencies.get(source).add(dependency);
+            }
+        }
+    }
+}

--- a/inject-python/src/main/java/io/micronaut/python/compiler/JavaCompilationTracker.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/JavaCompilationTracker.java
@@ -77,6 +77,7 @@ final class JavaCompilationTracker implements TaskListener {
             Set.of(),
             Set.of(),
             Set.of(),
+            Set.of(),
             true
         );
     }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
@@ -30,7 +30,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.processing.Processor;
 import java.util.StringTokenizer;
 import java.util.function.Consumer;
@@ -72,6 +74,8 @@ public final class PyronautCompiler {
     private final File errorDumpDirectory;
     private final List<PythonSourceVisitor> pythonSourceVisitors;
     private final List<Processor> annotationProcessors;
+    private final boolean incremental;
+    private final File incrementalCacheDirectory;
 
     private PyronautCompiler(Builder builder) {
         this.packageName = builder.packageName;
@@ -92,6 +96,8 @@ public final class PyronautCompiler {
         this.errorDumpDirectory = builder.errorDumpDirectory;
         this.annotationProcessors = builder.annotationProcessors == null ? List.of() : List.copyOf(builder.annotationProcessors);
         this.pythonSourceVisitors = builder.pythonSourceVisitors == null ? List.of() : List.copyOf(builder.pythonSourceVisitors);
+        this.incremental = builder.incremental;
+        this.incrementalCacheDirectory = builder.incrementalCacheDirectory;
         validateConfiguration();
     }
 
@@ -163,8 +169,136 @@ public final class PyronautCompiler {
         }
 
         PyronautJavaCompiler compiler = createCompiler();
-        JavaFileObject[] sources = createJavaSources();
-        compiler.compileToDisk(targetDir, sources, classpath, bootclasspath, annotationProcessorPath, compilerOptions);
+        if (!incremental) {
+            JavaFileObject[] sources = createJavaSources();
+            compiler.compileToDisk(targetDir, sources, classpath, bootclasspath, annotationProcessorPath, compilerOptions);
+            return;
+        }
+
+        File cacheDirectory = incrementalCacheDirectory != null
+            ? incrementalCacheDirectory
+            : defaultIncrementalCacheDirectory();
+        List<String> incrementalCompilerOptions = incrementalCompilerOptions();
+        IncrementalCompilation incrementalCompilation = new IncrementalCompilation(
+            javaSrc,
+            pythonSrc,
+            pythonCode,
+            getPackageName(),
+            applicationClass,
+            targetDir,
+            cacheDirectory,
+            classpath,
+            bootclasspath,
+            annotationProcessorPath,
+            incrementalCompilerOptions,
+            compilePythonBytecode,
+            annotationProcessors,
+            pythonSourceVisitors
+        );
+        boolean aggregating = compiler.hasAggregatingProcessors(
+            classpath,
+            annotationProcessorPath,
+            javaSrc,
+            pythonSrc
+        );
+        IncrementalCompilation.Plan plan = incrementalCompilation.plan(aggregating);
+        if (plan.upToDate()) {
+            return;
+        }
+        try {
+            IncrementalCompilationTrace compilationTrace = compileIncrementally(
+                compiler,
+                incrementalCompilation,
+                plan,
+                incrementalCompilerOptions
+            );
+            if (!plan.fullRebuild()
+                && (!compilationTrace.processorCompatible()
+                    || !compilationTrace.contractViolatingOutputs().isEmpty())) {
+                incrementalCompilation.invalidate();
+                if (!annotationProcessors.isEmpty()) {
+                    incrementalCompilation.prepareOutput(incrementalCompilation.plan(aggregating));
+                    throw new PyronautCompilerException(
+                        "An explicitly supplied annotation processor violated its incremental "
+                            + "contract; the output was cleaned and must be compiled again with "
+                            + "fresh processor instances"
+                    );
+                }
+                plan = incrementalCompilation.plan(aggregating);
+                compilationTrace = compileIncrementally(
+                    compiler,
+                    incrementalCompilation,
+                    plan,
+                    incrementalCompilerOptions
+                );
+            }
+            incrementalCompilation.complete(plan, compilationTrace);
+        } catch (RuntimeException e) {
+            incrementalCompilation.invalidate();
+            throw e;
+        }
+    }
+
+    private IncrementalCompilationTrace compileIncrementally(
+        PyronautJavaCompiler compiler,
+        IncrementalCompilation incrementalCompilation,
+        IncrementalCompilation.Plan plan,
+        List<String> incrementalCompilerOptions
+    ) {
+        incrementalCompilation.prepareOutput(plan);
+        boolean includeGeneratedApplication = applicationClass == null
+            && (plan.fullRebuild()
+                || plan.affectsPythonSources()
+                || (plan.aggregating() && !plan.currentPythonSources().isEmpty()));
+        if (plan.fullRebuild() || !plan.processesAllPythonSources()) {
+            compiler.setIncrementalPythonSources(
+                plan.fullRebuild() ? null : plan.pythonSources()
+            );
+        }
+        JavaFileObject[] sources = createJavaSources(plan.javaSources(), includeGeneratedApplication);
+        if (sources.length == 0) {
+            return IncrementalCompilationTrace.empty();
+        }
+        List<File> effectiveClasspath = plan.fullRebuild()
+            ? classpath
+            : appendClasspath(classpath, targetDir);
+        return compiler.compileToDisk(
+            targetDir,
+            sources,
+            effectiveClasspath,
+            bootclasspath,
+            annotationProcessorPath,
+            incrementalCompilerOptions
+        );
+    }
+
+    private File defaultIncrementalCacheDirectory() {
+        File absoluteTarget = targetDir.getAbsoluteFile();
+        File parent = absoluteTarget.getParentFile();
+        if (parent == null) {
+            parent = new File(".").getAbsoluteFile();
+        }
+        return new File(parent, "." + absoluteTarget.getName() + "-incremental");
+    }
+
+    private static List<File> appendClasspath(List<File> classpath, File entry) {
+        Set<File> result = new LinkedHashSet<>();
+        if (classpath != null) {
+            result.addAll(classpath);
+        }
+        result.add(entry);
+        return List.copyOf(result);
+    }
+
+    private List<String> incrementalCompilerOptions() {
+        List<String> options = new ArrayList<>();
+        if (compilerOptions != null) {
+            compilerOptions.stream()
+                .filter(option -> !option.startsWith("-Amicronaut.processing.incremental="))
+                .forEach(options::add);
+        }
+        options.add("-Amicronaut.processing.incremental=true");
+        return List.copyOf(options);
     }
 
     private PyronautJavaCompiler createCompiler() {
@@ -195,12 +329,17 @@ public final class PyronautCompiler {
     }
 
     private JavaFileObject[] createJavaSources() {
+        return createJavaSources(null, true);
+    }
+
+    private JavaFileObject[] createJavaSources(Set<Path> selectedSources,
+                                               boolean includeGeneratedApplication) {
         List<JavaFileObject> sources = new ArrayList<>();
 
         // Add user-provided Java sources if specified
         if (javaSrc != null && !javaSrc.isEmpty()) {
             try {
-                addJavaSourcesFromDirectory(sources, Paths.get(javaSrc));
+                addJavaSourcesFromDirectory(sources, Paths.get(javaSrc), selectedSources);
             } catch (IOException e) {
                 throw new RuntimeException("Failed to read Java sources from: " + javaSrc, e);
             }
@@ -212,7 +351,7 @@ public final class PyronautCompiler {
                 throw new IllegalArgumentException("javaSrc must be specified when applicationClass is provided");
             }
             // The application class should already be in the sources list from javaSrc
-        } else {
+        } else if (includeGeneratedApplication) {
             // Generate the default PyronautMain class
             String className = getPackageName() + ".PyronautMain";
             String sourceCode = generateMainClassSource();
@@ -262,7 +401,9 @@ public final class PyronautCompiler {
         }
     }
 
-    private void addJavaSourcesFromDirectory(List<JavaFileObject> sources, Path dir) throws IOException {
+    private void addJavaSourcesFromDirectory(List<JavaFileObject> sources,
+                                             Path dir,
+                                             Set<Path> selectedSources) throws IOException {
         if (!Files.isDirectory(dir)) {
             return;
         }
@@ -270,11 +411,13 @@ public final class PyronautCompiler {
         try (Stream<Path> paths = Files.walk(dir)) {
             paths.filter(Files::isRegularFile)
                  .filter(path -> path.toString().endsWith(".java"))
+                 .filter(path -> selectedSources == null
+                     || selectedSources.contains(normalizeSourcePath(path)))
                  .forEach(path -> {
                      try {
                          String content = Files.readString(path);
                          sources.add(new SimpleJavaFileObject(
-                             java.net.URI.create("file:///" + path),
+                             path.toAbsolutePath().normalize().toUri(),
                              JavaFileObject.Kind.SOURCE
                          ) {
                              @Override
@@ -286,6 +429,14 @@ public final class PyronautCompiler {
                          throw new RuntimeException("Failed to read Java source: " + path, e);
                      }
                  });
+        }
+    }
+
+    private static Path normalizeSourcePath(Path path) {
+        try {
+            return path.toRealPath().normalize();
+        } catch (IOException e) {
+            return path.toAbsolutePath().normalize();
         }
     }
 
@@ -363,6 +514,8 @@ public final class PyronautCompiler {
         private File errorDumpDirectory;
         private List<PythonSourceVisitor> pythonSourceVisitors;
         private List<Processor> annotationProcessors;
+        private boolean incremental;
+        private File incrementalCacheDirectory;
 
         private Builder() {
         }
@@ -540,6 +693,32 @@ public final class PyronautCompiler {
         }
 
         /**
+         * Enable incremental disk compilation. Incremental compilation is disabled by default and
+         * has no effect on {@link PyronautCompiler#buildClassLoader()}.
+         *
+         * @param incremental Whether disk compilation should reuse compatible previous outputs
+         * @return This builder
+         * @since 5.2.0
+         */
+        public Builder incremental(boolean incremental) {
+            this.incremental = incremental;
+            return this;
+        }
+
+        /**
+         * Set the directory used to persist incremental compilation state. The directory must not
+         * contain, or be contained by, the target output directory.
+         *
+         * @param incrementalCacheDirectory The incremental compilation state directory
+         * @return This builder
+         * @since 5.2.0
+         */
+        public Builder incrementalCacheDirectory(File incrementalCacheDirectory) {
+            this.incrementalCacheDirectory = incrementalCacheDirectory;
+            return this;
+        }
+
+        /**
          * Set the directory used for full compiler error dump files.
          *
          * @param errorDumpDirectory The dump directory
@@ -551,6 +730,8 @@ public final class PyronautCompiler {
         }
 
         /**
+         * Supplies visitors for Python source metadata.
+         *
          * @param pythonSourceVisitors visitors to invoke for Python source metadata in this compilation
          * @return this builder
          */

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
@@ -198,13 +198,13 @@ public final class PyronautCompiler {
             pythonSourceVisitors,
             pythonIncrementalMode
         );
-        boolean aggregating = compiler.hasAggregatingProcessors(
+        Set<String> aggregatingSources = compiler.aggregatingSources(
             classpath,
             annotationProcessorPath,
             javaSrc,
             pythonSrc
         );
-        IncrementalCompilation.Plan plan = incrementalCompilation.plan(aggregating);
+        IncrementalCompilation.Plan plan = incrementalCompilation.plan(aggregatingSources);
         if (plan.upToDate()) {
             return;
         }
@@ -220,14 +220,14 @@ public final class PyronautCompiler {
                     || !compilationTrace.contractViolatingOutputs().isEmpty())) {
                 incrementalCompilation.invalidate();
                 if (!annotationProcessors.isEmpty()) {
-                    incrementalCompilation.prepareOutput(incrementalCompilation.plan(aggregating));
+                    incrementalCompilation.prepareOutput(incrementalCompilation.plan(aggregatingSources));
                     throw new PyronautCompilerException(
                         "An explicitly supplied annotation processor violated its incremental "
                             + "contract; the output was cleaned and must be compiled again with "
                             + "fresh processor instances"
                     );
                 }
-                plan = incrementalCompilation.plan(aggregating);
+                plan = incrementalCompilation.plan(aggregatingSources);
                 compilationTrace = compileIncrementally(
                     compiler,
                     incrementalCompilation,
@@ -249,10 +249,11 @@ public final class PyronautCompiler {
         List<String> incrementalCompilerOptions
     ) {
         incrementalCompilation.prepareOutput(plan);
+        compiler.setProcessAggregatingPythonVisitors(plan.fullRebuild() || plan.aggregating());
         boolean includeGeneratedApplication = applicationClass == null
             && (plan.fullRebuild()
                 || plan.affectsPythonSources()
-                || (plan.aggregating() && !plan.currentPythonSources().isEmpty()));
+                || plan.aggregatingAffectsPythonSources());
         if (plan.fullRebuild() || !plan.processesAllPythonSources()) {
             compiler.setIncrementalPythonSources(
                 plan.fullRebuild() ? null : plan.pythonSources()

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
@@ -17,6 +17,7 @@ package io.micronaut.python.compiler;
 
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.python.processing.PythonProcessingSession;
 import io.micronaut.python.processing.PythonSourceVisitor;
 
 import javax.tools.JavaFileObject;
@@ -77,6 +78,7 @@ public final class PyronautCompiler {
     private final boolean incremental;
     private final File incrementalCacheDirectory;
     private final PythonIncrementalMode pythonIncrementalMode;
+    private final PythonProcessingSession pythonProcessingSession;
 
     private PyronautCompiler(Builder builder) {
         this.packageName = builder.packageName;
@@ -100,6 +102,7 @@ public final class PyronautCompiler {
         this.incremental = builder.incremental;
         this.incrementalCacheDirectory = builder.incrementalCacheDirectory;
         this.pythonIncrementalMode = builder.pythonIncrementalMode;
+        this.pythonProcessingSession = builder.pythonProcessingSession;
         validateConfiguration();
     }
 
@@ -315,6 +318,7 @@ public final class PyronautCompiler {
         compiler.setCompilePythonBytecode(compilePythonBytecode);
         compiler.setAnnotationProcessors(annotationProcessors);
         compiler.setPythonSourceVisitors(pythonSourceVisitors);
+        compiler.setPythonProcessingSession(pythonProcessingSession);
         return compiler;
     }
 
@@ -521,6 +525,7 @@ public final class PyronautCompiler {
         private boolean incremental;
         private File incrementalCacheDirectory;
         private PythonIncrementalMode pythonIncrementalMode = PythonIncrementalMode.CONSERVATIVE;
+        private PythonProcessingSession pythonProcessingSession;
 
         private Builder() {
         }
@@ -735,6 +740,23 @@ public final class PyronautCompiler {
             this.pythonIncrementalMode = java.util.Objects.requireNonNull(
                 pythonIncrementalMode,
                 "pythonIncrementalMode"
+            );
+            return this;
+        }
+
+        /**
+         * Reuse an initialized GraalPy context across serialized compiler invocations.
+         *
+         * <p>The caller owns the session and must close it after the final compilation.</p>
+         *
+         * @param pythonProcessingSession The reusable Python processing session
+         * @return This builder
+         * @since 5.2.0
+         */
+        public Builder pythonProcessingSession(PythonProcessingSession pythonProcessingSession) {
+            this.pythonProcessingSession = java.util.Objects.requireNonNull(
+                pythonProcessingSession,
+                "pythonProcessingSession"
             );
             return this;
         }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
@@ -76,6 +76,7 @@ public final class PyronautCompiler {
     private final List<Processor> annotationProcessors;
     private final boolean incremental;
     private final File incrementalCacheDirectory;
+    private final PythonIncrementalMode pythonIncrementalMode;
 
     private PyronautCompiler(Builder builder) {
         this.packageName = builder.packageName;
@@ -98,6 +99,7 @@ public final class PyronautCompiler {
         this.pythonSourceVisitors = builder.pythonSourceVisitors == null ? List.of() : List.copyOf(builder.pythonSourceVisitors);
         this.incremental = builder.incremental;
         this.incrementalCacheDirectory = builder.incrementalCacheDirectory;
+        this.pythonIncrementalMode = builder.pythonIncrementalMode;
         validateConfiguration();
     }
 
@@ -193,7 +195,8 @@ public final class PyronautCompiler {
             incrementalCompilerOptions,
             compilePythonBytecode,
             annotationProcessors,
-            pythonSourceVisitors
+            pythonSourceVisitors,
+            pythonIncrementalMode
         );
         boolean aggregating = compiler.hasAggregatingProcessors(
             classpath,
@@ -516,6 +519,7 @@ public final class PyronautCompiler {
         private List<Processor> annotationProcessors;
         private boolean incremental;
         private File incrementalCacheDirectory;
+        private PythonIncrementalMode pythonIncrementalMode = PythonIncrementalMode.CONSERVATIVE;
 
         private Builder() {
         }
@@ -715,6 +719,22 @@ public final class PyronautCompiler {
          */
         public Builder incrementalCacheDirectory(File incrementalCacheDirectory) {
             this.incrementalCacheDirectory = incrementalCacheDirectory;
+            return this;
+        }
+
+        /**
+         * Set how incremental compilation handles dynamic or unresolved Python relationships.
+         * Defaults to {@link PythonIncrementalMode#CONSERVATIVE}.
+         *
+         * @param pythonIncrementalMode The Python incremental dependency policy
+         * @return This builder
+         * @since 5.2.0
+         */
+        public Builder pythonIncrementalMode(PythonIncrementalMode pythonIncrementalMode) {
+            this.pythonIncrementalMode = java.util.Objects.requireNonNull(
+                pythonIncrementalMode,
+                "pythonIncrementalMode"
+            );
             return this;
         }
 

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
@@ -15,14 +15,17 @@
  */
 package io.micronaut.python.compiler;
 
+import com.sun.source.util.JavacTask;
 import io.micronaut.annotation.processing.AggregatingTypeElementVisitorProcessor;
 import io.micronaut.annotation.processing.BeanDefinitionInjectProcessor;
 import io.micronaut.annotation.processing.MixinVisitorProcessor;
 import io.micronaut.annotation.processing.PackageElementVisitorProcessor;
 import io.micronaut.annotation.processing.TypeElementVisitorProcessor;
+import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.python.processing.PythonSourceVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.python.processing.PythonAnnotationProcessor;
@@ -52,8 +55,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -85,6 +92,7 @@ final class PyronautJavaCompiler {
     private boolean compilePythonBytecode;
     private List<PythonSourceVisitor> pythonSourceVisitors = List.of();
     private List<Processor> annotationProcessors = List.of();
+    private Set<String> incrementalPythonSources;
 
     /**
      * Set the callback to be invoked for each class element created during processing.
@@ -149,6 +157,125 @@ final class PyronautJavaCompiler {
     }
 
     /**
+     * Restricts isolating Python processing to the supplied source paths.
+     *
+     * @param incrementalPythonSources The affected Python sources, or {@code null} for all sources
+     */
+    void setIncrementalPythonSources(Set<String> incrementalPythonSources) {
+        this.incrementalPythonSources = incrementalPythonSources == null
+            ? null
+            : Set.copyOf(incrementalPythonSources);
+    }
+
+    boolean hasAggregatingProcessors(List<File> classpath,
+                                     List<File> annotationProcessorPath,
+                                     String javaSrc,
+                                     String pythonSrc) {
+        if (!pythonSourceVisitors.isEmpty()) {
+            return true;
+        }
+        for (Processor processor : annotationProcessors) {
+            Set<String> supportedOptions = processor.getSupportedOptions();
+            if (!supportedOptions.contains("org.gradle.annotation.processing.isolating")) {
+                return true;
+            }
+        }
+
+        List<File> processorClasspath = mergeClasspath(annotationProcessorPath, classpath);
+        ClassLoader classLoader = createAnnotationProcessorClassLoader(processorClasspath);
+        try {
+            @SuppressWarnings({"rawtypes", "unchecked"})
+            List<TypeElementVisitor<?, ?>> visitors = (List) SoftServiceLoader
+                .load(TypeElementVisitor.class, classLoader)
+                .disableFork()
+                .collectAll();
+            for (TypeElementVisitor<?, ?> visitor : visitors) {
+                if (visitor.isEnabled()
+                    && visitor.getVisitorKind() == TypeElementVisitor.VisitorKind.AGGREGATING
+                    && sourcesUseAnnotations(visitor.getSupportedAnnotationNames(), javaSrc, pythonSrc)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Throwable e) {
+            if (e instanceof VirtualMachineError virtualMachineError) {
+                throw virtualMachineError;
+            }
+            // Unknown visitor behavior must not be treated as isolating.
+            return true;
+        } finally {
+            if (classLoader instanceof URLClassLoader urlClassLoader) {
+                try {
+                    urlClassLoader.close();
+                } catch (IOException ignored) {
+                    // Nothing to do.
+                }
+            }
+        }
+    }
+
+    private static boolean sourcesUseAnnotations(Set<String> annotationNames,
+                                                 String javaSrc,
+                                                 String pythonSrc) {
+        if (annotationNames.contains("*")) {
+            return true;
+        }
+        List<String> normalizedNames = annotationNames.stream()
+            .map(name -> {
+                int separator = name.lastIndexOf('.');
+                String simpleName = separator == -1 ? name : name.substring(separator + 1);
+                return normalizeAnnotationName(simpleName);
+            })
+            .toList();
+        for (java.nio.file.Path root : sourceRoots(javaSrc, pythonSrc)) {
+            try (Stream<java.nio.file.Path> paths = Files.walk(root)) {
+                boolean found = paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".java") || path.toString().endsWith(".py"))
+                    .anyMatch(path -> {
+                        try {
+                            String source = normalizeAnnotationName(Files.readString(path));
+                            return normalizedNames.stream().anyMatch(source::contains);
+                        } catch (IOException e) {
+                            return true;
+                        }
+                    });
+                if (found) {
+                    return true;
+                }
+            } catch (IOException e) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<java.nio.file.Path> sourceRoots(String javaSrc, String pythonSrc) {
+        List<java.nio.file.Path> roots = new ArrayList<>();
+        if (javaSrc != null && !javaSrc.isBlank()) {
+            roots.add(java.nio.file.Path.of(javaSrc));
+        }
+        if (pythonSrc != null && !pythonSrc.isBlank()) {
+            StringTokenizer tokenizer = new StringTokenizer(pythonSrc, ",");
+            while (tokenizer.hasMoreTokens()) {
+                roots.add(java.nio.file.Path.of(tokenizer.nextToken().trim()));
+            }
+        }
+        return roots.stream().filter(Files::isDirectory).toList();
+    }
+
+    private static String normalizeAnnotationName(String value) {
+        StringBuilder normalized = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (Character.isLetterOrDigit(character)) {
+                normalized.append(Character.toLowerCase(character));
+            }
+        }
+        return normalized.toString();
+    }
+
+    /**
      * Compile sources to memory using in-memory file manager.
      *
      * @param sources The Java sources to compile
@@ -170,13 +297,13 @@ final class PyronautJavaCompiler {
         return inMemoryJavaFileManager.getOutputFiles();
     }
 
-    private void compileJava(JavaFileObject[] sources,
-                             List<File> classpath,
-                             List<File> bootclasspath,
-                             List<File> annotationProcessorPath,
-                             List<String> compilerOptions,
-                             JavaFileManager fileManager,
-                             DiagnosticCollector<JavaFileObject> diagnosticCollector) {
+    private IncrementalCompilationTrace compileJava(JavaFileObject[] sources,
+                                                    List<File> classpath,
+                                                    List<File> bootclasspath,
+                                                    List<File> annotationProcessorPath,
+                                                    List<String> compilerOptions,
+                                                    JavaFileManager fileManager,
+                                                    DiagnosticCollector<JavaFileObject> diagnosticCollector) {
         List<File> processorClasspath = mergeClasspath(annotationProcessorPath, classpath);
         List<File> compileClasspath = effectiveClasspath(classpath);
         List<String> options = buildCompilerOptions(compileClasspath, bootclasspath, annotationProcessorPath, compilerOptions);
@@ -199,11 +326,58 @@ final class PyronautJavaCompiler {
                 Arrays.asList(sources) // Source files
             );
 
-            if (!processors.isEmpty()) {
-                task.setProcessors(processors);
+            JavaCompilationTracker compilationTracker = null;
+            IncrementalProcessorTracker processorTracker = null;
+            if (task instanceof JavacTask javacTask) {
+                compilationTracker = new JavaCompilationTracker(javacTask);
+                javacTask.addTaskListener(compilationTracker);
+                if (fileManager instanceof TrackingJavaFileManager trackingFileManager) {
+                    trackingFileManager.setSourceResolver(
+                        compilationTracker::sourceKey,
+                        compilationTracker::isPythonGeneratedSource
+                    );
+                }
             }
-
+            List<Processor> taskProcessors = processors;
+            if (compilationTracker != null
+                && fileManager instanceof TrackingJavaFileManager trackingFileManager) {
+                processorTracker = new IncrementalProcessorTracker(
+                    compilationTracker,
+                    trackingFileManager.targetDirectory()
+                );
+                taskProcessors = processorTracker.wrap(processors);
+            }
+            if (!taskProcessors.isEmpty()) {
+                task.setProcessors(taskProcessors);
+            }
             success = task.call();
+            if (success && compilationTracker != null) {
+                Map<String, Set<String>> outputs = new LinkedHashMap<>();
+                if (fileManager instanceof TrackingJavaFileManager trackingFileManager) {
+                    mergeOutputs(outputs, trackingFileManager.outputs());
+                }
+                if (processorTracker != null) {
+                    mergeOutputs(outputs, processorTracker.isolatingOutputs());
+                }
+                Set<String> pythonProcessorOutputs = new LinkedHashSet<>();
+                if (fileManager instanceof TrackingJavaFileManager trackingFileManager) {
+                    pythonProcessorOutputs.addAll(trackingFileManager.pythonGeneratedOutputs());
+                }
+                if (processorTracker != null) {
+                    pythonProcessorOutputs.addAll(processorTracker.pythonProcessorOutputs());
+                }
+                IncrementalCompilationTrace trace = compilationTracker.trace(outputs);
+                return new IncrementalCompilationTrace(
+                    trace.analyzedSources(),
+                    trace.dependencies(),
+                    trace.declaredTypes(),
+                    trace.outputs(),
+                    processorTracker == null ? Set.of() : processorTracker.aggregatingOutputs(),
+                    Set.copyOf(pythonProcessorOutputs),
+                    processorTracker == null ? Set.of() : processorTracker.contractViolatingOutputs(),
+                    processorTracker == null || processorTracker.processorCompatible()
+                );
+            }
         } catch (RuntimeException e) {
             RuntimeException propagated = propagatedException(e);
             if (propagated != null) {
@@ -219,6 +393,14 @@ final class PyronautJavaCompiler {
         if (!success) {
             throw processingFailure(diagnosticCollector, null);
         }
+        return IncrementalCompilationTrace.empty();
+    }
+
+    private static void mergeOutputs(Map<String, Set<String>> destination,
+                                     Map<String, Set<String>> source) {
+        source.forEach((key, values) -> destination
+            .computeIfAbsent(key, ignored -> new LinkedHashSet<>())
+            .addAll(values));
     }
 
     private RuntimeException processingFailure(DiagnosticCollector<JavaFileObject> diagnosticCollector, RuntimeException exception) {
@@ -482,15 +664,19 @@ final class PyronautJavaCompiler {
      * @param bootclasspath Boot classpath (null to use default)
      * @param annotationProcessorPath Annotation processor path
      */
-    void compileToDisk(File targetDir,
-                       JavaFileObject[] sources,
-                       List<File> classpath,
-                       List<File> bootclasspath,
-                       List<File> annotationProcessorPath,
-                       List<String> compilerOptions) {
+    IncrementalCompilationTrace compileToDisk(File targetDir,
+                                              JavaFileObject[] sources,
+                                              List<File> classpath,
+                                              List<File> bootclasspath,
+                                              List<File> annotationProcessorPath,
+                                              List<String> compilerOptions) {
         DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
         StandardJavaFileManager fileManager =
             compiler.getStandardFileManager(diagnosticCollector, null, null);
+        TrackingJavaFileManager trackingFileManager = new TrackingJavaFileManager(
+            fileManager,
+            targetDir.toPath()
+        );
 
         // Set the class output location
         try {
@@ -500,7 +686,15 @@ final class PyronautJavaCompiler {
             throw new RuntimeException("Failed to set output location", e);
         }
 
-        compileJava(sources, classpath, bootclasspath, annotationProcessorPath, compilerOptions, fileManager, diagnosticCollector);
+        return compileJava(
+            sources,
+            classpath,
+            bootclasspath,
+            annotationProcessorPath,
+            compilerOptions,
+            trackingFileManager,
+            diagnosticCollector
+        );
     }
 
     private List<String> buildCompilerOptions(List<File> classpath,
@@ -600,6 +794,7 @@ final class PyronautJavaCompiler {
         pythonProcessor.setClassLoader(classLoader);
         pythonProcessor.setCompilePythonBytecode(compilePythonBytecode);
         pythonProcessor.setPythonSourceVisitors(pythonSourceVisitors);
+        pythonProcessor.setIncrementalSources(incrementalPythonSources);
         if (classElementCallback != null) {
             pythonProcessor.setClassElementCallback(classElementCallback);
         }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
@@ -76,6 +76,7 @@ import java.util.stream.Stream;
 final class PyronautJavaCompiler {
 
     private static final String MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER = "micronaut.introspections.use.context.classloader";
+    private static final String ISOLATING_PROCESSOR = "org.gradle.annotation.processing.isolating";
     private static final Pattern SOURCE_IN_MESSAGE = Pattern.compile("Python source \\[([^]]+)]");
     private static final Pattern LINE_IN_MESSAGE = Pattern.compile("line (\\d+)");
     private static final DateTimeFormatter DUMP_FILE_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS");
@@ -93,6 +94,7 @@ final class PyronautJavaCompiler {
     private List<PythonSourceVisitor> pythonSourceVisitors = List.of();
     private List<Processor> annotationProcessors = List.of();
     private Set<String> incrementalPythonSources;
+    private boolean processAggregatingPythonVisitors = true;
 
     /**
      * Set the callback to be invoked for each class element created during processing.
@@ -167,17 +169,26 @@ final class PyronautJavaCompiler {
             : Set.copyOf(incrementalPythonSources);
     }
 
-    boolean hasAggregatingProcessors(List<File> classpath,
-                                     List<File> annotationProcessorPath,
-                                     String javaSrc,
-                                     String pythonSrc) {
+    void setProcessAggregatingPythonVisitors(boolean processAggregatingPythonVisitors) {
+        this.processAggregatingPythonVisitors = processAggregatingPythonVisitors;
+    }
+
+    Set<String> aggregatingSources(List<File> classpath,
+                                   List<File> annotationProcessorPath,
+                                   String javaSrc,
+                                   String pythonSrc) {
+        Set<String> candidates = new LinkedHashSet<>();
         if (!pythonSourceVisitors.isEmpty()) {
-            return true;
+            candidates.addAll(sourceFiles(null, pythonSrc));
         }
         for (Processor processor : annotationProcessors) {
             Set<String> supportedOptions = processor.getSupportedOptions();
-            if (!supportedOptions.contains("org.gradle.annotation.processing.isolating")) {
-                return true;
+            if (!supportedOptions.contains(ISOLATING_PROCESSOR)) {
+                candidates.addAll(sourcesUsingAnnotations(
+                    processor.getSupportedAnnotationTypes(),
+                    javaSrc,
+                    pythonSrc
+                ));
             }
         }
 
@@ -191,15 +202,18 @@ final class PyronautJavaCompiler {
                 .collectAll();
             for (TypeElementVisitor<?, ?> visitor : visitors) {
                 if (visitor.isEnabled()
-                    && visitor.getVisitorKind() == TypeElementVisitor.VisitorKind.AGGREGATING
-                    && sourcesUseAnnotations(visitor.getSupportedAnnotationNames(), javaSrc, pythonSrc)) {
-                    return true;
+                    && visitor.getVisitorKind() == TypeElementVisitor.VisitorKind.AGGREGATING) {
+                    candidates.addAll(sourcesUsingAnnotations(
+                        visitor.getSupportedAnnotationNames(),
+                        javaSrc,
+                        pythonSrc
+                    ));
                 }
             }
-            return false;
+            return Set.copyOf(candidates);
         } catch (Exception | LinkageError e) {
             // Unknown visitor behavior must not be treated as isolating.
-            return true;
+            return sourceFiles(javaSrc, pythonSrc);
         } finally {
             if (classLoader instanceof URLClassLoader urlClassLoader) {
                 try {
@@ -211,11 +225,11 @@ final class PyronautJavaCompiler {
         }
     }
 
-    private static boolean sourcesUseAnnotations(Set<String> annotationNames,
-                                                 String javaSrc,
-                                                 String pythonSrc) {
-        if (annotationNames.contains("*")) {
-            return true;
+    private static Set<String> sourcesUsingAnnotations(Set<String> annotationNames,
+                                                       String javaSrc,
+                                                       String pythonSrc) {
+        if (annotationNames.stream().anyMatch(name -> name.contains("*"))) {
+            return sourceFiles(javaSrc, pythonSrc);
         }
         List<String> normalizedNames = annotationNames.stream()
             .map(name -> {
@@ -224,27 +238,52 @@ final class PyronautJavaCompiler {
                 return normalizeAnnotationName(simpleName);
             })
             .toList();
+        Set<String> sources = new LinkedHashSet<>();
         for (java.nio.file.Path root : sourceRoots(javaSrc, pythonSrc)) {
             try (Stream<java.nio.file.Path> paths = Files.walk(root)) {
-                boolean found = paths
+                paths
                     .filter(Files::isRegularFile)
                     .filter(path -> path.toString().endsWith(".java") || path.toString().endsWith(".py"))
-                    .anyMatch(path -> {
+                    .forEach(path -> {
                         try {
                             String source = normalizeAnnotationName(Files.readString(path));
-                            return normalizedNames.stream().anyMatch(source::contains);
+                            if (normalizedNames.stream().anyMatch(source::contains)) {
+                                sources.add(normalizeSourcePath(path));
+                            }
                         } catch (IOException e) {
-                            return true;
+                            sources.add(normalizeSourcePath(path));
                         }
                     });
-                if (found) {
-                    return true;
-                }
             } catch (IOException e) {
-                return true;
+                return sourceFiles(javaSrc, pythonSrc);
             }
         }
-        return false;
+        return Set.copyOf(sources);
+    }
+
+    private static Set<String> sourceFiles(String javaSrc, String pythonSrc) {
+        Set<String> sources = new LinkedHashSet<>();
+        for (java.nio.file.Path root : sourceRoots(javaSrc, pythonSrc)) {
+            try (Stream<java.nio.file.Path> paths = Files.walk(root)) {
+                paths.filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".java") || path.toString().endsWith(".py"))
+                    .map(PyronautJavaCompiler::normalizeSourcePath)
+                    .forEach(sources::add);
+            } catch (IOException e) {
+                return sourceRoots(javaSrc, pythonSrc).stream()
+                    .map(PyronautJavaCompiler::normalizeSourcePath)
+                    .collect(java.util.stream.Collectors.toUnmodifiableSet());
+            }
+        }
+        return Set.copyOf(sources);
+    }
+
+    private static String normalizeSourcePath(java.nio.file.Path path) {
+        try {
+            return path.toRealPath().normalize().toString();
+        } catch (IOException e) {
+            return path.toAbsolutePath().normalize().toString();
+        }
     }
 
     private static List<java.nio.file.Path> sourceRoots(String javaSrc, String pythonSrc) {
@@ -310,7 +349,10 @@ final class PyronautJavaCompiler {
         ClassLoader previous = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(classLoader);
 
-        List<Processor> processors = getAnnotationProcessors(classLoader);
+        java.nio.file.Path outputDirectory = fileManager instanceof TrackingJavaFileManager trackingFileManager
+            ? trackingFileManager.targetDirectory()
+            : null;
+        List<Processor> processors = getAnnotationProcessors(classLoader, outputDirectory);
 
         boolean success;
         try {
@@ -369,6 +411,7 @@ final class PyronautJavaCompiler {
                     trace.dependencies(),
                     trace.declaredTypes(),
                     trace.outputs(),
+                    processorTracker == null ? Set.of() : processorTracker.aggregatingInputs(),
                     processorTracker == null ? Set.of() : processorTracker.aggregatingOutputs(),
                     Set.copyOf(pythonProcessorOutputs),
                     processorTracker == null ? Set.of() : processorTracker.contractViolatingOutputs(),
@@ -779,7 +822,8 @@ final class PyronautJavaCompiler {
      *
      * @return The processors
      */
-    private @NonNull List<Processor> getAnnotationProcessors(ClassLoader classLoader) {
+    private @NonNull List<Processor> getAnnotationProcessors(ClassLoader classLoader,
+                                                              java.nio.file.Path outputDirectory) {
         List<Processor> processors = new ArrayList<>();
         processors.addAll(annotationProcessors);
         processors.add(new MixinVisitorProcessor());
@@ -792,6 +836,8 @@ final class PyronautJavaCompiler {
         pythonProcessor.setCompilePythonBytecode(compilePythonBytecode);
         pythonProcessor.setPythonSourceVisitors(pythonSourceVisitors);
         pythonProcessor.setIncrementalSources(incrementalPythonSources);
+        pythonProcessor.setProcessAggregatingVisitors(processAggregatingPythonVisitors);
+        pythonProcessor.setOutputDirectory(outputDirectory);
         if (classElementCallback != null) {
             pythonProcessor.setClassElementCallback(classElementCallback);
         }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
@@ -29,6 +29,7 @@ import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.python.processing.PythonSourceVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.python.processing.PythonAnnotationProcessor;
+import io.micronaut.python.processing.PythonProcessingSession;
 import org.jspecify.annotations.NonNull;
 
 import javax.annotation.processing.Processor;
@@ -93,6 +94,7 @@ final class PyronautJavaCompiler {
     private boolean compilePythonBytecode;
     private List<PythonSourceVisitor> pythonSourceVisitors = List.of();
     private List<Processor> annotationProcessors = List.of();
+    private PythonProcessingSession pythonProcessingSession;
     private Set<String> incrementalPythonSources;
     private boolean processAggregatingPythonVisitors = true;
 
@@ -156,6 +158,10 @@ final class PyronautJavaCompiler {
      */
     public void setAnnotationProcessors(List<Processor> annotationProcessors) {
         this.annotationProcessors = List.copyOf(annotationProcessors);
+    }
+
+    void setPythonProcessingSession(PythonProcessingSession pythonProcessingSession) {
+        this.pythonProcessingSession = pythonProcessingSession;
     }
 
     /**
@@ -838,6 +844,7 @@ final class PyronautJavaCompiler {
         pythonProcessor.setIncrementalSources(incrementalPythonSources);
         pythonProcessor.setProcessAggregatingVisitors(processAggregatingPythonVisitors);
         pythonProcessor.setOutputDirectory(outputDirectory);
+        pythonProcessor.setProcessingSession(pythonProcessingSession);
         if (classElementCallback != null) {
             pythonProcessor.setClassElementCallback(classElementCallback);
         }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
@@ -197,10 +197,7 @@ final class PyronautJavaCompiler {
                 }
             }
             return false;
-        } catch (Throwable e) {
-            if (e instanceof VirtualMachineError virtualMachineError) {
-                throw virtualMachineError;
-            }
+        } catch (Exception | LinkageError e) {
             // Unknown visitor behavior must not be treated as isolating.
             return true;
         } finally {

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PythonBytecodeCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PythonBytecodeCompiler.java
@@ -59,12 +59,28 @@ public final class PythonBytecodeCompiler implements AutoCloseable {
 
     private final Context context;
     private final Value compiler;
+    private final boolean ownsContext;
 
     /**
      * Create an embedded GraalPy bytecode compiler.
      */
     public PythonBytecodeCompiler() {
-        context = Context.newBuilder(PYTHON).allowAllAccess(true).build();
+        this(Context.newBuilder(PYTHON).allowAllAccess(true).build(), true);
+    }
+
+    /**
+     * Create a bytecode compiler that reuses an existing GraalPy context.
+     * Closing this compiler does not close the supplied context.
+     *
+     * @param context The existing context
+     */
+    public PythonBytecodeCompiler(Context context) {
+        this(context, false);
+    }
+
+    private PythonBytecodeCompiler(Context context, boolean ownsContext) {
+        this.context = context;
+        this.ownsContext = ownsContext;
         context.eval(COMPILE_SOURCE);
         compiler = context.getBindings(PYTHON).getMember("_mn_compile_python_bytecode");
     }
@@ -140,7 +156,9 @@ public final class PythonBytecodeCompiler implements AutoCloseable {
 
     @Override
     public void close() {
-        context.close();
+        if (ownsContext) {
+            context.close();
+        }
     }
 
     /**

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PythonIncrementalMode.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PythonIncrementalMode.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import io.micronaut.core.annotation.Experimental;
+
+/**
+ * Controls how incremental compilation handles dynamic or unresolved Python relationships.
+ *
+ * @since 5.2.0
+ */
+@Experimental
+public enum PythonIncrementalMode {
+    /**
+     * Reprocess every Python source when static dependency analysis cannot prove isolation.
+     */
+    CONSERVATIVE,
+
+    /**
+     * Reprocess only sources selected by the statically discovered dependency graph.
+     */
+    OPTIMISTIC
+}

--- a/inject-python/src/main/java/io/micronaut/python/compiler/TrackingJavaFileManager.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/TrackingJavaFileManager.java
@@ -56,7 +56,7 @@ final class TrackingJavaFileManager extends ForwardingJavaFileManager<StandardJa
                                                JavaFileObject.Kind kind,
                                                FileObject sibling) throws IOException {
         JavaFileObject output = super.getJavaFileForOutput(location, className, kind, sibling);
-        record(sibling, output);
+        trackOutput(sibling, output);
         return output;
     }
 
@@ -66,7 +66,7 @@ final class TrackingJavaFileManager extends ForwardingJavaFileManager<StandardJa
                                        String relativeName,
                                        FileObject sibling) throws IOException {
         FileObject output = super.getFileForOutput(location, packageName, relativeName, sibling);
-        record(sibling, output);
+        trackOutput(sibling, output);
         return output;
     }
 
@@ -88,7 +88,7 @@ final class TrackingJavaFileManager extends ForwardingJavaFileManager<StandardJa
         this.pythonSourceResolver = pythonSourceResolver;
     }
 
-    private void record(FileObject sibling, FileObject output) {
+    private void trackOutput(FileObject sibling, FileObject output) {
         if (!(sibling instanceof JavaFileObject javaSibling)) {
             return;
         }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/TrackingJavaFileManager.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/TrackingJavaFileManager.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileManager;
+import javax.tools.StandardJavaFileManager;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Associates javac outputs with the source file supplied as their sibling.
+ */
+final class TrackingJavaFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
+    private final Path targetDirectory;
+    private final Map<String, Set<String>> outputs = new LinkedHashMap<>();
+    private final Set<String> pythonGeneratedOutputs = new LinkedHashSet<>();
+    private Function<JavaFileObject, String> sourceResolver = TrackingJavaFileManager::fileSourceKey;
+    private Predicate<JavaFileObject> pythonSourceResolver = ignored -> false;
+
+    TrackingJavaFileManager(StandardJavaFileManager fileManager, Path targetDirectory) {
+        super(fileManager);
+        Path normalizedTarget;
+        try {
+            normalizedTarget = targetDirectory.toRealPath().normalize();
+        } catch (IOException e) {
+            normalizedTarget = targetDirectory.toAbsolutePath().normalize();
+        }
+        this.targetDirectory = normalizedTarget;
+    }
+
+    @Override
+    public JavaFileObject getJavaFileForOutput(JavaFileManager.Location location,
+                                               String className,
+                                               JavaFileObject.Kind kind,
+                                               FileObject sibling) throws IOException {
+        JavaFileObject output = super.getJavaFileForOutput(location, className, kind, sibling);
+        record(sibling, output);
+        return output;
+    }
+
+    @Override
+    public FileObject getFileForOutput(JavaFileManager.Location location,
+                                       String packageName,
+                                       String relativeName,
+                                       FileObject sibling) throws IOException {
+        FileObject output = super.getFileForOutput(location, packageName, relativeName, sibling);
+        record(sibling, output);
+        return output;
+    }
+
+    Map<String, Set<String>> outputs() {
+        return outputs;
+    }
+
+    Set<String> pythonGeneratedOutputs() {
+        return pythonGeneratedOutputs;
+    }
+
+    Path targetDirectory() {
+        return targetDirectory;
+    }
+
+    void setSourceResolver(Function<JavaFileObject, String> sourceResolver,
+                           Predicate<JavaFileObject> pythonSourceResolver) {
+        this.sourceResolver = sourceResolver;
+        this.pythonSourceResolver = pythonSourceResolver;
+    }
+
+    private void record(FileObject sibling, FileObject output) {
+        if (!(sibling instanceof JavaFileObject javaSibling)) {
+            return;
+        }
+        String source = sourceResolver.apply(javaSibling);
+        if (source == null) {
+            return;
+        }
+        try {
+            Path outputPath = Path.of(output.toUri()).toAbsolutePath().normalize();
+            if (outputPath.startsWith(targetDirectory)) {
+                String relative = targetDirectory.relativize(outputPath).toString()
+                    .replace(outputPath.getFileSystem().getSeparator(), "/");
+                outputs.computeIfAbsent(source, ignored -> new LinkedHashSet<>()).add(relative);
+                if (pythonSourceResolver.test(javaSibling)) {
+                    pythonGeneratedOutputs.add(relative);
+                }
+            }
+        } catch (Exception ignored) {
+            // Outputs that cannot be attributed are handled conservatively as aggregating.
+        }
+    }
+
+    private static String fileSourceKey(JavaFileObject source) {
+        try {
+            Path path = Path.of(source.toUri());
+            return java.nio.file.Files.exists(path)
+                ? path.toRealPath().normalize().toString()
+                : path.toAbsolutePath().normalize().toString();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -88,6 +88,8 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     private boolean compilePythonBytecode;
     private PythonBytecodeCompiler bytecodeCompiler;
     private Set<String> incrementalSources;
+    private boolean processAggregatingVisitors = true;
+    private Path outputDirectory;
 
     /**
      * Set the callback to be invoked for each class element created during processing.
@@ -126,6 +128,26 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     @Internal
     public void setIncrementalSources(Set<String> incrementalSources) {
         this.incrementalSources = incrementalSources == null ? null : Set.copyOf(incrementalSources);
+    }
+
+    /**
+     * Sets whether aggregating Python type visitors should run.
+     *
+     * @param processAggregatingVisitors Whether aggregating visitors should run
+     */
+    @Internal
+    public void setProcessAggregatingVisitors(boolean processAggregatingVisitors) {
+        this.processAggregatingVisitors = processAggregatingVisitors;
+    }
+
+    /**
+     * Sets the class output directory used to reuse unchanged generated Python resources.
+     *
+     * @param outputDirectory The class output directory, or {@code null} for in-memory compilation
+     */
+    @Internal
+    public void setOutputDirectory(Path outputDirectory) {
+        this.outputDirectory = outputDirectory;
     }
 
     @Override
@@ -345,15 +367,17 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             ClassLoader effectiveClassLoader = this.classLoader != null
                 ? this.classLoader : PythonAnnotationProcessor.class.getClassLoader();
             Predicate<ClassElement> affectedElements = affectedElements(transformedList, srcDirs);
-            PythonTypeElementVisitorProcessor aggregatingVisitors =
-                new PythonTypeElementVisitorProcessor(effectiveClassLoader, io.micronaut.inject.visitor.TypeElementVisitor.VisitorKind.AGGREGATING);
-            aggregatingVisitors.init(processingEnvironment);
-            aggregatingVisitors.process(
-                processingEnvironment,
-                ignored -> true,
-                incrementalSources == null,
-                false
-            );
+            if (processAggregatingVisitors) {
+                PythonTypeElementVisitorProcessor aggregatingVisitors =
+                    new PythonTypeElementVisitorProcessor(effectiveClassLoader, io.micronaut.inject.visitor.TypeElementVisitor.VisitorKind.AGGREGATING);
+                aggregatingVisitors.init(processingEnvironment);
+                aggregatingVisitors.process(
+                    processingEnvironment,
+                    ignored -> true,
+                    incrementalSources == null,
+                    false
+                );
+            }
             PythonTypeElementVisitorProcessor isolatingVisitors =
                 new PythonTypeElementVisitorProcessor(effectiveClassLoader, io.micronaut.inject.visitor.TypeElementVisitor.VisitorKind.ISOLATING);
             isolatingVisitors.init(processingEnvironment);
@@ -607,17 +631,28 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                                   String filePath,
                                   String content,
                                   ClassElement originatingElement) {
-        javaVisitorContext.visitMetaInfFile(filePath, originatingElement)
-            .ifPresent(generatedFile -> {
-                try (var writer = generatedFile.openWriter()) {
-                    writer.write(content);
-                } catch (IOException e) {
-                    throw new ProcessingException(originatingElement, "Failed to write Python code to [" + filePath + "]: " + e.getMessage(), e);
+        boolean unchanged = false;
+        var generatedFile = javaVisitorContext.visitMetaInfFile(filePath, originatingElement).orElse(null);
+        if (generatedFile != null) {
+            try {
+                if (outputDirectory != null) {
+                    Path existingFile = outputDirectory.resolve("META-INF").resolve(filePath);
+                    unchanged = Files.isRegularFile(existingFile) && content.equals(Files.readString(existingFile));
                 }
-            });
+                if (unchanged) {
+                    generatedFile.getTextContent();
+                } else {
+                    try (var writer = generatedFile.openWriter()) {
+                        writer.write(content);
+                    }
+                }
+            } catch (IOException e) {
+                throw new ProcessingException(originatingElement, "Failed to write Python code to [" + filePath + "]: " + e.getMessage(), e);
+            }
+        }
         filesList.append("/META-INF/").append(filePath).append('\n');
 
-        if (!compilePythonBytecode) {
+        if (!compilePythonBytecode || unchanged) {
             return;
         }
         try {
@@ -627,8 +662,8 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             PythonBytecodeCompiler.Result result = bytecodeCompiler.compile(content, filePath);
             String cacheFilePath = cacheFilePath(filePath, result.cachePath());
             javaVisitorContext.visitMetaInfFile(cacheFilePath, originatingElement)
-                .ifPresent(generatedFile -> {
-                    try (var output = generatedFile.openOutputStream()) {
+                .ifPresent(bytecodeFile -> {
+                    try (var output = bytecodeFile.openOutputStream()) {
                         output.write(result.bytes());
                     } catch (IOException e) {
                         throw new ProcessingException(originatingElement, "Failed to write Python bytecode to [" + cacheFilePath + "]: " + e.getMessage(), e);

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -159,12 +159,13 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                 classLoader = PythonAnnotationProcessor.class.getClassLoader();
             }
         }
-        parser = new PythonAstParser(classLoader);
     }
 
     @Override
     public void close() throws Exception {
-        parser.close();
+        if (parser != null) {
+            parser.close();
+        }
         if (bytecodeCompiler != null) {
             bytecodeCompiler.close();
         }
@@ -173,7 +174,9 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         if (roundEnv.processingOver()) {
-            parser.close();
+            if (parser != null) {
+                parser.close();
+            }
             return false;
         }
         if (annotations.isEmpty()) {
@@ -199,9 +202,16 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             if (element instanceof TypeElement typeElement) {
                 PythonApplicationValues values = readPythonApplicationValues(element).orElse(null);
                 if (values != null) {
+                    initializeParser();
                     processAnnotation(typeElement, values);
                 }
             }
+        }
+    }
+
+    private void initializeParser() {
+        if (parser == null) {
+            parser = new PythonAstParser(classLoader, incrementalSources != null);
         }
     }
 

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -73,6 +73,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     public static final String APPLICATION_SRC_PATH = "GRAALPY-VFS/micronaut-application/src/";
     public static final String APPLICATION_LAUNCHER_PATH = APPLICATION_SRC_PATH + "__main__.py";
     static final String PYTHON_APPLICATION_ANNOTATION = "io.micronaut.context.python.annotation.PythonApplication";
+    private static final String PYTHON_LANGUAGE = "python";
     private static final Set<String> PYTHON_KEYWORDS = Set.of(
         "False", "None", "True", "and", "as", "assert", "async", "await", "break",
         "class", "continue", "def", "del", "elif", "else", "except", "finally",
@@ -433,7 +434,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             if (!isAffectedSource(source)) {
                 continue;
             }
-            String packageName = "python";
+            String packageName = PYTHON_LANGUAGE;
             for (String srcDir : srcDirs) {
                 if (source.getPath() != null && source.getPath().startsWith(srcDir)) {
                     packageName = PythonAstParser.getPackageNameOfSource(srcDir, source);
@@ -484,7 +485,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
         if (!code.isEmpty()) {
             // Transform the source code first
             try {
-                return parser.transform(javaVisitorContext, Source.create("python", code));
+                return parser.transform(javaVisitorContext, Source.create(PYTHON_LANGUAGE, code));
             } catch (Exception e) {
                 throw new ProcessingException(originatingElement, "Error transforming python code: " + e.getMessage(), e);
             }
@@ -526,7 +527,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                                                     "Micronaut generates package __init__.py files for the GraalPy VFS; remove [" + relative + "] from the project source."
                                             );
                                         }
-                                        sources.add(Source.newBuilder("python", file.toFile()).build());
+                                        sources.add(Source.newBuilder(PYTHON_LANGUAGE, file.toFile()).build());
                                     }
                                     return FileVisitResult.CONTINUE;
                                 }

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -16,6 +16,7 @@
 package io.micronaut.python.processing;
 
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.annotation.processing.AbstractInjectAnnotationProcessor;
 import io.micronaut.annotation.processing.visitor.JavaNativeElement;
 import io.micronaut.core.naming.NameUtils;
@@ -55,6 +56,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -84,6 +86,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     private ClassLoader classLoader;
     private boolean compilePythonBytecode;
     private PythonBytecodeCompiler bytecodeCompiler;
+    private Set<String> incrementalSources;
 
     /**
      * Set the callback to be invoked for each class element created during processing.
@@ -112,6 +115,16 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
      */
     public void setCompilePythonBytecode(boolean compilePythonBytecode) {
         this.compilePythonBytecode = compilePythonBytecode;
+    }
+
+    /**
+     * Restricts isolating visitors and bean generation to affected Python sources.
+     *
+     * @param incrementalSources The affected absolute source paths, or {@code null} for all sources
+     */
+    @Internal
+    public void setIncrementalSources(Set<String> incrementalSources) {
+        this.incrementalSources = incrementalSources == null ? null : Set.copyOf(incrementalSources);
     }
 
     @Override
@@ -251,7 +264,9 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                                 }
                             }
                             Source runtimeSource = transformResult.runtimeSource();
-                            writePythonToVfs(filesList, targetSource, runtimeSource.getCharacters().toString(), originatingElement);
+                            if (isAffectedSource(source)) {
+                                writePythonToVfs(filesList, targetSource, runtimeSource.getCharacters().toString(), originatingElement);
+                            }
                         }
                     }
 
@@ -326,14 +341,31 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             writeAllToVFS(filesList, allDecorators, allImports, originatingElement);
 
             // Run type element visitor processing
-            PythonTypeElementVisitorProcessor typeElementVisitorProcessor =
-                new PythonTypeElementVisitorProcessor(this.classLoader != null ? this.classLoader : PythonAnnotationProcessor.class.getClassLoader());
-            typeElementVisitorProcessor.init(processingEnvironment);
-            typeElementVisitorProcessor.process(processingEnvironment);
+            ClassLoader effectiveClassLoader = this.classLoader != null
+                ? this.classLoader : PythonAnnotationProcessor.class.getClassLoader();
+            Predicate<ClassElement> affectedElements = affectedElements(transformedList, srcDirs);
+            PythonTypeElementVisitorProcessor aggregatingVisitors =
+                new PythonTypeElementVisitorProcessor(effectiveClassLoader, io.micronaut.inject.visitor.TypeElementVisitor.VisitorKind.AGGREGATING);
+            aggregatingVisitors.init(processingEnvironment);
+            aggregatingVisitors.process(
+                processingEnvironment,
+                ignored -> true,
+                incrementalSources == null,
+                false
+            );
+            PythonTypeElementVisitorProcessor isolatingVisitors =
+                new PythonTypeElementVisitorProcessor(effectiveClassLoader, io.micronaut.inject.visitor.TypeElementVisitor.VisitorKind.ISOLATING);
+            isolatingVisitors.init(processingEnvironment);
+            isolatingVisitors.process(
+                processingEnvironment,
+                affectedElements,
+                incrementalSources != null,
+                true
+            );
 
             // Process bean definitions for Python classes
             var beanDefinitionProcessor = new PythonBeanDefinitionProcessor();
-            beanDefinitionProcessor.processBeanDefinitions(processingEnvironment);
+            beanDefinitionProcessor.processBeanDefinitions(processingEnvironment, affectedElements);
 
             // Invoke callback for each class element if callback is set
             if (classElementCallback != null) {
@@ -364,6 +396,62 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             error("Failed Trace: %s", stacktrace);
             error("Fatal error processing Python code: %s", e.getMessage());
         }
+    }
+
+    private boolean isAffectedSource(Source source) {
+        if (incrementalSources == null) {
+            return true;
+        }
+        String path = source.getPath();
+        if (path == null) {
+            return false;
+        }
+        Path sourcePath = Path.of(path).toAbsolutePath().normalize();
+        if (incrementalSources.contains(sourcePath.toString())) {
+            return true;
+        }
+        for (String incrementalSource : incrementalSources) {
+            try {
+                if (Files.isSameFile(sourcePath, Path.of(incrementalSource))) {
+                    return true;
+                }
+            } catch (IOException ignored) {
+                // A missing source cannot be an affected source being processed.
+            }
+        }
+        return false;
+    }
+
+    private Predicate<ClassElement> affectedElements(List<PythonAstParser.TransformResult> transformedList,
+                                                     String[] srcDirs) {
+        if (incrementalSources == null) {
+            return ignored -> true;
+        }
+        Set<String> names = new LinkedHashSet<>();
+        for (PythonAstParser.TransformResult transformed : transformedList) {
+            Source source = transformed.originalSource();
+            if (!isAffectedSource(source)) {
+                continue;
+            }
+            String packageName = "python";
+            for (String srcDir : srcDirs) {
+                if (source.getPath() != null && source.getPath().startsWith(srcDir)) {
+                    packageName = PythonAstParser.getPackageNameOfSource(srcDir, source);
+                    break;
+                }
+            }
+            for (String className : transformed.allClassNames()) {
+                names.add(packageName + '.' + className);
+            }
+            String sourceName = source.getName();
+            if (sourceName.endsWith(".py")) {
+                sourceName = sourceName.substring(0, sourceName.length() - ".py".length());
+            }
+            if (!sourceName.isEmpty()) {
+                names.add(packageName + '.' + Character.toUpperCase(sourceName.charAt(0)) + sourceName.substring(1));
+            }
+        }
+        return element -> names.contains(element.getName());
     }
 
     private void processPythonSourceVisitors(List<PythonAstParser.TransformResult> transformedList,

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -90,6 +90,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     private Set<String> incrementalSources;
     private boolean processAggregatingVisitors = true;
     private Path outputDirectory;
+    private PythonProcessingSession processingSession;
 
     /**
      * Set the callback to be invoked for each class element created during processing.
@@ -150,6 +151,16 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
         this.outputDirectory = outputDirectory;
     }
 
+    /**
+     * Sets a session that owns the GraalPy context across compiler invocations.
+     *
+     * @param processingSession The reusable processing session
+     */
+    @Internal
+    public void setProcessingSession(PythonProcessingSession processingSession) {
+        this.processingSession = processingSession;
+    }
+
     @Override
     public synchronized void init(ProcessingEnvironment processingEnv) {
         super.init(processingEnv);
@@ -163,7 +174,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
 
     @Override
     public void close() throws Exception {
-        if (parser != null) {
+        if (parser != null && processingSession == null) {
             parser.close();
         }
         if (bytecodeCompiler != null) {
@@ -174,7 +185,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         if (roundEnv.processingOver()) {
-            if (parser != null) {
+            if (parser != null && processingSession == null) {
                 parser.close();
             }
             return false;
@@ -211,7 +222,9 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
 
     private void initializeParser() {
         if (parser == null) {
-            parser = new PythonAstParser(classLoader, incrementalSources != null);
+            parser = processingSession == null
+                ? new PythonAstParser(classLoader, incrementalSources != null)
+                : processingSession.parser(classLoader, incrementalSources != null);
         }
     }
 

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -773,7 +773,11 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
         javaVisitorContext.visitMetaInfFile(APPLICATION_PATH + "fileslist.txt", originatingElement)
             .ifPresent(generatedFile -> {
                 try (var writer = generatedFile.openWriter()) {
-                    writer.write(filesList.toString());
+                    List<String> entries = filesList.toString().lines().sorted().toList();
+                    if (!entries.isEmpty()) {
+                        writer.write(String.join("\n", entries));
+                        writer.write('\n');
+                    }
                 } catch (IOException e) {
                     throw new ProcessingException(originatingElement, "Failed to write fileslist.txt to VFS");
                 }

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -258,6 +258,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
 
             String mainPy;
             StringBuilder filesList = new StringBuilder();
+            boolean processSharedOutputs = incrementalSources == null || processAggregatingVisitors;
             if (StringUtils.isNotEmpty(values.code())) {
                 mainPy = transformedList.get(0).runtimeCode();
                 writePythonToVfs(filesList, APPLICATION_LAUNCHER_PATH, mainPy, originatingElement);
@@ -284,7 +285,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                                 path = path.substring(srcDir.length() + 1);
                             }
                             String targetSource = APPLICATION_SRC_PATH + path;
-                            if (!transformResult.allClassNames().isEmpty()) {
+                            if (processSharedOutputs && !transformResult.allClassNames().isEmpty()) {
                                 // has classes
                                 int parentIndex = path.lastIndexOf('/');
                                 if (parentIndex > -1) {
@@ -303,51 +304,52 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                         }
                     }
 
-                    TreeSet<String> byParent = allModules.keySet().stream().map(pe -> pe.parent)
-                        .collect(Collectors.toCollection(TreeSet::new));
-                    for (String parent : byParent) {
-                        if (StringUtils.isEmpty(parent)) {
-                            // root, generate __main__.py instead
-                            String mainFilePath = APPLICATION_SRC_PATH + parent + "__main__.py";
-                            StringBuilder mainContent = new StringBuilder();
-                            List<Map.Entry<PathEntry, List<String>>> entries = allModules.entrySet().stream()
-                                .filter(entry -> entry.getKey().parent.equals(parent))
-                                .toList();
-                            for (Map.Entry<PathEntry, List<String>> entry : entries) {
-                                List<String> types = entry.getValue();
-                                String filename = entry.getKey().filename;
-                                if (!types.isEmpty()) {
-                                    for (String type : types) {
-                                        mainContent.append("from ").append(NameUtils.filename(filename)).append(" import ").append(type).append('\n');
-                                    }
-                                }
-                            }
-                            writePythonToVfs(filesList, mainFilePath, mainContent.toString(), originatingElement);
-                        } else {
-
-                            String initFilePath = APPLICATION_SRC_PATH + parent + "__init__.py";
-                            StringBuilder initContent = new StringBuilder();
-                            List<Map.Entry<PathEntry, List<String>>> entries = allModules.entrySet().stream()
-                                .filter(entry -> entry.getKey().parent.equals(parent))
-                                .toList();
-                            List<String> exportedTypes = new ArrayList<>();
-                            for (Map.Entry<PathEntry, List<String>> entry : entries) {
-                                List<String> types = entry.getValue();
-                                String filename = entry.getKey().filename;
-                                if (!types.isEmpty()) {
-                                    for (String type : types) {
-                                        initContent.append("from .").append(NameUtils.filename(filename)).append(" import ").append(type).append('\n');
-                                        // Check if this type has decorators (is in allExportedTypes)
-                                        if (allExportedTypes.contains(type)) {
-                                            exportedTypes.add(type);
+                    if (processSharedOutputs) {
+                        TreeSet<String> byParent = allModules.keySet().stream().map(pe -> pe.parent)
+                            .collect(Collectors.toCollection(TreeSet::new));
+                        for (String parent : byParent) {
+                            if (StringUtils.isEmpty(parent)) {
+                                // root, generate __main__.py instead
+                                String mainFilePath = APPLICATION_SRC_PATH + parent + "__main__.py";
+                                StringBuilder mainContent = new StringBuilder();
+                                List<Map.Entry<PathEntry, List<String>>> entries = allModules.entrySet().stream()
+                                    .filter(entry -> entry.getKey().parent.equals(parent))
+                                    .toList();
+                                for (Map.Entry<PathEntry, List<String>> entry : entries) {
+                                    List<String> types = entry.getValue();
+                                    String filename = entry.getKey().filename;
+                                    if (!types.isEmpty()) {
+                                        for (String type : types) {
+                                            mainContent.append("from ").append(NameUtils.filename(filename)).append(" import ").append(type).append('\n');
                                         }
                                     }
                                 }
+                                writePythonToVfs(filesList, mainFilePath, mainContent.toString(), originatingElement);
+                            } else {
+                                String initFilePath = APPLICATION_SRC_PATH + parent + "__init__.py";
+                                StringBuilder initContent = new StringBuilder();
+                                List<Map.Entry<PathEntry, List<String>>> entries = allModules.entrySet().stream()
+                                    .filter(entry -> entry.getKey().parent.equals(parent))
+                                    .toList();
+                                List<String> exportedTypes = new ArrayList<>();
+                                for (Map.Entry<PathEntry, List<String>> entry : entries) {
+                                    List<String> types = entry.getValue();
+                                    String filename = entry.getKey().filename;
+                                    if (!types.isEmpty()) {
+                                        for (String type : types) {
+                                            initContent.append("from .").append(NameUtils.filename(filename)).append(" import ").append(type).append('\n');
+                                            // Check if this type has decorators (is in allExportedTypes)
+                                            if (allExportedTypes.contains(type)) {
+                                                exportedTypes.add(type);
+                                            }
+                                        }
+                                    }
+                                }
+                                if (!exportedTypes.isEmpty()) {
+                                    initContent.append("\n__all__ = ").append(toListOfString(exportedTypes)).append("\n");
+                                }
+                                writePythonToVfs(filesList, initFilePath, initContent.toString(), originatingElement);
                             }
-                            if (!exportedTypes.isEmpty()) {
-                                initContent.append("\n__all__ = ").append(toListOfString(exportedTypes)).append("\n");
-                            }
-                            writePythonToVfs(filesList, initFilePath, initContent.toString(), originatingElement);
                         }
                     }
                 }
@@ -371,7 +373,9 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                 });
 
             }
-            writeAllToVFS(filesList, allDecorators, allImports, originatingElement);
+            if (processSharedOutputs) {
+                writeAllToVFS(filesList, allDecorators, allImports, originatingElement);
+            }
 
             // Run type element visitor processing
             ClassLoader effectiveClassLoader = this.classLoader != null
@@ -576,8 +580,18 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             } else {
                 throw new ProcessingException(originatingElement, "Source directories are not set.");
             }
-            return parser.transform(javaVisitorContext, sources.toArray(new Source[0]));
+            return parser.transform(
+                javaVisitorContext,
+                selectTransformSources(sources).toArray(new Source[0])
+            );
         }
+    }
+
+    final List<Source> selectTransformSources(List<Source> sources) {
+        if (incrementalSources == null || processAggregatingVisitors) {
+            return sources;
+        }
+        return sources.stream().filter(this::isAffectedSource).toList();
     }
 
     private Optional<PythonApplicationValues> readPythonApplicationValues(Element element) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -667,7 +667,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
         }
         try {
             if (bytecodeCompiler == null) {
-                bytecodeCompiler = new PythonBytecodeCompiler();
+                bytecodeCompiler = parser.bytecodeCompiler();
             }
             PythonBytecodeCompiler.Result result = bytecodeCompiler.compile(content, filePath);
             String cacheFilePath = cacheFilePath(filePath, result.cachePath());

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
@@ -20,6 +20,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.python.compiler.PythonBytecodeCompiler;
 import io.micronaut.python.processing.visitor.ClassDef;
 import io.micronaut.python.processing.visitor.DecoratorDef;
 import io.micronaut.python.processing.visitor.ScriptDef;
@@ -66,7 +67,7 @@ public final class PythonAstParser {
         this(classLoader, false);
     }
 
-    PythonAstParser(ClassLoader classLoader, boolean interpreterOnly) {
+    PythonAstParser(ClassLoader classLoader, boolean incremental) {
         var contextBuilder = GraalPyResources.contextBuilder(VirtualFileSystem.newBuilder()
                 .resourceDirectory(INJECT_RESOURCES)
                 .resourceLoadingClass(PythonAstParser.class)
@@ -75,14 +76,18 @@ public final class PythonAstParser {
             .allowHostAccess(HostAccess.ALL)
             .hostClassLoader(classLoader)
             .allowHostClassLookup(name -> name.startsWith("io.micronaut"));
-        if (interpreterOnly) {
-            // Incremental processing is a short-lived workload. Avoid spending more time compiling
-            // Python processing code than the reduced source set can recover during this invocation.
+        if (incremental) {
+            // Incremental processing is a short-lived workload. A single compiler thread avoids
+            // paying the startup cost of GraalPy's core-count-based compiler thread pool.
             contextBuilder.allowExperimentalOptions(true)
-                .option("engine.Compilation", "false");
+                .option("engine.CompilerThreads", "1");
         }
         this.context = contextBuilder.build();
         context.initialize(PYTHON);
+    }
+
+    PythonBytecodeCompiler bytecodeCompiler() {
+        return new PythonBytecodeCompiler(context);
     }
 
     public PythonEnvironment parse(@Language("python") String sources) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
@@ -63,15 +63,25 @@ public final class PythonAstParser {
     }
 
     PythonAstParser(ClassLoader classLoader) {
-        this.context = GraalPyResources.contextBuilder(VirtualFileSystem.newBuilder()
+        this(classLoader, false);
+    }
+
+    PythonAstParser(ClassLoader classLoader, boolean interpreterOnly) {
+        var contextBuilder = GraalPyResources.contextBuilder(VirtualFileSystem.newBuilder()
                 .resourceDirectory(INJECT_RESOURCES)
                 .resourceLoadingClass(PythonAstParser.class)
                 .build())
             // Future hardening should constrain host access to the required Micronaut API surface.
             .allowHostAccess(HostAccess.ALL)
             .hostClassLoader(classLoader)
-            .allowHostClassLookup(name -> name.startsWith("io.micronaut"))
-            .build();
+            .allowHostClassLookup(name -> name.startsWith("io.micronaut"));
+        if (interpreterOnly) {
+            // Incremental processing is a short-lived workload. Avoid spending more time compiling
+            // Python processing code than the reduced source set can recover during this invocation.
+            contextBuilder.allowExperimentalOptions(true)
+                .option("engine.Compilation", "false");
+        }
+        this.context = contextBuilder.build();
         context.initialize(PYTHON);
     }
 

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
@@ -77,9 +77,10 @@ public final class PythonAstParser {
             .hostClassLoader(classLoader)
             .allowHostClassLookup(name -> name.startsWith("io.micronaut"));
         if (incremental) {
-            // Incremental processing is a short-lived workload. A single compiler thread avoids
-            // paying the startup cost of GraalPy's core-count-based compiler thread pool.
+            // Incremental processing is a short-lived workload. Tune GraalPy for startup latency
+            // and avoid paying for a core-count-based compiler thread pool.
             contextBuilder.allowExperimentalOptions(true)
+                .option("engine.Mode", "latency")
                 .option("engine.CompilerThreads", "1");
         }
         this.context = contextBuilder.build();

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonProcessingSession.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonProcessingSession.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.processing;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Owns the initialized GraalPy processing context across multiple serialized compilations.
+ *
+ * <p>A session is not thread safe. Callers must serialize compilations that share it.</p>
+ *
+ * @since 5.2.0
+ */
+@Experimental
+public final class PythonProcessingSession implements AutoCloseable {
+    private PythonAstParser parser;
+    private boolean closed;
+
+    /**
+     * Obtains the parser for a compilation, initializing GraalPy on first use.
+     *
+     * @param classLoader The annotation processor class loader
+     * @param incremental Whether the compilation is incremental
+     * @return The session parser
+     */
+    @Internal
+    public PythonAstParser parser(ClassLoader classLoader, boolean incremental) {
+        if (closed) {
+            throw new IllegalStateException("Python processing session is closed");
+        }
+        if (parser == null) {
+            parser = new PythonAstParser(classLoader, incremental);
+        }
+        return parser;
+    }
+
+    /**
+     * Reports whether GraalPy has been initialized.
+     *
+     * @return Whether GraalPy has been initialized for this session
+     */
+    public boolean initialized() {
+        return parser != null;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        if (parser != null) {
+            parser.close();
+            parser = null;
+        }
+    }
+}

--- a/inject-python/src/main/java/io/micronaut/python/processing/TargetTypeMappingGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/TargetTypeMappingGenerator.java
@@ -55,6 +55,11 @@ public final class TargetTypeMappingGenerator implements TypeElementVisitor<Obje
     private static final String TARGET_TYPE_MAPPING = "io.micronaut.context.python.TargetTypeMapping";
 
     @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
     public TypeElementQuery query() {
         return TypeElementQuery.onlyClass();
     }

--- a/inject-python/src/main/java/io/micronaut/python/processing/beans/PythonBeanDefinitionProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/beans/PythonBeanDefinitionProcessor.java
@@ -16,9 +16,11 @@
 package io.micronaut.python.processing.beans;
 
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import io.micronaut.core.annotation.Generated;
 import io.micronaut.core.annotation.Vetoed;
@@ -47,11 +49,25 @@ public final class PythonBeanDefinitionProcessor {
     public void processBeanDefinitions(
         PythonProcessingEnvironment processingEnvironment
     ) {
+        processBeanDefinitions(processingEnvironment, ignored -> true);
+    }
+
+    /**
+     * Processes bean definitions for selected source elements.
+     *
+     * @param processingEnvironment The processing environment
+     * @param sourceFilter The source element filter
+     */
+    @Internal
+    public void processBeanDefinitions(
+        PythonProcessingEnvironment processingEnvironment,
+        Predicate<ClassElement> sourceFilter
+    ) {
         PythonVisitorContext visitorContext = processingEnvironment.visitorContext();
-        for (ClassElement classElement : processingEnvironment.classes().values()) {
+        for (ClassElement classElement : processingEnvironment.classes().values().stream().filter(sourceFilter).toList()) {
             processClassElement(classElement, visitorContext);
         }
-        for (ClassElement classElement : processingEnvironment.scripts().values()) {
+        for (ClassElement classElement : processingEnvironment.scripts().values().stream().filter(sourceFilter).toList()) {
             processClassElement(classElement, visitorContext);
         }
     }

--- a/inject-python/src/main/java/io/micronaut/python/processing/visitor/PythonTypeElementVisitorProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/visitor/PythonTypeElementVisitorProcessor.java
@@ -27,6 +27,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Generated;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.io.service.SoftServiceLoader;
@@ -65,6 +66,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -73,12 +75,24 @@ import java.util.stream.Collectors;
 @Experimental
 public final class PythonTypeElementVisitorProcessor {
     private final ClassLoader classLoader;
+    private final TypeElementVisitor.VisitorKind visitorKind;
 
     private Collection<? extends TypeElementVisitor<?, ?>> typeElementVisitors;
     private List<LoadedVisitor> loadedVisitors;
 
     public PythonTypeElementVisitorProcessor(ClassLoader classLoader) {
+        this(classLoader, null);
+    }
+
+    /**
+     * @param classLoader The visitor class loader
+     * @param visitorKind The visitor kind to execute
+     */
+    @Internal
+    public PythonTypeElementVisitorProcessor(ClassLoader classLoader,
+                                             TypeElementVisitor.VisitorKind visitorKind) {
         this.classLoader = classLoader;
+        this.visitorKind = visitorKind;
     }
 
     /**
@@ -120,6 +134,22 @@ public final class PythonTypeElementVisitorProcessor {
      * @param environment The processing environment
      */
     public void process(PythonProcessingEnvironment environment) {
+        process(environment, ignored -> true, true, true);
+    }
+
+    /**
+     * Processes a selected set of source elements for one visitor kind.
+     *
+     * @param environment The processing environment
+     * @param sourceFilter The source element filter
+     * @param applyMixins Whether mixins should be applied
+     * @param writeAssociatedBeans Whether associated bean definitions should be written
+     */
+    @Internal
+    public void process(PythonProcessingEnvironment environment,
+                        Predicate<ClassElement> sourceFilter,
+                        boolean applyMixins,
+                        boolean writeAssociatedBeans) {
         PythonVisitorContext pythonVisitorContext = environment.visitorContext();
         for (LoadedVisitor loadedVisitor : loadedVisitors) {
             try {
@@ -129,8 +159,10 @@ public final class PythonTypeElementVisitorProcessor {
             }
         }
 
-        applyMixins(environment, pythonVisitorContext);
-        List<ClassElement> allClasses = collectClassElements(environment, pythonVisitorContext);
+        if (applyMixins) {
+            applyMixins(environment, pythonVisitorContext, sourceFilter);
+        }
+        List<ClassElement> allClasses = collectClassElements(environment, pythonVisitorContext, sourceFilter);
         for (LoadedVisitor loadedVisitor : loadedVisitors) {
             for (ClassElement element : allClasses) {
                 if (element.hasAnnotation(Generated.class)) {
@@ -154,7 +186,9 @@ public final class PythonTypeElementVisitorProcessor {
                 failVisitor(pythonVisitorContext, loadedVisitor, "finish", e);
             }
         }
-        writeAssociatedBeanDefinitions(pythonVisitorContext);
+        if (writeAssociatedBeans) {
+            writeAssociatedBeanDefinitions(pythonVisitorContext);
+        }
     }
 
     private static void failVisitor(PythonVisitorContext visitorContext, LoadedVisitor loadedVisitor, String phase, Throwable throwable) {
@@ -170,8 +204,10 @@ public final class PythonTypeElementVisitorProcessor {
         ), null);
     }
 
-    private void applyMixins(PythonProcessingEnvironment environment, PythonVisitorContext pythonVisitorContext) {
-        for (ClassElement mixin : collectPythonClassElements(environment)) {
+    private void applyMixins(PythonProcessingEnvironment environment,
+                             PythonVisitorContext pythonVisitorContext,
+                             Predicate<ClassElement> sourceFilter) {
+        for (ClassElement mixin : collectPythonClassElements(environment, sourceFilter)) {
             AnnotationValue<Mixin> mixinAnnotation = mixin.getAnnotation(Mixin.class);
             if (mixinAnnotation == null) {
                 continue;
@@ -191,17 +227,20 @@ public final class PythonTypeElementVisitorProcessor {
         }
     }
 
-    private List<ClassElement> collectPythonClassElements(PythonProcessingEnvironment environment) {
+    private List<ClassElement> collectPythonClassElements(PythonProcessingEnvironment environment,
+                                                          Predicate<ClassElement> sourceFilter) {
         Map<String, ClassElement> classes = environment.classes();
         Map<String, ClassElement> scripts = environment.scripts();
         List<ClassElement> allClasses = new ArrayList<>(classes.size() + scripts.size());
-        allClasses.addAll(classes.values());
-        allClasses.addAll(scripts.values());
+        classes.values().stream().filter(sourceFilter).forEach(allClasses::add);
+        scripts.values().stream().filter(sourceFilter).forEach(allClasses::add);
         return allClasses;
     }
 
-    private List<ClassElement> collectClassElements(PythonProcessingEnvironment environment, PythonVisitorContext pythonVisitorContext) {
-        List<ClassElement> allClasses = collectPythonClassElements(environment);
+    private List<ClassElement> collectClassElements(PythonProcessingEnvironment environment,
+                                                    PythonVisitorContext pythonVisitorContext,
+                                                    Predicate<ClassElement> sourceFilter) {
+        List<ClassElement> allClasses = collectPythonClassElements(environment, sourceFilter);
         Map<String, ClassElement> uniqueClasses = new LinkedHashMap<>();
         allClasses.forEach(classElement -> uniqueClasses.putIfAbsent(classElement.getName(), classElement));
         for (ClassElement classElement : new ArrayList<>(allClasses)) {
@@ -209,7 +248,9 @@ public final class PythonTypeElementVisitorProcessor {
                 // Imported-element collection can rediscover Python classes that are already part of
                 // the source environment. Type visitors may register associated beans, so visiting the
                 // same class twice would generate duplicate bean definitions for the same association.
-                uniqueClasses.putIfAbsent(importedElement.getName(), importedElement);
+                if (!(importedElement instanceof AbstractPythonClassElement) || sourceFilter.test(importedElement)) {
+                    uniqueClasses.putIfAbsent(importedElement.getName(), importedElement);
+                }
             }
         }
         return new ArrayList<>(uniqueClasses.values());
@@ -384,8 +425,10 @@ public final class PythonTypeElementVisitorProcessor {
     }
 
     private boolean isSupportedVisitorKind(TypeElementVisitor.VisitorKind visitorKind) {
-        return visitorKind == TypeElementVisitor.VisitorKind.ISOLATING
-            || visitorKind == TypeElementVisitor.VisitorKind.AGGREGATING;
+        return this.visitorKind == null
+            ? visitorKind == TypeElementVisitor.VisitorKind.ISOLATING
+                || visitorKind == TypeElementVisitor.VisitorKind.AGGREGATING
+            : this.visitorKind == visitorKind;
     }
 
     /**

--- a/inject-python/src/main/java/io/micronaut/python/processing/visitor/PythonTypeElementVisitorProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/visitor/PythonTypeElementVisitorProcessor.java
@@ -209,21 +209,19 @@ public final class PythonTypeElementVisitorProcessor {
                              Predicate<ClassElement> sourceFilter) {
         for (ClassElement mixin : collectPythonClassElements(environment, sourceFilter)) {
             AnnotationValue<Mixin> mixinAnnotation = mixin.getAnnotation(Mixin.class);
-            if (mixinAnnotation == null) {
-                continue;
+            if (mixinAnnotation != null) {
+                String target = mixinAnnotation.stringValue("target")
+                    .orElse(mixinAnnotation.stringValue().orElse(null));
+                if (target != null && !Object.class.getName().equals(target)) {
+                    ClassElement mixinTarget = pythonVisitorContext.getClassElement(target).orElse(null);
+                    if (mixinTarget == null) {
+                        pythonVisitorContext.warn("Cannot access class: " + target, mixin);
+                    } else {
+                        VisitorUtils.applyMixin(mixinAnnotation, mixin, mixinTarget, pythonVisitorContext);
+                        copyPythonPropertyMixinAnnotations(mixinAnnotation, mixin, mixinTarget);
+                    }
+                }
             }
-            String target = mixinAnnotation.stringValue("target")
-                .orElse(mixinAnnotation.stringValue().orElse(null));
-            if (target == null || Object.class.getName().equals(target)) {
-                continue;
-            }
-            ClassElement mixinTarget = pythonVisitorContext.getClassElement(target).orElse(null);
-            if (mixinTarget == null) {
-                pythonVisitorContext.warn("Cannot access class: " + target, mixin);
-                continue;
-            }
-            VisitorUtils.applyMixin(mixinAnnotation, mixin, mixinTarget, pythonVisitorContext);
-            copyPythonPropertyMixinAnnotations(mixinAnnotation, mixin, mixinTarget);
         }
     }
 

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -993,6 +993,34 @@ final class PyronautCompilerIncrementalTest {
     }
 
     @Test
+    void regeneratesSharedPythonPackageOutputsAfterStructuralChange(@TempDir Path directory)
+        throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python/pkg"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = python.resolve("alpha.py");
+        Files.writeString(alpha, "class Alpha:\n    value: int = 1\n");
+        Files.writeString(python.resolve("beta.py"), "class Beta:\n    value: int = 2\n");
+        compilePython(directory.resolve("python"), java, output, cache);
+        Path initializer = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/pkg/__init__.py"
+        );
+
+        Files.writeString(alpha, """
+            class Alpha:
+                value: int = 1
+            class Added:
+                value: int = 3
+            """);
+        compilePython(directory.resolve("python"), java, output, cache);
+
+        String content = Files.readString(initializer);
+        assertTrue(content.contains("from .alpha import Added"));
+        assertTrue(content.contains("from .beta import Beta"));
+    }
+
+    @Test
     void propagatesDependenciesAcrossJavaAndPython(@TempDir Path directory) throws Exception {
         Path python = Files.createDirectories(directory.resolve("python"));
         Path java = Files.createDirectories(directory.resolve("java/example"));

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -933,6 +933,8 @@ final class PyronautCompilerIncrementalTest {
         Path filesList = output.resolve(
             "META-INF/GRAALPY-VFS/micronaut-application/fileslist.txt"
         );
+        List<String> cleanEntries = Files.readAllLines(filesList);
+        assertEquals(cleanEntries.stream().sorted().toList(), cleanEntries);
         Files.setLastModifiedTime(initializer, UNCHANGED_MARKER);
         Files.setLastModifiedTime(filesList, UNCHANGED_MARKER);
 

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -342,10 +342,27 @@ final class PyronautCompilerIncrementalTest {
             @TestAggregate
             public class Two {}
             """);
+        Path unrelated = sources.resolve("Unrelated.java");
+        Files.writeString(unrelated, "public class Unrelated {}\n");
 
         compileJava(sources, output, cache);
+        Set<String> aggregatingInputs = decodeStateList(
+            state(cache).getProperty("aggregating.inputs")
+        );
+        assertTrue(aggregatingInputs.contains(one.toRealPath().toString()));
+        assertTrue(aggregatingInputs.contains(sources.resolve("Two.java").toRealPath().toString()));
+        assertFalse(aggregatingInputs.contains(unrelated.toRealPath().toString()));
         Path twoClass = output.resolve("Two.class");
+        Path aggregate = output.resolve("META-INF/pyronaut/aggregating.txt");
         Files.setLastModifiedTime(twoClass, UNCHANGED_MARKER);
+        Files.setLastModifiedTime(aggregate, UNCHANGED_MARKER);
+
+        Files.writeString(unrelated, "public class Unrelated { int changed; }\n");
+        compileJava(sources, output, cache);
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(twoClass));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(aggregate));
+        Path unrelatedClass = output.resolve("Unrelated.class");
+        Files.setLastModifiedTime(unrelatedClass, UNCHANGED_MARKER);
 
         Files.writeString(one, """
             import io.micronaut.python.compiler.TestAggregate;
@@ -355,7 +372,8 @@ final class PyronautCompilerIncrementalTest {
         compileJava(sources, output, cache);
 
         assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(twoClass));
-        String summary = Files.readString(output.resolve("META-INF/pyronaut/aggregating.txt"));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(unrelatedClass));
+        String summary = Files.readString(aggregate);
         assertTrue(summary.contains("One"));
         assertTrue(summary.contains("Two"));
         assertFalse(state(cache).getProperty("aggregating.inputs").isBlank());
@@ -416,7 +434,7 @@ final class PyronautCompilerIncrementalTest {
         Files.setLastModifiedTime(aggregate, UNCHANGED_MARKER);
         Files.writeString(java.resolve("Helper.java"), "class Helper {}\n");
         compilePython(python, java, output, cache);
-        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(aggregate));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(aggregate));
         summary = Files.readString(aggregate);
         assertTrue(summary.contains("python.One"));
         assertTrue(summary.contains("python.Two"));
@@ -945,7 +963,7 @@ final class PyronautCompilerIncrementalTest {
     }
 
     @Test
-    void regeneratesSharedPythonPackageOutputs(@TempDir Path directory) throws Exception {
+    void preservesUnchangedSharedPythonPackageOutputs(@TempDir Path directory) throws Exception {
         Path python = Files.createDirectories(directory.resolve("python/pkg"));
         Path java = Files.createDirectories(directory.resolve("java"));
         Path output = directory.resolve("classes");
@@ -967,7 +985,7 @@ final class PyronautCompilerIncrementalTest {
         Files.writeString(alpha, "class Alpha:\n    value: int = 2\n");
         compilePython(directory.resolve("python"), java, output, cache);
 
-        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(initializer));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(initializer));
         assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(filesList));
         assertTrue(Files.readString(filesList).contains("/pkg/__init__.py"));
         assertTrue(decodeStateList(state(cache).getProperty("python.aggregating.outputs")).stream()

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -1,0 +1,1192 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class PyronautCompilerIncrementalTest {
+    private static final FileTime UNCHANGED_MARKER = FileTime.fromMillis(1_000);
+
+    @Test
+    void incrementalCompilationIsDisabledByDefault(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = Files.createDirectories(directory.resolve("classes"));
+        Path cache = directory.resolve("incremental");
+        Files.writeString(sources.resolve("Greeting.java"), "public class Greeting {}\n");
+
+        PyronautCompiler.builder()
+            .javaSrc(sources.toString())
+            .targetDir(output.toFile())
+            .incrementalCacheDirectory(cache.toFile())
+            .build()
+            .compile();
+
+        assertFalse(Files.exists(cache));
+    }
+
+    @Test
+    void recompilesOnlyChangedIndependentJavaSources(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = sources.resolve("Alpha.java");
+        Files.writeString(alpha, "public class Alpha { int value() { return 1; } }\n");
+        Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+
+        compileJava(sources, output, cache);
+        Path betaClass = output.resolve("Beta.class");
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, "public class Alpha { int value() { return 2; } }\n");
+        compileJava(sources, output, cache);
+
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+        assertTrue(Files.isRegularFile(cache.resolve("state.properties")));
+    }
+
+    @Test
+    void noChangeCompilationLeavesOutputsUntouched(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Files.writeString(sources.resolve("Alpha.java"), "public class Alpha {}\n");
+
+        compileJava(sources, output, cache);
+        Path alphaClass = output.resolve("Alpha.class");
+        Files.setLastModifiedTime(alphaClass, UNCHANGED_MARKER);
+
+        compileJava(sources, output, cache);
+
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(alphaClass));
+    }
+
+    @Test
+    void tracksJavaIsolatingVisitorOutputsAcrossAddDeleteAndRename(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path one = sources.resolve("One.java");
+        Path two = sources.resolve("Two.java");
+        Files.writeString(one, """
+            import io.micronaut.python.compiler.TestIsolate;
+            @TestIsolate
+            public class One {}
+            """);
+        Files.writeString(two, """
+            import io.micronaut.python.compiler.TestIsolate;
+            @TestIsolate
+            public class Two {}
+            """);
+
+        compileJava(sources, output, cache);
+        Path oneOutput = output.resolve("META-INF/pyronaut/isolating-One.txt");
+        Path twoOutput = output.resolve("META-INF/pyronaut/isolating-Two.txt");
+        Files.setLastModifiedTime(twoOutput, UNCHANGED_MARKER);
+
+        Files.writeString(one, """
+            import io.micronaut.python.compiler.TestIsolate;
+            @TestIsolate
+            public class One { int changed; }
+            """);
+        compileJava(sources, output, cache);
+        assertTrue(Files.isRegularFile(oneOutput));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(twoOutput));
+
+        Files.delete(one);
+        Path renamed = sources.resolve("Renamed.java");
+        Files.writeString(renamed, """
+            import io.micronaut.python.compiler.TestIsolate;
+            @TestIsolate
+            public class Renamed {}
+            """);
+        compileJava(sources, output, cache);
+
+        assertFalse(Files.exists(oneOutput));
+        assertFalse(Files.exists(output.resolve("One.class")));
+        assertTrue(Files.isRegularFile(output.resolve("META-INF/pyronaut/isolating-Renamed.txt")));
+        assertTrue(Files.isRegularFile(output.resolve("Renamed.class")));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(twoOutput));
+    }
+
+    @Test
+    void tracksClassesGeneratedFromIsolatingProcessorSources(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = sources.resolve("Alpha.java");
+        Files.writeString(alpha, """
+            import io.micronaut.python.compiler.TestIsolate;
+            @TestIsolate
+            public class Alpha {}
+            """);
+        Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+
+        compileWithProcessor(
+            sources,
+            output,
+            cache,
+            new TestIsolatingSourceGeneratingProcessor()
+        );
+        Path generatedClass = output.resolve("generated/UnrelatedGenerated.class");
+        Path betaClass = output.resolve("Beta.class");
+        assertTrue(Files.isRegularFile(generatedClass));
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, """
+            import io.micronaut.python.compiler.TestIsolate;
+            @TestIsolate
+            public class Alpha { int changed; }
+            """);
+        compileWithProcessor(
+            sources,
+            output,
+            cache,
+            new TestIsolatingSourceGeneratingProcessor()
+        );
+
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+        assertTrue(Files.isRegularFile(generatedClass));
+        assertEquals(
+            "true",
+            state(cache).getProperty("processor.compatible"),
+            Files.readString(cache.resolve("state.properties"))
+        );
+
+        Files.delete(alpha);
+        compileWithProcessor(
+            sources,
+            output,
+            cache,
+            new TestIsolatingSourceGeneratingProcessor()
+        );
+        assertFalse(Files.exists(generatedClass));
+    }
+
+    @Test
+    void recompilesTransitiveJavaDependents(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = sources.resolve("Alpha.java");
+        Files.writeString(alpha, "public class Alpha { int value() { return 1; } }\n");
+        Files.writeString(
+            sources.resolve("Beta.java"),
+            "public class Beta { Alpha alpha = new Alpha(); }\n"
+        );
+
+        compileJava(sources, output, cache);
+        Path betaClass = output.resolve("Beta.class");
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, "public class Alpha { int value() { return 2; } }\n");
+        compileJava(sources, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+    }
+
+    @Test
+    void removesOutputsForDeletedJavaSources(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = sources.resolve("Alpha.java");
+        Files.writeString(alpha, "public class Alpha {}\n");
+        Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+
+        compileJava(sources, output, cache);
+        assertTrue(Files.deleteIfExists(alpha));
+        compileJava(sources, output, cache);
+
+        assertFalse(Files.exists(output.resolve("Alpha.class")));
+        assertTrue(Files.isRegularFile(output.resolve("Beta.class")));
+    }
+
+    @Test
+    void preservesUnchangedPythonSourceOutputs(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = python.resolve("alpha.py");
+        Files.writeString(alpha, """
+            from jakarta.inject import Singleton
+            @Singleton
+            class Alpha:
+                value: int = 1
+            """);
+        Files.writeString(python.resolve("beta.py"), """
+            from jakarta.inject import Singleton
+            @Singleton
+            class Beta:
+                value: int = 2
+            """);
+
+        compilePython(python, java, output, cache);
+        Path betaVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/beta.py"
+        );
+        Path alphaBean = findOutput(output, "Alpha$Definition.class");
+        Path betaBean = findOutput(output, "Beta$Definition.class");
+        Files.setLastModifiedTime(betaVfs, UNCHANGED_MARKER);
+        Files.setLastModifiedTime(betaBean, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, """
+            from jakarta.inject import Singleton
+            @Singleton
+            class Alpha:
+                value: int = 3
+            """);
+        compilePython(python, java, output, cache);
+
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaVfs));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaBean));
+        assertTrue(Files.readString(output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/alpha.py"
+        )).contains("3"));
+
+        Files.delete(alpha);
+        compilePython(python, java, output, cache);
+        assertFalse(Files.exists(alphaBean));
+        assertTrue(Files.isRegularFile(betaBean));
+    }
+
+    @Test
+    void preservesUnchangedPythonIsolatingVisitorAndBytecodeOutputs(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = python.resolve("alpha.py");
+        Files.writeString(alpha, """
+            from io.micronaut.python.compiler import TestIsolate
+            @TestIsolate
+            class Alpha:
+                value: int = 1
+            """);
+        Files.writeString(python.resolve("beta.py"), """
+            from io.micronaut.python.compiler import TestIsolate
+            @TestIsolate
+            class Beta:
+                value: int = 2
+            """);
+
+        compilePython(python, java, output, cache, true);
+        Path betaVisitorOutput = output.resolve("META-INF/pyronaut/isolating-Beta.txt");
+        Path alphaBytecode = findOutput(output, "alpha.", ".pyc");
+        Path betaBytecode = findOutput(output, "beta.", ".pyc");
+        Files.setLastModifiedTime(betaVisitorOutput, UNCHANGED_MARKER);
+        Files.setLastModifiedTime(betaBytecode, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, """
+            from io.micronaut.python.compiler import TestIsolate
+            @TestIsolate
+            class Alpha:
+                value: int = 3
+            """);
+        compilePython(python, java, output, cache, true);
+
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaVisitorOutput));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaBytecode));
+
+        Files.delete(alpha);
+        compilePython(python, java, output, cache, true);
+        assertFalse(Files.exists(alphaBytecode));
+        assertTrue(Files.isRegularFile(betaBytecode));
+    }
+
+    @Test
+    void recompilesAllContributorsForAggregatingVisitors(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path one = sources.resolve("One.java");
+        Files.writeString(one, """
+            import io.micronaut.python.compiler.TestAggregate;
+            @TestAggregate
+            public class One {}
+            """);
+        Files.writeString(sources.resolve("Two.java"), """
+            import io.micronaut.python.compiler.TestAggregate;
+            @TestAggregate
+            public class Two {}
+            """);
+
+        compileJava(sources, output, cache);
+        Path twoClass = output.resolve("Two.class");
+        Files.setLastModifiedTime(twoClass, UNCHANGED_MARKER);
+
+        Files.writeString(one, """
+            import io.micronaut.python.compiler.TestAggregate;
+            @TestAggregate
+            public class One { int changed; }
+            """);
+        compileJava(sources, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(twoClass));
+        String summary = Files.readString(output.resolve("META-INF/pyronaut/aggregating.txt"));
+        assertTrue(summary.contains("One"));
+        assertTrue(summary.contains("Two"));
+        assertFalse(state(cache).getProperty("aggregating.inputs").isBlank());
+
+        Files.delete(sources.resolve("Two.java"));
+        compileJava(sources, output, cache);
+
+        summary = Files.readString(output.resolve("META-INF/pyronaut/aggregating.txt"));
+        assertTrue(summary.contains("One"));
+        assertFalse(summary.contains("Two"));
+        assertFalse(Files.exists(twoClass));
+
+        Files.writeString(one, "public class One {}\n");
+        compileJava(sources, output, cache);
+        assertFalse(Files.exists(output.resolve("META-INF/pyronaut/aggregating.txt")));
+    }
+
+    @Test
+    void recompilesAllPythonContributorsForAggregatingVisitors(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path one = python.resolve("one.py");
+        Files.writeString(one, """
+            from io.micronaut.python.compiler import TestAggregate
+            @TestAggregate
+            class One:
+                value: int = 1
+            """);
+        Files.writeString(python.resolve("two.py"), """
+            from io.micronaut.python.compiler import TestAggregate
+            @TestAggregate
+            class Two:
+                value: int = 2
+            """);
+
+        compilePython(python, java, output, cache);
+        Path aggregate = output.resolve("META-INF/pyronaut/aggregating.txt");
+        String summary = Files.readString(aggregate);
+        assertTrue(summary.contains("python.One"));
+        assertTrue(summary.contains("python.Two"));
+        assertTrue(Files.readString(cache.resolve("state.properties"))
+            .contains("processor.compatible=true"));
+
+        Files.writeString(one, """
+            from io.micronaut.python.compiler import TestAggregate
+            @TestAggregate
+            class One:
+                value: int = 3
+            """);
+        compilePython(python, java, output, cache);
+
+        summary = Files.readString(aggregate);
+        assertTrue(summary.contains("python.One"));
+        assertTrue(summary.contains("python.Two"));
+
+        Files.setLastModifiedTime(aggregate, UNCHANGED_MARKER);
+        Files.writeString(java.resolve("Helper.java"), "class Helper {}\n");
+        compilePython(python, java, output, cache);
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(aggregate));
+        summary = Files.readString(aggregate);
+        assertTrue(summary.contains("python.One"));
+        assertTrue(summary.contains("python.Two"));
+
+        Files.delete(python.resolve("two.py"));
+        compilePython(python, java, output, cache);
+
+        summary = Files.readString(aggregate);
+        assertTrue(summary.contains("python.One"));
+        assertFalse(summary.contains("python.Two"));
+    }
+
+    @Test
+    void invalidatesForCompilerOptionsCorruptStateAndMissingOutputs(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Files.writeString(sources.resolve("Alpha.java"), "public class Alpha {}\n");
+        Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+
+        compileJava(sources, output, cache);
+        Path betaClass = output.resolve("Beta.class");
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+
+        compileJava(sources, output, cache, List.of(), "-parameters");
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+        Files.writeString(cache.resolve("state.properties"), "not valid state");
+        compileJava(sources, output, cache, List.of(), "-parameters");
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+        Files.delete(output.resolve("Alpha.class"));
+        compileJava(sources, output, cache, List.of(), "-parameters");
+        assertTrue(Files.isRegularFile(output.resolve("Alpha.class")));
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+    }
+
+    @Test
+    void invalidatesForClasspathContentChanges(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path classpath = Files.createDirectories(directory.resolve("classpath"));
+        Path fingerprintedDependency = classpath.resolve("dependency.version");
+        Files.writeString(fingerprintedDependency, "one");
+        Files.writeString(sources.resolve("Alpha.java"), "public class Alpha {}\n");
+        Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+
+        compileJava(sources, output, cache, List.of(classpath));
+        Path betaClass = output.resolve("Beta.class");
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+
+        Files.writeString(fingerprintedDependency, "two");
+        compileJava(sources, output, cache, List.of(classpath));
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+    }
+
+    @Test
+    void rejectsStateOutputsOutsideTheTargetDirectory(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = sources.resolve("Alpha.java");
+        Files.writeString(alpha, "public class Alpha {}\n");
+        Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+        compileJava(sources, output, cache);
+
+        Path outside = directory.resolve("outside.class");
+        Files.writeString(outside, "unmanaged");
+        Properties properties = state(cache);
+        properties.setProperty(
+            "aggregating.outputs",
+            java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(
+                "../outside.class".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+            )
+        );
+        try (var stateOutput = Files.newOutputStream(cache.resolve("state.properties"))) {
+            properties.store(stateOutput, "unsafe incremental state");
+        }
+        Path betaClass = output.resolve("Beta.class");
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+        Files.writeString(alpha, "public class Alpha { int changed; }\n");
+
+        compileJava(sources, output, cache);
+
+        assertTrue(Files.isRegularFile(outside));
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+    }
+
+    @Test
+    void invalidatesForProcessorPathBootClasspathAndBytecodeMode(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path processorPath = Files.createDirectories(directory.resolve("processor-path"));
+        Path bootClasspath = Files.createDirectories(directory.resolve("boot-classpath"));
+        Files.writeString(sources.resolve("Alpha.java"), "public class Alpha {}\n");
+        Files.writeString(processorPath.resolve("processor.version"), "one");
+        Files.writeString(bootClasspath.resolve("boot.version"), "one");
+
+        IncrementalCompilation initial = incrementalState(
+            sources,
+            output,
+            cache,
+            processorPath,
+            bootClasspath,
+            false
+        );
+        IncrementalCompilation.Plan initialPlan = initial.plan(false);
+        assertTrue(initialPlan.fullRebuild());
+        initial.prepareOutput(initialPlan);
+        initial.complete(initialPlan, IncrementalCompilationTrace.empty());
+
+        assertTrue(incrementalState(
+            sources,
+            output,
+            cache,
+            processorPath,
+            bootClasspath,
+            false
+        ).plan(false).upToDate());
+
+        Files.writeString(processorPath.resolve("processor.version"), "two");
+        assertTrue(incrementalState(
+            sources,
+            output,
+            cache,
+            processorPath,
+            bootClasspath,
+            false
+        ).plan(false).fullRebuild());
+        Files.writeString(processorPath.resolve("processor.version"), "one");
+
+        Files.writeString(bootClasspath.resolve("boot.version"), "two");
+        assertTrue(incrementalState(
+            sources,
+            output,
+            cache,
+            processorPath,
+            bootClasspath,
+            false
+        ).plan(false).fullRebuild());
+        Files.writeString(bootClasspath.resolve("boot.version"), "one");
+
+        assertTrue(incrementalState(
+            sources,
+            output,
+            cache,
+            processorPath,
+            bootClasspath,
+            true
+        ).plan(false).fullRebuild());
+    }
+
+    @Test
+    void invalidatesForApplicationSettings(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path processorPath = Files.createDirectories(directory.resolve("processor-path"));
+        Path bootClasspath = Files.createDirectories(directory.resolve("boot-classpath"));
+        Files.writeString(sources.resolve("Alpha.java"), "public class Alpha {}\n");
+
+        IncrementalCompilation initial = incrementalState(
+            sources,
+            output,
+            cache,
+            processorPath,
+            bootClasspath,
+            false,
+            "example.one",
+            null
+        );
+        IncrementalCompilation.Plan initialPlan = initial.plan(false);
+        initial.prepareOutput(initialPlan);
+        initial.complete(initialPlan, IncrementalCompilationTrace.empty());
+
+        assertTrue(incrementalState(
+            sources,
+            output,
+            cache,
+            processorPath,
+            bootClasspath,
+            false,
+            "example.two",
+            null
+        ).plan(false).fullRebuild());
+        assertTrue(incrementalState(
+            sources,
+            output,
+            cache,
+            processorPath,
+            bootClasspath,
+            false,
+            "example.one",
+            "Alpha"
+        ).plan(false).fullRebuild());
+    }
+
+    @Test
+    void invalidatesStateAfterFailedCompilationAndRepairsOnNextRun(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = sources.resolve("Alpha.java");
+        Files.writeString(alpha, "public class Alpha {}\n");
+        compileJava(sources, output, cache);
+
+        Files.writeString(alpha, "public class Alpha { syntax error }\n");
+        assertThrows(RuntimeException.class, () -> compileJava(sources, output, cache));
+        assertFalse(Files.exists(cache.resolve("state.properties")));
+
+        Files.writeString(alpha, "public class Alpha { int repaired; }\n");
+        compileJava(sources, output, cache);
+        assertTrue(Files.isRegularFile(output.resolve("Alpha.class")));
+        assertTrue(Files.isRegularFile(cache.resolve("state.properties")));
+    }
+
+    @Test
+    void recompilesJavaConstantAndTransitiveDependents(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path constants = sources.resolve("Constants.java");
+        Files.writeString(constants, "class Constants { static final int VALUE = 1; }\n");
+        Files.writeString(
+            sources.resolve("Consumer.java"),
+            "class Consumer { int value = Constants.VALUE; }\n"
+        );
+        Files.writeString(
+            sources.resolve("Transitive.java"),
+            "class Transitive { Consumer consumer = new Consumer(); }\n"
+        );
+        compileJava(sources, output, cache);
+        Path consumerClass = output.resolve("Consumer.class");
+        Path transitiveClass = output.resolve("Transitive.class");
+        Files.setLastModifiedTime(consumerClass, UNCHANGED_MARKER);
+        Files.setLastModifiedTime(transitiveClass, UNCHANGED_MARKER);
+
+        Files.writeString(constants, "class Constants { static final int VALUE = 2; }\n");
+        compileJava(sources, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(consumerClass));
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(transitiveClass));
+    }
+
+    @Test
+    void recompilesJavaAnnotationDependents(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path annotation = sources.resolve("Marker.java");
+        Files.writeString(annotation, "@interface Marker { int value() default 1; }\n");
+        Files.writeString(sources.resolve("Annotated.java"), "@Marker class Annotated {}\n");
+        compileJava(sources, output, cache);
+        Path annotatedClass = output.resolve("Annotated.class");
+        Files.setLastModifiedTime(annotatedClass, UNCHANGED_MARKER);
+
+        Files.writeString(annotation, "@interface Marker { int value() default 2; }\n");
+        compileJava(sources, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(annotatedClass));
+    }
+
+    @Test
+    void recompilesDependentsOfPackagePrivateMembers(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path api = sources.resolve("PackageApi.java");
+        Files.writeString(api, """
+            class PackageApi {
+                int value() { return 1; }
+            }
+            """);
+        Files.writeString(sources.resolve("PackageConsumer.java"), """
+            class PackageConsumer {
+                int value() { return new PackageApi().value(); }
+            }
+            """);
+        compileJava(sources, output, cache);
+        Path consumerClass = output.resolve("PackageConsumer.class");
+        Files.setLastModifiedTime(consumerClass, UNCHANGED_MARKER);
+
+        Files.writeString(api, """
+            class PackageApi {
+                int value() { return 2; }
+            }
+            """);
+        compileJava(sources, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(consumerClass));
+    }
+
+    @Test
+    void fallsBackToFullCompilationAfterIsolatingProcessorContractViolation(
+        @TempDir Path directory
+    ) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = sources.resolve("Alpha.java");
+        Files.writeString(alpha, "public class Alpha {}\n");
+        Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+
+        compileWithContractViolatingProcessor(sources, output, cache);
+        Path betaClass = output.resolve("Beta.class");
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, "public class Alpha { int changed; }\n");
+        compileWithContractViolatingProcessor(sources, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+        assertTrue(Files.isRegularFile(output.resolve("META-INF/contract-violation.txt")));
+    }
+
+    @Test
+    void immediatelyRepairsAfterAProcessorStartsViolatingItsIsolatingContract(
+        @TempDir Path directory
+    ) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = sources.resolve("Alpha.java");
+        Files.writeString(alpha, """
+            import io.micronaut.python.compiler.TestConditionalIsolate;
+            @TestConditionalIsolate(valid = true)
+            public class Alpha {}
+            """);
+        Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+
+        compileJava(sources, output, cache);
+        Path betaClass = output.resolve("Beta.class");
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+        Files.writeString(output.resolve("stale-output.txt"), "stale");
+
+        Files.writeString(alpha, """
+            import io.micronaut.python.compiler.TestConditionalIsolate;
+            @TestConditionalIsolate(valid = false)
+            public class Alpha { int changed; }
+            """);
+        compileJava(sources, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+        assertFalse(Files.exists(output.resolve("stale-output.txt")));
+        assertFalse(Boolean.parseBoolean(state(cache).getProperty("processor.compatible")));
+    }
+
+    @Test
+    void fallsBackToFullCompilationForNonIncrementalProcessor(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = sources.resolve("Alpha.java");
+        Files.writeString(alpha, "public class Alpha {}\n");
+        Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+
+        compileWithProcessor(sources, output, cache, new TestNonIncrementalProcessor());
+        Path betaClass = output.resolve("Beta.class");
+        Files.setLastModifiedTime(betaClass, UNCHANGED_MARKER);
+        Files.writeString(output.resolve("stale-output.txt"), "stale");
+
+        Files.writeString(alpha, "public class Alpha { int changed; }\n");
+        compileWithProcessor(sources, output, cache, new TestNonIncrementalProcessor());
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaClass));
+        assertTrue(Files.readString(cache.resolve("state.properties"))
+            .contains("processor.compatible=false"));
+        assertFalse(Files.exists(output.resolve("stale-output.txt")));
+    }
+
+    @Test
+    void removesDeletedPythonOutputsAndReprocessesImportDependents(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path dependency = python.resolve("dependency.py");
+        Path consumer = python.resolve("consumer.py");
+        Files.writeString(dependency, "class Dependency:\n    value: int = 1\n");
+        Files.writeString(
+            consumer,
+            "from dependency import Dependency\nclass Consumer:\n    value: Dependency\n"
+        );
+        compilePython(python, java, output, cache);
+        Path consumerVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/consumer.py"
+        );
+        Files.setLastModifiedTime(consumerVfs, UNCHANGED_MARKER);
+
+        Files.writeString(dependency, "class Dependency:\n    value: int = 2\n");
+        compilePython(python, java, output, cache);
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(consumerVfs));
+
+        Files.delete(dependency);
+        compilePython(python, java, output, cache);
+        assertFalse(Files.exists(output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/dependency.py"
+        )));
+    }
+
+    @Test
+    void reprocessesAllPythonSourcesForDynamicRelationships(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = python.resolve("alpha.py");
+        Files.writeString(alpha, "class Alpha:\n    value: int = 1\n");
+        Files.writeString(python.resolve("dynamic.py"), """
+            class Dynamic:
+                value: object = getattr(object(), "value", None)
+            """);
+        compilePython(python, java, output, cache);
+        Path dynamicVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/dynamic.py"
+        );
+        Files.setLastModifiedTime(dynamicVfs, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, "class Alpha:\n    value: int = 2\n");
+        compilePython(python, java, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(dynamicVfs));
+    }
+
+    @Test
+    void reprocessesAllPythonSourcesForUnresolvedRelativeImports(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python/pkg"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = python.resolve("alpha.py");
+        Files.writeString(alpha, "class Alpha:\n    value: int = 1\n");
+        Files.writeString(python.resolve("consumer.py"), """
+            from .missing import Missing
+            class Consumer:
+                value: int = 1
+            """);
+        compilePython(directory.resolve("python"), java, output, cache);
+        Path consumerVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/pkg/consumer.py"
+        );
+        Files.setLastModifiedTime(consumerVfs, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, "class Alpha:\n    value: int = 2\n");
+        compilePython(directory.resolve("python"), java, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(consumerVfs));
+    }
+
+    @Test
+    void regeneratesSharedPythonPackageOutputs(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python/pkg"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = python.resolve("alpha.py");
+        Files.writeString(alpha, "class Alpha:\n    value: int = 1\n");
+        compilePython(directory.resolve("python"), java, output, cache);
+        Path initializer = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/pkg/__init__.py"
+        );
+        Path filesList = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/fileslist.txt"
+        );
+        Files.setLastModifiedTime(initializer, UNCHANGED_MARKER);
+        Files.setLastModifiedTime(filesList, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, "class Alpha:\n    value: int = 2\n");
+        compilePython(directory.resolve("python"), java, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(initializer));
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(filesList));
+        assertTrue(Files.readString(filesList).contains("/pkg/__init__.py"));
+        assertTrue(decodeStateList(state(cache).getProperty("python.aggregating.outputs")).stream()
+            .anyMatch(outputPath -> outputPath.endsWith("/pkg/__init__.py")));
+    }
+
+    @Test
+    void propagatesDependenciesAcrossJavaAndPython(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java/example"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path javaDependency = java.resolve("SharedJava.java");
+        Files.writeString(javaDependency, """
+            package example;
+            public class SharedJava { public int value() { return 1; } }
+            """);
+        Files.writeString(python.resolve("consumer.py"), """
+            from example import SharedJava
+            class Consumer:
+                value: SharedJava
+            """);
+        Files.writeString(python.resolve("dynamic.py"), """
+            class Dynamic:
+                value: object = getattr(object(), "value", None)
+            """);
+
+        compilePython(python, directory.resolve("java"), output, cache);
+        Path consumerVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/consumer.py"
+        );
+        Path dynamicVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/dynamic.py"
+        );
+        Files.setLastModifiedTime(consumerVfs, UNCHANGED_MARKER);
+        Files.setLastModifiedTime(dynamicVfs, UNCHANGED_MARKER);
+
+        Files.writeString(javaDependency, """
+            package example;
+            public class SharedJava { public int value() { return 2; } }
+            """);
+        compilePython(python, directory.resolve("java"), output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(consumerVfs));
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(dynamicVfs));
+    }
+
+    @Test
+    void recompilesJavaSourcesThatReferenceGeneratedPythonTypes(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path pythonType = python.resolve("alpha.py");
+        Files.writeString(pythonType, """
+            class Alpha:
+                value: int = 1
+            """);
+        Files.writeString(java.resolve("Consumer.java"), """
+            class Consumer {
+                python.Alpha value;
+            }
+            """);
+
+        compilePython(python, java, output, cache);
+        Path consumerClass = output.resolve("Consumer.class");
+        Files.setLastModifiedTime(consumerClass, UNCHANGED_MARKER);
+
+        Files.writeString(pythonType, """
+            class Alpha:
+                value: int = 2
+            """);
+        compilePython(python, java, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(consumerClass));
+    }
+
+    @Test
+    void changingApplicationSourceDoesNotDeleteUnchangedPythonOutputs(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java/example"));
+        Path javaRoot = directory.resolve("java");
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path application = java.resolve("Application.java");
+        String escapedPython = python.toString().replace("\\", "\\\\");
+        Files.writeString(application, """
+            package example;
+            import io.micronaut.context.python.annotation.PythonApplication;
+            @PythonApplication(src = "%s")
+            public class Application {}
+            """.formatted(escapedPython));
+        Files.writeString(python.resolve("alpha.py"), "class Alpha:\n    value: int = 1\n");
+        Files.writeString(python.resolve("beta.py"), "class Beta:\n    value: int = 2\n");
+
+        compilePythonWithApplication(
+            python,
+            javaRoot,
+            output,
+            cache,
+            "example.Application"
+        );
+        assertEquals(
+            "true",
+            state(cache).getProperty("processor.compatible"),
+            Files.readString(cache.resolve("state.properties"))
+        );
+        Path betaVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/beta.py"
+        );
+        Files.setLastModifiedTime(betaVfs, UNCHANGED_MARKER);
+
+        Files.writeString(application, """
+            package example;
+            import io.micronaut.context.python.annotation.PythonApplication;
+            @PythonApplication(src = "%s")
+            public class Application { int changed; }
+            """.formatted(escapedPython));
+        compilePythonWithApplication(
+            python,
+            javaRoot,
+            output,
+            cache,
+            "example.Application"
+        );
+
+        assertTrue(Files.isRegularFile(betaVfs));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(betaVfs));
+    }
+
+    private static void compileJava(Path sources, Path output, Path cache) {
+        compileJava(sources, output, cache, List.of());
+    }
+
+    private static void compileJava(Path sources,
+                                    Path output,
+                                    Path cache,
+                                    List<Path> classpath,
+                                    String... options) {
+        PyronautCompiler.builder()
+            .javaSrc(sources.toString())
+            .targetDir(output.toFile())
+            .classpath(classpath.stream().map(Path::toFile).toList())
+            .annotationProcessorPath(classpath.stream().map(Path::toFile).toList())
+            .options(List.of(options))
+            .incremental(true)
+            .incrementalCacheDirectory(cache.toFile())
+            .build()
+            .compile();
+    }
+
+    private static void compilePython(Path python, Path java, Path output, Path cache) {
+        compilePython(python, java, output, cache, false);
+    }
+
+    private static void compilePython(Path python,
+                                      Path java,
+                                      Path output,
+                                      Path cache,
+                                      boolean bytecode) {
+        PyronautCompiler.builder()
+            .pythonSrc(python.toString())
+            .javaSrc(java.toString())
+            .targetDir(output.toFile())
+            .compilePythonBytecode(bytecode)
+            .incremental(true)
+            .incrementalCacheDirectory(cache.toFile())
+            .build()
+            .compile();
+    }
+
+    private static void compilePythonWithApplication(Path python,
+                                                     Path java,
+                                                     Path output,
+                                                     Path cache,
+                                                     String applicationClass) {
+        PyronautCompiler.builder()
+            .pythonSrc(python.toString())
+            .javaSrc(java.toString())
+            .applicationClass(applicationClass)
+            .targetDir(output.toFile())
+            .incremental(true)
+            .incrementalCacheDirectory(cache.toFile())
+            .build()
+            .compile();
+    }
+
+    private static IncrementalCompilation incrementalState(Path sources,
+                                                           Path output,
+                                                           Path cache,
+                                                           Path processorPath,
+                                                           Path bootClasspath,
+                                                           boolean bytecode) {
+        return incrementalState(
+            sources,
+            output,
+            cache,
+            processorPath,
+            bootClasspath,
+            bytecode,
+            "pyronaut_application",
+            null
+        );
+    }
+
+    private static IncrementalCompilation incrementalState(Path sources,
+                                                           Path output,
+                                                           Path cache,
+                                                           Path processorPath,
+                                                           Path bootClasspath,
+                                                           boolean bytecode,
+                                                           String packageName,
+                                                           String applicationClass) {
+        return new IncrementalCompilation(
+            sources.toString(),
+            null,
+            null,
+            packageName,
+            applicationClass,
+            output.toFile(),
+            cache.toFile(),
+            List.of(),
+            List.of(bootClasspath.toFile()),
+            List.of(processorPath.toFile()),
+            List.of("-Amicronaut.processing.incremental=true"),
+            bytecode,
+            List.of(),
+            List.of()
+        );
+    }
+
+    private static Properties state(Path cache) throws Exception {
+        Properties properties = new Properties();
+        try (var input = Files.newInputStream(cache.resolve("state.properties"))) {
+            properties.load(input);
+        }
+        return properties;
+    }
+
+    private static Set<String> decodeStateList(String value) {
+        if (value == null || value.isEmpty()) {
+            return Set.of();
+        }
+        return java.util.Arrays.stream(value.split(","))
+            .map(encoded -> new String(
+                java.util.Base64.getUrlDecoder().decode(encoded),
+                java.nio.charset.StandardCharsets.UTF_8
+            ))
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+
+    private static void compileWithContractViolatingProcessor(Path sources,
+                                                              Path output,
+                                                              Path cache) {
+        compileWithProcessor(sources, output, cache, new TestContractViolatingProcessor());
+    }
+
+    private static void compileWithProcessor(Path sources,
+                                             Path output,
+                                             Path cache,
+                                             AbstractProcessor processor) {
+        PyronautCompiler.builder()
+            .javaSrc(sources.toString())
+            .targetDir(output.toFile())
+            .annotationProcessors(List.of(processor))
+            .incremental(true)
+            .incrementalCacheDirectory(cache.toFile())
+            .build()
+            .compile();
+    }
+
+    private static Path findOutput(Path output, String nameToken) throws Exception {
+        return findOutput(output, nameToken, "");
+    }
+
+    private static Path findOutput(Path output, String nameToken, String suffix) throws Exception {
+        try (var paths = Files.walk(output)) {
+            return paths.filter(Files::isRegularFile)
+                .filter(path -> path.getFileName().toString().contains(nameToken))
+                .filter(path -> path.getFileName().toString().endsWith(suffix))
+                .findFirst()
+                .orElseThrow();
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    private static final class TestNonIncrementalProcessor extends AbstractProcessor {
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            return false;
+        }
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
+    }
+}

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -846,6 +846,54 @@ final class PyronautCompilerIncrementalTest {
     }
 
     @Test
+    void optimisticModeDoesNotExpandDynamicPythonRelationships(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = python.resolve("alpha.py");
+        Files.writeString(alpha, "class Alpha:\n    value: int = 1\n");
+        Files.writeString(python.resolve("dynamic.py"), """
+            class Dynamic:
+                value: object = getattr(object(), "value", None)
+            """);
+        compilePython(python, java, output, cache, PythonIncrementalMode.OPTIMISTIC);
+        Path dynamicVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/dynamic.py"
+        );
+        Files.setLastModifiedTime(dynamicVfs, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, "class Alpha:\n    value: int = 2\n");
+        compilePython(python, java, output, cache, PythonIncrementalMode.OPTIMISTIC);
+
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(dynamicVfs));
+    }
+
+    @Test
+    void doesNotReprocessDynamicPythonSourcesForUnrelatedJavaChanges(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Files.writeString(python.resolve("dynamic.py"), """
+            class Dynamic:
+                value: object = getattr(object(), "value", None)
+            """);
+        Path unrelatedJava = java.resolve("Unrelated.java");
+        Files.writeString(unrelatedJava, "class Unrelated { int value = 1; }\n");
+        compilePython(python, java, output, cache);
+        Path dynamicVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/dynamic.py"
+        );
+        Files.setLastModifiedTime(dynamicVfs, UNCHANGED_MARKER);
+
+        Files.writeString(unrelatedJava, "class Unrelated { int value = 2; }\n");
+        compilePython(python, java, output, cache);
+
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(dynamicVfs));
+    }
+
+    @Test
     void reprocessesAllPythonSourcesForUnresolvedRelativeImports(@TempDir Path directory) throws Exception {
         Path python = Files.createDirectories(directory.resolve("python/pkg"));
         Path java = Files.createDirectories(directory.resolve("java"));
@@ -1051,6 +1099,22 @@ final class PyronautCompilerIncrementalTest {
                                       Path java,
                                       Path output,
                                       Path cache,
+                                      PythonIncrementalMode pythonIncrementalMode) {
+        PyronautCompiler.builder()
+            .pythonSrc(python.toString())
+            .javaSrc(java.toString())
+            .targetDir(output.toFile())
+            .incremental(true)
+            .incrementalCacheDirectory(cache.toFile())
+            .pythonIncrementalMode(pythonIncrementalMode)
+            .build()
+            .compile();
+    }
+
+    private static void compilePython(Path python,
+                                      Path java,
+                                      Path output,
+                                      Path cache,
                                       boolean bytecode) {
         PyronautCompiler.builder()
             .pythonSrc(python.toString())
@@ -1119,7 +1183,8 @@ final class PyronautCompilerIncrementalTest {
             List.of("-Amicronaut.processing.incremental=true"),
             bytecode,
             List.of(),
-            List.of()
+            List.of(),
+            PythonIncrementalMode.CONSERVATIVE
         );
     }
 

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -17,6 +17,7 @@ package io.micronaut.python.compiler;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import io.micronaut.python.processing.PythonProcessingSession;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
@@ -54,6 +55,27 @@ final class PyronautCompilerIncrementalTest {
             .compile();
 
         assertFalse(Files.exists(cache));
+    }
+
+    @Test
+    void reusesPythonProcessingSessionAcrossIncrementalCompilations(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path source = python.resolve("example.py");
+        Files.writeString(source, "class Example:\n    value: int = 1\n");
+
+        try (PythonProcessingSession session = new PythonProcessingSession()) {
+            compilePython(python, java, output, cache, session);
+            assertTrue(session.initialized());
+
+            Files.writeString(source, "class Example:\n    value: int = 2\n");
+            compilePython(python, java, output, cache, session);
+            assertTrue(Files.readString(output.resolve(
+                "META-INF/GRAALPY-VFS/micronaut-application/src/example.py"
+            )).contains("value: int = 2"));
+        }
     }
 
     @Test
@@ -1167,6 +1189,22 @@ final class PyronautCompilerIncrementalTest {
 
     private static void compilePython(Path python, Path java, Path output, Path cache) {
         compilePython(python, java, output, cache, false);
+    }
+
+    private static void compilePython(Path python,
+                                      Path java,
+                                      Path output,
+                                      Path cache,
+                                      PythonProcessingSession session) {
+        PyronautCompiler.builder()
+            .pythonSrc(python.toString())
+            .javaSrc(java.toString())
+            .targetDir(output.toFile())
+            .incremental(true)
+            .incrementalCacheDirectory(cache.toFile())
+            .pythonProcessingSession(session)
+            .build()
+            .compile();
     }
 
     private static void compilePython(Path python,

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -919,6 +919,32 @@ final class PyronautCompilerIncrementalTest {
     }
 
     @Test
+    void reprocessesAllPythonSourcesForRelativeStarImports(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python/pkg"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = python.resolve("alpha.py");
+        Files.writeString(alpha, "class Alpha:\n    value: int = 1\n");
+        Files.writeString(python.resolve("symbols.py"), "VALUE = 1\n");
+        Files.writeString(python.resolve("consumer.py"), """
+            from .symbols import *
+            class Consumer:
+                value: int = VALUE
+            """);
+        compilePython(directory.resolve("python"), java, output, cache);
+        Path consumerVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/pkg/consumer.py"
+        );
+        Files.setLastModifiedTime(consumerVfs, UNCHANGED_MARKER);
+
+        Files.writeString(alpha, "class Alpha:\n    value: int = 2\n");
+        compilePython(directory.resolve("python"), java, output, cache);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(consumerVfs));
+    }
+
+    @Test
     void regeneratesSharedPythonPackageOutputs(@TempDir Path directory) throws Exception {
         Path python = Files.createDirectories(directory.resolve("python/pkg"));
         Path java = Files.createDirectories(directory.resolve("java"));

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestAggregate.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestAggregate.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface TestAggregate {
+}

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestAggregatingVisitor.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestAggregatingVisitor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public final class TestAggregatingVisitor implements TypeElementVisitor<TestAggregate, Object> {
+    private final Set<String> visited = new LinkedHashSet<>();
+    private boolean written;
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.AGGREGATING;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of(TestAggregate.class.getName());
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        visited.add(element.getName());
+    }
+
+    @Override
+    public void finish(VisitorContext visitorContext) {
+        if (visited.isEmpty() || written) {
+            return;
+        }
+        written = true;
+        visitorContext.visitMetaInfFile("pyronaut/aggregating.txt")
+            .ifPresent(file -> {
+                try (var writer = file.openWriter()) {
+                    for (String name : visited) {
+                        writer.write(name);
+                        writer.write(System.lineSeparator());
+                    }
+                } catch (IOException e) {
+                    visitorContext.fail("Failed to write aggregating test output: " + e.getMessage(), null);
+                }
+            });
+    }
+}

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestAggregatingVisitor.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestAggregatingVisitor.java
@@ -48,7 +48,7 @@ public final class TestAggregatingVisitor implements TypeElementVisitor<TestAggr
             return;
         }
         written = true;
-        visitorContext.visitMetaInfFile("pyronaut/aggregating.txt")
+        visitorContext.visitGeneratedFile("META-INF/pyronaut/aggregating.txt")
             .ifPresent(file -> {
                 try (var writer = file.openWriter()) {
                     for (String name : visited) {

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestConditionalIsolate.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestConditionalIsolate.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface TestConditionalIsolate {
+    boolean valid();
+}

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestConditionalIsolatingVisitor.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestConditionalIsolatingVisitor.java
@@ -36,8 +36,8 @@ public final class TestConditionalIsolatingVisitor implements TypeElementVisitor
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
         var generatedFile = element.booleanValue(TestConditionalIsolate.class, "valid").orElse(false)
-            ? context.visitMetaInfFile("pyronaut/conditional-isolating.txt", element)
-            : context.visitMetaInfFile("pyronaut/conditional-isolating.txt");
+            ? context.visitGeneratedFile("META-INF/pyronaut/conditional-isolating.txt", element)
+            : context.visitGeneratedFile("META-INF/pyronaut/conditional-isolating.txt");
         generatedFile.ifPresent(file -> {
             try (var writer = file.openWriter()) {
                 writer.write(element.getName());

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestConditionalIsolatingVisitor.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestConditionalIsolatingVisitor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.io.IOException;
+import java.util.Set;
+
+public final class TestConditionalIsolatingVisitor implements TypeElementVisitor<TestConditionalIsolate, Object> {
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of(TestConditionalIsolate.class.getName());
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        var generatedFile = element.booleanValue(TestConditionalIsolate.class, "valid").orElse(false)
+            ? context.visitMetaInfFile("pyronaut/conditional-isolating.txt", element)
+            : context.visitMetaInfFile("pyronaut/conditional-isolating.txt");
+        generatedFile.ifPresent(file -> {
+            try (var writer = file.openWriter()) {
+                writer.write(element.getName());
+            } catch (IOException e) {
+                context.fail("Failed to write conditional isolating test output: " + e.getMessage(), element);
+            }
+        });
+    }
+}

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestContractViolatingProcessor.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestContractViolatingProcessor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.util.Set;
+
+@SupportedAnnotationTypes("*")
+@SupportedOptions("org.gradle.annotation.processing.isolating")
+final class TestContractViolatingProcessor extends AbstractProcessor {
+    private boolean generated;
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (generated || roundEnv.processingOver()) {
+            return false;
+        }
+        generated = true;
+        try {
+            processingEnv.getFiler()
+                .createResource(
+                    StandardLocation.CLASS_OUTPUT,
+                    "",
+                    "META-INF/contract-violation.txt",
+                    roundEnv.getRootElements().toArray(javax.lang.model.element.Element[]::new)
+                )
+                .openWriter()
+                .close();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return false;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+}

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestIsolate.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestIsolate.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface TestIsolate {
+}

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestIsolatingSourceGeneratingProcessor.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestIsolatingSourceGeneratingProcessor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Set;
+
+final class TestIsolatingSourceGeneratingProcessor extends AbstractProcessor {
+    private boolean generated;
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        return Set.of("org.gradle.annotation.processing.isolating");
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of(TestIsolate.class.getName());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnvironment) {
+        if (generated || annotations.isEmpty()) {
+            return false;
+        }
+        for (Element element : roundEnvironment.getElementsAnnotatedWith(TestIsolate.class)) {
+            try {
+                JavaFileObject source = processingEnv.getFiler()
+                    .createSourceFile("generated.UnrelatedGenerated", element);
+                try (Writer writer = source.openWriter()) {
+                    writer.write("""
+                        package generated;
+                        public final class UnrelatedGenerated {}
+                        """);
+                }
+                generated = true;
+                break;
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        return false;
+    }
+}

--- a/inject-python/src/test/java/io/micronaut/python/compiler/TestIsolatingVisitor.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/TestIsolatingVisitor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.compiler;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.io.IOException;
+import java.util.Set;
+
+public final class TestIsolatingVisitor implements TypeElementVisitor<TestIsolate, Object> {
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of(TestIsolate.class.getName());
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        context.visitMetaInfFile(
+            "pyronaut/isolating-" + element.getSimpleName() + ".txt",
+            element
+        ).ifPresent(file -> {
+            try (var writer = file.openWriter()) {
+                writer.write(element.getName());
+            } catch (IOException e) {
+                context.fail("Failed to write isolating test output: " + e.getMessage(), element);
+            }
+        });
+    }
+}

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -52,6 +52,24 @@ import org.graalvm.polyglot.Source;
 public class PythonAstParserTest {
 
     @Test
+    void incrementalProcessorTransformsOnlyAffectedSourcesUnlessAggregationIsRequired(
+        @TempDir Path directory
+    ) throws Exception {
+        Path alphaPath = Files.writeString(directory.resolve("alpha.py"), "answer = 1\n");
+        Path betaPath = Files.writeString(directory.resolve("beta.py"), "answer = 2\n");
+        Source alpha = Source.newBuilder("python", alphaPath.toFile()).build();
+        Source beta = Source.newBuilder("python", betaPath.toFile()).build();
+        var processor = new PythonAnnotationProcessor();
+        processor.setIncrementalSources(Set.of(alphaPath.toAbsolutePath().normalize().toString()));
+        processor.setProcessAggregatingVisitors(false);
+
+        assertEquals(List.of(alpha), processor.selectTransformSources(List.of(alpha, beta)));
+
+        processor.setProcessAggregatingVisitors(true);
+        assertEquals(List.of(alpha, beta), processor.selectTransformSources(List.of(alpha, beta)));
+    }
+
+    @Test
     void bytecodeCompilerReusesParserContextWithoutOwningIt() {
         PythonAstParser parser = new PythonAstParser();
         try {

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -52,6 +52,22 @@ import org.graalvm.polyglot.Source;
 public class PythonAstParserTest {
 
     @Test
+    void bytecodeCompilerReusesParserContextWithoutOwningIt() {
+        PythonAstParser parser = new PythonAstParser();
+        try {
+            try (var compiler = parser.bytecodeCompiler()) {
+                assertTrue(compiler.compile("answer = 42", "/graalpy_vfs/src/example.py").bytes().length > 0);
+            }
+
+            try (PythonEnvironment environment = parser.parse("answer = 42")) {
+                assertNotNull(environment);
+            }
+        } finally {
+            parser.close();
+        }
+    }
+
+    @Test
     void extractsCallsWithoutEvaluatingSource() {
         PythonAstParser parser = new PythonAstParser();
         try {

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -83,6 +85,23 @@ public class PythonAstParserTest {
         } finally {
             parser.close();
         }
+    }
+
+    @Test
+    void processingSessionReusesInitializedContextAcrossCompilations() {
+        PythonProcessingSession session = new PythonProcessingSession();
+        PythonAstParser first = session.parser(getClass().getClassLoader(), true);
+        assertTrue(session.initialized());
+        assertNotNull(first.parse("answer = 1"));
+        PythonAstParser second = session.parser(getClass().getClassLoader(), true);
+        assertSame(first, second);
+        assertNotNull(second.parse("answer = 2"));
+
+        session.close();
+        assertThrows(
+            IllegalStateException.class,
+            () -> session.parser(getClass().getClassLoader(), true)
+        );
     }
 
     @Test

--- a/inject-python/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-python/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -1,0 +1,3 @@
+io.micronaut.python.compiler.TestAggregatingVisitor
+io.micronaut.python.compiler.TestConditionalIsolatingVisitor
+io.micronaut.python.compiler.TestIsolatingVisitor


### PR DESCRIPTION
## Summary

Adds opt-in incremental compilation support to `PyronautCompiler` for Java and Python sources. The implementation tracks source fingerprints, Java dependencies and compiler outputs, Python dependencies and outputs, and isolating/aggregating processor contributions without a Gradle runtime dependency.

## Highlights

- Adds experimental `incremental(boolean)`, `incrementalCacheDirectory(File)`, and `pythonIncrementalMode(PythonIncrementalMode)` builder methods.
- Supports conservative (default) and optimistic handling of dynamic or unresolved Python relationships.
- Reuses unchanged class outputs and recompiles changed sources plus transitive dependents.
- Tracks Java declarations/references with `JavacTask`, `Trees`, and a forwarding file manager.
- Decorates processor `ProcessingEnvironment`/`Filer` for isolating and aggregating output attribution.
- Splits Python isolating and aggregating visitor processing and tracks VFS/bytecode/shared outputs.
- Emits the shared GraalPy VFS index deterministically in both full and incremental builds.
- Falls back to clean full compilation for invalid state, unsupported processors, contract violations, dependency-wide changes, and failed recovery.

## Validation

- `:micronaut-inject-java:test`
- `-Ppython-ci :micronaut-inject-python:test`
- `:micronaut-inject-python:spotlessCheck`
- `:micronaut-inject-python:japiCmp`
- Composite validation from the Pyronaut worktree
- Full 32-test incremental compiler regression suite
- Main and test-pass compilation of `pyronaut-petclinic`, including unchanged runs, simultaneous Python/Java edits, additions, and deletions
- Byte-for-byte clean-versus-incremental parity for petclinic main and test output trees after addition/change and deletion scenarios

Pyronaut integration is in the companion draft PR on the `python-incremental-compilation` branch.
