### PR TITLE
fix(cors): resolve preflight config from the requested method's route

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CrossOriginTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CrossOriginTest.java
@@ -134,6 +134,26 @@ public class CrossOriginTest {
     }
 
     @Test
+    void preflightIsNotApprovedByACrossOriginOfARouteWithAnotherHttpMethod() throws IOException {
+        asserts(SPECNAME,
+            preflight(UriBuilder.of("/permethod").path("resource"), "https://foo.com", HttpMethod.POST),
+            (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.METHOD_NOT_ALLOWED)
+                .assertResponse(CorsUtils::assertCorsHeadersNotPresent)
+                .build()));
+    }
+
+    @Test
+    void preflightIsApprovedByTheCrossOriginOfTheRouteServingTheRequestedMethod() throws IOException {
+        asserts(SPECNAME,
+            preflight(UriBuilder.of("/permethod").path("resource"), "https://bar.com", HttpMethod.POST),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.OK)
+                .assertResponse(response -> assertCorsHeaders(response, "https://bar.com", HttpMethod.POST, false))
+                .build()));
+    }
+
+    @Test
     void allowedOriginsRegexHappyPath() throws IOException {
         URI uri = UriBuilder.of("/allowedoriginsregex").path("foo").build();
         String origin = "https://foo.com";
@@ -472,6 +492,25 @@ public class CrossOriginTest {
         @Get("/all")
         String defaults() {
             return "bar";
+        }
+    }
+
+    @Requires(property = "spec.name", value = SPECNAME)
+    @Controller("/permethod")
+    static class PerMethod {
+
+        @CrossOrigin("https://foo.com")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get("/resource")
+        String read() {
+            return "read";
+        }
+
+        @CrossOrigin("https://bar.com")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Post("/resource")
+        String write() {
+            return "write";
         }
     }
 

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -387,7 +387,11 @@ public class CorsFilter implements Ordered, ConditionalFilter {
             return Optional.empty();
         }
         if (router != null) {
+            HttpMethod methodToMatch = methodToMatch(request);
             for (UriRouteMatch<Object, Object> routeMatch : router.findAny(request)) {
+                if (!routeMatch.getHttpMethod().equals(methodToMatch)) {
+                    continue;
+                }
                 Optional<CorsOriginConfiguration> corsOriginConfiguration = CrossOriginUtil.getCorsOriginConfiguration(routeMatch);
                 if (corsOriginConfiguration.isPresent() && matchesOrigin(corsOriginConfiguration.get(), requestOrigin)) {
                     return corsOriginConfiguration;


### PR DESCRIPTION
getAnyConfiguration resolves the preflight policy by walking router.findAny, which returns every route on the path regardless of http method, and takes the first one whose @CrossOrigin matches the origin. a GET route annotated for one origin therefore approves an Access-Control-Request-Method of POST aimed at a sibling POST route annotated for a different origin, because the annotation leaves allowedMethods at any and availableHttpMethods only checks the method exists somewhere on that path. the preflight comes back 200 with Access-Control-Allow-Methods: POST, so the browser goes ahead and sends the real non-simple request and the per-endpoint policy the docs advertise stops holding. skipping route matches whose getHttpMethod differs from methodToMatch keeps the lookup on the route that would actually serve the request; getConfiguration already resolves from the matched route and is unaffected.