### PR TITLE
fix(http-client): preserve PropagatedContext for client filters with micrometer context-propagation

### DIFF
--- a/context-propagation/src/test/kotlin/io/micronaut/context/propagation/client/ClientFilterPropagatedContextSpec.kt
+++ b/context-propagation/src/test/kotlin/io/micronaut/context/propagation/client/ClientFilterPropagatedContextSpec.kt
@@ -1,0 +1,109 @@
+package io.micronaut.context.propagation.client
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.propagation.MutablePropagatedContext
+import io.micronaut.core.propagation.PropagatedContextElement
+import io.micronaut.http.annotation.ClientFilter
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.RequestFilter
+import io.micronaut.http.annotation.ServerFilter
+import io.micronaut.http.annotation.ServerFilter.MATCH_ALL_PATTERN
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * Regression for https://github.com/micronaut-projects/micronaut-core/issues/12851
+ *
+ * With io.micrometer:context-propagation (Reactor automatic context propagation), sequential
+ * suspend HTTP client calls must still see PropagatedContext in client filters.
+ */
+class ClientFilterPropagatedContextSpec {
+
+    @Test
+    fun clientFiltersSeeServerPropagatedContextWithMicrometerContextPropagation() {
+        ApplicationContext.run(
+            EmbeddedServer::class.java,
+            mapOf(
+                "spec.name" to "ClientFilterPropagatedContextSpec",
+                "micronaut.propagation" to "thread-local",
+                // explicit: micrometer context-propagation is on the test classpath and enables this by default
+                "reactor.enable-automatic-context-propagation" to "true"
+            )
+        ).use { server ->
+            val clientFilter = server.applicationContext.getBean(RecordingClientFilter::class.java)
+            HttpClient.create(server.url).use { httpClient ->
+                // Exercise multiple sequential client calls from a suspend controller
+                val response = httpClient.toBlocking().retrieve("/")
+                assertTrue(response.startsWith("OK"), "controller should return OK, was: $response")
+            }
+
+            assertTrue(clientFilter.contextValues.isNotEmpty(), "client filter should have been invoked")
+            assertTrue(
+                clientFilter.contextValues.all { it == "test-value" },
+                "expected all client filter invocations to see test-value, got: ${clientFilter.contextValues}"
+            )
+        }
+    }
+
+    @Requires(property = "spec.name", value = "ClientFilterPropagatedContextSpec")
+    @Controller
+    open class TestController(
+        private val client: TestClient
+    ) {
+        @Get("/")
+        open suspend fun index(): String {
+            repeat(10) {
+                client.ping()
+            }
+            return "OK"
+        }
+    }
+
+    @Requires(property = "spec.name", value = "ClientFilterPropagatedContextSpec")
+    @Client("/")
+    interface TestClient {
+        @Get("/ping")
+        suspend fun ping(): String
+    }
+
+    @Requires(property = "spec.name", value = "ClientFilterPropagatedContextSpec")
+    @Controller
+    open class PingController {
+        @Get("/ping")
+        open fun ping(): String = "pong"
+    }
+
+    @Requires(property = "spec.name", value = "ClientFilterPropagatedContextSpec")
+    @ServerFilter(MATCH_ALL_PATTERN)
+    open class TestServerFilter {
+        @RequestFilter
+        open fun filter(context: MutablePropagatedContext) {
+            context.add(TestContextElement("test-value"))
+        }
+    }
+
+    @Requires(property = "spec.name", value = "ClientFilterPropagatedContextSpec")
+    @ClientFilter("/ping")
+    @Singleton
+    open class RecordingClientFilter {
+        val contextValues = mutableListOf<String?>()
+
+        @RequestFilter
+        open fun filter(context: MutablePropagatedContext) {
+            val value = context.context
+                ?.find(TestContextElement::class.java)
+                ?.getOrNull()
+                ?.value
+            contextValues.add(value)
+        }
+    }
+
+    data class TestContextElement(val value: String) : PropagatedContextElement
+}

--- a/http-client-core/build.gradle.kts
+++ b/http-client-core/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     api(projects.micronautDiscoveryCore)
 
     compileOnly(libs.managed.kotlin.stdlib)
