### PR TITLE
Backport fix for NPE when SSE events are received with no `data` field

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -718,7 +718,7 @@ public class DefaultHttpClient implements
                                             case "data" -> {
                                                 ByteBuffer<?> content = buffer.slice(fromIndex, toIndex);
                                                 byte[] d = currentEvent.data;
-                                                if (d == null) {
+                                                if (d.length == 0) {
                                                     currentEvent.data = content.toByteArray();
                                                 } else {
                                                     currentEvent.data = ArrayUtils.concat(d, content.toByteArray());
@@ -2279,7 +2279,7 @@ public class DefaultHttpClient implements
      * Used as a holder for the current SSE event.
      */
     private static final class CurrentEvent {
-        byte[] data;
+        byte[] data = new byte[0];
         String id;
         String name;
         Duration retry;

--- a/http/src/main/java/io/micronaut/http/sse/Event.java
+++ b/http/src/main/java/io/micronaut/http/sse/Event.java
@@ -127,7 +127,6 @@ public interface Event<T> {
      * @return The event instance
      */
     static <ET> Event<ET> of(Event event, ET data) {
-        ArgumentUtils.check("data", data).notNull();
         return new DefaultEvent<>(data)
             .id(event.getId())
             .comment(event.getComment())


### PR DESCRIPTION
Auth0 event streams include events with no `data` field, which results in a NullPointerException when `byteBufferFactory.wrap(currentEvent.data)` is called. This is already fixed in 5.x by https://github.com/micronaut-projects/micronaut-core/pull/12363/changes#diff-2d6e881f8d13084a9ebabcf6d3fdaa88df24d15431df685539574d59d6232548R2241. This PR makes the minimal changes from that PR to solve the exception.

Let me know if you're no longer accepting bug fixes to 4.x.