### PR TITLE
Preserve original Python sources for debugging

### DIFF
--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
@@ -157,6 +157,7 @@ class BetaService:
 
         cleanup:
         context?.close()
+        classLoader?.close()
         firstRoot.deleteDir()
         secondRoot.deleteDir()
         tempTargetDir.deleteDir()
@@ -664,6 +665,7 @@ class KeywordMethodService:
 
         cleanup:
         context?.close()
+        classLoader?.close()
         tempDir.deleteDir()
     }
 
@@ -748,6 +750,7 @@ def debug_failure():
 
         cleanup:
         context?.close()
+        classLoader?.close()
         tempDir.deleteDir()
 
         where:
@@ -809,6 +812,7 @@ def debug_failure():
 
         cleanup:
         context?.close()
+        classLoader?.close()
         tempSrcDir.deleteDir()
         tempTargetDir.deleteDir()
 

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.data.model.Association
 import io.micronaut.data.model.runtime.RuntimePersistentEntity
 import io.micronaut.data.intercept.annotation.DataMethod
 import io.micronaut.python.processing.PythonAnnotationProcessor
+import org.graalvm.polyglot.PolyglotException
 import org.graalvm.polyglot.Value
 import spock.lang.Specification
 
@@ -70,6 +71,95 @@ class TestClass:
 
         cleanup:
         tempDir.deleteDir()
+    }
+
+    def "test file-backed VFS sources preserve exact content across relative imports"() {
+        given:
+        def tempSrcDir = File.createTempDir("pyronaut-test-original-src", "")
+        def tempTargetDir = File.createTempDir("pyronaut-test-original-target", "")
+        def packageDir = new File(tempSrcDir, "example")
+        packageDir.mkdirs()
+        def serviceCode = '''# debugger-visible comment
+from .helper import answer
+
+
+class Service:
+    def value(self):
+        return answer(  21  )  # preserve spacing
+'''
+        def helperCode = '''def answer(value):
+    return value * 2
+'''
+        new File(packageDir, "service.py").text = serviceCode
+        new File(packageDir, "helper.py").text = helperCode
+        def compiler = PyronautCompiler.builder()
+            .pythonSrc(tempSrcDir.absolutePath)
+            .targetDir(tempTargetDir)
+            .build()
+
+        when:
+        compiler.compile()
+
+        then:
+        new File(tempTargetDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}example/service.py").text == serviceCode
+        new File(tempTargetDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}example/helper.py").text == helperCode
+
+        cleanup:
+        tempSrcDir.deleteDir()
+        tempTargetDir.deleteDir()
+    }
+
+    def "test multiple Python source roots preserve exact source and remain loadable"() {
+        given:
+        def firstRoot = File.createTempDir("pyronaut-test-first-root", "")
+        def secondRoot = File.createTempDir("pyronaut-test-second-root", "")
+        def tempTargetDir = File.createTempDir("pyronaut-test-multiple-roots-target", "")
+        def alphaDir = new File(firstRoot, "alpha")
+        def betaDir = new File(secondRoot, "beta")
+        alphaDir.mkdirs()
+        betaDir.mkdirs()
+        def alphaCode = '''# first source root
+from jakarta.inject import Singleton
+
+@Singleton
+class AlphaService:
+    def value(self) -> str:
+        return "alpha"
+'''
+        def betaCode = '''# second source root
+from jakarta.inject import Singleton
+
+@Singleton
+class BetaService:
+    def value(self) -> str:
+        return "beta"
+'''
+        new File(alphaDir, "AlphaService.py").text = alphaCode
+        new File(betaDir, "BetaService.py").text = betaCode
+        def compiler = PyronautCompiler.builder()
+            .pythonSrc("${firstRoot.absolutePath},${secondRoot.absolutePath}")
+            .targetDir(tempTargetDir)
+            .build()
+
+        when:
+        compiler.compile()
+        def classLoader = new URLClassLoader(tempTargetDir.toURI().toURL())
+        def context = ApplicationContext.builder()
+            .classLoader(classLoader)
+            .build()
+            .start()
+
+        then:
+        new File(tempTargetDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}alpha/AlphaService.py").text == alphaCode
+        new File(tempTargetDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}beta/BetaService.py").text == betaCode
+        context.getBean(classLoader.loadClass('alpha.AlphaService')) != null
+        context.getBean(classLoader.loadClass('beta.BetaService')) != null
+
+        cleanup:
+        context?.close()
+        firstRoot.deleteDir()
+        secondRoot.deleteDir()
+        tempTargetDir.deleteDir()
     }
 
     def "test buildClassLoader uses explicit parent classloader"() {
@@ -512,11 +602,11 @@ class AsyncImportService:
         tempDir.deleteDir()
     }
 
