### PR TITLE
Support Python module annotations and JUnit 5 tests

### DIFF
--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonEnvironment.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonEnvironment.java
@@ -49,7 +49,9 @@ public record PythonEnvironment(
         scripts = Collections.unmodifiableMap(scripts.entrySet()
         .stream()
             .filter(entry ->
-                !entry.getValue().functions().isEmpty() || !entry.getValue().attributes().isEmpty()
+                !entry.getValue().functions().isEmpty()
+                    || !entry.getValue().attributes().isEmpty()
+                    || !entry.getValue().decorators().isEmpty()
             )
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
         decorators = Collections.unmodifiableMap(decorators);

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -143,6 +143,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
     private Map<String, ClassElement> allClasses = Map.of();
 
     public static final String JUNIT_TEST = "org.junit.jupiter.api.Test";
+    private static final String ANN_MICRONAUT_TEST = "io.micronaut.test.extensions.junit5.annotation.MicronautTest";
     public static final String ANN_JSON_PROPERTY = "com.fasterxml.jackson.annotation.JsonProperty";
     public static final String ANN_JSON_CREATOR = "com.fasterxml.jackson.annotation.JsonCreator";
 
@@ -215,14 +216,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                 if (decoratorDef != null) {
                     return;
                 }
-                boolean hasRoute = !scriptElement.getEnclosedElements(
-                    ElementQuery.ALL_METHODS
-                        .onlyAccessible()
-                        .onlyInstance()
-                        .onlyDeclared()
-                        .annotated(ann -> ann.hasStereotype("io.micronaut.http.annotation.HttpMethodMapping"))
-                ).isEmpty();
-                if (hasRoute || scriptElement.hasStereotype("io.micronaut.context.python.scope.ContextPooled")) {
+                if (scriptElement.hasStereotype("io.micronaut.context.python.scope.ContextPooled")) {
                     if (classBuilders.containsKey(scriptElement.getName())) {
                         return;
                     }
@@ -1740,6 +1734,10 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             .get(scriptElement.getName());
     }
 
+    private static boolean isScriptTestMethod(MethodElement methodElement) {
+        return methodElement.getName().startsWith("test");
+    }
+
     private AnnotationObjectDef generateAnnotationStub(DecoratorDef decoratorDef, PythonVisitorContext visitorContext) {
         AnnotationObjectDef.AnnotationObjectDefBuilder builder = AnnotationObjectDef.builder(decoratorDef.annotationName())
             .addModifiers(Modifier.PUBLIC)
@@ -2285,7 +2283,9 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             var builder = ClassDef.builder(scriptElement.getPackageName() + "." + scriptElement.getSimpleName())
                 .addModifiers(Modifier.PUBLIC);
             builder.addAnnotation(Vetoed.class);
+            copyAnnotations(scriptElement, builder, ANNOTATION_PACKAGES_TO_COPY, context);
             builder.addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.ValueCoercible"));
+            boolean isJunit5TestModule = scriptElement.hasAnnotation(ANN_MICRONAUT_TEST);
 
             // Scripts are singletons - add a static instance field
             ClassTypeDef thisType = ClassTypeDef.of(typeName);
@@ -2359,7 +2359,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                     .onlyAccessible()
                     .onlyInstance()
                     .onlyDeclared()
-                    .annotated(ann ->
+                    .annotated(ann -> isJunit5TestModule ||
                         ann.hasStereotype(Executable.class) ||
                             ann.hasAnnotation(AnnotationUtil.PRE_DESTROY) ||
                             ann.hasAnnotation(AnnotationUtil.POST_CONSTRUCT) ||
@@ -2368,12 +2368,14 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                             isDeclaredBeanMethod(ann)));
 
             for (MethodElement methodElement : methodsToBridge) {
+                boolean isJunit5Test = methodElement.hasDeclaredAnnotation(JUNIT_TEST)
+                    || (isJunit5TestModule && isScriptTestMethod(methodElement));
                 addBridgeMethod(
                     methodElement,
                     scriptElement,
                     builder,
                     context,
-                    false,
+                    isJunit5Test,
                     true,
                     addedMethodNames
                 );
@@ -2387,7 +2389,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                     addSetterScript(beanProperty, builder, pythonValue);
                 }
 
-                if (beanProperty.hasStereotype(Bean.class)) {
+                if (beanProperty.hasStereotype(Bean.class) || beanProperty.hasStereotype(AnnotationUtil.INJECT)) {
                     addGetterScript(beanProperty, builder, pythonValue);
                 }
             }
@@ -3014,10 +3016,14 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         addMethodTypeVariables(signatureMethod, methodBuilder, bridgeSignatureTypeArguments, inferredMethodBounds);
 
         copyAnnotations(methodElement, methodBuilder, ANNOTATION_PACKAGES_TO_COPY, visitorContext);
+        if (isJunit5Test && !methodElement.hasDeclaredAnnotation(JUNIT_TEST)) {
+            methodBuilder.addAnnotation(JUNIT_TEST);
+        }
         @NonNull ParameterElement[] parameters = methodElement.getParameters();
         @NonNull ParameterElement[] signatureParameters = signatureMethod.getParameters();
         @NonNull ParameterElement[] resolvedSignatureParameters = resolvedSignatureMethod.getParameters();
-        for (int i = 0; i < parameters.length; i++) {
+        int receiverOffset = isScript && parameters.length > 0 && "self".equals(parameters[0].getName()) ? 1 : 0;
+        for (int i = receiverOffset; i < parameters.length; i++) {
             @NonNull ParameterElement parameter = parameters[i];
             ParameterElement signatureParameter = i < signatureParameters.length ? signatureParameters[i] : parameter;
             ParameterElement resolvedSignatureParameter = i < resolvedSignatureParameters.length ? resolvedSignatureParameters[i] : signatureParameter;
@@ -3055,9 +3061,12 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                     }
                     var targetValue = targetValueExpression;
                     var targetContext = targetValue.invoke("getContext", POLYGLOT_CONTEXT);
-                    for (int i = 0; i < parameters.length; i++) {
+                    if (receiverOffset == 1) {
+                        parameterExpressions.add(aThis);
+                    }
+                    for (int i = receiverOffset; i < parameters.length; i++) {
                         @NonNull ParameterElement parameter = parameters[i];
-                        VariableDef.MethodParameter methodParameter = methodParameters.get(i);
+                        VariableDef.MethodParameter methodParameter = methodParameters.get(i - receiverOffset);
                         coerceParameterToPolyglotValue(parameter, parameterExpressions, methodParameter, targetContext);
                     }
                     invokedValue = RUNTIME_UTIL.invokeStatic(

--- a/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonAnnotationMetadataBuilder.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonAnnotationMetadataBuilder.java
@@ -209,6 +209,8 @@ public final class PythonAnnotationMetadataBuilder extends AbstractAnnotationMet
             return List.of(argumentDef);
         } else if (element instanceof ReturnDef returnDef) {
             return List.of(returnDef);
+        } else if (element instanceof ScriptDef scriptDef) {
+            return List.of(scriptDef);
         }
         return List.of();
     }

--- a/inject-python/src/main/java/io/micronaut/python/processing/visitor/ControllerScriptElementProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/visitor/ControllerScriptElementProcessor.java
@@ -28,7 +28,8 @@ public class ControllerScriptElementProcessor implements PythonScriptElementProc
 
     @Override
     public void process(ClassElement classElement, MemberElement memberElement) {
-        if (memberElement.hasStereotype("io.micronaut.http.annotation.HttpMethodMapping")) {
+        if (!classElement.hasAnnotation("io.micronaut.http.annotation.Controller")
+            && memberElement.hasStereotype("io.micronaut.http.annotation.HttpMethodMapping")) {
             classElement.annotate("io.micronaut.http.annotation.Controller");
         }
     }

--- a/inject-python/src/main/java/io/micronaut/python/processing/visitor/PythonScriptElement.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/visitor/PythonScriptElement.java
@@ -33,6 +33,7 @@ import io.micronaut.inject.ast.annotation.ElementAnnotationMetadata;
 import io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate;
 import io.micronaut.inject.ast.utils.EnclosedElementsQuery;
 import io.micronaut.python.processing.PythonProcessingEnvironment;
+import jakarta.inject.Scope;
 import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
 
@@ -70,8 +71,11 @@ public final class PythonScriptElement extends AbstractPythonElement implements 
                 enclosedElement.hasStereotype(AnnotationUtil.QUALIFIER) ||
                 enclosedElement.hasStereotype(Executable.class)) {
                 // make bean.
-                // Mark pooled to opt the script into pooled stub generation
-                annotate("io.micronaut.context.python.scope.ContextPooled");
+                // Mark pooled to opt the script into pooled stub generation unless
+                // the module already declares an explicit/default scope.
+                if (!hasStereotype(Scope.class)) {
+                    annotate("io.micronaut.context.python.scope.ContextPooled");
+                }
                 annotate(Bean.class);
                 applyTypeLevelDefaultAnnotations(enclosedElement);
             }

--- a/inject-python/src/main/java/io/micronaut/python/processing/visitor/ScriptDef.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/visitor/ScriptDef.java
@@ -35,6 +35,7 @@ import java.util.Objects;
  * @param functions The functions defined at module level.
  * @param attributes The attributes defined at module level.
  * @param documentation The script documentation string.
+ * @param decorators The annotations invoked at module level.
  */
 @Experimental
 public record ScriptDef(
@@ -42,7 +43,8 @@ public record ScriptDef(
     String packageName,
     List<FunctionDef> functions,
     List<AttributeDef> attributes,
-    String documentation
+    String documentation,
+    List<DecoratorDef> decorators
 ) implements ElementDef {
 
     public ScriptDef {
@@ -55,10 +57,32 @@ public record ScriptDef(
         } else {
             attributes = attributes.stream().filter(ad -> ad.typeName() != null).toList();
         }
+        if (decorators == null) {
+            decorators = List.of();
+        } else {
+            decorators = List.copyOf(decorators);
+        }
+    }
+
+    /**
+     * Backwards-compatible constructor for scripts without module annotations.
+     *
+     * @param name The script name
+     * @param packageName The package name
+     * @param functions The functions
+     * @param attributes The attributes
+     * @param documentation The documentation
+     */
+    public ScriptDef(String name,
+                     String packageName,
+                     List<FunctionDef> functions,
+                     List<AttributeDef> attributes,
+                     String documentation) {
+        this(name, packageName, functions, attributes, documentation, List.of());
     }
 
     public ScriptDef(String name) {
-        this(name, "", List.of(), List.of(), null);
+        this(name, "", List.of(), List.of(), null, List.of());
     }
 
     public ScriptDef withFunction(FunctionDef function) {
@@ -70,7 +94,8 @@ public record ScriptDef(
             packageName,
             functions,
             attributes,
-            documentation
+            documentation,
+            decorators
         );
     }
 
@@ -81,7 +106,7 @@ public record ScriptDef(
         }
         List<AttributeDef> attributes = new ArrayList<>(this.attributes);
         attributes.add(attribute);
-        return new ScriptDef(name, packageName, functions, attributes, documentation);
+        return new ScriptDef(name, packageName, functions, attributes, documentation, decorators);
     }
 
     public String qualifiedName() {

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
@@ -153,6 +153,8 @@ class MicronautAstVisitor(ast.NodeVisitor):
         self.current_script = None
         self.current_script_attributes = []
         self.current_script_functions = []
+        self.current_script_function_candidates = []
+        self.current_script_decorators = []
         self.script_name = file_name
 
     def _resolve_top_level_import(self, module_name, imported_name):
@@ -352,8 +354,11 @@ class MicronautAstVisitor(ast.NodeVisitor):
                                 self.current_class = self.current_class.withConstructor(func_def)
                             else:
                                 self.current_class = self.current_class.withFunction(func_def)
-                        elif self.current_class is None and self._is_script_function(node):
-                            self._handle_script_function(func_def)
+                        elif self.current_class is None and node.name != 'micronaut_annotation':
+                            if self._is_script_function(node):
+                                self._handle_script_function(func_def)
+                            else:
+                                self.current_script_function_candidates.append(func_def)
                         return super().visit(node)
                 finally:
                     self.in_function = was_in_function
@@ -456,6 +461,8 @@ class MicronautAstVisitor(ast.NodeVisitor):
                 # Handle potential field docstrings - string literals that follow attribute assignments
                 if self.current_class is not None and self.last_attribute is not None:
                     self._handle_field_docstring(node)
+                elif self.current_class is None and not self.in_function:
+                    self._handle_script_annotation(node)
                 return node
             case ast.Module():
                 # Process the module and create script element if we have script-level constructs
@@ -465,15 +472,36 @@ class MicronautAstVisitor(ast.NodeVisitor):
                 )
                 result = super().visit(node)
 
-                # Create script element if we have collected script attributes or functions
-                if self.current_script_attributes or self.current_script_functions:
-                    script_def = ScriptDef(self.script_name, self.package_name, self.current_script_functions, self.current_script_attributes, None)
+                # A MicronautTest module owns all of its top-level functions. Other
+                # scripts retain the existing decorated-function-only behavior.
+                micronaut_test_decorator = next(
+                    (decorator for decorator in self.current_script_decorators
+                     if decorator.annotationName() == "io.micronaut.test.extensions.junit5.annotation.MicronautTest"),
+                    None
+                )
+                script_functions = list(self.current_script_functions)
+                if micronaut_test_decorator is not None:
+                    script_functions.extend(self.current_script_function_candidates)
+
+                # Create script element if we have collected script attributes,
+                # functions, or module-level annotations.
+                if self.current_script_attributes or script_functions or self.current_script_decorators:
+                    script_def = ScriptDef(
+                        self.script_name,
+                        self.package_name,
+                        script_functions,
+                        self.current_script_attributes,
+                        None,
+                        self.current_script_decorators
+                    )
                     self.callback.apply(script_def)
 
                     # Reset script state
                     self.current_script = None
                     self.current_script_attributes = []
                     self.current_script_functions = []
+                    self.current_script_function_candidates = []
+                    self.current_script_decorators = []
 
                 return result
             case _:
@@ -990,6 +1018,39 @@ class MicronautAstVisitor(ast.NodeVisitor):
         """
         # Add the function to the script
         self.current_script_functions.append(func_def)
+
+    def _handle_script_annotation(self, node):
+        """Collect a resolvable annotation invocation used as a module annotation."""
+        if not isinstance(getattr(node, "value", None), ast.Call):
+            return
+        decorator = decorator_to_function(self, node.value)
+        if decorator is None or not self._is_annotation_type(decorator):
+            return
+        self.current_script_decorators.append(decorator)
+
+    def _is_annotation_type(self, decorator):
+        annotation_name = decorator.annotationName()
+        if any(known.annotationName() == annotation_name for known in self.known_decorators.values()):
+            return True
+        if annotation_name in getattr(self, "python_annotation_decorators", set()):
+            return True
+        if decorator.name() in getattr(self, "python_annotation_decorators", set()):
+            return True
+        if annotation_name in self.imported_types.values():
+            package_name = annotation_name.rsplit(".", 1)[0] if "." in annotation_name else ""
+            if package_name.endswith(".annotation") or package_name in (
+                "jakarta.inject",
+                "javax.inject",
+                "org.junit.jupiter.api",
+            ):
+                return True
+        if self.visitor_context is None:
+            return False
+        try:
+            class_element = self.visitor_context.getClassElement(annotation_name).orElse(None)
+            return class_element is not None and class_element_is_annotation_type(class_element)
+        except Exception:
+            return False
 
     def _is_enum_class(self, node):
         """

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -42,6 +42,7 @@ import io.micronaut.python.processing.visitor.PythonEnumElement;
 import io.micronaut.python.processing.visitor.PythonFieldElement;
 import io.micronaut.python.processing.visitor.PythonMethodElement;
 import io.micronaut.python.processing.visitor.PythonParameterElement;
+import io.micronaut.python.processing.visitor.ScriptDef;
 import io.micronaut.sourcegen.model.EnumDef;
 import io.micronaut.sourcegen.model.FieldDef;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
@@ -135,6 +136,62 @@ public class PythonAstParserTest {
             assertTrue(environment.decorators().containsKey(Singleton.class.getName()));
             assertTrue(environment.decorators().containsKey(Scope.class.getName()));
             assertTrue(environment.decorators().containsKey(Named.class.getName()));
+        }
+    }
+
+    @Test
+    void parsesModuleLevelAnnotationInvocationsIntoScriptMetadata() {
+        try (PythonEnvironment environment = new PythonAstParser().parse("""
+            def micronaut_annotation(name):
+                return lambda func: func
+
+            @micronaut_annotation("ModuleMarker")
+            def ModuleMarker(value):
+                return lambda target: target
+
+            @micronaut_annotation("Get")
+            def Get(value):
+                return lambda target: target
+
+            ModuleMarker("/module")
+
+            @Get("/")
+            def root() -> str:
+                ModuleMarker("/inside-function")
+                return "ok"
+            """, "example")) {
+            ScriptDef script = environment.scripts().get("example.Unknown");
+            assertNotNull(script);
+            assertEquals(1, script.decorators().size());
+            assertEquals("example.ModuleMarker", script.decorators().getFirst().annotationName());
+            assertEquals("/module", script.decorators().getFirst().members().get("value").asString());
+            assertEquals(1, script.functions().size());
+
+            try (PythonProcessingEnvironment processingEnvironment = new PythonProcessingEnvironment(environment)) {
+                ClassElement scriptElement = processingEnvironment.scripts().get("example.Unknown");
+                assertNotNull(scriptElement);
+                assertTrue(scriptElement.hasAnnotation("example.ModuleMarker"));
+                assertEquals("/module", scriptElement.stringValue("example.ModuleMarker", "value").orElseThrow());
+            }
+        }
+    }
+
+    @Test
+    void parsesImportedMicronautAnnotationsAtModuleLevel() {
+        try (PythonEnvironment environment = new PythonAstParser().parse("""
+            from micronaut.test.extensions.junit5.annotation import MicronautTest
+
+            MicronautTest()
+
+            value: int = 1
+
+            def test_root(self) -> None:
+                pass
+            """, "example")) {
+            ScriptDef script = environment.scripts().get("example.Unknown");
+            assertNotNull(script);
+            assertEquals("io.micronaut.test.extensions.junit5.annotation.MicronautTest", script.decorators().getFirst().annotationName());
+            assertEquals("test_root", script.functions().getFirst().name());
         }
     }
 

--- a/src/main/docs/guide/languageSupport/python/moduleScripts.adoc
+++ b/src/main/docs/guide/languageSupport/python/moduleScripts.adoc
@@ -1,0 +1,9 @@
+Python modules can declare Micronaut annotations directly at module level. The annotation becomes metadata on the generated script class, while module-level functions become methods on that class.
+
+For example, a classless controller can declare its route prefix without defining a Python class:
+
+snippet::example.module_routes[tags="module-controller", indent=0, title="Module-level controller annotation"]
+
+Top-level calls are treated as annotations only when the target resolves to a Micronaut or Python-defined annotation. Ordinary module calls remain ordinary Python code.
+
+An explicit controller annotation takes precedence over the implicit controller added for modules containing HTTP routes. Explicit scope annotations also take precedence over the automatic `ContextPooled` scope used by otherwise unscoped route modules.

--- a/src/main/docs/guide/languageSupport/python/moduleScripts/testing.adoc
+++ b/src/main/docs/guide/languageSupport/python/moduleScripts/testing.adoc
@@ -1,0 +1,7 @@
+JUnit 5 tests can be written as Python modules by declaring `MicronautTest()` at module level. Injected module attributes are available through the generated test object, and helper functions can use a `self` receiver.
+
+Functions whose names start with `test` are automatically exposed as JUnit 5 test methods. An explicit `@Test` decorator remains supported when a different test naming style is needed.
+
+snippet::example.ModuleSpec[tags="module-test", indent=0, title="JUnit 5 module test"]
+
+The generated Java test class carries the runtime `MicronautTest` and `Test` annotations required by the JUnit 5 and Micronaut test extensions. The synthetic `self` parameter is omitted from the Java method signature and is supplied automatically when the Python function is invoked.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -337,6 +337,9 @@ languageSupport:
     typeOrdering: Type Ordering and Forward References
     standardTypes: Standard Library Type Conversions
     keywords: Python Keywords in Java APIs
+    moduleScripts:
+      title: Module Scripts
+      testing: JUnit 5 Module Tests
     graalTools: GraalPy Tools
     asyncAwait:
       title: Async/Await

--- a/test-suite-python/src/test/python/example/ModuleSpec.py
+++ b/test-suite-python/src/test/python/example/ModuleSpec.py
@@ -1,0 +1,19 @@
+# tag::module-test[]
+from typing import Annotated
+
+from jakarta.inject import Inject
+from micronaut.http.client import HttpClient
+from micronaut.http.client.annotation import Client
+from micronaut.test.extensions.junit5.annotation import MicronautTest
+
+MicronautTest()
+
+client: Annotated[HttpClient, Inject, Client("/")]
+
+def client_for(self):
+    return self.client
+
+def test_root(self):
+    response = self.client_for().toBlocking().retrieve("/module/")
+    assert "World" in response
+# end::module-test[]

--- a/test-suite-python/src/test/python/example/module_routes.py
+++ b/test-suite-python/src/test/python/example/module_routes.py
@@ -1,0 +1,9 @@
+# tag::module-controller[]
+from micronaut.http.annotation import Controller, Get
+
+Controller("/module")
+
+@Get("/")
+def module_root() -> dict:
+    return {"Hello": "World"}
+# end::module-controller[]


### PR DESCRIPTION
## Summary
- support module-level Micronaut annotation invocations and metadata
- add JUnit 5 module test conventions and generated annotations
- document module scripts and add coverage fixtures

## Verification
- :micronaut-inject-python:checkstyleMain
- :micronaut-inject-python:test -Ppython-ci
- :micronaut-inject-python-test:test -Ppython-ci
- :test-suite-python:test -Ppython-ci
- :micronaut-inject-python:spotlessCheck