### PR TITLE
fix(aop): preserve toString behavior for lazy proxies

### DIFF
--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -675,7 +675,9 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                             .invoke(COPY_BEAN_CONTEXT_FOR_LAZY_PROXY_TARGET_METHOD, aThis.field(proxyBeanDefinitionField))
                     )
                 ));
-                proxyBuilder.addMethod(getLazyProxyTargetToStringMethod());
+                if (shouldGenerateLazyProxyTargetToStringMethod(interceptedMethods)) {
+                    proxyBuilder.addMethod(getLazyProxyTargetToStringMethod());
+                }
             } else {
                 if (hotswap) {
                     proxyBuilder.addSuperinterface(TypeDef.parameterized(HotSwappableInterceptedProxy.class, targetType));
@@ -931,6 +933,15 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
     private MethodDef getLazyProxyTargetToStringMethod() {
         return MethodDef.override(METHOD_OBJECT_TO_STRING)
             .build((aThis, methodParameters) -> aThis.invoke(METHOD_INTERCEPTED_TARGET).invoke(METHOD_OBJECT_TO_STRING).returning());
+    }
+
+    private static boolean isToStringMethod(MethodElement methodElement) {
+        return methodElement.getName().equals(METHOD_OBJECT_TO_STRING.getName()) && methodElement.getParameters().length == 0;
+    }
+
+    private boolean shouldGenerateLazyProxyTargetToStringMethod(List<MethodElement> interceptedMethods) {
+        return interceptedMethods.stream().noneMatch(AopProxyWriter::isToStringMethod)
+            && targetType.getMethods().stream().noneMatch(method -> method.isFinal() && isToStringMethod(method));
     }
 
     private MethodDef getCacheLazyTargetInterceptedTargetMethod(FieldDef targetField,

--- a/inject-java/src/test/groovy/io/micronaut/aop/scope/ScopedProxyToStringSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/scope/ScopedProxyToStringSpec.groovy
@@ -1,0 +1,122 @@
+package io.micronaut.aop.scope
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.InterceptedProxy
+import io.micronaut.context.ApplicationContext
+
+class ScopedProxyToStringSpec extends AbstractTypeElementSpec {
+
+    void "refreshable bean delegates default toString to target"() {
+        given:
+        ApplicationContext context = buildContext("test.RefreshableBean", '''
+package test;
+
+import io.micronaut.runtime.context.scope.Refreshable;
+
+@Refreshable
+class RefreshableBean {
+}
+''')
+        Class<?> beanType = context.classLoader.loadClass("test.RefreshableBean")
+
+        when:
+        Object bean = context.getBean(beanType)
+
+        then:
+        bean instanceof InterceptedProxy
+        bean.toString().startsWith("test.RefreshableBean@")
+
+        cleanup:
+        context?.close()
+    }
+
+    void "refreshable bean can inherit non-final toString"() {
+        given:
+        ApplicationContext context = buildContext("test.RefreshableBean", '''
+package test;
+
+import io.micronaut.runtime.context.scope.Refreshable;
+
+class ParentBean {
+    @Override
+    public String toString() {
+        return "inherited-non-final";
+    }
+}
+
+@Refreshable
+class RefreshableBean extends ParentBean {
+}
+''')
+        Class<?> beanType = context.classLoader.loadClass("test.RefreshableBean")
+
+        when:
+        Object bean = context.getBean(beanType)
+
+        then:
+        bean instanceof InterceptedProxy
+        bean.toString() == "inherited-non-final"
+
+        cleanup:
+        context?.close()
+    }
+
+    void "refreshable bean can inherit final toString"() {
+        given:
+        ApplicationContext context = buildContext("test.RefreshableBean", '''
+package test;
+
+import io.micronaut.runtime.context.scope.Refreshable;
+
+class ParentBean {
+    @Override
+    public final String toString() {
+        return "inherited-final";
+    }
+}
+
+@Refreshable
+class RefreshableBean extends ParentBean {
+}
+''')
+        Class<?> beanType = context.classLoader.loadClass("test.RefreshableBean")
+
+        when:
+        Object bean = context.getBean(beanType)
+
+        then:
+        bean instanceof InterceptedProxy
+        bean.toString() == "inherited-final"
+
+        cleanup:
+        context?.close()
+    }
+
+    void "refreshable bean can override toString"() {
+        given:
+        ApplicationContext context = buildContext("test.RefreshableBean", '''
+package test;
+
+import io.micronaut.runtime.context.scope.Refreshable;
+
+@Refreshable
+class RefreshableBean {
+    @Override
+    public String toString() {
+        return "refreshable";
+    }
+}
+''')
+        Class<?> beanType = context.classLoader.loadClass("test.RefreshableBean")
+
+        when:
+        Object bean = context.getBean(beanType)
+
+        then:
+        bean instanceof InterceptedProxy
+        bean.toString() == "refreshable"
+
+        cleanup:
+        context?.close()
+    }
+}


### PR DESCRIPTION
Fixes #12873

## Summary

- avoid emitting a duplicate lazy-proxy `toString()` when the target declares an interceptable override
- avoid overriding an inherited final `toString()` while preserving default and inherited non-final behavior
- add annotation-processing and runtime coverage for `@Refreshable` proxies

## Verification

- focused `ScopedProxyToStringSpec`: 4 tests passed
- related AOP and final-method tests: 41 tests passed
- `RefreshScopeSpec`: 9 tests passed
- full `micronaut-inject-java` tests: 4,880 tests, 8 skipped, 0 failed
- `spotlessCheck`
- `micronaut-core-processor` and `micronaut-inject-java` Checkstyle, build, and `japiCmp` tasks

Local verification used OpenJDK 26 because the GraalVM for JDK 25 version specified by `CONTRIBUTING.md` was not available in the test environment. The affected module builds completed successfully while reporting existing Javadoc diagnostics from unchanged files. Upstream CI has not yet run for this pull request.