-    def "test Python keyword-safe Java method aliases are rewritten"() {
+    def "test imported Java keyword methods use generated facades and direct aliases use mapped bytecode"() {
         given:
         def pythonCode = '''
 from java.lang import Thread
-from reactor.core.publisher import Mono
+from reactor.core.publisher import Mono as ImportedMono
 import java
 
 ThreadAlias = java.type("java.lang.Thread")
@@ -534,7 +624,7 @@ class KeywordMethodService:
         return ThreadAlias.yield_()
 
     def imported_reactor(self, publisher):
-        return Mono.from_(publisher)
+        return ImportedMono.from_(publisher)
 
     def assigned_reactor(self, publisher):
         return FluxAlias.from_(publisher)
@@ -551,26 +641,33 @@ class KeywordMethodService:
 
         when:
         compiler.compile()
+        def classLoader = new URLClassLoader(tempDir.toURI().toURL())
+        def context = ApplicationContext.builder()
+            .classLoader(classLoader)
+            .build()
+            .start()
+        def pythonContext = context.getBean(org.graalvm.polyglot.Context)
 
         then:
-        def transformedFile = new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_LAUNCHER_PATH}")
-        transformedFile.exists()
-        def transformedContent = transformedFile.text
-        transformedContent.contains("getattr(Thread, 'yield')()")
-        transformedContent.contains("getattr(ThreadAlias, 'yield')()")
-        transformedContent.contains("getattr(Mono, 'from')(publisher)")
-        transformedContent.contains("getattr(FluxAlias, 'from')(publisher)")
-        transformedContent.contains("keyword.from_()")
-        !transformedContent.contains("Thread.yield_")
-        !transformedContent.contains("ThreadAlias.yield_")
-        !transformedContent.contains("Mono.from_")
-        !transformedContent.contains("FluxAlias.from_")
+        def sourceFile = new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_LAUNCHER_PATH}")
+        sourceFile.exists()
+        sourceFile.text == pythonCode
+        new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}java/lang/__init__.py")
+            .text.contains("Thread = _MicronautJavaType(java.type('java.lang.Thread'), False)")
+        new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}reactor/core/publisher/__init__.py")
+            .text.contains("Mono = _MicronautJavaType(java.type('reactor.core.publisher.Mono'), False)")
+        new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}__pycache__")
+            .listFiles().any { it.name.startsWith('__main__.') && it.name.endsWith('.pyc') }
+        pythonContext.eval("python", "KeywordMethodService().imported_reactor(ImportedMono.just('imported')).block()").asString() == 'imported'
+        pythonContext.eval("python", "KeywordMethodService().assigned_reactor(ImportedMono.just('assigned')).blockFirst()").asString() == 'assigned'
+        pythonContext.eval("python", "KeywordMethodService().python_method()").asString() == 'python'
 
         cleanup:
+        context?.close()
         tempDir.deleteDir()
     }
 
-    def "test Python keyword-safe annotation members are rewritten"() {
+    def "test Python keyword-safe annotation members keep original runtime source"() {
         given:
         def pythonCode = '''
 from micronaut.http.annotation import Controller, Error
@@ -591,14 +688,132 @@ class ErrorController:
         compiler.compile()
 
         then:
-        def transformedFile = new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_LAUNCHER_PATH}")
-        transformedFile.exists()
-        def transformedContent = transformedFile.text
-        transformedContent.contains("@Error(**{'global': True})")
-        !transformedContent.contains("@Error(global_")
+        def sourceFile = new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_LAUNCHER_PATH}")
+        sourceFile.exists()
+        sourceFile.text == pythonCode
+        new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}micronaut/http/annotation/Error.py")
+            .text.contains('@micronaut_annotation("io.micronaut.http.annotation.Error"')
 
         cleanup:
         tempDir.deleteDir()
