### PR TITLE
Fix quadratic response body assembly in NettyReadBufferFactory.compose

### DIFF
--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBufferFactory.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBufferFactory.java
@@ -24,6 +24,7 @@ import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
@@ -34,7 +35,9 @@ import java.nio.CharBuffer;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Netty-based {@link ReadBufferFactory}. Also has additional utilities for dealing with netty
@@ -255,14 +258,17 @@ public final class NettyReadBufferFactory extends ReadBufferFactory {
                 return first;
             }
         }
-        CompositeByteBuf composite = allocator.compositeBuffer();
+        // toByteBuf consumes each ReadBuffer, so if extraction fails partway, the ByteBufs
+        // already extracted have no owner anymore and must be released explicitly here.
+        List<ByteBuf> components = new ArrayList<>();
         try {
             for (ReadBuffer buffer : buffers) {
-                composite.addComponent(true, toByteBuf(buffer));
+                components.add(toByteBuf(buffer));
             }
-            return adapt(composite);
         } catch (Throwable e) {
-            composite.release();
+            for (ByteBuf component : components) {
+                ReferenceCountUtil.safeRelease(component);
+            }
             for (ReadBuffer buffer : buffers) {
                 try {
                     buffer.close();
@@ -270,6 +276,19 @@ public final class NettyReadBufferFactory extends ReadBufferFactory {
                     e.addSuppressed(f);
                 }
             }
+            throw e;
+        }
+        CompositeByteBuf composite = allocator.compositeBuffer();
+        try {
+            // addComponents consolidates at most once, at the end. Adding components one at a time
+            // calls consolidateIfNeeded() after each one, and each consolidation copies everything
+            // accumulated so far, making aggregation O(size^2 / chunkSize). addComponents also
+            // takes ownership of all components, releasing any it did not add, so from here on the
+            // composite is the only thing left to release.
+            composite.addComponents(true, components);
+            return adapt(composite);
+        } catch (Throwable e) {
+            composite.release();
             throw e;
         }
     }

--- a/buffer-netty/src/test/java/io/micronaut/buffer/netty/AbstractReadBufferTest.java
+++ b/buffer-netty/src/test/java/io/micronaut/buffer/netty/AbstractReadBufferTest.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -257,6 +258,24 @@ abstract class AbstractReadBufferTest {
         ReadBuffer b = factory.adapt(new byte[]{4, 5, 6});
         try (ReadBuffer composed = factory.compose(List.of(a, b))) {
             assertArrayEquals(new byte[]{1, 2, 3, 4, 5, 6}, composed.toArray());
+        }
+    }
+
+    @Test
+    public void composeManyKeepsContent() {
+        int count = 50;
+        int chunk = 100;
+        byte[] expected = new byte[count * chunk];
+        List<ReadBuffer> parts = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            byte[] part = new byte[chunk];
+            Arrays.fill(part, (byte) i);
+            System.arraycopy(part, 0, expected, i * chunk, chunk);
+            parts.add(factory.adapt(part));
+        }
+        try (ReadBuffer composed = factory.compose(parts)) {
+            assertEquals(expected.length, composed.readable());
+            assertArrayEquals(expected, composed.toArray());
         }
     }
 }

