### PR TITLE
fix(cookie): parse request Cookie header as name/value pairs

### DIFF
--- a/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
@@ -16,11 +16,14 @@
 package io.micronaut.http.cookie;
 
 import io.micronaut.core.annotation.Internal;
-import java.net.HttpCookie;
+
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * {@link ServerCookieDecoder} implementation backed by {@link HttpCookie#parse(String)}.
+ * {@link ServerCookieDecoder} implementation that parses an HTTP {@code Cookie} request header into
+ * its individual name/value pairs, as defined by
+ * <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-4.2.1">RFC 6265, Section 4.2.1</a>.
  *
  * @author Sergio del Amo
  * @since 4.3.0
@@ -29,9 +32,52 @@ import java.util.List;
 public final class DefaultServerCookieDecoder implements ServerCookieDecoder {
     @Override
     public List<Cookie> decode(String header) {
-        return HttpCookie.parse(header)
-                .stream()
-                .map(httpCookie -> (Cookie) new CookieHttpCookieAdapter(httpCookie))
-                .toList();
+        if (header == null || header.isEmpty()) {
+            return List.of();
+        }
+        List<Cookie> cookies = new ArrayList<>();
+        int length = header.length();
+        int pos = 0;
+        while (pos < length) {
+            int semicolon = header.indexOf(';', pos);
+            int end = semicolon == -1 ? length : semicolon;
+            addCookie(header, pos, end, cookies);
+            pos = end + 1;
+        }
+        return cookies;
+    }
+
+    private static void addCookie(String header, int start, int end, List<Cookie> cookies) {
+        while (start < end && header.charAt(start) == ' ') {
+            start++;
+        }
+        while (end > start && header.charAt(end - 1) == ' ') {
+            end--;
+        }
+        if (start == end) {
+            return;
+        }
+        int equals = header.indexOf('=', start);
+        if (equals == -1 || equals >= end) {
+            return;
+        }
+        String name = header.substring(start, equals).trim();
+        if (name.isEmpty()) {
+            return;
+        }
+        String value = unwrapValue(header.substring(equals + 1, end).trim());
+        try {
+            cookies.add(Cookie.of(name, value));
+        } catch (IllegalArgumentException e) {
+            // skip a single malformed pair rather than rejecting the whole header
+        }
+    }
+
+    private static String unwrapValue(String value) {
+        int length = value.length();
+        if (length >= 2 && value.charAt(0) == '"' && value.charAt(length - 1) == '"') {
+            return value.substring(1, length - 1);
+        }
+        return value;
     }
 }

--- a/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.cookie;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,8 +58,14 @@ public final class DefaultServerCookieDecoder implements ServerCookieDecoder {
         if (start == end) {
             return;
         }
-        int equals = header.indexOf('=', start);
-        if (equals == -1 || equals >= end) {
+        int equals = -1;
+        for (int i = start; i < end; i++) {
+            if (header.charAt(i) == '=') {
+                equals = i;
+                break;
+            }
+        }
+        if (equals == -1) {
             return;
         }
         String name = header.substring(start, equals).trim();
@@ -66,17 +73,26 @@ public final class DefaultServerCookieDecoder implements ServerCookieDecoder {
             return;
         }
         String value = unwrapValue(header.substring(equals + 1, end).trim());
+        if (value == null) {
+            return;
+        }
         try {
             cookies.add(Cookie.of(name, value));
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException ignored) {
             // skip a single malformed pair rather than rejecting the whole header
         }
     }
 
+    // Returns null when the value starts with a double quote that is never closed, so the caller
+    // drops the pair, matching Netty's ServerCookieDecoder.LAX.
+    @Nullable
     private static String unwrapValue(String value) {
         int length = value.length();
-        if (length >= 2 && value.charAt(0) == '"' && value.charAt(length - 1) == '"') {
-            return value.substring(1, length - 1);
+        if (length > 0 && value.charAt(0) == '"') {
+            if (length >= 2 && value.charAt(length - 1) == '"') {
+                return value.substring(1, length - 1);
+            }
+            return null;
         }
         return value;
     }

--- a/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
+++ b/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
@@ -63,4 +63,18 @@ class DefaultServerCookieDecoderTest {
         assertEquals("quoted value", cookies.get(0).getValue());
         assertEquals("dark", cookies.get(1).getValue());
     }
+
+    @Test
+    void unbalancedOpeningQuoteDropsThePair() {
+        // Netty's ServerCookieDecoder.LAX drops a value that starts with a double quote but never
+        // closes it; both server decoders must agree on this input.
+        ServerCookieDecoder decoder = new DefaultServerCookieDecoder();
+        List<Cookie> cookies = decoder.decode("a=\"unterminated; b=2");
+        assertEquals(1, cookies.size());
+        assertEquals("b", cookies.get(0).getName());
+        assertEquals("2", cookies.get(0).getValue());
+
+        assertEquals(List.of(), decoder.decode("a=\""));
+        assertEquals("", decoder.decode("a=\"\"").get(0).getValue());
+    }
 }

--- a/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
+++ b/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
@@ -14,32 +14,53 @@ class DefaultServerCookieDecoderTest {
 
     @Test
     void testCookieDecoding() {
-        String header = "SID=31d4d96e407aad42; Path=/; Domain=example.com";
+        // A Cookie request header is a list of name/value pairs; Path/Domain are ordinary cookies
+        // here, not attributes of the preceding cookie (RFC 6265 section 4.2.1).
         ServerCookieDecoder decoder = new DefaultServerCookieDecoder();
-        List<Cookie> cookies = decoder.decode(header);
+        List<Cookie> cookies = decoder.decode("SID=31d4d96e407aad42; Path=/; Domain=example.com");
         assertNotNull(cookies);
-        assertEquals(1, cookies.size());
-        Cookie cookie = cookies.get(0);
-        assertEquals("SID", cookie.getName());
-        assertEquals("31d4d96e407aad42", cookie.getValue());
-        assertEquals("/", cookie.getPath());
-        assertEquals("example.com", cookie.getDomain());
-        assertFalse(cookie.isHttpOnly());
-        assertFalse(cookie.isSecure());
-        assertTrue(cookie.getSameSite().isEmpty());
+        assertEquals(3, cookies.size());
+        assertEquals("SID", cookies.get(0).getName());
+        assertEquals("31d4d96e407aad42", cookies.get(0).getValue());
+        assertNull(cookies.get(0).getPath());
+        assertNull(cookies.get(0).getDomain());
+        assertEquals("Path", cookies.get(1).getName());
+        assertEquals("/", cookies.get(1).getValue());
+        assertEquals("Domain", cookies.get(2).getName());
+        assertEquals("example.com", cookies.get(2).getValue());
 
-        header = "SID=31d4d96e407aad42; Path=/; Secure; HttpOnly";
+        // Attribute-only pairs without a value are not cookie-pairs and are dropped.
+        cookies = decoder.decode("SID=31d4d96e407aad42; Path=/; Secure; HttpOnly");
+        assertEquals(2, cookies.size());
+        assertEquals("SID", cookies.get(0).getName());
+        assertEquals("Path", cookies.get(1).getName());
+    }
 
-        cookies = decoder.decode(header);
-        assertNotNull(cookies);
-        assertEquals(1, cookies.size());
-        cookie = cookies.get(0);
-        assertEquals("SID", cookie.getName());
-        assertEquals("31d4d96e407aad42", cookie.getValue());
-        assertEquals("/", cookie.getPath());
-        assertNull(cookie.getDomain());
-        assertTrue(cookie.isHttpOnly());
-        assertTrue(cookie.isSecure());
-        assertTrue(cookie.getSameSite().isEmpty());
+    @Test
+    void multipleCookiesAreAllDecoded() {
+        List<Cookie> cookies = new DefaultServerCookieDecoder().decode("SID=abc; JSESSIONID=xyz; foo=bar");
+        assertEquals(3, cookies.size());
+        assertEquals("SID", cookies.get(0).getName());
+        assertEquals("abc", cookies.get(0).getValue());
+        assertEquals("JSESSIONID", cookies.get(1).getName());
+        assertEquals("xyz", cookies.get(1).getValue());
+        assertEquals("foo", cookies.get(2).getName());
+        assertEquals("bar", cookies.get(2).getValue());
+    }
+
+    @Test
+    void malformedPairsAreSkippedInsteadOfThrowing() {
+        ServerCookieDecoder decoder = new DefaultServerCookieDecoder();
+        assertEquals(List.of(), decoder.decode("foo"));
+        assertEquals("a", decoder.decode("=noname; a=1").get(0).getName());
+        assertEquals(3, decoder.decode("a=1;;b=2; ;c=3").size());
+    }
+
+    @Test
+    void quotedValuesAreUnwrapped() {
+        List<Cookie> cookies = new DefaultServerCookieDecoder().decode("SID=\"quoted value\"; theme=dark");
+        assertEquals(2, cookies.size());
+        assertEquals("quoted value", cookies.get(0).getValue());
+        assertEquals("dark", cookies.get(1).getValue());
     }
 }


### PR DESCRIPTION
DefaultServerCookieDecoder.decode parses an inbound Cookie request header on runtimes without http-netty, but delegates to java.net.HttpCookie.parse, a Set-Cookie response parser. on a Cookie header with several pairs it returns only the first and drops the rest (SID=a; JSESSIONID=b yields just SID), throws IllegalArgumentException on a malformed name so a bad request turns into a 500, and treats Path/Domain/Max-Age as attributes on the inbound cookie, letting a client set cookie.getPath() which NettyCookies uses to filter which cookies reach the app. the NettyLaxServerCookieDecoder sibling backed by netty ServerCookieDecoder.LAX already parses it as a plain name/value list, so the two SPI implementations disagree on identical input. rewrite decode to split on ';', unwrap balanced quotes, and skip empty or unparsable pairs instead of interpreting attributes or throwing.