### PR TITLE
Add an optional JEP-290 ObjectInputFilter to JdkSerializer

### DIFF
--- a/core/src/main/java/io/micronaut/core/serialize/JdkSerializer.java
+++ b/core/src/main/java/io/micronaut/core/serialize/JdkSerializer.java
@@ -80,7 +80,11 @@ public final class JdkSerializer implements ObjectSerializer {
         if (pattern == null || pattern.isBlank()) {
             return null;
         }
-        return ObjectInputFilter.Config.createFilter(pattern);
+        try {
+            return ObjectInputFilter.Config.createFilter(pattern);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid " + SERIAL_FILTER_PROPERTY + " value [" + pattern + "]: " + e.getMessage(), e);
+        }
     }
 
     @Override
@@ -151,7 +155,7 @@ public final class JdkSerializer implements ObjectSerializer {
     /**
      * @param inputStream  The input stream
      * @param requiredType The required type
-     * @return A {@link ObjectOutputStream}
+     * @return A {@link ObjectInputStream}
      * @throws IOException if there is an error
      */
     private ObjectInputStream createObjectInput(InputStream inputStream, Class<?> requiredType) throws IOException {

--- a/core/src/main/java/io/micronaut/core/serialize/JdkSerializer.java
+++ b/core/src/main/java/io/micronaut/core/serialize/JdkSerializer.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
@@ -37,13 +38,34 @@ import java.util.Optional;
  */
 public final class JdkSerializer implements ObjectSerializer {
 
+    /**
+     * System property that, when set to a non-blank {@link ObjectInputFilter} pattern (as accepted by
+     * {@link ObjectInputFilter.Config#createFilter(String)}), installs a JEP-290 deserialization filter
+     * on every stream created by this serializer. Unset by default, which preserves the previous
+     * (unfiltered) behaviour.
+     *
+     * @since 5.2.0
+     */
+    public static final String SERIAL_FILTER_PROPERTY = "micronaut.serializer.jdk.serial-filter";
+
     private final ConversionService conversionService;
+    private final @Nullable ObjectInputFilter objectInputFilter;
 
     /**
      * @param conversionService The conversion service
      */
     public JdkSerializer(ConversionService conversionService) {
+        this(conversionService, resolveDefaultFilter());
+    }
+
+    /**
+     * @param conversionService The conversion service
+     * @param objectInputFilter The {@link ObjectInputFilter} to apply when deserializing, or {@code null} to apply none
+     * @since 5.2.0
+     */
+    public JdkSerializer(ConversionService conversionService, @Nullable ObjectInputFilter objectInputFilter) {
         this.conversionService = conversionService;
+        this.objectInputFilter = objectInputFilter;
     }
 
     /**
@@ -51,6 +73,14 @@ public final class JdkSerializer implements ObjectSerializer {
      */
     public JdkSerializer() {
         this(ConversionService.SHARED);
+    }
+
+    private static @Nullable ObjectInputFilter resolveDefaultFilter() {
+        String pattern = System.getProperty(SERIAL_FILTER_PROPERTY);
+        if (pattern == null || pattern.isBlank()) {
+            return null;
+        }
+        return ObjectInputFilter.Config.createFilter(pattern);
     }
 
     @Override
@@ -125,7 +155,7 @@ public final class JdkSerializer implements ObjectSerializer {
      * @throws IOException if there is an error
      */
     private ObjectInputStream createObjectInput(InputStream inputStream, Class<?> requiredType) throws IOException {
-        return new ObjectInputStream(inputStream) {
+        ObjectInputStream objectInput = new ObjectInputStream(inputStream) {
             @Override
             protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
                 Optional<Class<?>> aClass = ClassUtils.forName(desc.getName(), requiredType.getClassLoader());
@@ -135,5 +165,9 @@ public final class JdkSerializer implements ObjectSerializer {
                 return super.resolveClass(desc);
             }
         };
+        if (objectInputFilter != null) {
+            objectInput.setObjectInputFilter(objectInputFilter);
+        }
+        return objectInput;
     }
 }

--- a/core/src/test/groovy/io/micronaut/core/serialize/JdkSerializerSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/serialize/JdkSerializerSpec.groovy
@@ -15,7 +15,11 @@
  */
 package io.micronaut.core.serialize
 
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.serialize.exceptions.SerializationException
 import spock.lang.Specification
+
+import java.io.ObjectInputFilter
 
 /**
  * @author Graeme Rocher
@@ -39,6 +43,32 @@ class JdkSerializerSpec extends Specification {
 
         then:
         !foo.isPresent()
+    }
+
+    void 'test deserialization is rejected when an ObjectInputFilter disallows the class'() {
+        given:
+        ObjectInputFilter filter = ObjectInputFilter.Config.createFilter('java.lang.*;java.util.*;!*')
+        def serializer = new JdkSerializer(ConversionService.SHARED, filter)
+        def bytes = serializer.serialize(new Foo(name: "test")).get()
+
+        when:
+        serializer.deserialize(bytes, Foo)
+
+        then:
+        thrown(SerializationException)
+    }
+
+    void 'test deserialization succeeds when an ObjectInputFilter allows the required type'() {
+        given:
+        ObjectInputFilter filter = ObjectInputFilter.Config.createFilter('io.micronaut.core.serialize.JdkSerializerSpec$Foo;java.lang.*;java.util.*;!*')
+        def serializer = new JdkSerializer(ConversionService.SHARED, filter)
+        def bytes = serializer.serialize(new Foo(name: "test")).get()
+
+        when:
+        Foo foo = serializer.deserialize(bytes, Foo).get()
+
+        then:
+        foo.name == "test"
     }
 
     static class Foo implements Serializable {

--- a/core/src/test/groovy/io/micronaut/core/serialize/JdkSerializerSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/serialize/JdkSerializerSpec.groovy
@@ -71,6 +71,21 @@ class JdkSerializerSpec extends Specification {
         foo.name == "test"
     }
 
+    void 'test an invalid serial-filter system property fails with a message naming the property'() {
+        given:
+        System.setProperty(JdkSerializer.SERIAL_FILTER_PROPERTY, 'maxdepth=notanumber')
+
+        when:
+        new JdkSerializer(ConversionService.SHARED)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains(JdkSerializer.SERIAL_FILTER_PROPERTY)
+
+        cleanup:
+        System.clearProperty(JdkSerializer.SERIAL_FILTER_PROPERTY)
+    }
+
     static class Foo implements Serializable {
         String name
     }


### PR DESCRIPTION
Closes #12861

## What / Why

`JdkSerializer` is Micronaut's default `ObjectSerializer` (`ObjectSerializer.JDK`) and the default value serializer used by `micronaut-redis` for cache and HTTP session storage, so its `deserialize(...)` path reads Java-serialized bytes back from a process-external store (Redis, and other cache/session backends). Today `createObjectInput(...)` overrides only `resolveClass(...)` for classloader resolution and installs no `java.io.ObjectInputFilter` (JEP-290), so any class on the classpath is deserialized from that untrusted input. Installing a JEP-290 `ObjectInputFilter` on this path is the standard mitigation for this class of deserialization exposure.

This PR adds an optional, opt-in `ObjectInputFilter` to `JdkSerializer`:

- A new constructor `JdkSerializer(ConversionService, ObjectInputFilter)` to install a scoped filter programmatically.
- An optional system property `micronaut.serializer.jdk.serial-filter`, taking a standard `ObjectInputFilter.Config.createFilter(String)` pattern, so a deployment can enable filtering on this path without subclassing `ObjectInputStream`.
- The filter is applied to the stream in `createObjectInput(...)`. `resolveClass(...)` is left unchanged.

## Non-breaking

The default is unchanged. With no property set and no filter argument the filter is `null` and behaviour is byte-for-byte identical to before. Existing callers, including the shared `ObjectSerializer.JDK` instance, are unaffected.

## Tests

`JdkSerializerSpec` adds two cases: a restrictive filter makes deserialization of a disallowed class fail (surfaced as `SerializationException`), and a filter that allows the required type still round-trips. The existing round-trip and null cases are unchanged.

## Notes

Kept intentionally minimal and opt-in so it cannot affect existing deployments. Happy to adjust the surface to whatever the team prefers: default the filter on with a conservative resource-limit pattern (`maxdepth` / `maxrefs` / `maxbytes` / `maxarray`), bind it through `@ConfigurationProperties` instead of a system property, or keep only the constructor and drop the property. Whichever default is chosen, the single choke point stays in one place.