+    }
+
+    def "test mapped runtime bytecode preserves original traceback locations with optional bytecode #compileBytecode"() {
+        given:
+        def pythonCode = '''from jakarta.inject import Singleton
+import java
+
+Mono = java.type("reactor.core.publisher.Mono")
+
+@Singleton
+class DebugService:
+    pass
+
+def debug_failure():
+    Mono.from_(Mono.just("ready")).block()
+    raise RuntimeError("debug boom")
+'''
+        def tempDir = File.createTempDir("pyronaut-test-traceback", "")
+        def compiler = PyronautCompiler.builder()
+            .pythonCode(pythonCode)
+            .targetDir(tempDir)
+            .compilePythonBytecode(compileBytecode)
+            .build()
+
+        when:
+        compiler.compile()
+        def classLoader = new URLClassLoader(tempDir.toURI().toURL())
+        def context = ApplicationContext.builder()
+            .classLoader(classLoader)
+            .build()
+            .start()
+        def pythonContext = context.getBean(org.graalvm.polyglot.Context)
+        pythonContext.eval("python", "debug_failure()")
+
+        then:
+        def error = thrown(PolyglotException)
+        error.message.contains("debug boom")
+        def applicationFrame = error.polyglotStackTrace.find { it.rootName == 'debug_failure' }
+        applicationFrame != null
+        applicationFrame.sourceLocation.startLine == 12
+        applicationFrame.sourceLocation.source.name == '/graalpy_vfs/src/__main__.py'
+        pythonContext.eval("python", "'getattr' in debug_failure.__code__.co_names and 'from_' not in debug_failure.__code__.co_names").asBoolean()
+        new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_LAUNCHER_PATH}").text == pythonCode
+        def cacheFile = new File(tempDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}__pycache__")
+            .listFiles().find { it.name.startsWith('__main__.') && it.name.endsWith('.pyc') }
+        cacheFile != null
+        java.nio.ByteBuffer.wrap(cacheFile.bytes, 4, 4)
+            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+            .getInt() == 3
+
+        cleanup:
+        context?.close()
+        tempDir.deleteDir()
+
+        where:
+        compileBytecode << [false, true]
+    }
+
+    def "test file-backed mapped runtime bytecode preserves original traceback locations with optional bytecode #compileBytecode"() {
+        given:
+        def pythonCode = '''# directory-backed debugger source
+from jakarta.inject import Singleton
+import java
+
+Mono = java.type("reactor.core.publisher.Mono")
+
+@Singleton
+class DebugService:
+    pass
+
+def debug_failure():
+    Mono.from_(Mono.just("ready")).block()
+    raise RuntimeError("directory debug boom")
+'''
+        def tempSrcDir = File.createTempDir("pyronaut-test-directory-traceback-src", "")
+        def tempTargetDir = File.createTempDir("pyronaut-test-directory-traceback-target", "")
+        def packageDir = new File(tempSrcDir, "example")
+        packageDir.mkdirs()
+        new File(packageDir, "debug_service.py").text = pythonCode
+        def compiler = PyronautCompiler.builder()
+            .pythonSrc(tempSrcDir.absolutePath)
+            .targetDir(tempTargetDir)
+            .compilePythonBytecode(compileBytecode)
+            .build()
+
+        when:
+        compiler.compile()
+        def classLoader = new URLClassLoader(tempTargetDir.toURI().toURL())
+        def context = ApplicationContext.builder()
+            .classLoader(classLoader)
+            .build()
+            .start()
+        def pythonContext = context.getBean(org.graalvm.polyglot.Context)
+        pythonContext.eval("python", "from example.debug_service import debug_failure; debug_failure()")
+
+        then:
+        def error = thrown(PolyglotException)
+        error.message.contains("directory debug boom")
+        def applicationFrame = error.polyglotStackTrace.find { it.rootName == 'debug_failure' }
+        applicationFrame != null
+        applicationFrame.sourceLocation.startLine == 13
+        applicationFrame.sourceLocation.source.name == '/graalpy_vfs/src/example/debug_service.py'
+        pythonContext.eval("python", "'getattr' in debug_failure.__code__.co_names and 'from_' not in debug_failure.__code__.co_names").asBoolean()
+        def moduleCache = pythonContext.eval(
+            "python",
+            "__import__('example.debug_service', fromlist=['']).__cached__"
+        ).asString()
+        moduleCache.contains('/example/__pycache__/debug_service.')
+        moduleCache.endsWith('.pyc')
+        new File(tempTargetDir, "META-INF/${PythonAnnotationProcessor.APPLICATION_SRC_PATH}example/debug_service.py").text == pythonCode
+
+        cleanup:
+        context?.close()
+        tempSrcDir.deleteDir()
+        tempTargetDir.deleteDir()
+
+        where:
+        compileBytecode << [false, true]
     }
 
     def "test nested annotation members are generated as Python attributes"() {

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautCompiler.java
@@ -468,7 +468,17 @@ public final class PyronautCompiler {
         sb.append("@PythonApplication(\n");
 
         if (hasSrc) {
-            sb.append("    src = \"").append(pythonSrc).append("\"");
+            sb.append("    src = {");
+            StringTokenizer tokenizer = new StringTokenizer(pythonSrc, ",");
+            String separator = "";
+            while (tokenizer.hasMoreTokens()) {
+                sb.append(separator)
+                    .append('"')
+                    .append(escapeJavaString(tokenizer.nextToken().trim()))
+                    .append('"');
+                separator = ", ";
+            }
+            sb.append('}');
             if (hasCode) {
                 sb.append(",\n");
             }
@@ -691,9 +701,10 @@ public final class PyronautCompiler {
 
         /**
          * Enable generation of hash-based GraalPy bytecode for Python resources generated during
-         * annotation processing. Source resources remain available alongside the bytecode.
+         * annotation processing. Source resources remain available alongside the bytecode. Disabling
+         * this option does not suppress bytecode required for runtime compatibility.
          *
-         * @param compilePythonBytecode Whether generated Python resources should include bytecode
+         * @param compilePythonBytecode Whether generated Python resources should include optional bytecode
          * @return This builder
          * @since 5.2.0
          */

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
@@ -136,9 +136,10 @@ final class PyronautJavaCompiler {
     }
 
     /**
-     * Set whether the Python annotation processor should emit bytecode resources.
+     * Set whether the Python annotation processor should emit optional bytecode resources.
+     * Disabling this option does not suppress bytecode required for runtime compatibility.
      *
-     * @param compilePythonBytecode Whether bytecode resources should be emitted
+     * @param compilePythonBytecode Whether optional bytecode resources should be emitted
      */
     public void setCompilePythonBytecode(boolean compilePythonBytecode) {
         this.compilePythonBytecode = compilePythonBytecode;

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -788,7 +788,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
 
     private static String runtimeFilename(String filePath) {
         String relativePath = filePath.substring(APPLICATION_PATH.length());
-        return "/graalpy_vfs" + relativePath;
+        return "/graalpy_vfs/" + relativePath;
     }
 
     private static String cacheFilePath(String sourcePath, String cachePath) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -112,9 +112,11 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     }
 
     /**
-     * Set whether generated Python VFS resources should include GraalPy bytecode caches.
+     * Set whether generated Python VFS resources should include optional GraalPy bytecode caches.
+     * Application sources that require runtime compatibility transformations may include a cache
+     * regardless of this setting so that the original source remains available for debugging.
      *
-     * @param compilePythonBytecode Whether bytecode caches should be emitted
+     * @param compilePythonBytecode Whether optional bytecode caches should be emitted
      * @since 5.2.0
      */
     public void setCompilePythonBytecode(boolean compilePythonBytecode) {
@@ -273,8 +275,15 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             StringBuilder filesList = new StringBuilder();
             boolean processSharedOutputs = incrementalSources == null || processAggregatingVisitors;
             if (StringUtils.isNotEmpty(values.code())) {
-                mainPy = transformedList.get(0).runtimeCode();
-                writePythonToVfs(filesList, APPLICATION_LAUNCHER_PATH, mainPy, originatingElement);
+                PythonAstParser.TransformResult transformResult = transformedList.get(0);
+                mainPy = transformResult.originalSource().getCharacters().toString();
+                writeApplicationPythonToVfs(
+                    filesList,
+                    APPLICATION_LAUNCHER_PATH,
+                    mainPy,
+                    transformResult,
+                    originatingElement
+                );
             } else {
                 if (hasSrcDirs) {
                     // source mode, so we need to write out each source to META-INF
@@ -310,9 +319,14 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                                         .addAll(transformResult.allClassNames());
                                 }
                             }
-                            Source runtimeSource = transformResult.runtimeSource();
                             if (isAffectedSource(source)) {
-                                writePythonToVfs(filesList, targetSource, runtimeSource.getCharacters().toString(), originatingElement);
+                                writeApplicationPythonToVfs(
+                                    filesList,
+                                    targetSource,
+                                    source.getCharacters().toString(),
+                                    transformResult,
+                                    originatingElement
+                                );
                             }
                         }
                     }
@@ -668,6 +682,47 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                                   String filePath,
                                   String content,
                                   ClassElement originatingElement) {
+        boolean unchanged = writePythonSourceToVfs(filesList, filePath, content, originatingElement);
+
+        if (!compilePythonBytecode || unchanged) {
+            return;
+        }
+        try {
+            PythonBytecodeCompiler.Result result = bytecodeCompiler().compile(content, filePath);
+            writePythonBytecodeToVfs(filesList, filePath, result, originatingElement);
+        } catch (ProcessingException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ProcessingException(originatingElement, "Failed to compile Python bytecode for [" + filePath + "]: " + e.getMessage(), e);
+        }
+    }
+
+    private void writeApplicationPythonToVfs(StringBuilder filesList,
+                                             String filePath,
+                                             String content,
+                                             PythonAstParser.TransformResult transformResult,
+                                             ClassElement originatingElement) {
+        writePythonSourceToVfs(filesList, filePath, content, originatingElement);
+        if (!compilePythonBytecode && !parser.requiresRuntimeBytecode(transformResult)) {
+            return;
+        }
+        try {
+            PythonBytecodeCompiler.Result result = parser.compileRuntimeBytecode(
+                transformResult,
+                runtimeFilename(filePath)
+            );
+            writePythonBytecodeToVfs(filesList, filePath, result, originatingElement);
+        } catch (ProcessingException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ProcessingException(originatingElement, "Failed to compile mapped Python bytecode for [" + filePath + "]: " + e.getMessage(), e);
+        }
+    }
+
+    private boolean writePythonSourceToVfs(StringBuilder filesList,
+                                           String filePath,
+                                           String content,
+                                           ClassElement originatingElement) {
         boolean unchanged = false;
         var generatedFile = javaVisitorContext.visitMetaInfFile(filePath, originatingElement).orElse(null);
         if (generatedFile != null) {
@@ -688,30 +743,52 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             }
         }
         filesList.append("/META-INF/").append(filePath).append('\n');
+        return unchanged;
+    }
 
-        if (!compilePythonBytecode || unchanged) {
-            return;
+    private PythonBytecodeCompiler bytecodeCompiler() {
+        if (bytecodeCompiler == null) {
+            bytecodeCompiler = parser.bytecodeCompiler();
         }
-        try {
-            if (bytecodeCompiler == null) {
-                bytecodeCompiler = parser.bytecodeCompiler();
+        return bytecodeCompiler;
+    }
+
+    private void writePythonBytecodeToVfs(StringBuilder filesList,
+                                          String sourcePath,
+                                          PythonBytecodeCompiler.Result result,
+                                          ClassElement originatingElement) {
+        String bytecodePath = cacheFilePath(sourcePath, result.cachePath());
+        boolean unchanged = false;
+        if (outputDirectory != null) {
+            Path existingFile = outputDirectory.resolve("META-INF").resolve(bytecodePath);
+            try {
+                unchanged = Files.isRegularFile(existingFile) && Arrays.equals(result.bytes(), Files.readAllBytes(existingFile));
+            } catch (IOException e) {
+                throw new ProcessingException(originatingElement, "Failed to read Python bytecode from [" + bytecodePath + "]: " + e.getMessage(), e);
             }
-            PythonBytecodeCompiler.Result result = bytecodeCompiler.compile(content, filePath);
-            String cacheFilePath = cacheFilePath(filePath, result.cachePath());
-            javaVisitorContext.visitMetaInfFile(cacheFilePath, originatingElement)
-                .ifPresent(bytecodeFile -> {
-                    try (var output = bytecodeFile.openOutputStream()) {
-                        output.write(result.bytes());
-                    } catch (IOException e) {
-                        throw new ProcessingException(originatingElement, "Failed to write Python bytecode to [" + cacheFilePath + "]: " + e.getMessage(), e);
-                    }
-                });
-            filesList.append("/META-INF/").append(cacheFilePath).append('\n');
-        } catch (ProcessingException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new ProcessingException(originatingElement, "Failed to compile Python bytecode for [" + filePath + "]: " + e.getMessage(), e);
         }
+        boolean bytecodeUnchanged = unchanged;
+        javaVisitorContext.visitMetaInfFile(bytecodePath, originatingElement)
+            .ifPresent(bytecodeFile -> {
+                try {
+                    if (bytecodeUnchanged) {
+                        // Opening the existing output records it for incremental compilation.
+                        bytecodeFile.openInputStream().close();
+                    } else {
+                        try (var output = bytecodeFile.openOutputStream()) {
+                            output.write(result.bytes());
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new ProcessingException(originatingElement, "Failed to write Python bytecode to [" + bytecodePath + "]: " + e.getMessage(), e);
+                }
+            });
+        filesList.append("/META-INF/").append(bytecodePath).append('\n');
+    }
+
+    private static String runtimeFilename(String filePath) {
+        String relativePath = filePath.substring(APPLICATION_PATH.length());
+        return "/graalpy_vfs" + relativePath;
     }
 
     private static String cacheFilePath(String sourcePath, String cachePath) {
@@ -729,7 +806,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
         ClassElement originatingElement) {
         // Collect all packages that need __init__.py files
         Map<String, List<String>> decoratorsByPackage = new LinkedHashMap<>();
-        Map<String, Map<String, String>> javaClassesByPackage = new LinkedHashMap<>();
+        Map<String, Map<String, JavaClassImport>> javaClassesByPackage = new LinkedHashMap<>();
 
 
         // Process decorators
@@ -769,13 +846,18 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
         if (javaClassImports != null && !javaClassImports.isEmpty()) {
             javaClassImports.forEach((packageName, imports) -> {
                 String pythonPackageName = toPythonImportName(packageName);
-                Map<String, String> classMappings = javaClassesByPackage.computeIfAbsent(pythonPackageName, (k) ->
+                Map<String, JavaClassImport> classMappings = javaClassesByPackage.computeIfAbsent(pythonPackageName, (k) ->
                     new LinkedHashMap<>()
                 );
                 for (Map<String, String> importInfo : imports) {
                     String variable = importInfo.get("variable");
                     String className = importInfo.get("class_name");
-                    classMappings.put(variable, className);
+                    JavaClassImport javaClassImport = new JavaClassImport(
+                        className,
+                        Boolean.parseBoolean(importInfo.get("interface")),
+                        Boolean.parseBoolean(importInfo.get("keyword_safe"))
+                    );
+                    classMappings.merge(variable, javaClassImport, JavaClassImport::merge);
                 }
             });
         }
@@ -792,7 +874,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
         // Write __init__.py files for all packages
         for (String packageName : allPackages) {
             List<String> decoratorsInPackage = decoratorsByPackage.get(packageName);
-            Map<String, String> javaClassesInPackage = javaClassesByPackage.get(packageName);
+            Map<String, JavaClassImport> javaClassesInPackage = javaClassesByPackage.get(packageName);
 
             String packagePath = packageName.replace('.', '/');
             String initFilePath = APPLICATION_SRC_PATH + packagePath + "/__init__.py";
@@ -802,6 +884,35 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             // Add Java import if we have Java classes
             if (javaClassesInPackage != null && !javaClassesInPackage.isEmpty()) {
                 initContent.append("import java\n\n");
+                if (javaClassesInPackage.values().stream().anyMatch(JavaClassImport::requiresFacade)) {
+                    initContent.append("""
+                        import keyword
+
+                        class _MicronautJavaType:
+                            def __init__(self, target, interface=False):
+                                self._target = target
+                                self._interface = interface
+
+                            def __getattr__(self, name):
+                                if name.endswith('_') and keyword.iskeyword(name[:-1]):
+                                    name = name[:-1]
+                                return getattr(self._target, name)
+
+                            def __call__(self, *args, **kwargs):
+                                return self._target(*args, **kwargs)
+
+                            def __getitem__(self, item):
+                                if self._interface:
+                                    return self
+                                return self._target[item]
+
+                            def __mro_entries__(self, bases):
+                                if self._interface:
+                                    return ()
+                                return (self._target,)
+
+                        """);
+                }
             }
 
             List<String> allNames = new java.util.ArrayList<>();
@@ -816,9 +927,22 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
 
             // Add Java class assignments
             if (javaClassesInPackage != null) {
-                for (java.util.Map.Entry<String, String> mapping : javaClassesInPackage.entrySet()) {
+                for (java.util.Map.Entry<String, JavaClassImport> mapping : javaClassesInPackage.entrySet()) {
                     String typeName = mapping.getKey();
-                    initContent.append(typeName).append(" = java.type('").append(mapping.getValue()).append("')\n");
+                    JavaClassImport javaClassImport = mapping.getValue();
+                    if (javaClassImport.requiresFacade()) {
+                        initContent.append(typeName)
+                            .append(" = _MicronautJavaType(java.type('")
+                            .append(javaClassImport.className())
+                            .append("'), ")
+                            .append(javaClassImport.interfaceType() ? "True" : "False")
+                            .append(")\n");
+                    } else {
+                        initContent.append(typeName)
+                            .append(" = java.type('")
+                            .append(javaClassImport.className())
+                            .append("')\n");
+                    }
                     allNames.add(typeName);
                 }
             }
@@ -913,5 +1037,19 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     }
 
     private record PythonApplicationValues(String code, String[] src) {
+    }
+
+    private record JavaClassImport(String className, boolean interfaceType, boolean keywordSafe) {
+        private boolean requiresFacade() {
+            return interfaceType || keywordSafe;
+        }
+
+        private JavaClassImport merge(JavaClassImport other) {
+            return new JavaClassImport(
+                other.className,
+                interfaceType || other.interfaceType,
+                keywordSafe || other.keywordSafe
+            );
+        }
     }
 }

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,26 @@ public final class PythonAstParser {
         "for", "from", "global", "if", "import", "in", "is", "lambda", "nonlocal",
         "not", "or", "pass", "raise", "return", "try", "while", "with", "yield"
     );
+    private static final Source COMPILE_RUNTIME_AST_SOURCE = Source.newBuilder(PYTHON, """
+        import importlib.util as _mn_runtime_importlib_util
+        import marshal as _mn_runtime_marshal
+        import struct as _mn_runtime_struct
+
+        def _mn_compile_runtime_ast(tree, source, filename):
+            code = compile(tree, filename, 'exec')
+            header = (
+                _mn_runtime_importlib_util.MAGIC_NUMBER
+                + _mn_runtime_struct.pack('<I', 0x03)
+                + _mn_runtime_importlib_util.source_hash(source.encode('utf-8'))
+            )
+            return (
+                _mn_runtime_importlib_util.cache_from_source(filename),
+                header + _mn_runtime_marshal.dumps(code)
+            )
+        """, "micronaut-runtime-ast-compiler.py").cached(true).buildLiteral();
     private final Context context;
+    private final Value runtimeAstCompiler;
+    private final IdentityHashMap<TransformResult, RuntimeArtifact> runtimeArtifacts = new IdentityHashMap<>();
 
     public PythonAstParser() {
         this(PythonAstParser.class.getClassLoader());
@@ -85,6 +105,8 @@ public final class PythonAstParser {
         }
         this.context = contextBuilder.build();
         context.initialize(PYTHON);
+        context.eval(COMPILE_RUNTIME_AST_SOURCE);
+        runtimeAstCompiler = context.getBindings(PYTHON).getMember("_mn_compile_runtime_ast");
     }
 
     PythonBytecodeCompiler bytecodeCompiler() {
@@ -281,6 +303,7 @@ public final class PythonAstParser {
     }
 
     public @NotNull List<TransformResult> transform(VisitorContext visitorContext, Source... pythonSource) {
+        runtimeArtifacts.clear();
         Value bindings = context.getBindings(PYTHON);
         Map<String, ClassElement> classElementCache = new LinkedHashMap<>();
         Set<String> missingClassElements = new java.util.HashSet<>();
@@ -337,7 +360,7 @@ public final class PythonAstParser {
             java.util.List<String> exportedTypes = map.containsKey("exportedTypes") ? (java.util.List<String>) map.get("exportedTypes") : new ArrayList<>();
             java.util.List<String> allClassNames = map.containsKey("allClassNames") ? (java.util.List<String>) map.get("allClassNames") : new ArrayList<>();
             java.util.List<String> validationErrors = map.containsKey("validationErrors") ? (java.util.List<String>) map.get("validationErrors") : new ArrayList<>();
-            results.add(new TransformResult(
+            TransformResult transformResult = new TransformResult(
                 source,
                 code,
                 runtimeCode,
@@ -346,9 +369,39 @@ public final class PythonAstParser {
                 exportedTypes,
                 allClassNames,
                 validationErrors
-            ));
+            );
+            results.add(transformResult);
+            runtimeArtifacts.put(
+                transformResult,
+                new RuntimeArtifact(
+                    result.getHashValue("runtimeTree"),
+                    result.getHashValue("runtimeRequired").asBoolean()
+                )
+            );
         }
         return results;
+    }
+
+    PythonBytecodeCompiler.Result compileRuntimeBytecode(TransformResult transformResult,
+                                                         String filename) {
+        RuntimeArtifact artifact = runtimeArtifacts.get(transformResult);
+        if (artifact == null) {
+            throw new IllegalArgumentException("Unknown Python transform result");
+        }
+        Value result = runtimeAstCompiler.execute(
+            artifact.tree(),
+            transformResult.originalSource().getCharacters().toString(),
+            filename
+        );
+        return new PythonBytecodeCompiler.Result(
+            result.getArrayElement(0).asString(),
+            result.getArrayElement(1).as(byte[].class)
+        );
+    }
+
+    boolean requiresRuntimeBytecode(TransformResult transformResult) {
+        RuntimeArtifact artifact = runtimeArtifacts.get(transformResult);
+        return artifact != null && artifact.required();
     }
 
     private static String normalizeKeywordSafePackageName(String name) {
@@ -391,19 +444,31 @@ public final class PythonAstParser {
     private static @Language("python") String getTransformSource() {
         return """
             import ast
-            from micronaut_transformer import MicronautTransformer, unparse
+            from micronaut_transformer import MicronautRuntimeTransformer, MicronautTransformer, unparse
 
             tree = ast.parse(src)
             transformer = MicronautTransformer(callback_get_class_element, callback_get_class_elements)
             transformed_tree = transformer.visit(tree)
-            runtime_tree = ast.parse(src)
-            runtime_transformer = MicronautTransformer(callback_get_class_element, callback_get_class_elements, True)
-            transformed_runtime_tree = runtime_transformer.visit(runtime_tree)
+            diagnostic_runtime_tree = ast.parse(src)
+            diagnostic_runtime_transformer = MicronautTransformer(callback_get_class_element, callback_get_class_elements, True)
+            transformed_diagnostic_runtime_tree = diagnostic_runtime_transformer.visit(diagnostic_runtime_tree)
+            executable_runtime_tree = ast.parse(src)
+            original_runtime_tree = ast.dump(executable_runtime_tree, include_attributes=False)
+            missing_decorator_code = transformer.get_missing_runtime_decorator_code(executable_runtime_tree)
+            runtime_transformer = MicronautRuntimeTransformer(
+                callback_get_class_element,
+                callback_get_class_elements,
+                missing_decorator_code
+            )
+            transformed_runtime_tree = runtime_transformer.visit(executable_runtime_tree)
+            ast.fix_missing_locations(transformed_runtime_tree)
             {
                 "code": unparse(transformed_tree),
-                "runtimeCode": unparse(transformed_runtime_tree),
+                "runtimeCode": unparse(transformed_diagnostic_runtime_tree),
+                "runtimeTree": transformed_runtime_tree,
+                "runtimeRequired": ast.dump(transformed_runtime_tree, include_attributes=False) != original_runtime_tree,
                 "decorators": transformer.get_generated_decorator_code(),
-                "javaClassImports": transformer.java_class_imports,
+                "javaClassImports": transformer.get_java_class_imports(),
                 "exportedTypes": transformer.get_exported_types(),
                 "allClassNames": transformer.all_class_names,
                 "validationErrors": transformer.validation_errors
@@ -436,7 +501,11 @@ public final class PythonAstParser {
     }
 
     public void close() {
+        runtimeArtifacts.clear();
         this.context.close();
+    }
+
+    private record RuntimeArtifact(Value tree, boolean required) {
     }
 
     /**

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
@@ -84,6 +84,7 @@ class MicronautTransformer(ast.NodeTransformer):
         self.java_class_imports = {}
         self.java_interface_names = set()
         self.java_keyword_method_aliases = {}
+        self.java_keyword_safe_imports = set()
         self.validation_errors = []
         self.has_java_import = False
         self.exported_types = []
@@ -391,6 +392,10 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
         if java_method_name is None:
             return node
 
+        owner_name = self._base_name(node.value)
+        if owner_name is not None:
+            self.java_keyword_safe_imports.add(owner_name)
+
         return ast.copy_location(
             ast.Call(
                 func=ast.Name(id='getattr', ctx=ast.Load()),
@@ -494,7 +499,12 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
             else:
                 self._track_java_class(variable_name, class_element)
                 # Collect Java class import for VFS generation
-                self._collect_java_class_import(transformed_module_name, variable_name, class_element.getName())
+                self._collect_java_class_import(
+                    transformed_module_name,
+                    import_name,
+                    variable_name,
+                    class_element
+                )
                 # Generate java.type() assignment for regular Java types
                 java_type_assignment = f"{variable_name} = java.type('{class_element.getName()}')"
                 self.java_type_assignments.append(java_type_assignment)
@@ -518,7 +528,12 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
                     else:
                         self._track_java_class(variable_name, class_element)
                         # Collect Java class import for VFS generation
-                        self._collect_java_class_import(transformed_module_name, variable_name, class_element.getName())
+                        self._collect_java_class_import(
+                            transformed_module_name,
+                            import_name,
+                            variable_name,
+                            class_element
+                        )
                         # Generate java.type() assignment for regular Java types
                         java_type_assignment = f"{variable_name} = java.type('{class_element.getName()}')"
                         self.java_type_assignments.append(java_type_assignment)
@@ -902,6 +917,11 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
 
         # Generate the decorator function with imports, meta-annotations and micronaut_annotation for VFS
         imports_section = '\n'.join(import_lines) + '\n\n' if import_lines else ''
+        exported_decorator_name = str(class_element.getSimpleName()).split('$')[-1]
+        export_alias = (
+            f'\n{exported_decorator_name} = {decorator_name}\n'
+            if exported_decorator_name != decorator_name else ''
+        )
 
         decorator_code = f'''
 {imports_section}def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
@@ -920,7 +940,9 @@ def {decorator_name}({param_signature}):
     """
     if len(args) == 1 and callable(args[0]) and not kwargs:
         target = args[0]
-        if not any(value is target for value in globals().values()):
+        caller_frame = __import__('sys')._getframe(1)
+        if (not any(value is target for value in caller_frame.f_locals.values())
+                and not any(value is target for value in caller_frame.f_globals.values())):
             return target
 
     def decorator(target):
@@ -928,6 +950,7 @@ def {decorator_name}({param_signature}):
 
     return decorator
 {nested_members_code}
+{export_alias}
 '''
 
         # Store the generated code in the dict for extraction (use qualified annotation name as key)
@@ -974,6 +997,11 @@ def {decorator_name}({param_signature}):
 
         # Generate the decorator function with custom annotation name and micronaut_annotation
         nested_members_prelude, nested_members_code, _ = self._generate_nested_members_sections(class_element, decorator_name)
+        exported_decorator_name = str(class_element.getSimpleName()).split('$')[-1]
+        export_alias = (
+            f'\n{exported_decorator_name} = {decorator_name}\n'
+            if exported_decorator_name != decorator_name else ''
+        )
         decorator_code = f'''
 def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
     """
@@ -991,7 +1019,9 @@ def {decorator_name}({param_signature}):
     """
     if len(args) == 1 and callable(args[0]) and not kwargs:
         target = args[0]
-        if not any(value is target for value in globals().values()):
+        caller_frame = __import__('sys')._getframe(1)
+        if (not any(value is target for value in caller_frame.f_locals.values())
+                and not any(value is target for value in caller_frame.f_globals.values())):
             return target
 
     def decorator(target):
@@ -999,6 +1029,7 @@ def {decorator_name}({param_signature}):
 
     return decorator
 {nested_members_code}
+{export_alias}
 '''
         self.generated_decorator_code[custom_annotation_name] = decorator_code
         # Handle nested annotations (annotations referenced by this annotation's parameters)
@@ -1145,7 +1176,9 @@ def {nested_decorator_name}(*args, **kwargs):
     """
     if len(args) == 1 and callable(args[0]) and not kwargs:
         target = args[0]
-        if not any(value is target for value in globals().values()):
+        caller_frame = __import__('sys')._getframe(1)
+        if (not any(value is target for value in caller_frame.f_locals.values())
+                and not any(value is target for value in caller_frame.f_globals.values())):
             return target
 
     def decorator(target):
@@ -1242,17 +1275,83 @@ except Exception:
             return parent_name + '$' + nested_name[len(prefix):]
         return nested_name
 
-    def _collect_java_class_import(self, package_name: str, variable_name: str, full_class_name: str):
+    def _collect_java_class_import(self, package_name: str, import_name: str, variable_name: str, class_element):
         """
         Collect Java class import for VFS generation.
         """
         if package_name not in self.java_class_imports:
             self.java_class_imports[package_name] = []
 
+        is_interface = False
+        try:
+            is_interface = class_element.isInterface()
+        except Exception:
+            pass
         self.java_class_imports[package_name].append({
-            'variable': variable_name,
-            'class_name': full_class_name
+            'variable': import_name,
+            'usage_variable': variable_name,
+            'class_name': class_element.getName(),
+            'interface': str(is_interface).lower()
         })
+
+    def get_java_class_imports(self):
+        """
+        Get Java imports and mark the types that need Python keyword method aliases.
+        """
+        for imports in self.java_class_imports.values():
+            for import_info in imports:
+                variable_name = import_info['usage_variable']
+                import_info['keyword_safe'] = str(variable_name in self.java_keyword_safe_imports).lower()
+        return self.java_class_imports
+
+    def get_missing_runtime_decorator_code(self, tree: ast.Module):
+        """
+        Return compatibility stubs for generated decorators used without an import.
+        """
+        bound_names = set()
+        missing_names = set()
+        for statement in tree.body:
+            for child in ast.walk(statement):
+                decorator_lists = []
+                if isinstance(child, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                    decorator_lists.append(child.decorator_list)
+                for decorators in decorator_lists:
+                    for decorator in decorators:
+                        decorator_name = self._get_decorator_name(decorator)
+                        if decorator_name in self.generated_decorators and decorator_name not in bound_names:
+                            missing_names.add(decorator_name)
+            bound_names.update(self._statement_bound_names(statement))
+
+        missing_code = []
+        for decorator_name in missing_names:
+            definition = f'def {decorator_name}('
+            for decorator_code in self.generated_decorator_code.values():
+                if definition in decorator_code:
+                    missing_code.append(decorator_code)
+                    break
+        return missing_code
+
+    def _statement_bound_names(self, statement: ast.AST):
+        names = set()
+        if isinstance(statement, ast.ImportFrom):
+            names.update(
+                alias.asname if alias.asname else alias.name
+                for alias in statement.names
+                if alias.name != '*'
+            )
+        elif isinstance(statement, ast.Import):
+            names.update(
+                alias.asname if alias.asname else alias.name.split('.')[0]
+                for alias in statement.names
+            )
+        elif isinstance(statement, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            names.add(statement.name)
+        elif isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        return names
 
     def _to_java_import_module(self, module_name: str) -> str:
         """
@@ -1306,3 +1405,137 @@ except Exception:
         Get the list of types (classes/functions) that have Micronaut decorators.
         """
         return self.exported_types
+
+
+class MicronautRuntimeTransformer(MicronautTransformer):
+    """
+    Minimal runtime-only compatibility transformer.
+
+    Generated VFS modules provide imported annotations and Java types. This
+    transformer handles only constructs that cannot be represented by those
+    imports while retaining the original locations on user AST nodes.
+    """
+
+    def __init__(self, callback_get_class_element, callback_get_class_elements, missing_decorator_code=None):
+        super().__init__(callback_get_class_element, callback_get_class_elements, True)
+        if missing_decorator_code:
+            self.transformed_code.extend(missing_decorator_code)
+        self.java_runtime_names = set()
+        self.imported_java_interface_names = set()
+
+    def visit_Module(self, node: ast.Module) -> ast.Module:
+        self.generic_visit(node)
+
+        if self._has_java_annotations(node):
+            self._ensure_future_annotations(node)
+
+        if not (self.transformed_code or self.java_type_assignments):
+            return node
+
+        generated_nodes = []
+        if self.transformed_code:
+            generated_nodes.extend(ast.parse('''
+def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
+    def decorator(target):
+        return target
+    return decorator
+''').body)
+
+        micronaut_annotation_emitted = bool(self.transformed_code)
+        for decorator_code in self.transformed_code:
+            for generated_node in ast.parse(decorator_code).body:
+                if (isinstance(generated_node, ast.FunctionDef)
+                        and generated_node.name == 'micronaut_annotation'):
+                    if micronaut_annotation_emitted:
+                        continue
+                    micronaut_annotation_emitted = True
+                generated_nodes.append(generated_node)
+
+        insert_at = self._generated_code_insert_index(node)
+        node.body = node.body[:insert_at] + generated_nodes + node.body[insert_at:]
+        return node
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        if not node.module:
+            return node
+        if node.module == 'pyronaut.build':
+            return None
+
+        java_module = self._to_java_import_module(node.module)
+        for alias in node.names:
+            if alias.name == '*':
+                continue
+            class_element = self.callback_get_class_element(f'{java_module}.{alias.name}')
+            if class_element and not self._is_annotation_class(class_element):
+                variable_name = alias.asname if alias.asname else alias.name
+                self.java_runtime_names.add(variable_name)
+                try:
+                    if class_element.isInterface():
+                        self.imported_java_interface_names.add(variable_name)
+                except Exception:
+                    pass
+
+        if java_module.startswith('io.micronaut.'):
+            transformed_module = self._to_python_import_module(java_module)[3:]
+            return ast.copy_location(
+                ast.ImportFrom(module=transformed_module, names=node.names, level=node.level),
+                node
+            )
+        return node
+
+    def visit_Import(self, node: ast.Import):
+        return node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.ClassDef:
+        has_imported_interface_base = any(
+            self._base_name(base) in self.imported_java_interface_names
+            for base in node.bases
+        )
+        transformed = super().visit_ClassDef(node)
+        if has_imported_interface_base:
+            transformed.keywords = [
+                class_keyword
+                for class_keyword in transformed.keywords
+                if class_keyword.arg != 'new_style'
+            ]
+        return transformed
+
+    def visit_Assign(self, node: ast.Assign):
+        variable_name = self._java_type_assignment_name(node)
+        if variable_name is not None:
+            class_name = self._java_type_name(node.value)
+            class_element = self.callback_get_class_element(class_name)
+            if not class_element or not self._is_annotation_class(class_element):
+                self.java_runtime_names.add(variable_name)
+        return super().visit_Assign(node)
+
+    def visit_Expr(self, node: ast.Expr):
+        if isinstance(node.value, ast.Call):
+            function = node.value.func
+            name = function.id if isinstance(function, ast.Name) else function.attr if isinstance(function, ast.Attribute) else ''
+            if name in {'Dependency', 'MavenRepository', 'AppConfig'}:
+                return None
+        return self.generic_visit(node)
+
+    def _java_type_assignment_name(self, node: ast.Assign) -> Optional[str]:
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            return None
+        if self._java_type_name(node.value):
+            return node.targets[0].id
+        return None
+
+    def _has_java_annotations(self, node: ast.Module) -> bool:
+        for child in ast.walk(node):
+            annotations = []
+            if isinstance(child, ast.arg) and child.annotation is not None:
+                annotations.append(child.annotation)
+            elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.returns is not None:
+                annotations.append(child.returns)
+            elif isinstance(child, ast.AnnAssign):
+                annotations.append(child.annotation)
+
+            for annotation in annotations:
+                for annotation_node in ast.walk(annotation):
+                    if isinstance(annotation_node, ast.Name) and annotation_node.id in self.java_runtime_names:
+                        return True
+        return False

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerIncrementalTest.java
@@ -349,6 +349,65 @@ final class PyronautCompilerIncrementalTest {
     }
 
     @Test
+    void tracksMandatoryRuntimeBytecodeTransitionsIncrementally(@TempDir Path directory) throws Exception {
+        Path python = Files.createDirectories(directory.resolve("python"));
+        Path java = Files.createDirectories(directory.resolve("java"));
+        Path output = directory.resolve("classes");
+        Path cache = directory.resolve("incremental");
+        Path application = python.resolve("application.py");
+        String originalSource = "# original formatting\nanswer  =  42\n";
+        Files.writeString(application, originalSource);
+        Files.writeString(python.resolve("other.py"), "value = 1\n");
+
+        compilePython(python, java, output, cache);
+        Path vfsSource = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/application.py"
+        );
+        Path filesList = output.resolve(
+            "META-INF/GRAALPY-VFS/micronaut-application/fileslist.txt"
+        );
+        assertEquals(originalSource, Files.readString(vfsSource));
+        assertFalse(hasOutput(output, "application.", ".pyc"));
+        assertTrue(Files.readString(filesList).contains("/src/application.py"));
+        assertFalse(Files.readString(filesList).contains("/src/__pycache__/application."));
+
+        String transformedSource = """
+            import java
+            Thread = java.type("java.lang.Thread")
+            def yield_thread():
+                Thread.yield_()
+            """;
+        Files.writeString(application, transformedSource);
+        compilePython(python, java, output, cache);
+        Path mandatoryBytecode = findOutput(output, "application.", ".pyc");
+        assertEquals(transformedSource, Files.readString(vfsSource));
+        assertTrue(Files.isRegularFile(mandatoryBytecode));
+        assertTrue(Files.readString(filesList).contains("/src/__pycache__/application."));
+
+        Files.setLastModifiedTime(vfsSource, UNCHANGED_MARKER);
+        Files.setLastModifiedTime(mandatoryBytecode, UNCHANGED_MARKER);
+        compilePython(python, java, output, cache);
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(vfsSource));
+        assertEquals(UNCHANGED_MARKER, Files.getLastModifiedTime(mandatoryBytecode));
+
+        Files.writeString(application, originalSource);
+        compilePython(python, java, output, cache);
+        assertEquals(originalSource, Files.readString(vfsSource));
+        assertFalse(hasOutput(output, "application.", ".pyc"));
+        assertFalse(Files.readString(filesList).contains("/src/__pycache__/application."));
+
+        Files.writeString(application, transformedSource);
+        compilePython(python, java, output, cache);
+        assertTrue(hasOutput(output, "application.", ".pyc"));
+        Files.delete(application);
+        compilePython(python, java, output, cache);
+        assertFalse(Files.exists(vfsSource));
+        assertFalse(hasOutput(output, "application.", ".pyc"));
+        assertFalse(Files.readString(filesList).contains("/src/application.py"));
+        assertFalse(Files.readString(filesList).contains("/src/__pycache__/application."));
+    }
+
+    @Test
     void recompilesAllContributorsForAggregatingVisitors(@TempDir Path directory) throws Exception {
         Path sources = Files.createDirectories(directory.resolve("sources"));
         Path output = directory.resolve("classes");
@@ -1351,6 +1410,14 @@ final class PyronautCompilerIncrementalTest {
                 .filter(path -> path.getFileName().toString().endsWith(suffix))
                 .findFirst()
                 .orElseThrow();
+        }
+    }
+
+    private static boolean hasOutput(Path output, String nameToken, String suffix) throws Exception {
+        try (var paths = Files.walk(output)) {
+            return paths.filter(Files::isRegularFile)
+                .map(path -> path.getFileName().toString())
+                .anyMatch(name -> name.contains(nameToken) && name.endsWith(suffix));
         }
     }
 

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -24,10 +24,27 @@ import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class PyronautCompilerTest {
+
+    @Test
+    void preservesOriginalInlineSourceInTheInMemoryVfs() throws Exception {
+        String source = "# debugger comment\r\n\r\nanswer  =  42  # spacing\r\n";
+        ClassLoader classLoader = PyronautCompiler.builder()
+            .pythonCode(source)
+            .build()
+            .buildClassLoader();
+
+        try (var input = classLoader.getResourceAsStream(
+            "META-INF/GRAALPY-VFS/micronaut-application/src/__main__.py"
+        )) {
+            assertNotNull(input);
+            assertEquals(source, new String(input.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
 
     @Test
     void compilesJavaSourcesWithoutPythonApplication(@TempDir Path sourceDirectory) throws Exception {


### PR DESCRIPTION
## Summary

- Keep original Python sources in the GraalPy VFS for debugger-visible filenames and line numbers.
- Compile minimally transformed runtime ASTs into checked-hash caches only when runtime compatibility requires them.
- Add generated Java facades for keyword methods (including `Mono.from_()`) and Java interfaces.
- Preserve multi-file, multiple-root, and incremental cache behavior.

## Verification

- `./gradlew :micronaut-inject-python:check :micronaut-inject-python-test:check :micronaut-context-python:check :micronaut-context-python-netty:check :test-suite-python:check -Ppython-ci --no-daemon --continue`
- `./gradlew spotlessCheck docs --no-daemon --continue`
- Python suites passed: 90, 572, and 194 tests.
- Full repository `japiCmp` remains affected by an unrelated existing `micronaut-http-server-netty` 5.2.0-vs-5.1.10 binary compatibility delta.