+    compileOnly(libs.managed.kotlinx.coroutines.core)
 
     testImplementation(projects.micronautJacksonDatabind)
 }

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -19,6 +19,7 @@ import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.InterceptorBean;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.aop.kotlin.KotlinInterceptedMethod;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.AnnotationMetadata;
@@ -40,7 +41,6 @@ import io.micronaut.core.type.MutableArgumentValue;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.core.util.KotlinUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.version.annotation.Version;
 import io.micronaut.http.BasicHttpAttributes;
@@ -114,25 +114,6 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
      * The default Accept-Types.
      */
     private static final MediaType[] DEFAULT_ACCEPT_TYPES = {MediaType.APPLICATION_JSON_TYPE};
-
-    /**
-     * Whether Kotlin coroutine {@link PropagatedContext} recovery is usable.
-     * Resolved like {@link KotlinUtils}: try to touch optional helpers at class
-     * init and treat {@link NoClassDefFoundError} as unavailable (no reflective
-     * {@code ClassUtils.isPresent} strings that need GraalVM metadata).
-     */
-    private static final boolean KOTLIN_CLIENT_PROPAGATION_AVAILABLE;
-
-    static {
-        boolean available;
-        try {
-            available = KotlinUtils.KOTLIN_COROUTINES_SUPPORTED
-                && KotlinClientPropagatedContext.isAvailable();
-        } catch (NoClassDefFoundError e) {
-            available = false;
-        }
-        KOTLIN_CLIENT_PROPAGATION_AVAILABLE = available;
-    }
 
     private final List<ReactiveClientResultTransformer> transformers;
     private final HttpClientBinderRegistry binderRegistry;
