### PR TITLE
fix: allow validated @Value constructor params without @Introspected

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
@@ -289,7 +289,7 @@ public class DefaultElementBeanDefinitionBuilderFactory implements ElementBeanDe
             if (target.hasStereotype(ConfigurationReader.class)) {
                 BeanDefinitionWriter beanDefinitionWriter = (BeanDefinitionWriter) aopProxyWriter.beanDefinitionBuilder();
                 // Configuration beans are validated at the startup and don't require validation advice
-                beanDefinitionWriter.setValidated(true);
+                beanDefinitionWriter.setRequiresPostConstructBeanValidation(true);
             } else {
                 for (MethodElement methodElement : target.getEnclosedElements(ElementQuery.ALL_METHODS.annotated(am -> am.hasAnnotation(ANN_REQUIRES_VALIDATION)))) {
                     methodElement.annotate(ANN_VALIDATED);

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -596,6 +596,12 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     private static final Method GET_MAP_METHOD = ReflectionUtils.getRequiredMethod(Map.class, "get", Object.class);
     private static final Method LOAD_REFERENCE_METHOD = ReflectionUtils.getRequiredMethod(BeanDefinitionReference.class, "load");
     private static final Method IS_CONTEXT_SCOPE_METHOD = ReflectionUtils.getRequiredMethod(BeanDefinitionReference.class, "isContextScope");
+    private static final Method VALIDATE_BEAN_METHOD = ReflectionUtils.getRequiredMethod(
+        ValidatedBeanDefinition.class,
+        "validate",
+        BeanResolutionContext.class,
+        Object.class
+    );
     private static final Method IS_PROXIED_BEAN_METHOD = ReflectionUtils.getRequiredMethod(BeanDefinitionReference.class, "isProxiedBean");
     private static final Method IS_ENABLED_METHOD = ReflectionUtils.getRequiredMethod(BeanContextConditional.class, "isEnabled", BeanContext.class);
     private static final Method IS_ENABLED2_METHOD = ReflectionUtils.getRequiredMethod(BeanContextConditional.class, "isEnabled", BeanContext.class, BeanResolutionContext.class);
@@ -681,6 +687,13 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     private ClassDef.ClassDefBuilder classDefBuilder;
 
     private boolean validated;
+    /**
+     * When true, post-construct {@link ValidatedBeanDefinition#validate} runs full bean validation
+     * (configuration properties). When false, only injection-point validation via
+     * {@link ValidatedBeanDefinition#validateBeanArgument} is needed — typical for
+     * {@code @Singleton} beans with constrained {@code @Value} constructor parameters.
+     */
+    private boolean requiresPostConstructBeanValidation;
 
     private final Function<String, ExpressionDef> loadClassValueExpressionFn;
 
@@ -921,7 +934,14 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     private void applyConfigurationInjectionIfNecessary(AnnotationMetadata annotationMetadata, List<BeanDefinitionInjectionPoint<ClassElement>> injectionPoints) {
         if (annotationMetadata.hasDeclaredAnnotation(RequiresValidation.class)) {
             if (injectionPoints.stream().anyMatch(BeanDefinitionWriter::isValidationRequiredForInjectionPoint)) {
-                setValidated(true);
+                // Configuration properties need post-construct bean validation (missing props stay
+                // null until validate). Ordinary beans only need injection-point validation so
+                // constrained @Value constructor params work without @Introspected (#12847).
+                if (isConfigurationProperties) {
+                    setRequiresPostConstructBeanValidation(true);
+                } else {
+                    setValidated(true);
+                }
             }
         }
     }
@@ -1121,6 +1141,12 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     }
 
     /**
+     * Marks the bean as a {@link ValidatedBeanDefinition} so constructor and member injection
+     * points can be validated via {@link ValidatedBeanDefinition#validateBeanArgument}.
+     * <p>
+     * Does not enable post-construct bean validation; that requires
+     * {@link #setRequiresPostConstructBeanValidation(boolean)}.
+     *
      * @param validated If the bean is validated
      */
     public void setValidated(boolean validated) {
@@ -1133,6 +1159,23 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
             if (this.validated) {
                 throw new IllegalStateException("Bean definition " + beanTypeDef + " already marked for validation");
             }
+        }
+    }
+
+    /**
+     * Marks that the bean requires post-construct bean validation (e.g. configuration
+     * properties validated via introspection). Implies {@link #setValidated(true)}.
+     * <p>
+     * Injection-point-only cases (constrained {@code @Value} on a {@code @Singleton}
+     * constructor) should use {@link #setValidated(true)} alone so the bean does not
+     * need {@code @Introspected}.
+     *
+     * @param requiresPostConstructBeanValidation whether to validate the bean after creation
+     */
+    public void setRequiresPostConstructBeanValidation(boolean requiresPostConstructBeanValidation) {
+        if (requiresPostConstructBeanValidation) {
+            setValidated(true);
+            this.requiresPostConstructBeanValidation = true;
         }
     }
 
