### PR TITLE
fix: improve incremental Python compiler sessions

### DIFF
--- a/inject-python/build.gradle.kts
+++ b/inject-python/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     testImplementation(projects.micronautContext)
     testImplementation(projects.micronautAop)
     testImplementation(projects.micronautContextPython)
+    testImplementation(projects.micronautHttp)
 }
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -55,7 +55,7 @@ import java.util.stream.Stream;
 @Internal
 final class IncrementalCompilation {
     private static final String STATE_FILE = "state.properties";
-    private static final String STATE_VERSION = "7";
+    private static final String STATE_VERSION = "8";
     private static final String SOURCE_PREFIX = "source.";
     private static final String VFS_SOURCE_PREFIX = "META-INF/GRAALPY-VFS/micronaut-application/src/";
     private static final String VFS_ROOT = "META-INF/GRAALPY-VFS/micronaut-application";
@@ -67,6 +67,7 @@ final class IncrementalCompilation {
     private static final Pattern PYTHON_FROM_IMPORT = Pattern.compile("(?m)^\\s*from\\s+(\\S+)\\s+import\\s+");
     private static final Pattern PYTHON_DIRECT_IMPORT = Pattern.compile("(?m)^\\s*import\\s+([\\w.]+)");
     private static final Pattern PYTHON_STAR_IMPORT = Pattern.compile("(?m)^\\s*from\\s+\\S+\\s+import\\s+\\*");
+    private static final Pattern PYTHON_DECLARATION = Pattern.compile("[A-Za-z_]\\w*\\s*(?::|=(?!=))");
     private static final Pattern DYNAMIC_PYTHON_REFERENCE = Pattern.compile(
         "\\b(?:__import__|import_module|getattr|globals|locals)\\s*\\(|@\\s*Mixin\\b"
     );
@@ -164,7 +165,12 @@ final class IncrementalCompilation {
             );
         }
 
-        Set<String> affected = affectedSources(changed, previous.sources(), currentSources);
+        Set<String> affected = affectedSources(
+            changed,
+            previous.sources(),
+            currentSources,
+            pythonIncrementalMode
+        );
         if ((pythonIncrementalMode == PythonIncrementalMode.CONSERVATIVE
             && requiresConservativePythonProcessing(affected, scannedSources))
             || containsDeletedPythonSource(affected, currentSources, previous.sources())) {
@@ -517,7 +523,8 @@ final class IncrementalCompilation {
 
     private static Set<String> affectedSources(Set<String> changed,
                                                Map<String, SourceState> previous,
-                                               Map<String, SourceState> current) {
+                                               Map<String, SourceState> current,
+                                               PythonIncrementalMode pythonIncrementalMode) {
         Map<String, Set<String>> dependents = new HashMap<>();
         Stream.concat(previous.values().stream(), current.values().stream()).forEach(source -> {
             for (String dependency : source.dependencies()) {
@@ -525,7 +532,9 @@ final class IncrementalCompilation {
             }
         });
         Set<String> affected = new LinkedHashSet<>(changed);
-        ArrayDeque<String> queue = new ArrayDeque<>(changed);
+        ArrayDeque<String> queue = changed.stream()
+            .filter(source -> propagatesToDependents(source, previous, current, pythonIncrementalMode))
+            .collect(java.util.stream.Collectors.toCollection(ArrayDeque::new));
         while (!queue.isEmpty()) {
             String source = queue.removeFirst();
             for (String dependent : dependents.getOrDefault(source, Set.of())) {
@@ -535,6 +544,21 @@ final class IncrementalCompilation {
             }
         }
         return affected;
+    }
+
+    private static boolean propagatesToDependents(String source,
+                                                  Map<String, SourceState> previous,
+                                                  Map<String, SourceState> current,
+                                                  PythonIncrementalMode pythonIncrementalMode) {
+        if (pythonIncrementalMode != PythonIncrementalMode.OPTIMISTIC) {
+            return true;
+        }
+        SourceState old = previous.get(source);
+        SourceState replacement = current.get(source);
+        if (old == null || replacement == null || replacement.language() != Language.PYTHON) {
+            return true;
+        }
+        return !old.pythonSharedFingerprint().equals(replacement.pythonSharedFingerprint());
     }
 
     private Map<String, ScannedSource> scanSources() {
@@ -652,18 +676,35 @@ final class IncrementalCompilation {
 
     private static String pythonSharedFingerprint(String content) {
         MessageDigest digest = digest();
+        ArrayDeque<PythonScope> scopes = new ArrayDeque<>();
         boolean continuation = false;
         int bracketDepth = 0;
         for (String line : content.lines().toList()) {
             String stripped = line.stripLeading();
-            boolean sharedInput = continuation
-                || stripped.startsWith("@")
-                || stripped.startsWith("class ")
-                || stripped.startsWith("def ")
-                || stripped.startsWith("async def ")
-                || stripped.startsWith("import ")
-                || stripped.startsWith("from ");
+            if (!continuation && (stripped.isBlank() || stripped.startsWith("#"))) {
+                continue;
+            }
+            int indentation = line.length() - stripped.length();
+            if (!continuation) {
+                while (!scopes.isEmpty() && indentation <= scopes.peek().indentation()) {
+                    scopes.removeFirst();
+                }
+            }
+            boolean functionHeader = stripped.startsWith("def ") || stripped.startsWith("async def ");
+            boolean classHeader = stripped.startsWith("class ");
+            boolean insideFunction = scopes.stream().anyMatch(PythonScope::function);
+            boolean sharedInput = continuation || (!insideFunction && (
+                stripped.startsWith("@")
+                    || classHeader
+                    || functionHeader
+                    || stripped.startsWith("import ")
+                    || stripped.startsWith("from ")
+                    || PYTHON_DECLARATION.matcher(stripped).lookingAt()
+            ));
             if (!sharedInput) {
+                if (classHeader || functionHeader) {
+                    scopes.addFirst(new PythonScope(indentation, functionHeader));
+                }
                 continue;
             }
             update(digest, stripped);
@@ -671,6 +712,9 @@ final class IncrementalCompilation {
             continuation = bracketDepth > 0 || stripped.endsWith("\\");
             if (!continuation) {
                 bracketDepth = 0;
+            }
+            if (classHeader || functionHeader) {
+                scopes.addFirst(new PythonScope(indentation, functionHeader));
             }
         }
         return HexFormat.of().formatHex(digest.digest());
@@ -932,7 +976,10 @@ final class IncrementalCompilation {
                 .toList();
         }
         Files.createDirectories(filesList.getParent());
-        Files.writeString(filesList, String.join(System.lineSeparator(), entries) + System.lineSeparator());
+        String contents = entries.isEmpty() ? "" : String.join("\n", entries) + '\n';
+        if (!Files.isRegularFile(filesList) || !Files.readString(filesList).equals(contents)) {
+            Files.writeString(filesList, contents);
+        }
     }
 
     private void deleteManagedOutput(String output) throws IOException {
@@ -1314,6 +1361,9 @@ final class IncrementalCompilation {
     }
 
     private record ScannedSource(SourceState state, String content) {
+    }
+
+    private record PythonScope(int indentation, boolean function) {
     }
 
     private enum Language {

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -681,40 +681,35 @@ final class IncrementalCompilation {
         int bracketDepth = 0;
         for (String line : content.lines().toList()) {
             String stripped = line.stripLeading();
-            if (!continuation && (stripped.isBlank() || stripped.startsWith("#"))) {
-                continue;
-            }
-            int indentation = line.length() - stripped.length();
-            if (!continuation) {
-                while (!scopes.isEmpty() && indentation <= scopes.peek().indentation()) {
-                    scopes.removeFirst();
+            if (continuation || (!stripped.isBlank() && !stripped.startsWith("#"))) {
+                int indentation = line.length() - stripped.length();
+                if (!continuation) {
+                    while (!scopes.isEmpty() && indentation <= scopes.peek().indentation()) {
+                        scopes.removeFirst();
+                    }
                 }
-            }
-            boolean functionHeader = stripped.startsWith("def ") || stripped.startsWith("async def ");
-            boolean classHeader = stripped.startsWith("class ");
-            boolean insideFunction = scopes.stream().anyMatch(PythonScope::function);
-            boolean sharedInput = continuation || (!insideFunction && (
-                stripped.startsWith("@")
-                    || classHeader
-                    || functionHeader
-                    || stripped.startsWith("import ")
-                    || stripped.startsWith("from ")
-                    || PYTHON_DECLARATION.matcher(stripped).lookingAt()
-            ));
-            if (!sharedInput) {
+                boolean functionHeader = stripped.startsWith("def ") || stripped.startsWith("async def ");
+                boolean classHeader = stripped.startsWith("class ");
+                boolean insideFunction = scopes.stream().anyMatch(PythonScope::function);
+                boolean sharedInput = continuation || (!insideFunction && (
+                    stripped.startsWith("@")
+                        || classHeader
+                        || functionHeader
+                        || stripped.startsWith("import ")
+                        || stripped.startsWith("from ")
+                        || PYTHON_DECLARATION.matcher(stripped).lookingAt()
+                ));
+                if (sharedInput) {
+                    update(digest, stripped);
+                    bracketDepth += bracketDelta(stripped);
+                    continuation = bracketDepth > 0 || stripped.endsWith("\\");
+                    if (!continuation) {
+                        bracketDepth = 0;
+                    }
+                }
                 if (classHeader || functionHeader) {
                     scopes.addFirst(new PythonScope(indentation, functionHeader));
                 }
-                continue;
-            }
-            update(digest, stripped);
-            bracketDepth += bracketDelta(stripped);
-            continuation = bracketDepth > 0 || stripped.endsWith("\\");
-            if (!continuation) {
-                bracketDepth = 0;
-            }
-            if (classHeader || functionHeader) {
-                scopes.addFirst(new PythonScope(indentation, functionHeader));
             }
         }
         return HexFormat.of().formatHex(digest.digest());

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -1204,9 +1204,6 @@ final class IncrementalCompilation {
         }
     }
 
-    private record FileDigest(long size, long modified, String digest) {
-    }
-
     private void validateDirectories() {
         if (cacheDirectory.startsWith(targetDirectory) || targetDirectory.startsWith(cacheDirectory)) {
             throw new IllegalArgumentException(
@@ -1396,6 +1393,9 @@ final class IncrementalCompilation {
                                Set<String> dependencies,
                                Set<String> outputs,
                                Set<String> types) {
+    }
+
+    private record FileDigest(long size, long modified, String digest) {
     }
 
     private record ScannedSource(SourceState state, String content) {

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -44,6 +44,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -54,6 +56,8 @@ import java.util.stream.Stream;
  */
 @Internal
 final class IncrementalCompilation {
+    private static final int MAX_GLOBAL_FILE_DIGESTS = 8192;
+    private static final Map<Path, FileDigest> GLOBAL_FILE_DIGESTS = new ConcurrentHashMap<>();
     private static final String STATE_FILE = "state.properties";
     private static final String STATE_VERSION = "8";
     private static final String SOURCE_PREFIX = "source.";
@@ -200,6 +204,16 @@ final class IncrementalCompilation {
             currentAggregatingInputs,
             hasAggregatingProcessors
         );
+    }
+
+    /**
+     * Performs the inexpensive portion of planning. Aggregating processor
+     * discovery is deliberately deferred until a change has been detected.
+     *
+     * @return the current incremental plan
+     */
+    Plan plan() {
+        return plan(Set.of());
     }
 
     Plan plan(boolean hasAggregatingProcessors) {
@@ -943,15 +957,26 @@ final class IncrementalCompilation {
     }
 
     private boolean hasMissingOutputs(State state) {
-        return Stream.of(
+        Set<String> expected = Stream.of(
                 state.sources().values().stream().flatMap(source -> source.outputs().stream()),
                 state.aggregatingOutputs().stream(),
                 state.pythonAggregatingOutputs().stream(),
                 state.sharedOutputs().stream()
             )
             .flatMap(Stream::sequential)
-            .map(targetDirectory::resolve)
-            .anyMatch(Predicate.not(Files::isRegularFile));
+            .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        if (expected.isEmpty() || !Files.isDirectory(targetDirectory)) {
+            return !expected.isEmpty();
+        }
+        try (Stream<Path> paths = Files.walk(targetDirectory)) {
+            paths.filter(Files::isRegularFile)
+                .map(targetDirectory::relativize)
+                .map(path -> path.toString().replace(File.separatorChar, '/'))
+                .forEach(expected::remove);
+            return !expected.isEmpty();
+        } catch (IOException e) {
+            return true;
+        }
     }
 
     private void rebuildPythonFilesList() throws IOException {
@@ -1157,11 +1182,29 @@ final class IncrementalCompilation {
 
     private static void updateFile(MessageDigest digest, Path file) {
         try {
-            digest.update(Files.readAllBytes(file));
-            digest.update((byte) 0);
+            Path normalized = file.toAbsolutePath().normalize();
+            long size = Files.size(normalized);
+            long modified = Files.getLastModifiedTime(normalized).to(TimeUnit.NANOSECONDS);
+            FileDigest cached = GLOBAL_FILE_DIGESTS.get(normalized);
+            String value;
+            if (cached != null && cached.size() == size && cached.modified() == modified) {
+                value = cached.digest();
+            } else {
+                MessageDigest fileDigest = digest();
+                fileDigest.update(Files.readAllBytes(normalized));
+                value = HexFormat.of().formatHex(fileDigest.digest());
+                if (GLOBAL_FILE_DIGESTS.size() >= MAX_GLOBAL_FILE_DIGESTS) {
+                    GLOBAL_FILE_DIGESTS.clear();
+                }
+                GLOBAL_FILE_DIGESTS.put(normalized, new FileDigest(size, modified, value));
+            }
+            update(digest, value);
         } catch (IOException e) {
             throw new PyronautCompilerException("Failed to fingerprint " + file + ": " + e.getMessage());
         }
+    }
+
+    private record FileDigest(long size, long modified, String digest) {
     }
 
     private void validateDirectories() {

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
@@ -79,6 +79,7 @@ public final class PyronautCompiler {
     private final File incrementalCacheDirectory;
     private final PythonIncrementalMode pythonIncrementalMode;
     private final PythonProcessingSession pythonProcessingSession;
+    private final Consumer<IncrementalCompilationPlan> incrementalCompilationPlanCallback;
 
     private PyronautCompiler(Builder builder) {
         this.packageName = builder.packageName;
@@ -103,6 +104,7 @@ public final class PyronautCompiler {
         this.incrementalCacheDirectory = builder.incrementalCacheDirectory;
         this.pythonIncrementalMode = builder.pythonIncrementalMode;
         this.pythonProcessingSession = builder.pythonProcessingSession;
+        this.incrementalCompilationPlanCallback = builder.incrementalCompilationPlanCallback;
         validateConfiguration();
     }
 
@@ -208,6 +210,7 @@ public final class PyronautCompiler {
             pythonSrc
         );
         IncrementalCompilation.Plan plan = incrementalCompilation.plan(aggregatingSources);
+        notifyIncrementalCompilationPlan(plan);
         if (plan.upToDate()) {
             return;
         }
@@ -231,6 +234,7 @@ public final class PyronautCompiler {
                     );
                 }
                 plan = incrementalCompilation.plan(aggregatingSources);
+                notifyIncrementalCompilationPlan(plan);
                 compilationTrace = compileIncrementally(
                     compiler,
                     incrementalCompilation,
@@ -243,6 +247,22 @@ public final class PyronautCompiler {
             incrementalCompilation.invalidate();
             throw e;
         }
+    }
+
+    private void notifyIncrementalCompilationPlan(IncrementalCompilation.Plan plan) {
+        if (incrementalCompilationPlanCallback == null) {
+            return;
+        }
+        List<Path> sources = plan.affectedSources().stream()
+            .filter(plan.currentSources()::containsKey)
+            .map(Path::of)
+            .sorted()
+            .toList();
+        incrementalCompilationPlanCallback.accept(new IncrementalCompilationPlan(
+            plan.upToDate(),
+            plan.fullRebuild(),
+            sources
+        ));
     }
 
     private IncrementalCompilationTrace compileIncrementally(
@@ -503,6 +523,23 @@ public final class PyronautCompiler {
     }
 
     /**
+     * Describes the source files selected by an incremental disk compilation.
+     *
+     * @param upToDate Whether no compilation is required
+     * @param fullRebuild Whether all current sources must be compiled
+     * @param sources The current source files selected for compilation
+     * @since 5.2.0
+     */
+    @Experimental
+    public record IncrementalCompilationPlan(boolean upToDate,
+                                             boolean fullRebuild,
+                                             List<Path> sources) {
+        public IncrementalCompilationPlan {
+            sources = List.copyOf(sources);
+        }
+    }
+
+    /**
      * Builder for PyronautCompiler.
      */
     @Experimental
@@ -529,6 +566,7 @@ public final class PyronautCompiler {
         private File incrementalCacheDirectory;
         private PythonIncrementalMode pythonIncrementalMode = PythonIncrementalMode.CONSERVATIVE;
         private PythonProcessingSession pythonProcessingSession;
+        private Consumer<IncrementalCompilationPlan> incrementalCompilationPlanCallback;
 
         private Builder() {
         }
@@ -728,6 +766,24 @@ public final class PyronautCompiler {
          */
         public Builder incrementalCacheDirectory(File incrementalCacheDirectory) {
             this.incrementalCacheDirectory = incrementalCacheDirectory;
+            return this;
+        }
+
+        /**
+         * Set a callback that receives each incremental disk compilation plan before it runs.
+         * The callback is also invoked for full rebuild and up-to-date plans while incremental
+         * compilation is enabled.
+         *
+         * @param callback The incremental compilation plan callback
+         * @return This builder
+         * @since 5.2.0
+         */
+        public Builder incrementalCompilationPlanCallback(
+            Consumer<IncrementalCompilationPlan> callback) {
+            this.incrementalCompilationPlanCallback = java.util.Objects.requireNonNull(
+                callback,
+                "callback"
+            );
             return this;
         }
 

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
@@ -319,6 +319,9 @@ public final class PyronautCompiler {
         compiler.setAnnotationProcessors(annotationProcessors);
         compiler.setPythonSourceVisitors(pythonSourceVisitors);
         compiler.setPythonProcessingSession(pythonProcessingSession);
+        if (classElementCallback != null) {
+            compiler.setClassElementCallback(classElementCallback);
+        }
         return compiler;
     }
 

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
@@ -203,13 +203,17 @@ public final class PyronautCompiler {
             pythonSourceVisitors,
             pythonIncrementalMode
         );
-        Set<String> aggregatingSources = compiler.aggregatingSources(
-            classpath,
-            annotationProcessorPath,
-            javaSrc,
-            pythonSrc
-        );
-        IncrementalCompilation.Plan plan = incrementalCompilation.plan(aggregatingSources);
+        Set<String> aggregatingSources = Set.of();
+        IncrementalCompilation.Plan plan = incrementalCompilation.plan();
+        if (!plan.upToDate()) {
+            aggregatingSources = compiler.aggregatingSources(
+                classpath,
+                annotationProcessorPath,
+                javaSrc,
+                pythonSrc
+            );
+            plan = incrementalCompilation.plan(aggregatingSources);
+        }
         notifyIncrementalCompilationPlan(plan);
         if (plan.upToDate()) {
             return;
@@ -226,7 +230,7 @@ public final class PyronautCompiler {
                     || !compilationTrace.contractViolatingOutputs().isEmpty())) {
                 incrementalCompilation.invalidate();
                 if (!annotationProcessors.isEmpty()) {
-                    incrementalCompilation.prepareOutput(incrementalCompilation.plan(aggregatingSources));
+                    incrementalCompilation.prepareOutput(incrementalCompilation.plan());
                     throw new PyronautCompilerException(
                         "An explicitly supplied annotation processor violated its incremental "
                             + "contract; the output was cleaned and must be compiled again with "

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
@@ -228,12 +228,8 @@ final class PyronautJavaCompiler {
             // Unknown visitor behavior must not be treated as isolating.
             return sourceFiles(javaSrc, pythonSrc);
         } finally {
-            if (pythonProcessingSession == null && classLoader instanceof URLClassLoader urlClassLoader) {
-                try {
-                    urlClassLoader.close();
-                } catch (IOException ignored) {
-                    // Nothing to do.
-                }
+            if (pythonProcessingSession == null) {
+                closeClassLoader(classLoader);
             }
         }
     }
@@ -368,7 +364,8 @@ final class PyronautJavaCompiler {
                                                     JavaFileManager fileManager,
                                                     DiagnosticCollector<JavaFileObject> diagnosticCollector) {
         synchronized (COMPILATION_LOCK) {
-            Properties systemProperties = (Properties) System.getProperties().clone();
+            Properties systemProperties = System.getProperties();
+            Properties originalSystemProperties = (Properties) systemProperties.clone();
             try {
                 return compileJavaIsolated(
                     sources,
@@ -380,7 +377,10 @@ final class PyronautJavaCompiler {
                     diagnosticCollector
                 );
             } finally {
-                System.setProperties(systemProperties);
+                synchronized (systemProperties) {
+                    systemProperties.clear();
+                    systemProperties.putAll(originalSystemProperties);
+                }
             }
         }
     }
@@ -409,7 +409,15 @@ final class PyronautJavaCompiler {
         java.nio.file.Path outputDirectory = fileManager instanceof TrackingJavaFileManager trackingFileManager
             ? trackingFileManager.targetDirectory()
             : null;
-        List<Processor> processors = getAnnotationProcessors(classLoader, outputDirectory);
+        List<Processor> processors;
+        try {
+            processors = getAnnotationProcessors(classLoader, outputDirectory);
+        } catch (RuntimeException | LinkageError e) {
+            if (pythonProcessingSession == null) {
+                closeClassLoader(classLoader);
+            }
+            throw e;
+        }
 
         boolean success;
         try {
@@ -486,6 +494,9 @@ final class PyronautJavaCompiler {
             System.clearProperty(VisitorContext.MICRONAUT_PROCESSING_USE_CONTEXT_CLASSLOADER);
             System.clearProperty(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER);
             shutdownProcessors(processors);
+            if (pythonProcessingSession == null) {
+                closeClassLoader(classLoader);
+            }
         }
         if (!success) {
             throw processingFailure(diagnosticCollector, null);
@@ -930,6 +941,16 @@ final class PyronautJavaCompiler {
             classLoader = new URLClassLoader(cp.toArray(new URL[0]), classLoader);
         }
         return classLoader;
+    }
+
+    private static void closeClassLoader(ClassLoader classLoader) {
+        if (classLoader instanceof URLClassLoader urlClassLoader) {
+            try {
+                urlClassLoader.close();
+            } catch (IOException ignored) {
+                // Nothing useful can be done while releasing a compiler class loader.
+            }
+        }
     }
 
     record SourceSnapshot(String name, String path, String content) {

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
@@ -61,6 +61,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Consumer;
@@ -76,6 +77,7 @@ import java.util.stream.Stream;
  */
 final class PyronautJavaCompiler {
 
+    private static final Object COMPILATION_LOCK = new Object();
     private static final String MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER = "micronaut.introspections.use.context.classloader";
     private static final String ISOLATING_PROCESSOR = "org.gradle.annotation.processing.isolating";
     private static final Pattern SOURCE_IN_MESSAGE = Pattern.compile("Python source \\[([^]]+)]");
@@ -199,7 +201,12 @@ final class PyronautJavaCompiler {
         }
 
         List<File> processorClasspath = mergeClasspath(annotationProcessorPath, classpath);
-        ClassLoader classLoader = createAnnotationProcessorClassLoader(processorClasspath);
+        ClassLoader classLoader = pythonProcessingSession == null
+            ? createAnnotationProcessorClassLoader(processorClasspath)
+            : pythonProcessingSession.classLoader(
+                processorClasspath,
+                () -> createAnnotationProcessorClassLoader(processorClasspath)
+            );
         try {
             @SuppressWarnings({"rawtypes", "unchecked"})
             List<TypeElementVisitor<?, ?>> visitors = (List) SoftServiceLoader
@@ -221,7 +228,7 @@ final class PyronautJavaCompiler {
             // Unknown visitor behavior must not be treated as isolating.
             return sourceFiles(javaSrc, pythonSrc);
         } finally {
-            if (classLoader instanceof URLClassLoader urlClassLoader) {
+            if (pythonProcessingSession == null && classLoader instanceof URLClassLoader urlClassLoader) {
                 try {
                     urlClassLoader.close();
                 } catch (IOException ignored) {
@@ -231,18 +238,15 @@ final class PyronautJavaCompiler {
         }
     }
 
-    private static Set<String> sourcesUsingAnnotations(Set<String> annotationNames,
-                                                       String javaSrc,
-                                                       String pythonSrc) {
-        if (annotationNames.stream().anyMatch(name -> name.contains("*"))) {
+    static Set<String> sourcesUsingAnnotations(Set<String> annotationNames,
+                                               String javaSrc,
+                                               String pythonSrc) {
+        if (annotationNames.contains("*")) {
             return sourceFiles(javaSrc, pythonSrc);
         }
         List<String> normalizedNames = annotationNames.stream()
-            .map(name -> {
-                int separator = name.lastIndexOf('.');
-                String simpleName = separator == -1 ? name : name.substring(separator + 1);
-                return normalizeAnnotationName(simpleName);
-            })
+            .flatMap(name -> annotationSearchTerms(name).stream())
+            .distinct()
             .toList();
         Set<String> sources = new LinkedHashSet<>();
         for (java.nio.file.Path root : sourceRoots(javaSrc, pythonSrc)) {
@@ -265,6 +269,23 @@ final class PyronautJavaCompiler {
             }
         }
         return Set.copyOf(sources);
+    }
+
+    private static List<String> annotationSearchTerms(String annotationName) {
+        if (annotationName.endsWith(".*")) {
+            String packageName = annotationName.substring(0, annotationName.length() - 2);
+            String normalizedPackage = normalizeAnnotationName(packageName);
+            if (packageName.startsWith("io.")) {
+                return List.of(
+                    normalizedPackage,
+                    normalizeAnnotationName(packageName.substring("io.".length()))
+                );
+            }
+            return List.of(normalizedPackage);
+        }
+        int separator = annotationName.lastIndexOf('.');
+        String simpleName = separator == -1 ? annotationName : annotationName.substring(separator + 1);
+        return List.of(normalizeAnnotationName(simpleName));
     }
 
     private static Set<String> sourceFiles(String javaSrc, String pythonSrc) {
@@ -346,10 +367,40 @@ final class PyronautJavaCompiler {
                                                     List<String> compilerOptions,
                                                     JavaFileManager fileManager,
                                                     DiagnosticCollector<JavaFileObject> diagnosticCollector) {
+        synchronized (COMPILATION_LOCK) {
+            Properties systemProperties = (Properties) System.getProperties().clone();
+            try {
+                return compileJavaIsolated(
+                    sources,
+                    classpath,
+                    bootclasspath,
+                    annotationProcessorPath,
+                    compilerOptions,
+                    fileManager,
+                    diagnosticCollector
+                );
+            } finally {
+                System.setProperties(systemProperties);
+            }
+        }
+    }
+
+    private IncrementalCompilationTrace compileJavaIsolated(JavaFileObject[] sources,
+                                                            List<File> classpath,
+                                                            List<File> bootclasspath,
+                                                            List<File> annotationProcessorPath,
+                                                            List<String> compilerOptions,
+                                                            JavaFileManager fileManager,
+                                                            DiagnosticCollector<JavaFileObject> diagnosticCollector) {
         List<File> processorClasspath = mergeClasspath(annotationProcessorPath, classpath);
         List<File> compileClasspath = effectiveClasspath(classpath);
         List<String> options = buildCompilerOptions(compileClasspath, bootclasspath, annotationProcessorPath, compilerOptions);
-        ClassLoader classLoader = createAnnotationProcessorClassLoader(processorClasspath);
+        ClassLoader classLoader = pythonProcessingSession == null
+            ? createAnnotationProcessorClassLoader(processorClasspath)
+            : pythonProcessingSession.classLoader(
+                processorClasspath,
+                () -> createAnnotationProcessorClassLoader(processorClasspath)
+            );
         System.setProperty(VisitorContext.MICRONAUT_PROCESSING_USE_CONTEXT_CLASSLOADER, StringUtils.TRUE);
         System.setProperty(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER, StringUtils.TRUE);
         ClassLoader previous = Thread.currentThread().getContextClassLoader();

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonProcessingSession.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonProcessingSession.java
@@ -22,9 +22,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * Owns the initialized GraalPy processing context across multiple serialized compilations.
@@ -121,17 +126,44 @@ public final class PythonProcessingSession implements AutoCloseable {
         if (classpath == null || classpath.isEmpty()) {
             return List.of();
         }
-        List<String> fingerprint = new ArrayList<>(classpath.size() * 3);
+        List<String> fingerprint = new ArrayList<>(classpath.size() * 2);
         for (File entry : classpath) {
             var path = entry.toPath().toAbsolutePath().normalize();
             fingerprint.add(path.toString());
             try {
-                fingerprint.add(Long.toString(Files.size(path)));
-                fingerprint.add(Long.toString(Files.getLastModifiedTime(path).toMillis()));
+                fingerprint.add(fingerprint(path));
             } catch (IOException e) {
                 fingerprint.add("missing");
             }
         }
         return List.copyOf(fingerprint);
+    }
+
+    private static String fingerprint(Path path) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+        if (Files.isDirectory(path)) {
+            try (Stream<Path> entries = Files.walk(path)) {
+                for (Path entry : entries.sorted().toList()) {
+                    update(digest, path.relativize(entry).toString());
+                    update(digest, Files.isDirectory(entry) ? "directory" : "file");
+                    update(digest, Long.toString(Files.size(entry)));
+                    update(digest, Long.toString(Files.getLastModifiedTime(entry).toMillis()));
+                }
+            }
+        } else {
+            update(digest, Long.toString(Files.size(path)));
+            update(digest, Long.toString(Files.getLastModifiedTime(path).toMillis()));
+        }
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static void update(MessageDigest digest, String value) {
+        digest.update(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        digest.update((byte) 0);
     }
 }

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonProcessingSession.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonProcessingSession.java
@@ -18,6 +18,14 @@ package io.micronaut.python.processing;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
 /**
  * Owns the initialized GraalPy processing context across multiple serialized compilations.
  *
@@ -28,7 +36,36 @@ import io.micronaut.core.annotation.Internal;
 @Experimental
 public final class PythonProcessingSession implements AutoCloseable {
     private PythonAstParser parser;
+    private ClassLoader classLoader;
+    private List<String> classLoaderFingerprint;
     private boolean closed;
+
+    /**
+     * Obtains the annotation processor class loader associated with this processing session.
+     *
+     * <p>The GraalPy context retains its host class loader. Reusing the context while creating a
+     * different processor class loader for every compilation makes annotation types loaded by
+     * Python incompatible with the visitors loaded for the current compilation. The class loader
+     * must therefore have the same lifetime as the context.</p>
+     *
+     * @param classpath The effective annotation processor classpath
+     * @param factory Creates the class loader when the classpath changes
+     * @return The session class loader
+     */
+    @Internal
+    public ClassLoader classLoader(List<File> classpath, Supplier<ClassLoader> factory) {
+        if (closed) {
+            throw new IllegalStateException("Python processing session is closed");
+        }
+        List<String> fingerprint = fingerprint(classpath);
+        if (classLoader != null && fingerprint.equals(classLoaderFingerprint)) {
+            return classLoader;
+        }
+        closeResources();
+        classLoader = factory.get();
+        classLoaderFingerprint = fingerprint;
+        return classLoader;
+    }
 
     /**
      * Obtains the parser for a compilation, initializing GraalPy on first use.
@@ -60,9 +97,41 @@ public final class PythonProcessingSession implements AutoCloseable {
     @Override
     public void close() {
         closed = true;
+        closeResources();
+    }
+
+    private void closeResources() {
         if (parser != null) {
             parser.close();
             parser = null;
         }
+        if (classLoader instanceof URLClassLoader urlClassLoader
+            && classLoader != PythonProcessingSession.class.getClassLoader()) {
+            try {
+                urlClassLoader.close();
+            } catch (IOException ignored) {
+                // Nothing useful can be done while releasing a compiler cache.
+            }
+        }
+        classLoader = null;
+        classLoaderFingerprint = null;
+    }
+
+    private static List<String> fingerprint(List<File> classpath) {
+        if (classpath == null || classpath.isEmpty()) {
+            return List.of();
+        }
+        List<String> fingerprint = new ArrayList<>(classpath.size() * 3);
+        for (File entry : classpath) {
+            var path = entry.toPath().toAbsolutePath().normalize();
+            fingerprint.add(path.toString());
+            try {
+                fingerprint.add(Long.toString(Files.size(path)));
+                fingerprint.add(Long.toString(Files.getLastModifiedTime(path).toMillis()));
+            } catch (IOException e) {
+                fingerprint.add("missing");
+            }
+        }
+        return List.copyOf(fingerprint);
     }
 }

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -27,6 +27,7 @@ import javax.lang.model.element.TypeElement;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -34,6 +35,8 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,10 +61,69 @@ final class PyronautCompilerIncrementalTest {
     }
 
     @Test
+    void restoresSystemPropertiesChangedByAnnotationProcessors(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = Files.createDirectories(directory.resolve("classes"));
+        Files.writeString(sources.resolve("Greeting.java"), "public class Greeting {}\n");
+        String property = "micronaut.test.compiler.processor.option";
+        String previous = System.getProperty(property);
+        System.setProperty(property, "before");
+        try {
+            PyronautCompiler.builder()
+                .javaSrc(sources.toString())
+                .targetDir(output.toFile())
+                .annotationProcessors(List.of(new SystemPropertyMutatingProcessor(property)))
+                .build()
+                .compile();
+
+            assertEquals("before", System.getProperty(property));
+        } finally {
+            if (previous == null) {
+                System.clearProperty(property);
+            } else {
+                System.setProperty(property, previous);
+            }
+        }
+    }
+
+    @Test
+    void packageWildcardOnlySelectsSourcesImportingThatAnnotationPackage(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path pythonController = Files.writeString(python.resolve("controller.py"), """
+            from micronaut.http.annotation import Get
+            @Get("/")
+            def index():
+                return "ok"
+            """);
+        Path unrelatedPython = Files.writeString(python.resolve("seed.py"), "value = 1\n");
+        Path javaController = Files.writeString(java.resolve("Controller.java"), """
+            import io.micronaut.http.annotation.Get;
+            class Controller {
+                @Get("/") String index() { return "ok"; }
+            }
+            """);
+        Path unrelatedJava = Files.writeString(java.resolve("Seed.java"), "class Seed {}\n");
+
+        Set<String> matches = PyronautJavaCompiler.sourcesUsingAnnotations(
+            Set.of("io.micronaut.http.annotation.*"),
+            java.toString(),
+            python.toString()
+        );
+
+        assertEquals(Set.of(
+            pythonController.toRealPath().toString(),
+            javaController.toRealPath().toString()
+        ), matches);
+        assertFalse(matches.contains(unrelatedPython.toRealPath().toString()));
+        assertFalse(matches.contains(unrelatedJava.toRealPath().toString()));
+    }
+
+    @Test
     void reusesPythonProcessingSessionAcrossIncrementalCompilations(@TempDir Path directory) throws Exception {
         Path python = Files.createDirectories(directory.resolve("python"));
         Path java = Files.createDirectories(directory.resolve("java"));
-        Path output = directory.resolve("classes");
+        Path output = Files.createDirectories(directory.resolve("classes"));
         Path cache = directory.resolve("incremental");
         Path source = python.resolve("example.py");
         Files.writeString(source, "class Example:\n    value: int = 1\n");
@@ -75,6 +137,54 @@ final class PyronautCompilerIncrementalTest {
             assertTrue(Files.readString(output.resolve(
                 "META-INF/GRAALPY-VFS/micronaut-application/src/example.py"
             )).contains("value: int = 2"));
+        }
+    }
+
+    @Test
+    void reusablePythonSessionPreservesAnnotationMetadata(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = Files.createDirectories(directory.resolve("classes"));
+        Path httpClasspath = Path.of(io.micronaut.http.annotation.Controller.class
+            .getProtectionDomain().getCodeSource().getLocation().toURI());
+        Path source = python.resolve("controller.py");
+        Files.writeString(source, """
+            from micronaut.http.annotation import Controller, Get
+            @Controller("/")
+            class Example:
+                @Get("/")
+                def index(self) -> str:
+                    return "first"
+            """);
+
+        try (PythonProcessingSession session = new PythonProcessingSession()) {
+            assertPythonControllerAnnotations(python, java, output, httpClasspath, session);
+            Files.writeString(source, Files.readString(source).replace("first", "second"));
+            assertPythonControllerAnnotations(python, java, output, httpClasspath, session);
+        }
+    }
+
+    @Test
+    void reusablePythonSessionRetainsTheProcessorClassLoader(@TempDir Path directory) throws Exception {
+        Path processorPath = Files.writeString(directory.resolve("processors.jar"), "test");
+        try (PythonProcessingSession session = new PythonProcessingSession()) {
+            ClassLoader first = session.classLoader(
+                List.of(processorPath.toFile()),
+                () -> new java.net.URLClassLoader(new java.net.URL[0], getClass().getClassLoader())
+            );
+            ClassLoader second = session.classLoader(
+                List.of(processorPath.toFile()),
+                () -> new java.net.URLClassLoader(new java.net.URL[0], getClass().getClassLoader())
+            );
+
+            assertSame(first, second);
+
+            Files.writeString(processorPath, "changed");
+            ClassLoader changed = session.classLoader(
+                List.of(processorPath.toFile()),
+                () -> new java.net.URLClassLoader(new java.net.URL[0], getClass().getClassLoader())
+            );
+            assertNotSame(first, changed);
         }
     }
 
@@ -910,6 +1020,60 @@ final class PyronautCompilerIncrementalTest {
     }
 
     @Test
+    void optimisticModeDoesNotReprocessImportDependentsForBodyOnlyChanges(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path dependency = python.resolve("dependency.py");
+        Files.writeString(
+            dependency,
+            "class Dependency:\n    def value(self) -> int:\n        result = 1\n        return result\n"
+        );
+        Files.writeString(
+            python.resolve("consumer.py"),
+            "from dependency import Dependency\nclass Consumer:\n    value: Dependency\n"
+        );
+        compilePython(python, java, output, cache, PythonIncrementalMode.OPTIMISTIC);
+        Path consumerVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/consumer.py"
+        );
+        Files.setLastModifiedTime(consumerVfs, UNCHANGED_MARKER);
+
+        Files.writeString(
+            dependency,
+            "class Dependency:\n    def value(self) -> int:\n        result = 2\n        return result\n"
+        );
+        compilePython(python, java, output, cache, PythonIncrementalMode.OPTIMISTIC);
+
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(consumerVfs));
+    }
+
+    @Test
+    void optimisticModeReprocessesImportDependentsForDeclarationChanges(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path dependency = python.resolve("dependency.py");
+        Files.writeString(dependency, "class Dependency:\n    value: int = 1\n");
+        Files.writeString(
+            python.resolve("consumer.py"),
+            "from dependency import Dependency\nclass Consumer:\n    value: Dependency\n"
+        );
+        compilePython(python, java, output, cache, PythonIncrementalMode.OPTIMISTIC);
+        Path consumerVfs = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/consumer.py"
+        );
+        Files.setLastModifiedTime(consumerVfs, UNCHANGED_MARKER);
+
+        Files.writeString(dependency, "class Dependency:\n    value: str = \"changed\"\n");
+        compilePython(python, java, output, cache, PythonIncrementalMode.OPTIMISTIC);
+
+        assertNotEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(consumerVfs));
+    }
+
+    @Test
     void doesNotReprocessDynamicPythonSourcesForUnrelatedJavaChanges(@TempDir Path directory) throws Exception {
         Path python = Files.createDirectories(directory.resolve("python"));
         Path java = Files.createDirectories(directory.resolve("java"));
@@ -1207,6 +1371,34 @@ final class PyronautCompilerIncrementalTest {
             .compile();
     }
 
+    private static void assertPythonControllerAnnotations(Path python,
+                                                          Path java,
+                                                          Path output,
+                                                          Path httpClasspath,
+                                                          PythonProcessingSession session) {
+        List<Boolean> controllerAnnotations = new ArrayList<>();
+        List<Boolean> routeAnnotations = new ArrayList<>();
+        PyronautCompiler.builder()
+            .pythonSrc(python.toString())
+            .javaSrc(java.toString())
+            .targetDir(output.toFile())
+            .classpath(List.of(httpClasspath.toFile()))
+            .annotationProcessorPath(List.of(httpClasspath.toFile()))
+            .pythonProcessingSession(session)
+            .classElementCallback(type -> {
+                if (type.getName().endsWith("Example")) {
+                    controllerAnnotations.add(type.isAnnotationPresent("io.micronaut.http.annotation.Controller"));
+                    type.getEnclosedElements(io.micronaut.inject.ast.ElementQuery.ALL_METHODS).stream()
+                        .filter(method -> method.getName().equals("index"))
+                        .forEach(method -> routeAnnotations.add(method.isAnnotationPresent("io.micronaut.http.annotation.Get")));
+                }
+            })
+            .build()
+            .compile();
+        assertEquals(List.of(true), controllerAnnotations);
+        assertEquals(List.of(true), routeAnnotations);
+    }
+
     private static void compilePython(Path python,
                                       Path java,
                                       Path output,
@@ -1351,6 +1543,26 @@ final class PyronautCompilerIncrementalTest {
                 .filter(path -> path.getFileName().toString().endsWith(suffix))
                 .findFirst()
                 .orElseThrow();
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    private static final class SystemPropertyMutatingProcessor extends AbstractProcessor {
+        private final String property;
+
+        private SystemPropertyMutatingProcessor(String property) {
+            this.property = property;
+        }
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            System.setProperty(property, "changed");
+            return false;
+        }
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
         }
     }
 

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -67,6 +67,7 @@ final class PyronautCompilerIncrementalTest {
         Files.writeString(sources.resolve("Greeting.java"), "public class Greeting {}\n");
         String property = "micronaut.test.compiler.processor.option";
         String previous = System.getProperty(property);
+        Properties systemProperties = System.getProperties();
         System.setProperty(property, "before");
         try {
             PyronautCompiler.builder()
@@ -77,6 +78,7 @@ final class PyronautCompilerIncrementalTest {
                 .compile();
 
             assertEquals("before", System.getProperty(property));
+            assertSame(systemProperties, System.getProperties());
         } finally {
             if (previous == null) {
                 System.clearProperty(property);
@@ -186,6 +188,61 @@ final class PyronautCompilerIncrementalTest {
             );
             assertNotSame(first, changed);
         }
+    }
+
+    @Test
+    void reusablePythonSessionInvalidatesTheProcessorClassLoaderForExplodedClasses(
+        @TempDir Path directory) throws Exception {
+        Path processorPath = Files.createDirectories(directory.resolve("processor-classes"));
+        Path processorClass = Files.writeString(processorPath.resolve("Example.class"), "first");
+        FileTime directoryTime = Files.getLastModifiedTime(processorPath);
+        try (PythonProcessingSession session = new PythonProcessingSession()) {
+            ClassLoader first = session.classLoader(
+                List.of(processorPath.toFile()),
+                () -> new java.net.URLClassLoader(new java.net.URL[0], getClass().getClassLoader())
+            );
+
+            Files.writeString(processorClass, "changed");
+            Files.setLastModifiedTime(processorPath, directoryTime);
+            ClassLoader changed = session.classLoader(
+                List.of(processorPath.toFile()),
+                () -> new java.net.URLClassLoader(new java.net.URL[0], getClass().getClassLoader())
+            );
+
+            assertNotSame(first, changed);
+        }
+    }
+
+    @Test
+    void reportsSourcesSelectedForIncrementalCompilation(@TempDir Path directory) throws Exception {
+        Path sources = Files.createDirectories(directory.resolve("sources"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path alpha = Files.writeString(
+            sources.resolve("Alpha.java"),
+            "public class Alpha { int value() { return 1; } }\n"
+        );
+        Path beta = Files.writeString(sources.resolve("Beta.java"), "public class Beta {}\n");
+        List<PyronautCompiler.IncrementalCompilationPlan> plans = new ArrayList<>();
+
+        compileJavaWithPlanCallback(sources, output, cache, plans);
+        assertEquals(1, plans.size());
+        assertTrue(plans.getFirst().fullRebuild());
+        assertEquals(Set.of(alpha.toRealPath(), beta.toRealPath()), Set.copyOf(plans.getFirst().sources()));
+
+        plans.clear();
+        Files.writeString(alpha, "public class Alpha { int value() { return 2; } }\n");
+        compileJavaWithPlanCallback(sources, output, cache, plans);
+        assertEquals(1, plans.size());
+        assertFalse(plans.getFirst().fullRebuild());
+        assertFalse(plans.getFirst().upToDate());
+        assertEquals(List.of(alpha.toRealPath()), plans.getFirst().sources());
+
+        plans.clear();
+        compileJavaWithPlanCallback(sources, output, cache, plans);
+        assertEquals(1, plans.size());
+        assertTrue(plans.getFirst().upToDate());
+        assertTrue(plans.getFirst().sources().isEmpty());
     }
 
     @Test
@@ -1347,6 +1404,21 @@ final class PyronautCompilerIncrementalTest {
             .options(List.of(options))
             .incremental(true)
             .incrementalCacheDirectory(cache.toFile())
+            .build()
+            .compile();
+    }
+
+    private static void compileJavaWithPlanCallback(
+        Path sources,
+        Path output,
+        Path cache,
+        List<PyronautCompiler.IncrementalCompilationPlan> plans) {
+        PyronautCompiler.builder()
+            .javaSrc(sources.toString())
+            .targetDir(output.toFile())
+            .incremental(true)
+            .incrementalCacheDirectory(cache.toFile())
+            .incrementalCompilationPlanCallback(plans::add)
             .build()
             .compile();
     }


### PR DESCRIPTION
Follow-up to #12850 based on live Petclinic verification.

- reuse the processor class loader with the GraalPy processing session
- preserve Python annotation metadata across daemon requests
- isolate annotation-processor system-property mutations between compilations
- narrow OpenAPI package-wildcard aggregation inputs
- improve optimistic Python dependency propagation 
-  keep the VFS file index deterministic