### PR TITLE
Handle empty form values when binding URL-encoded beans

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
@@ -170,7 +170,15 @@ final class NettyBodyAnnotationBinder<T> extends DefaultBodyAnnotationBinder<T> 
             for (RawFormField rff : toListNow(nhr.getRawFormFields(imm))) {
                 bodies.computeIfAbsent(rff.metadata().name(), k -> new ArrayList<>(1)).add(rff.byteBody());
             }
-            Object intermediate = io.micronaut.http.server.multipart.FormRouteCompleter.mapForGetBody(bodies, nhr.getCharacterEncoding());
+            Map<String, Object> intermediate = io.micronaut.http.server.multipart.FormRouteCompleter.mapForGetBody(bodies, nhr.getCharacterEncoding());
+            Class<T> targetType = context.getArgument().getType();
+            if (mediaType != null
+                    && mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+                    && !targetType.isInstance(intermediate)
+                    && !context.getArgument().isContainerType()
+                    && !ConvertibleValues.class.isAssignableFrom(targetType)) {
+                intermediate.values().removeIf(value -> value instanceof String text && text.isEmpty());
+            }
             Optional<T> converted = conversionService.convert(intermediate, context);
             nhr.setLegacyBody(converted.orElse(null));
             return converted;

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
@@ -78,6 +78,36 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
         e.response.status == HttpStatus.BAD_REQUEST
     }
 
+    void "test object body preserves empty form values"() {
+        when:
+        String result = client.exchange(HttpRequest.POST('/form/object', 'empty=&value=present')
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).body()
+
+        then:
+        result == '[empty:, value:present]'
+    }
+
+    void "test optional string property treats an empty form value as null"() {
+        when:
+        String result = client.exchange(HttpRequest.POST('/form/optional-pojo', 'name=')
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).body()
+
+        then:
+        result == 'null'
+    }
+
+    void "test multipart bean preserves an empty text field"() {
+        given:
+        MultipartBody body = MultipartBody.builder().addPart('name', '').build()
+
+        when:
+        String result = client.exchange(HttpRequest.POST('/multipart-form/pojo', body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE), String).body()
+
+        then:
+        result == '[]'
+    }
+
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/10446")
     @Unroll
     void "test application/x-www-form-urlencoded String #body is parsed to #parsedMapString"() {
@@ -290,10 +320,24 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
             formData.toMapString()
         }
 
+        @Post('/object')
+        String object(@Body Object formData) {
+            ((Map<String, Object>) formData).toMapString()
+        }
+
+        @Post('/optional-pojo')
+        String optionalPojo(@Body OptionalPerson person) {
+            person.name.toString()
+        }
+
         @EqualsAndHashCode
         static class Person {
             String name
             Integer age
+        }
+
+        static class OptionalPerson {
+            Optional<String> name
         }
     }
 
@@ -333,6 +377,19 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
     static class UrlEncodedPogo {
         String aaa0123456789
         String bbb0123456789
+    }
+
+    @Controller(value = '/multipart-form', consumes = MediaType.MULTIPART_FORM_DATA)
+    @Requires(property = "spec.name", value = "FormDataBindingSpec")
+    static class MultipartFormController {
+        @Post('/pojo')
+        String pojo(@Body MultipartPerson person) {
+            person.name == null ? 'null' : "[$person.name]"
+        }
+
+        static class MultipartPerson {
+            String name
+        }
     }
 
     @Client('/form/saml/test')

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
@@ -33,6 +33,8 @@ import io.micronaut.http.tck.TestScenario;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,19 +49,36 @@ public class FormsJacksonAnnotationsTest {
     private static final String SPEC_NAME = "FormsJacksonAnnotationsTest";
     private static final String JSON_WITH_PAGES = "{\"title\":\"Building Microservices\",\"paginas\":100}";
     private static final String JSON_WITHOUT_PAGES = "{\"title\":\"Building Microservices\"}";
+    private static final String JSON_WITH_WHITESPACE = "{\"title\":\"Building Microservices\",\"notes\":\" \"}";
+    private static final String JSON_WITH_REPEATED_VALUES = "{\"title\":\"Building Microservices\",\"tags\":[\"\",\"java\",\"\"]}";
 
     @Test
     public void serverFormSubmissionsSupportJacksonAnnotations() throws IOException {
         String body = "title=Building+Microservices&paginas=100";
         assertWithBody(body, JSON_WITH_PAGES);
 
-        body = "title=Building+Microservices&pages=";
+        body = "title=Building+Microservices&paginas=";
         assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&publishedAt=";
+        assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&category=";
+        assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&notes=";
+        assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&notes=+";
+        assertWithBody(body, JSON_WITH_WHITESPACE);
+
+        body = "title=Building+Microservices&tags=&tags=java&tags=";
+        assertWithBody(body, JSON_WITH_REPEATED_VALUES);
     }
 
     @Test
     public void httpClientFormSubmissionsDoesNotSupportJacksonAnnotations() throws IOException {
-        Book book = new Book("Building Microservices", 100);
+        Book book = new Book("Building Microservices", 100, null, null, null, null);
         // Jackson annotations (@JsonProperty) are not supported by the HTTP Client and form-url encoded payload.
         assertWithBody(book, JSON_WITHOUT_PAGES);
     }
@@ -92,7 +111,16 @@ public class FormsJacksonAnnotationsTest {
 
     @Introspected
     @ReflectiveAccess
-    record Book(@JsonProperty("title") String title, @JsonProperty("paginas") @Nullable Integer pages) {
+    record Book(@JsonProperty("title") String title,
+                @JsonProperty("paginas") @Nullable Integer pages,
+                @JsonProperty("publishedAt") LocalDateTime publishedAt,
+                @JsonProperty("category") Category category,
+                @JsonProperty("notes") String notes,
+                @JsonProperty("tags") List<String> tags) {
+    }
+
+    enum Category {
+        TECHNICAL
     }
 
 }


### PR DESCRIPTION
## Summary

- treat single empty URL-encoded fields as absent when binding form data to beans or records
- preserve empty values for `Map` and `Object` bodies, repeated fields, whitespace, and multipart text parts
- correct the Jackson alias regression fixture so the empty field uses the annotated name

Fixes #11213

## Verification

- `./gradlew :micronaut-http-server-netty:test` (1,135 tests, 12 skipped)
- `./gradlew :test-suite-http-server-tck-netty:test` (253 tests, 3 skipped)
- `./gradlew cM spotlessCheck`