### PR TITLE
fix(ksp): include Kotlin internal types in bean $EXPOSED_TYPES

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
@@ -99,7 +99,14 @@ internal abstract class AbstractKotlinElement<T : KotlinNativeElement>(
     }
 
     override fun isPublic() = if (annotatedInfo is KSDeclaration) {
-        annotatedInfo.getVisibility() == Visibility.PUBLIC
+        // Kotlin `internal` is public on the JVM (module-wide), so Class constants and
+        // bean exposed-type references are valid from any package in the compilation.
+        // Treating only Visibility.PUBLIC as public caused incomplete $EXPOSED_TYPES for
+        // internal interfaces implemented by beans in other packages (issue #12854).
+        when (annotatedInfo.getVisibility()) {
+            Visibility.PUBLIC, Visibility.INTERNAL -> true
+            else -> false
+        }
     } else {
         false
     }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
@@ -12,6 +12,7 @@ import io.micronaut.http.annotation.Header
 import io.micronaut.http.annotation.HttpMethodMapping
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.annotation.AnnotationMetadataSupport
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.inject.writer.BeanDefinitionVisitor
@@ -25,6 +26,9 @@ import static io.micronaut.annotation.processing.test.KotlinCompiler.buildContex
 import static io.micronaut.annotation.processing.test.KotlinCompiler.buildInterceptedBeanDefinition
 import static io.micronaut.annotation.processing.test.KotlinCompiler.getBean
 import static io.micronaut.annotation.processing.test.KotlinCompiler.getBeanDefinition
+
+import java.net.URL
+import java.net.URLClassLoader
 
 class BeanDefinitionSpec extends Specification {
 
@@ -857,6 +861,49 @@ class Test: Runnable {
 ''')
         expect:
         reference.exposedTypes == [Runnable] as Set
+    }
+
+    void "test exposed types include kotlin internal interface from another package"() {
+        // Regression for https://github.com/micronaut-projects/micronaut-core/issues/12854
+        // Kotlin `internal` is public on the JVM; exposed types must still include such interfaces
+        // when the bean lives in a different package from the interface.
+        given:
+        def pair = KotlinCompiler.compile([
+            KotlinCompiler.kotlinSource('Intf.kt', '''
+package demo.package1.subpackage2.subpackage3.subpackage4
+
+internal interface Intf {
+    fun a()
+}
+'''),
+            KotlinCompiler.kotlinSource('Failing.kt', '''
+package demo.package1.subpackage2.subpackage3.subpackage4.subpackage5.subpackage6
+
+import demo.package1.subpackage2.subpackage3.subpackage4.Intf
+import jakarta.inject.Singleton
+
+@Singleton
+internal class Failing : Intf {
+    override fun a() {}
+}
+''')
+        ], { }, [])
+
+        def classpath = []
+        classpath << pair.component1().component2().outputDirectory.toURI().toURL()
+        classpath << pair.component2().component2().outputDirectory.toURI().toURL()
+        classpath.addAll(pair.component2().component1().classpaths.collect { it.toURI().toURL() })
+        classpath.addAll(pair.component1().component1().classpaths.collect { it.toURI().toURL() })
+        def classLoader = new URLClassLoader(classpath as URL[], KotlinCompiler.classLoader)
+        def reference = classLoader
+                .loadClass('demo.package1.subpackage2.subpackage3.subpackage4.subpackage5.subpackage6.$Failing$Definition')
+                .getDeclaredConstructor()
+                .newInstance() as BeanDefinitionReference
+
+        expect:
+        def exposedTypeNames = reference.exposedTypes*.name as Set
+        exposedTypeNames.contains('demo.package1.subpackage2.subpackage3.subpackage4.subpackage5.subpackage6.Failing')
+        exposedTypeNames.contains('demo.package1.subpackage2.subpackage3.subpackage4.Intf')
     }
 
     void "test fail compilation on invalid exposed bean type"() {


### PR DESCRIPTION
## Summary
- Treat Kotlin `Visibility.INTERNAL` as public in `AbstractKotlinElement.isPublic()`.
- Kotlin `internal` types are public on the JVM; after #12783, `isAccessibleFromBeanDefinition` omitted internal interfaces from `$EXPOSED_TYPES` when the bean was in another package (same package still worked).
- Add KSP regression coverage matching the [reproducer](https://github.com/blued-gear/demo-micronaut-classdefinitionbug) from #12854.

Fixes #12854

## Testing
- `./gradlew :micronaut-inject-kotlin:test --tests 'io.micronaut.kotlin.processing.beans.BeanDefinitionSpec.test exposed types include kotlin internal interface from another package' --tests 'io.micronaut.kotlin.processing.beans.BeanDefinitionSpec.test limit the exposed bean types*' --tests 'io.micronaut.kotlin.processing.inject.ast.ClassElementSpec' --no-daemon` (JDK 25)
- `./gradlew :micronaut-inject-java:test --tests 'io.micronaut.inject.beans.BeanDefinitionSpec.test exposed types omit package-private supertypes from another package' --no-daemon` (JDK 25) — Java package-private filtering unchanged