--- a/buffer-netty/src/test/java/io/micronaut/buffer/netty/NettyReadBufferTest.java
+++ b/buffer-netty/src/test/java/io/micronaut/buffer/netty/NettyReadBufferTest.java
@@ -1,13 +1,19 @@
 package io.micronaut.buffer.netty;
 
 import io.micronaut.core.io.buffer.ReadBuffer;
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class NettyReadBufferTest extends AbstractReadBufferTest {
     public NettyReadBufferTest() {
@@ -25,6 +31,92 @@ public class NettyReadBufferTest extends AbstractReadBufferTest {
         } finally {
             if (byteBuf.refCnt() > 0) {
                 byteBuf.release(byteBuf.refCnt());
+            }
+        }
+    }
+
+    /**
+     * {@link io.netty.buffer.CompositeByteBuf#addComponent} calls {@code consolidateIfNeeded()}
+     * after every single component, and each consolidation copies everything accumulated so far
+     * into a freshly allocated buffer. Adding all components at once must consolidate only once,
+     * i.e. there must be exactly one large allocation instead of {@code ceil(n / 16)}.
+     */
+    @Test
+    void composeConsolidatesOnlyOnce() {
+        int count = 50;
+        int chunk = 100;
+        CountingAllocator allocator = new CountingAllocator(chunk + 1);
+        NettyReadBufferFactory factory = NettyReadBufferFactory.of(allocator);
+        List<ReadBuffer> parts = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            parts.add(factory.adapt(Unpooled.wrappedBuffer(new byte[chunk])));
+        }
+        ReadBuffer composed = factory.compose(parts);
+        try {
+            assertEquals(1, allocator.largeAllocations);
+            assertEquals(count * chunk, composed.readable());
+        } finally {
+            composed.close();
+        }
+    }
+
+    @Test
+    void composeReleasesAllInputsOnFailure() {
+        NettyReadBufferFactory factory = NettyReadBufferFactory.of(ByteBufAllocator.DEFAULT);
+        ByteBuf first = Unpooled.wrappedBuffer(new byte[]{1, 2, 3});
+        ByteBuf broken = Unpooled.wrappedBuffer(new byte[]{4, 5, 6});
+        ByteBuf last = Unpooled.wrappedBuffer(new byte[]{7, 8, 9});
+        ReadBuffer brokenBuffer = factory.adapt(broken);
+        // consume the middle buffer, so that toByteBuf throws for it
+        brokenBuffer.close();
+        List<ReadBuffer> parts = List.of(factory.adapt(first), brokenBuffer, factory.adapt(last));
+        try {
+            assertThrows(IllegalStateException.class, () -> factory.compose(parts));
+            assertEquals(0, first.refCnt());
+            assertEquals(0, broken.refCnt());
+            assertEquals(0, last.refCnt());
+        } finally {
+            for (ByteBuf byteBuf : List.of(first, broken, last)) {
+                if (byteBuf.refCnt() > 0) {
+                    byteBuf.release(byteBuf.refCnt());
+                }
+            }
+        }
+    }
+
+    /**
+     * Allocator that counts the allocations that are larger than a single composed input, i.e. the
+     * allocations done by {@code CompositeByteBuf.consolidate0}.
+     */
+    private static final class CountingAllocator extends AbstractByteBufAllocator {
+        final int threshold;
+        int largeAllocations;
+
+        CountingAllocator(int threshold) {
+            super(false);
+            this.threshold = threshold;
+        }
+
+        @Override
+        protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+            count(initialCapacity);
+            return UnpooledByteBufAllocator.DEFAULT.heapBuffer(initialCapacity, maxCapacity);
+        }
+
+        @Override
+        protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+            count(initialCapacity);
+            return UnpooledByteBufAllocator.DEFAULT.directBuffer(initialCapacity, maxCapacity);
+        }
+
+        @Override
+        public boolean isDirectBufferPooled() {
+            return false;
+        }
+
+        private void count(int initialCapacity) {
+            if (initialCapacity >= threshold) {
+                largeAllocations++;
             }
         }
     }


### PR DESCRIPTION
Fixes #12855

`NettyReadBufferFactory.compose(Iterable<ReadBuffer>)` received the complete `Iterable` of body
chunks but added them to the `CompositeByteBuf` one at a time via
`CompositeByteBuf.addComponent(boolean, ByteBuf)`, which calls `consolidateIfNeeded()` after every
single component. Each consolidation copies **everything accumulated so far**, making aggregation
of a body of size `S` in chunks of size `c` cost roughly `S² / (2 · maxNumComponents · c)` bytes of
copying — about 19 GB for a 200 MB response at the default 16 components and 64 KB socket reads,
entirely on the Netty event loop. See #12855 for the full analysis and two production stack traces.

### Change

- Extract all `ByteBuf`s from the input `ReadBuffer`s into a `List<ByteBuf>` first, then hand the
  complete list to `CompositeByteBuf.addComponents(boolean, Iterable<ByteBuf>)`, which consolidates
  at most once, at the end, instead of after every component.
- The extraction and handover are split into two separate `try` blocks because ownership of each
  `ByteBuf` moves in stages:
  - If extraction fails partway, the already-extracted buffers have no owner (since
    `NettyReadBuffer.toByteBuf()` nulls its field) and must be released explicitly.
  - `addComponents` takes ownership of everything it is given, releasing anything it did not add
    in its own `finally`, so after it is called only the composite itself needs releasing.
- `allocator.compositeBuffer()` (no-arg) is kept as-is, along with the existing size-0/size-1
  shortcuts, so the shape of the returned buffer (single component) is unchanged. This keeps the
  change safe for the server and proxy paths that write the composite back to a socket.

### Tests

- `composeManyKeepsContent` (in `AbstractReadBufferTest`, covering both the Netty and NIO
  factories): composes 50 small buffers and asserts the result matches the exact concatenation of
  the inputs.
- `composeConsolidatesOnlyOnce`: uses a counting allocator to assert that only one large
  (consolidation-sized) allocation happens, instead of `ceil(n / 16)`.
- `composeReleasesAllInputsOnFailure`: composes a list containing an already-consumed buffer and
  asserts every input `ByteBuf` ends at `refCnt() == 0`, guarding against a leak on the failure
  path.

### Verification

- `:micronaut-buffer-netty:test`, `checkstyleMain`/`checkstyleTest`: all green.
- `:micronaut-http-server-netty:test`: all green.
- `:micronaut-http-client:test`: green, aside from two pre-existing environment-flaky
  `ProxyBackpressureTest` HTTP/2 cases that fail identically with this change reverted (unrelated
  60s awaitility timeouts on a 128 MB transfer under memory pressure).