@@ -211,8 +192,8 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                 // Scope open is only attempted for Kotlin suspend clients (no Supplier alloc).
                 PropagatedContext.Scope kotlinScope = null;
                 try {
-                    if (KOTLIN_CLIENT_PROPAGATION_AVAILABLE) {
-                        kotlinScope = KotlinClientPropagatedContext.maybePropagate(interceptedMethod);
+                    if (interceptedMethod instanceof KotlinInterceptedMethod kotlinInterceptedMethod) {
+                        kotlinScope = KotlinClientPropagatedContext.maybePropagate(kotlinInterceptedMethod);
                     }
                     return dispatchClientCall(
                         context, returnType, reactiveValueType, httpMethod, httpMethodName, uri,
@@ -781,35 +762,22 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
     }
 
     /**
-     * Isolates Kotlin coroutine types so pure-Java apps without kotlinx-coroutines on the
-     * classpath do not fail class loading of {@link HttpClientIntroductionAdvice}.
-     * Availability is probed via direct class references (same pattern as {@link KotlinUtils}).
+     * Recovers {@link PropagatedContext} from the Kotlin coroutine context for suspend
+     * client calls. Only called by the caller once it has already established, via
+     * {@code instanceof} {@link KotlinInterceptedMethod}, that the current call is a
+     * Kotlin suspend function (the same guard {@link io.micronaut.aop.internal.intercepted
+     * .KotlinInterceptedMethodImpl} relies on before touching Kotlin coroutine types).
      */
     private static final class KotlinClientPropagatedContext {
         private KotlinClientPropagatedContext() {
         }
 
         /**
-         * Touch optional Kotlin helpers so missing deps surface as {@link NoClassDefFoundError}
-         * during nested-class init (caught by the outer static block).
-         */
-        static boolean isAvailable() {
-            // Direct references — GraalVM sees them without reflective ClassUtils strings.
-            Class<?> ignoredKim = io.micronaut.aop.kotlin.KotlinInterceptedMethod.class;
-            Object ignoredCompanion =
-                io.micronaut.core.async.propagation.KotlinCoroutinePropagation.Companion;
-            return ignoredKim != null && ignoredCompanion != null;
-        }
-
-        /**
-         * If {@code interceptedMethod} is a Kotlin suspend client call with a non-empty unbound
-         * {@link PropagatedContext} in the coroutine context, open a thread-bound scope.
+         * If {@code kotlinInterceptedMethod} carries a non-empty unbound
+         * {@link PropagatedContext} in its coroutine context, open a thread-bound scope.
          * Otherwise return {@code null} (caller skips close).
          */
-        static PropagatedContext.@Nullable Scope maybePropagate(InterceptedMethod interceptedMethod) {
-            if (!(interceptedMethod instanceof io.micronaut.aop.kotlin.KotlinInterceptedMethod kotlinInterceptedMethod)) {
-                return null;
-            }
+        static PropagatedContext.@Nullable Scope maybePropagate(KotlinInterceptedMethod kotlinInterceptedMethod) {
             PropagatedContext fromCoroutine =
                 io.micronaut.core.async.propagation.KotlinCoroutinePropagation.Companion
                     .findPropagatedContext(kotlinInterceptedMethod.getCoroutineContext());

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -35,12 +35,12 @@ import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.convert.format.Format;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.propagation.PropagatedContext;
-import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.MutableArgumentValue;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.KotlinUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.version.annotation.Version;
 import io.micronaut.http.BasicHttpAttributes;
@@ -115,14 +115,24 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
      */
     private static final MediaType[] DEFAULT_ACCEPT_TYPES = {MediaType.APPLICATION_JSON_TYPE};
 
-    private static final boolean KOTLIN_CLIENT_PROPAGATION_AVAILABLE =
-        ClassUtils.isPresent(
-            "io.micronaut.core.async.propagation.KotlinCoroutinePropagation",
-            HttpClientIntroductionAdvice.class.getClassLoader()
-        ) && ClassUtils.isPresent(
-            "io.micronaut.aop.kotlin.KotlinInterceptedMethod",
-            HttpClientIntroductionAdvice.class.getClassLoader()
-        );
+    /**
+     * Whether Kotlin coroutine {@link PropagatedContext} recovery is usable.
+     * Resolved like {@link KotlinUtils}: try to touch optional helpers at class
+     * init and treat {@link NoClassDefFoundError} as unavailable (no reflective
+     * {@code ClassUtils.isPresent} strings that need GraalVM metadata).
+     */
+    private static final boolean KOTLIN_CLIENT_PROPAGATION_AVAILABLE;
+
+    static {
+        boolean available;
+        try {
+            available = KotlinUtils.KOTLIN_COROUTINES_SUPPORTED
+                && KotlinClientPropagatedContext.isAvailable();
+        } catch (NoClassDefFoundError e) {
+            available = false;
+        }
+        KOTLIN_CLIENT_PROPAGATION_AVAILABLE = available;
+    }
 
     private final List<ReactiveClientResultTransformer> transformers;
     private final HttpClientBinderRegistry binderRegistry;
@@ -198,15 +208,20 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                 // propagation, ThreadLocals may be cleared around coroutine resumes even though
                 // the PropagatedContext is still present in the Kotlin coroutine context.
                 // Re-apply it for the synchronous client setup so filters capture the right context.
-                // Only allocate the capturing Supplier when Kotlin propagation can apply (hot path).
-                if (needsKotlinPropagatedContext(interceptedMethod)) {
-                    return withKotlinPropagatedContext(interceptedMethod, () -> dispatchClientCall(
+                // Scope open is only attempted for Kotlin suspend clients (no Supplier alloc).
+                PropagatedContext.Scope kotlinScope = null;
+                try {
+                    if (KOTLIN_CLIENT_PROPAGATION_AVAILABLE) {
+                        kotlinScope = KotlinClientPropagatedContext.maybePropagate(interceptedMethod);
+                    }
+                    return dispatchClientCall(
                         context, returnType, reactiveValueType, httpMethod, httpMethodName, uri,
-                        interceptedMethod, annotationMetadata, httpClient, errorType, valueType, declaringType));
+                        interceptedMethod, annotationMetadata, httpClient, errorType, valueType, declaringType);
+                } finally {
+                    if (kotlinScope != null) {
+                        kotlinScope.close();
+                    }
                 }
-                return dispatchClientCall(
-                    context, returnType, reactiveValueType, httpMethod, httpMethodName, uri,
-                    interceptedMethod, annotationMetadata, httpClient, errorType, valueType, declaringType);
             } catch (Exception e) {
                 return interceptedMethod.handleException(e);
             }
@@ -239,27 +254,6 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                 handleSynchronous(context, returnType, httpClient, httpMethod, httpMethodName, uri,
                     interceptedMethod, annotationMetadata, errorType, declaringType);
         };
-    }
-
-    private static boolean needsKotlinPropagatedContext(InterceptedMethod interceptedMethod) {
-        return KOTLIN_CLIENT_PROPAGATION_AVAILABLE
-            && interceptedMethod.getClass().getName().endsWith("KotlinInterceptedMethodImpl");
-    }
-
-    /**
-     * Ensures {@link PropagatedContext} from a Kotlin coroutine context is bound to the current
-     * thread for the duration of {@code action}. This recovers from ThreadLocal loss caused by
-     * Micrometer/Reactor automatic context propagation (see issue 12851).
-     *
-     * @param interceptedMethod The intercepted method
-     * @param action            The client invocation
-     * @return The action result
-     */
-    @Nullable
-    private static Object withKotlinPropagatedContext(InterceptedMethod interceptedMethod, Supplier<Object> action) {
-        // Isolate Kotlin types in a nested class so pure-Java apps without kotlinx-coroutines
-        // never resolve those class constants on this hot path.
-        return KotlinClientPropagatedContext.withPropagatedContext(interceptedMethod, action);
     }
 
     @Nullable
@@ -789,24 +783,40 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
     /**
      * Isolates Kotlin coroutine types so pure-Java apps without kotlinx-coroutines on the
      * classpath do not fail class loading of {@link HttpClientIntroductionAdvice}.
+     * Availability is probed via direct class references (same pattern as {@link KotlinUtils}).
      */
     private static final class KotlinClientPropagatedContext {
         private KotlinClientPropagatedContext() {
         }
 
-        @Nullable
-        static Object withPropagatedContext(InterceptedMethod interceptedMethod, Supplier<Object> action) {
-            io.micronaut.aop.kotlin.KotlinInterceptedMethod kotlinInterceptedMethod =
-                (io.micronaut.aop.kotlin.KotlinInterceptedMethod) interceptedMethod;
+        /**
+         * Touch optional Kotlin helpers so missing deps surface as {@link NoClassDefFoundError}
+         * during nested-class init (caught by the outer static block).
+         */
+        static boolean isAvailable() {
+            // Direct references — GraalVM sees them without reflective ClassUtils strings.
+            Class<?> ignoredKim = io.micronaut.aop.kotlin.KotlinInterceptedMethod.class;
+            Object ignoredCompanion =
+                io.micronaut.core.async.propagation.KotlinCoroutinePropagation.Companion;
+            return ignoredKim != null && ignoredCompanion != null;
+        }
+
+        /**
+         * If {@code interceptedMethod} is a Kotlin suspend client call with a non-empty unbound
+         * {@link PropagatedContext} in the coroutine context, open a thread-bound scope.
+         * Otherwise return {@code null} (caller skips close).
+         */
+        static PropagatedContext.@Nullable Scope maybePropagate(InterceptedMethod interceptedMethod) {
+            if (!(interceptedMethod instanceof io.micronaut.aop.kotlin.KotlinInterceptedMethod kotlinInterceptedMethod)) {
+                return null;
+            }
             PropagatedContext fromCoroutine =
                 io.micronaut.core.async.propagation.KotlinCoroutinePropagation.Companion
                     .findPropagatedContext(kotlinInterceptedMethod.getCoroutineContext());
             if (fromCoroutine == null || fromCoroutine.isEmpty() || fromCoroutine.isBound()) {
-                return action.get();
+                return null;
             }
-            try (PropagatedContext.Scope ignore = fromCoroutine.propagate()) {
-                return action.get();
-            }
+            return fromCoroutine.propagate();
         }
     }
 }

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -34,6 +34,8 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.convert.format.Format;
 import io.micronaut.core.io.buffer.ByteBuffer;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.MutableArgumentValue;
 import io.micronaut.core.type.ReturnType;
@@ -166,10 +168,8 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
         HttpClient httpClient = clientFactory.getClient(annotationMetadata);
         if (httpMethodMapping.isPresent() && context.hasStereotype(HttpMethodMapping.class) && httpClient != null) {
             AnnotationValue<HttpMethodMapping> mapping = Objects.requireNonNull(context.getAnnotation(HttpMethodMapping.class));
-            String uri = mapping.getRequiredValue(String.class);
-            if (StringUtils.isEmpty(uri)) {
-                uri = "/" + context.getMethodName();
-            }
+            String mappedUri = mapping.getRequiredValue(String.class);
+            final String uri = StringUtils.isEmpty(mappedUri) ? "/" + context.getMethodName() : mappedUri;
 
             Class<? extends Annotation> annotationType = httpMethodMapping.get();
             HttpMethod httpMethod = HttpMethod.parse(annotationType.getSimpleName().toUpperCase(Locale.ENGLISH));
@@ -185,7 +185,11 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
             try {
                 Argument<?> valueType = interceptedMethod.returnTypeValue();
                 Class<?> reactiveValueType = valueType.getType();
-                return switch (interceptedMethod.resultType()) {
+                // When io.micrometer:context-propagation enables Reactor automatic context
+                // propagation, ThreadLocals may be cleared around coroutine resumes even though
+                // the PropagatedContext is still present in the Kotlin coroutine context.
+                // Re-apply it for the synchronous client setup so filters capture the right context.
+                return withKotlinPropagatedContext(interceptedMethod, () -> switch (interceptedMethod.resultType()) {
                     case PUBLISHER ->
                             handlePublisher(context, returnType, reactiveValueType, httpMethod, httpMethodName,
                                 uri, interceptedMethod, annotationMetadata, httpClient, errorType, valueType, declaringType);
@@ -195,13 +199,66 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                     case SYNCHRONOUS ->
                             handleSynchronous(context, returnType, httpClient, httpMethod, httpMethodName, uri,
                                 interceptedMethod, annotationMetadata, errorType, declaringType);
-                };
+                });
             } catch (Exception e) {
                 return interceptedMethod.handleException(e);
             }
         }
         // try other introduction advice
         return context.proceed();
+    }
+
+    private static final boolean KOTLIN_CLIENT_PROPAGATION_AVAILABLE =
+        ClassUtils.isPresent(
+            "io.micronaut.core.async.propagation.KotlinCoroutinePropagation",
+            HttpClientIntroductionAdvice.class.getClassLoader()
+        ) && ClassUtils.isPresent(
+            "io.micronaut.aop.kotlin.KotlinInterceptedMethod",
+            HttpClientIntroductionAdvice.class.getClassLoader()
+        );
+
+    /**
+     * Ensures {@link PropagatedContext} from a Kotlin coroutine context is bound to the current
+     * thread for the duration of {@code action}. This recovers from ThreadLocal loss caused by
+     * Micrometer/Reactor automatic context propagation (see issue 12851).
+     *
+     * @param interceptedMethod The intercepted method
+     * @param action            The client invocation
+     * @return The action result
+     */
+    @Nullable
+    private static Object withKotlinPropagatedContext(InterceptedMethod interceptedMethod, Supplier<Object> action) {
+        // Isolate Kotlin types in a nested class so pure-Java apps without kotlinx-coroutines
+        // never resolve those class constants on this hot path.
+        if (!KOTLIN_CLIENT_PROPAGATION_AVAILABLE
+            || !interceptedMethod.getClass().getName().endsWith("KotlinInterceptedMethodImpl")) {
+            return action.get();
+        }
+        return KotlinClientPropagatedContext.withPropagatedContext(interceptedMethod, action);
+    }
+
+    /**
+     * Isolates Kotlin coroutine types so pure-Java apps without kotlinx-coroutines on the
+     * classpath do not fail class loading of {@link HttpClientIntroductionAdvice}.
+     */
+    private static final class KotlinClientPropagatedContext {
+        private KotlinClientPropagatedContext() {
+        }
+
+        @Nullable
+        static Object withPropagatedContext(InterceptedMethod interceptedMethod, Supplier<Object> action) {
+            io.micronaut.aop.kotlin.KotlinInterceptedMethod kotlinInterceptedMethod =
+                (io.micronaut.aop.kotlin.KotlinInterceptedMethod) interceptedMethod;
+            PropagatedContext fromCoroutine =
+                io.micronaut.core.async.propagation.KotlinCoroutinePropagation.Companion
+                    .findPropagatedContext(kotlinInterceptedMethod.getCoroutineContext());
+            if (fromCoroutine == null || fromCoroutine.isEmpty() || fromCoroutine.isBound()) {
+                return action.get();
+            }
+            try (PropagatedContext.Scope ignore = fromCoroutine.propagate()) {
+                return action.get();
+            }
+        }
     }
 
     @Nullable

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -115,6 +115,15 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
      */
     private static final MediaType[] DEFAULT_ACCEPT_TYPES = {MediaType.APPLICATION_JSON_TYPE};
 
+    private static final boolean KOTLIN_CLIENT_PROPAGATION_AVAILABLE =
+        ClassUtils.isPresent(
+            "io.micronaut.core.async.propagation.KotlinCoroutinePropagation",
+            HttpClientIntroductionAdvice.class.getClassLoader()
+        ) && ClassUtils.isPresent(
+            "io.micronaut.aop.kotlin.KotlinInterceptedMethod",
+            HttpClientIntroductionAdvice.class.getClassLoader()
+        );
+
     private final List<ReactiveClientResultTransformer> transformers;
     private final HttpClientBinderRegistry binderRegistry;
     private final JsonMediaTypeCodec jsonMediaTypeCodec;
@@ -189,17 +198,15 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                 // propagation, ThreadLocals may be cleared around coroutine resumes even though
                 // the PropagatedContext is still present in the Kotlin coroutine context.
                 // Re-apply it for the synchronous client setup so filters capture the right context.
-                return withKotlinPropagatedContext(interceptedMethod, () -> switch (interceptedMethod.resultType()) {
-                    case PUBLISHER ->
-                            handlePublisher(context, returnType, reactiveValueType, httpMethod, httpMethodName,
-                                uri, interceptedMethod, annotationMetadata, httpClient, errorType, valueType, declaringType);
-                    case COMPLETION_STAGE ->
-                            handleCompletionStage(context, httpMethod, httpMethodName, uri, interceptedMethod,
-                                annotationMetadata, httpClient, returnType, errorType, valueType, reactiveValueType, declaringType);
-                    case SYNCHRONOUS ->
-                            handleSynchronous(context, returnType, httpClient, httpMethod, httpMethodName, uri,
-                                interceptedMethod, annotationMetadata, errorType, declaringType);
-                });
+                // Only allocate the capturing Supplier when Kotlin propagation can apply (hot path).
+                if (needsKotlinPropagatedContext(interceptedMethod)) {
+                    return withKotlinPropagatedContext(interceptedMethod, () -> dispatchClientCall(
+                        context, returnType, reactiveValueType, httpMethod, httpMethodName, uri,
+                        interceptedMethod, annotationMetadata, httpClient, errorType, valueType, declaringType));
+                }
+                return dispatchClientCall(
+                    context, returnType, reactiveValueType, httpMethod, httpMethodName, uri,
+                    interceptedMethod, annotationMetadata, httpClient, errorType, valueType, declaringType);
             } catch (Exception e) {
                 return interceptedMethod.handleException(e);
             }
@@ -208,14 +215,36 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
         return context.proceed();
     }
 
