### PR TITLE
Use management refresh endpoint in CORS TCKs

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -17,15 +17,9 @@ package io.micronaut.http.server.tck.tests.cors;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventListener;
-import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
-import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Consumes;
-import io.micronaut.http.annotation.Controller;
-import io.micronaut.http.annotation.Post;
-import io.micronaut.http.annotation.Status;
 import io.micronaut.http.client.multipart.MultipartBody;
 import io.micronaut.http.server.tck.CorsAssertion;
 import io.micronaut.http.tck.AssertionUtils;
@@ -33,13 +27,13 @@ import io.micronaut.http.tck.HttpResponseAssertion;
 import io.micronaut.http.tck.RequestSupplier;
 import io.micronaut.http.tck.ServerUnderTest;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -58,6 +52,9 @@ public class CorsSimpleRequestTest {
     private static final String SPECNAME = "CorsSimpleRequestTest";
     private static final String PROPERTY_MICRONAUT_SERVER_CORS_ENABLED = "micronaut.server.cors.enabled";
     private static final String PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH = "micronaut.server.cors.localhost-pass-through";
+    public static final String ENDPOINTS_REFRESH_ENABLED = "endpoints.refresh.enabled";
+    public static final String ENDPOINTS_REFRESH_SENSITIVE = "endpoints.refresh.sensitive";
+    Map<String, Object> BASE_CONFIG = Map.of(ENDPOINTS_REFRESH_ENABLED, StringUtils.TRUE, ENDPOINTS_REFRESH_SENSITIVE, StringUtils.FALSE, PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE);
 
     /**
      * @see <a href="https://github.com/micronaut-projects/micronaut-core/security/advisories/GHSA-583g-g682-crxf">GHSA-583g-g682-crxf</a>
@@ -76,7 +73,7 @@ public class CorsSimpleRequestTest {
     @Tag("multipart")
     void corsSimpleRequestNotAllowedForLocalhostAndAny() throws IOException {
         asserts(SPECNAME,
-            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
+            BASE_CONFIG,
             createRequest("https://foo.com"),
             CorsSimpleRequestTest::isForbidden
         );
@@ -91,11 +88,10 @@ public class CorsSimpleRequestTest {
     @Test
     @Tag("multipart")
     void corsSimpleRequestAllowedForLocalhostAndAnyWhenSpecificallyTurnedOff() throws IOException {
+        Map<String, Object> config = new HashMap<>(BASE_CONFIG);
+        config.put(PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH, StringUtils.TRUE);
         asserts(SPECNAME,
-            Map.of(
-                PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE,
-                PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH, StringUtils.TRUE
-            ),
+            config,
             createRequest("https://foo.com"),
             CorsSimpleRequestTest::isSuccessful
         );
@@ -118,7 +114,7 @@ public class CorsSimpleRequestTest {
     @Tag("multipart")
     void corsSimpleRequestNotAllowedFor127AndAny() throws IOException {
         asserts(SPECNAME,
-            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
+            BASE_CONFIG,
             createRequestFor("127.0.0.1", "https://foo.com"),
             CorsSimpleRequestTest::isForbidden
         );
@@ -132,7 +128,7 @@ public class CorsSimpleRequestTest {
     @Tag("multipart")
     void corsSimpleRequestAllowedForLocalhostAndOriginLocalhost() throws IOException {
         asserts(SPECNAME,
-            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
+            BASE_CONFIG,
             createRequest("http://localhost:8000"),
             CorsSimpleRequestTest::isSuccessful
         );
@@ -147,7 +143,7 @@ public class CorsSimpleRequestTest {
     @Tag("multipart")
     void corsSimpleRequestAllowedForLocalhostAnd127Origin() throws IOException {
         asserts(SPECNAME,
-            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
+            BASE_CONFIG,
             createRequestFor("localhost", "http://127.0.0.1:8000"),
             CorsSimpleRequestTest::isSuccessful
         );
@@ -162,7 +158,7 @@ public class CorsSimpleRequestTest {
     @Tag("multipart")
     void corsSimpleRequestFailsForLocalhostAndSpoofed127Origin() throws IOException {
         asserts(SPECNAME,
-            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
+            BASE_CONFIG,
             createRequestFor("localhost", "http://127.0.0.1.hac0r.com:8000"),
             CorsSimpleRequestTest::isForbidden
         );
@@ -177,7 +173,7 @@ public class CorsSimpleRequestTest {
     @Tag("multipart")
     void corsSimpleRequestAllowedFor127RequestAndLocalhostOrigin() throws IOException {
         asserts(SPECNAME,
-            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
+            BASE_CONFIG,
             createRequestFor("127.0.0.1", "http://localhost:8000"),
             CorsSimpleRequestTest::isSuccessful
         );
@@ -190,11 +186,10 @@ public class CorsSimpleRequestTest {
     @Test
     @Tag("multipart")
     void corsSimpleRequestForLocalhostCanBeAllowedViaConfiguration() throws IOException {
+        Map<String, Object> config = new HashMap<>(BASE_CONFIG);
+        config.put("micronaut.server.cors.configurations.foo.allowed-origins", Collections.singletonList("https://foo.com"));
         asserts(SPECNAME,
-            Map.of(
-                PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE,
-                "micronaut.server.cors.configurations.foo.allowed-origins", Collections.singletonList("https://foo.com")
-            ),
+            config,
             createRequest("https://foo.com"),
             CorsSimpleRequestTest::isSuccessfulCorsAssertion
         );
@@ -208,11 +203,10 @@ public class CorsSimpleRequestTest {
     // "https://github.com/micronaut-projects/micronaut-core/issues/9423")
     @Tag("multipart")
     void corsSimpleRequestForLocalhostCanBeAllowedViaRegexConfiguration() throws IOException {
+        Map<String, Object> config = new HashMap<>(BASE_CONFIG);
+        config.put("micronaut.server.cors.configurations.foo.allowed-origins-regex", Collections.singletonList("^http(|s):\\/\\/foo\\.com$"));
         asserts(SPECNAME,
-            Map.of(
-                PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE,
-                "micronaut.server.cors.configurations.foo.allowed-origins-regex", Collections.singletonList("^http(|s):\\/\\/foo\\.com$")
-            ),
+            config,
             createRequest("https://foo.com"),
             CorsSimpleRequestTest::isSuccessfulCorsAssertion
         );
@@ -226,11 +220,10 @@ public class CorsSimpleRequestTest {
     // "https://github.com/micronaut-projects/micronaut-core/issues/9423")
     @Tag("multipart")
     void corsSimpleRequestForLocalhostForbiddenViaRegexConfiguration() throws IOException {
+        Map<String, Object> config = new HashMap<>(BASE_CONFIG);
+        config.put("micronaut.server.cors.configurations.foo.allowed-origins-regex", Collections.singletonList("^http(|s):\\/\\/foo\\.com$"));
         asserts(SPECNAME,
-            Map.of(
-                PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE,
-                "micronaut.server.cors.configurations.foo.allowed-origins-regex", Collections.singletonList("^http(|s):\\/\\/foo\\.com$")
-            ),
+            config,
             createRequest("https://bar.com"),
             CorsSimpleRequestTest::isForbidden
         );
@@ -243,11 +236,9 @@ public class CorsSimpleRequestTest {
     @Test
     @Tag("multipart")
     void corsSimpleRequestForLocalhostCanBeAllowedViaConfigurationWithRegexToo() throws IOException {
-        Map<String, Object> config = Map.of(
-            PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE,
-            "micronaut.server.cors.configurations.foo.allowed-origins-regex", Collections.singletonList("^http(|s):\\/\\/foo\\.com$"),
-            "micronaut.server.cors.configurations.foo.allowed-origins", Collections.singletonList("https://bar.com")
-        );
+        Map<String, Object> config = new HashMap<>(BASE_CONFIG);
+        config.put("micronaut.server.cors.configurations.foo.allowed-origins-regex", Collections.singletonList("^http(|s):\\/\\/foo\\.com$"));
+        config.put("micronaut.server.cors.configurations.foo.allowed-origins", Collections.singletonList("https://bar.com"));
         assertAll(
             () -> asserts(SPECNAME, config,
                 createRequest("https://foo.com"),
@@ -310,11 +301,10 @@ public class CorsSimpleRequestTest {
     @Test
     @Tag("multipart")
     void corsSimpleRequestForAllowedRegexDoesNotDefaultToAllAllowedorigins() throws IOException {
+        Map<String, Object> config = new HashMap<>(BASE_CONFIG);
+        config.put("micronaut.server.cors.configurations.foo.allowed-origins-regex", Collections.singletonList("^http(|s):\\/\\/foo\\.com$"));
         asserts(SPECNAME,
-            Map.of(
-                PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE,
-                "micronaut.server.cors.configurations.foo.allowed-origins-regex", Collections.singletonList("^http(|s):\\/\\/foo\\.com$")
-            ),
+            config,
             createRequest("https://bar.com"),
             CorsSimpleRequestTest::isForbidden
         );
@@ -380,20 +370,6 @@ public class CorsSimpleRequestTest {
             .header("Referer", origin)
             .header("Accept-Language", "en - GB, en")
             .header("content-length", "140");
-    }
-
-    @Requires(property = "spec.name", value = SPECNAME)
-    @Controller
-    static class RefreshController {
-        @Inject
-        ApplicationEventPublisher<RefreshEvent> refreshEventApplicationEventPublisher;
-
-        @Consumes(MediaType.MULTIPART_FORM_DATA)
-        @Post("/refresh")
-        @Status(HttpStatus.OK)
-        void refresh() {
-            refreshEventApplicationEventPublisher.publishEvent(new RefreshEvent());
-        }
     }
 
     @Requires(property = "spec.name", value = SPECNAME)

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -54,7 +54,10 @@ public class CorsSimpleRequestTest {
     private static final String PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH = "micronaut.server.cors.localhost-pass-through";
     private static final String ENDPOINTS_REFRESH_ENABLED = "endpoints.refresh.enabled";
     private static final String ENDPOINTS_REFRESH_SENSITIVE = "endpoints.refresh.sensitive";
-    private Map<String, Object> BASE_CONFIG = Map.of(ENDPOINTS_REFRESH_ENABLED, StringUtils.TRUE, ENDPOINTS_REFRESH_SENSITIVE, StringUtils.FALSE, PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE);
+    private static final Map<String, Object> BASE_CONFIG = Map.of(
+        ENDPOINTS_REFRESH_ENABLED, StringUtils.TRUE,
+        ENDPOINTS_REFRESH_SENSITIVE, StringUtils.FALSE,
+        PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE);
 
     /**
      * @see <a href="https://github.com/micronaut-projects/micronaut-core/security/advisories/GHSA-583g-g682-crxf">GHSA-583g-g682-crxf</a>

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -52,9 +52,9 @@ public class CorsSimpleRequestTest {
     private static final String SPECNAME = "CorsSimpleRequestTest";
     private static final String PROPERTY_MICRONAUT_SERVER_CORS_ENABLED = "micronaut.server.cors.enabled";
     private static final String PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH = "micronaut.server.cors.localhost-pass-through";
-    public static final String ENDPOINTS_REFRESH_ENABLED = "endpoints.refresh.enabled";
-    public static final String ENDPOINTS_REFRESH_SENSITIVE = "endpoints.refresh.sensitive";
-    Map<String, Object> BASE_CONFIG = Map.of(ENDPOINTS_REFRESH_ENABLED, StringUtils.TRUE, ENDPOINTS_REFRESH_SENSITIVE, StringUtils.FALSE, PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE);
+    private static final String ENDPOINTS_REFRESH_ENABLED = "endpoints.refresh.enabled";
+    private static final String ENDPOINTS_REFRESH_SENSITIVE = "endpoints.refresh.sensitive";
+    private Map<String, Object> BASE_CONFIG = Map.of(ENDPOINTS_REFRESH_ENABLED, StringUtils.TRUE, ENDPOINTS_REFRESH_SENSITIVE, StringUtils.FALSE, PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE);
 
     /**
      * @see <a href="https://github.com/micronaut-projects/micronaut-core/security/advisories/GHSA-583g-g682-crxf">GHSA-583g-g682-crxf</a>

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
@@ -17,22 +17,19 @@ package io.micronaut.http.server.tck.tests.cors;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventListener;
-import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
-import io.micronaut.http.annotation.Controller;
-import io.micronaut.http.annotation.Post;
-import io.micronaut.http.annotation.Status;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
+import io.micronaut.http.tck.ServerUnderTest;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static io.micronaut.http.tck.TestScenario.asserts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,6 +44,11 @@ public class SimpleRequestWithCorsNotEnabledTest {
 
     private static final String SPECNAME = "SimpleRequestWithCorsNotEnabledTest";
     private static final String PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH = "micronaut.server.cors.localhost-pass-through";
+    private static final String ENDPOINTS_REFRESH_ENABLED = "endpoints.refresh.enabled";
+    private static final String ENDPOINTS_REFRESH_SENSITIVE = "endpoints.refresh.sensitive";
+    private Map<String, Object> BASE_CONFIG = Map.of(
+        ENDPOINTS_REFRESH_ENABLED, StringUtils.TRUE,
+        ENDPOINTS_REFRESH_SENSITIVE, StringUtils.FALSE);
 
     /**
      * @see <a href="https://github.com/micronaut-projects/micronaut-core/security/advisories/GHSA-583g-g682-crxf">GHSA-583g-g682-crxf</a>
@@ -56,17 +58,9 @@ public class SimpleRequestWithCorsNotEnabledTest {
     @Test
     void corsSimpleRequestNotAllowedForLocalhostAndAny() throws IOException {
         asserts(SPECNAME,
+            BASE_CONFIG,
             createRequest("https://sdelamo.github.io"),
-            (server, request) -> {
-            RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
-                assertEquals(0, refreshCounter.getRefreshCount());
-
-                AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
-                    .status(HttpStatus.FORBIDDEN)
-                    .assertResponse(response -> assertFalse(response.getHeaders().contains("Vary")))
-                    .build());
-                assertEquals(0, refreshCounter.getRefreshCount());
-            });
+            this::assertRefreshEndpointNotHit);
     }
 
     /**
@@ -77,17 +71,12 @@ public class SimpleRequestWithCorsNotEnabledTest {
      */
     @Test
     void corsSimpleRequestAllowedForLocalhostAndAnyWhenConfiguredToAllowIt() throws IOException {
+        Map<String, Object> config = new HashMap<>(BASE_CONFIG);
+        config.put(PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH, StringUtils.TRUE);
         asserts(SPECNAME,
-            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH, StringUtils.TRUE),
+            config,
             createRequest("https://sdelamo.github.io"),
-            (server, request) -> {
-                RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
-                assertEquals(0, refreshCounter.getRefreshCount());
-                AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
-                    .status(HttpStatus.OK)
-                    .build());
-                assertEquals(1, refreshCounter.getRefreshCount());
-        });
+            this::assertRefreshEndpointHit);
     }
 
     /**
@@ -97,24 +86,44 @@ public class SimpleRequestWithCorsNotEnabledTest {
     @Test
     void corsSimpleRequestAllowedForLocalhostAndOriginLocalhost() throws IOException {
         asserts(SPECNAME,
+            BASE_CONFIG,
             createRequest("http://localhost:8000"),
-            (server, request) -> {
-                RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
-                assertEquals(0, refreshCounter.getRefreshCount());
-                AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
-                    .status(HttpStatus.OK)
-                    .build());
-                assertEquals(1, refreshCounter.getRefreshCount());
-            });
+            this::assertRefreshEndpointHit);
+    }
+
+    private void assertRefreshEndpointHit(ServerUnderTest server, HttpRequest<?> request) {
+        assertRefreshEndpointInvocation(server, request, HttpStatus.OK, 1);
+    }
+
+    private void assertRefreshEndpointNotHit(ServerUnderTest server, HttpRequest<?> request) {
+        assertRefreshEndpointInvocation(server, request, HttpStatus.FORBIDDEN, 0);
+    }
+
+    private void assertRefreshEndpointInvocation(ServerUnderTest server, HttpRequest<?> request,
+                                                 HttpStatus expectedStatus,
+                                                 int invocations) {
+        RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
+        assertEquals(0, refreshCounter.getRefreshCount());
+        if (expectedStatus.getCode() >= 400) {
+            AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+                .status(expectedStatus)
+                .assertResponse(response -> assertFalse(response.getHeaders().contains("Vary")))
+                .build());
+        } else {
+            AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.OK)
+                .build());
+        }
+        assertEquals(invocations, refreshCounter.getRefreshCount());
+        refreshCounter.reset();
     }
 
     private static HttpRequest<?> createRequest(String origin) {
-        return HttpRequest.POST("/refresh", Collections.emptyMap())
+        return HttpRequest.POST("/refresh", Map.of("force", StringUtils.TRUE))
             .header("Accept", "*/*")
             .header("Accept-Encoding", "gzip, deflate, br")
             .header("Accept-Language", "en-GB,en-US;q=0.9,en;q=0.8")
             .header("Connection", "keep-alive")