@@ -1205,6 +1248,16 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
                 LOAD_REFERENCE_METHOD
             ).build((aThis, methodParameters) -> aThis.type().instantiate().returning())
         );
+
+        // Injection-point constraints are validated via validateBeanArgument during construction.
+        // Skip post-construct bean validation so @Singleton beans with constrained @Value
+        // constructor parameters do not require @Introspected (see #12847).
+        if (validated && !requiresPostConstructBeanValidation) {
+            classDefBuilder.addMethod(
+                MethodDef.override(VALIDATE_BEAN_METHOD)
+                    .build((aThis, methodParameters) -> methodParameters.get(1).returning())
+            );
+        }
 
         if (annotationMetadata.hasDeclaredAnnotation(Context.class)) {
             classDefBuilder.addMethod(

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -933,11 +933,17 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     private void applyConfigurationInjectionIfNecessary(AnnotationMetadata annotationMetadata, List<BeanDefinitionInjectionPoint<ClassElement>> injectionPoints) {
         if (annotationMetadata.hasDeclaredAnnotation(RequiresValidation.class)) {
-            if (injectionPoints.stream().anyMatch(BeanDefinitionWriter::isValidationRequiredForInjectionPoint)) {
+            List<BeanDefinitionInjectionPoint<ClassElement>> validatedPoints = injectionPoints.stream()
+                .filter(BeanDefinitionWriter::isValidationRequiredForInjectionPoint)
+                .toList();
+            if (!validatedPoints.isEmpty()) {
                 // Configuration properties need post-construct bean validation (missing props stay
-                // null until validate). Ordinary beans only need injection-point validation so
-                // constrained @Value constructor params work without @Introspected (#12847).
-                if (isConfigurationProperties) {
+                // null until validate). Nullable bean injects with constraints (e.g. @Nullable
+                // @NotNull record params) also need post-construct validate.
+                // Injection-point-only validation is enough for constrained @Value/@Property
+                // parameters on ordinary @Singleton beans so they work without @Introspected
+                // (#12847) while keeping RecordBeansSpec / similar cases correct.
+                if (isConfigurationProperties || needsPostConstructBeanValidation(validatedPoints)) {
                     setRequiresPostConstructBeanValidation(true);
                 } else {
                     setValidated(true);
@@ -954,6 +960,19 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
             return false;
         }
         return true;
+    }
+
+    /**
+     * Post-construct {@link ValidatedBeanDefinition#validate} is required when a validated
+     * injection point is a (nullable) bean dependency — null can be injected and only full
+     * bean validation rejects it. Pure {@code @Value}/{@code @Property} constraints are
+     * covered by {@code validateBeanArgument} at inject time.
+     */
+    private boolean needsPostConstructBeanValidation(List<BeanDefinitionInjectionPoint<ClassElement>> validatedPoints) {
+        return validatedPoints.stream().anyMatch(ip ->
+            ip instanceof BeanInjectionPoint<?> || ip instanceof OptionalBeanInjectionPoint<?>
+                || !isValueType(ip.annotationMetadata())
+        );
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/ValidatedValueConstructorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/ValidatedValueConstructorSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.aop.compile
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.DependencyInjectionException
+import io.micronaut.core.reflect.ClassUtils
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ValidatedBeanDefinition
+
+/**
+ * Regression for https://github.com/micronaut-projects/micronaut-core/issues/12847
+ *
+ * Constrained {@code @Value} constructor parameters must be validated without requiring
+ * {@code @Introspected} on a plain {@code @Singleton}.
+ */
+class ValidatedValueConstructorSpec extends AbstractTypeElementSpec {
+
+    private static final String SERVICE = '''
+package test;
+
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Singleton;
+import jakarta.validation.constraints.Size;
+
+@Singleton
+class TestService {
+    private final String test;
+
+    TestService(@Size(min = 35, max = 255) @Value("${my.test}") String test) {
+        this.test = test;
+    }
+
+    String getTest() {
+        return test;
+    }
+}
+'''
+
+    void "singleton with validated @Value constructor param is ValidatedBeanDefinition without introspection"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.TestService', SERVICE)
+
+        then:
+        beanDefinition instanceof ValidatedBeanDefinition
+        // No $Introspection generated — @Introspected is not required for this case
+        ClassUtils.forName('test.$TestService$Introspection', beanDefinition.beanType.classLoader).isEmpty()
+    }
+
+    void "singleton with validated @Value constructor param starts without @Introspected"() {
+        given:
+        ApplicationContext context = buildContext('test.TestService', SERVICE, true, ['my.test': 'x' * 40])
+
+        when:
+        def bean = getBean(context, 'test.TestService')
+
+        then:
+        bean.getTest() == ('x' * 40)
+        // Must not fail with: Cannot validate bean [...]. No bean introspection present.
+        !ClassUtils.forName('test.$TestService$Introspection', context.classLoader).isPresent()
+
+        cleanup:
+        context.close()
+    }
+
+    void "singleton with validated @Value constructor param rejects invalid values"() {
+        given:
+        ApplicationContext context = buildContext('test.TestService', SERVICE, true, ['my.test': 'too-short'])
+
+        when:
+        getBean(context, 'test.TestService')
+
+        then:
+        def e = thrown(DependencyInjectionException)
+        def full = (e.message + ' ' + (e.cause?.message ?: '')).toLowerCase()
+        full.contains('size')
+        !full.contains('no bean introspection present')
+
+        cleanup:
+        context.close()
+    }
+}


### PR DESCRIPTION
## Description

Fixes #12847

A `@Singleton` with constrained `@Value` constructor parameters (e.g. `@Size` + `@Value`) became a `ValidatedBeanDefinition` so constructor args are validated via `validateBeanArgument`. Post-construct bean validation then required `@Introspected`, even though the bean has no introspected properties to validate.

This change separates:

- **Injection-point validation** (`setValidated(true)`) — used for ordinary beans with constrained constructor/method injection points; generates a no-op `validate()` so post-construct bean validation is skipped.
- **Post-construct bean validation** (`setRequiresPostConstructBeanValidation(true)`) — used for configuration properties that still need startup validation via introspection.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/micronaut-projects/micronaut-core/blob/5.2.x/CONTRIBUTING.md) guidelines
- [x] Tests related to the change have been added
- [x] Documentation related to the change has been updated (N/A)

## Testing

JDK 25:

```
./gradlew :micronaut-inject-java:test --tests 'io.micronaut.aop.compile.ValidatedValueConstructorSpec' \
  --tests 'io.micronaut.inject.configproperties.ValidatedConfigurationSpec' \
  --tests 'io.micronaut.inject.configproperties.ImmutableConfigurationPropertiesSpec' \
  --tests 'io.micronaut.inject.configproperties.ValidatedGetterConfigurationSpec' \
  --tests 'io.micronaut.aop.compile.ValidatedNonBeanSpec'

./gradlew :micronaut-inject-groovy:test --tests 'io.micronaut.inject.configproperties.ValidatedConfigurationSpec' \
  --tests 'io.micronaut.aop.compile.ValidatedNonBeanSpec'
```

All green (new regression + config validation still enforces constraints).