-    private static final boolean KOTLIN_CLIENT_PROPAGATION_AVAILABLE =
-        ClassUtils.isPresent(
-            "io.micronaut.core.async.propagation.KotlinCoroutinePropagation",
-            HttpClientIntroductionAdvice.class.getClassLoader()
-        ) && ClassUtils.isPresent(
-            "io.micronaut.aop.kotlin.KotlinInterceptedMethod",
-            HttpClientIntroductionAdvice.class.getClassLoader()
-        );
+    @Nullable
+    private Object dispatchClientCall(MethodInvocationContext<Object, Object> context,
+                                      ReturnType<?> returnType,
+                                      Class<?> reactiveValueType,
+                                      HttpMethod httpMethod,
+                                      String httpMethodName,
+                                      String uri,
+                                      InterceptedMethod interceptedMethod,
+                                      AnnotationMetadata annotationMetadata,
+                                      HttpClient httpClient,
+                                      Argument<?> errorType,
+                                      Argument<?> valueType,
+                                      Class<?> declaringType) {
+        return switch (interceptedMethod.resultType()) {
+            case PUBLISHER ->
+                handlePublisher(context, returnType, reactiveValueType, httpMethod, httpMethodName,
+                    uri, interceptedMethod, annotationMetadata, httpClient, errorType, valueType, declaringType);
+            case COMPLETION_STAGE ->
+                handleCompletionStage(context, httpMethod, httpMethodName, uri, interceptedMethod,
+                    annotationMetadata, httpClient, returnType, errorType, valueType, reactiveValueType, declaringType);
+            case SYNCHRONOUS ->
+                handleSynchronous(context, returnType, httpClient, httpMethod, httpMethodName, uri,
+                    interceptedMethod, annotationMetadata, errorType, declaringType);
+        };
+    }
+
+    private static boolean needsKotlinPropagatedContext(InterceptedMethod interceptedMethod) {
+        return KOTLIN_CLIENT_PROPAGATION_AVAILABLE
+            && interceptedMethod.getClass().getName().endsWith("KotlinInterceptedMethodImpl");
+    }
 
     /**
      * Ensures {@link PropagatedContext} from a Kotlin coroutine context is bound to the current
@@ -230,35 +259,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
     private static Object withKotlinPropagatedContext(InterceptedMethod interceptedMethod, Supplier<Object> action) {
         // Isolate Kotlin types in a nested class so pure-Java apps without kotlinx-coroutines
         // never resolve those class constants on this hot path.
-        if (!KOTLIN_CLIENT_PROPAGATION_AVAILABLE
-            || !interceptedMethod.getClass().getName().endsWith("KotlinInterceptedMethodImpl")) {
-            return action.get();
-        }
         return KotlinClientPropagatedContext.withPropagatedContext(interceptedMethod, action);
-    }
-
-    /**
-     * Isolates Kotlin coroutine types so pure-Java apps without kotlinx-coroutines on the
-     * classpath do not fail class loading of {@link HttpClientIntroductionAdvice}.
-     */
-    private static final class KotlinClientPropagatedContext {
-        private KotlinClientPropagatedContext() {
-        }
-
-        @Nullable
-        static Object withPropagatedContext(InterceptedMethod interceptedMethod, Supplier<Object> action) {
-            io.micronaut.aop.kotlin.KotlinInterceptedMethod kotlinInterceptedMethod =
-                (io.micronaut.aop.kotlin.KotlinInterceptedMethod) interceptedMethod;
-            PropagatedContext fromCoroutine =
-                io.micronaut.core.async.propagation.KotlinCoroutinePropagation.Companion
-                    .findPropagatedContext(kotlinInterceptedMethod.getCoroutineContext());
-            if (fromCoroutine == null || fromCoroutine.isEmpty() || fromCoroutine.isBound()) {
-                return action.get();
-            }
-            try (PropagatedContext.Scope ignore = fromCoroutine.propagate()) {
-                return action.get();
-            }
-        }
     }
 
     @Nullable