-            .header("Content-Length", "0")
             .header("Host", "localhost:8080")
             .header("Origin", origin)
             .header("sec-ch-ua", "\"Not?A_Brand\";v=\"8\", \"Chromium\";v=\"108\", \"Google Chrome\";v=\"108\"")
@@ -124,19 +133,6 @@ public class SimpleRequestWithCorsNotEnabledTest {
             .header("Sec-Fetch-Mode", "cors")
             .header("Sec-Fetch-Site", "cross-site")
             .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36");
-    }
-
-    @Requires(property = "spec.name", value = SPECNAME)
-    @Controller
-    static class RefreshController {
-        @Inject
-        ApplicationEventPublisher<RefreshEvent> refreshEventApplicationEventPublisher;
-
-        @Post("/refresh")
-        @Status(HttpStatus.OK)
-        void refresh() {
-            refreshEventApplicationEventPublisher.publishEvent(new RefreshEvent());
-        }
     }
 
     @Requires(property = "spec.name", value = SPECNAME)
@@ -151,6 +147,10 @@ public class SimpleRequestWithCorsNotEnabledTest {
 
         public int getRefreshCount() {
             return refreshCount;
+        }
+
+        public void reset() {
+            refreshCount = 0;
         }
     }
 }

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
@@ -46,7 +46,7 @@ public class SimpleRequestWithCorsNotEnabledTest {
     private static final String PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH = "micronaut.server.cors.localhost-pass-through";
     private static final String ENDPOINTS_REFRESH_ENABLED = "endpoints.refresh.enabled";
     private static final String ENDPOINTS_REFRESH_SENSITIVE = "endpoints.refresh.sensitive";
-    private Map<String, Object> BASE_CONFIG = Map.of(
+    private static final Map<String, Object> BASE_CONFIG = Map.of(
         ENDPOINTS_REFRESH_ENABLED, StringUtils.TRUE,
         ENDPOINTS_REFRESH_SENSITIVE, StringUtils.FALSE);
 

--- a/test-suite-http-server-tck-jdk/build.gradle.kts
+++ b/test-suite-http-server-tck-jdk/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 dependencies {
     testImplementation(projects.micronautHttpServerNetty)
     implementation(projects.micronautJacksonDatabind)
+    implementation(projects.micronautManagement)
     testImplementation(projects.micronautHttpClientJdk)
     testImplementation(projects.micronautHttpServerTck)
     testImplementation(libs.junit.platform.engine)

--- a/test-suite-http-server-tck-netty/build.gradle.kts
+++ b/test-suite-http-server-tck-netty/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     implementation(projects.micronautHttpServerTck)
     implementation(projects.micronautJacksonDatabind)
+    implementation(projects.micronautManagement)
     testImplementation(projects.micronautHttpServerNetty)
     testImplementation(projects.micronautHttpClient)
     testImplementation(libs.junit.platform.engine)


### PR DESCRIPTION
Update CORS TCK scenarios to exercise the management refresh endpoint, configure endpoint sensitivity consistently, and verify refresh events are triggered only for allowed requests.

Add the Micronaut management module to the JDK and Netty HTTP server TCK test suites, and simplify test setup by removing the embedded refresh controllers.