@@ -782,6 +783,30 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
 
         static RequestBinderResult withErrorResult(@Nullable Object errorResult) {
             return new RequestBinderResult(null, errorResult, true);
+        }
+    }
+
+    /**
+     * Isolates Kotlin coroutine types so pure-Java apps without kotlinx-coroutines on the
+     * classpath do not fail class loading of {@link HttpClientIntroductionAdvice}.
+     */
+    private static final class KotlinClientPropagatedContext {
+        private KotlinClientPropagatedContext() {
+        }
+
+        @Nullable
+        static Object withPropagatedContext(InterceptedMethod interceptedMethod, Supplier<Object> action) {
+            io.micronaut.aop.kotlin.KotlinInterceptedMethod kotlinInterceptedMethod =
+                (io.micronaut.aop.kotlin.KotlinInterceptedMethod) interceptedMethod;
+            PropagatedContext fromCoroutine =
+                io.micronaut.core.async.propagation.KotlinCoroutinePropagation.Companion
+                    .findPropagatedContext(kotlinInterceptedMethod.getCoroutineContext());
+            if (fromCoroutine == null || fromCoroutine.isEmpty() || fromCoroutine.isBound()) {
+                return action.get();
+            }
+            try (PropagatedContext.Scope ignore = fromCoroutine.propagate()) {
+                return action.get();
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #12851

When `io.micrometer:context-propagation` is on the classpath, Micronaut Reactor enables automatic context propagation. Across sequential Kotlin `suspend` HTTP client calls, the `PropagatedContext` ThreadLocal can be cleared even though the value remains in the Kotlin coroutine context. Declarative clients then capture an empty context for filters, so some outbound requests intermittently (or every other call) see no server-set context elements.

### Fix

In `HttpClientIntroductionAdvice`, for Kotlin coroutine client methods, re-apply `PropagatedContext` from the coroutine context for the synchronous client setup path (where context is captured for the filter runner). Kotlin types are isolated behind a presence check so pure-Java clients without kotlinx-coroutines are unaffected.

### Reproduction

Matches https://github.com/krystofrezac/micronaut-http-client-context-propagation-bug:
- Server filter adds a `PropagatedContextElement`
- Suspend controller issues multiple sequential `@Client` calls
- Client filter reads `MutablePropagatedContext`

Without this fix, filter sees alternating/missing values with micrometer context-propagation enabled.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Related tests have been included
- [x] Documentation related to the change is present in the PR (N/A – behavior restored to documented expectation)

## Testing

```bash
./gradlew :micronaut-context-propagation:test --tests 'io.micronaut.context.propagation.client.ClientFilterPropagatedContextSpec'
```

Result: **PASSED** (JDK 25)