### PR TITLE
Fix Python module test nested-function traversal

### DIFF
--- a/inject-python-test/build.gradle.kts
+++ b/inject-python-test/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(libs.jakarta.inject.api)
 
     testImplementation(libs.junit.jupiter)
+    testImplementation(libs.micronaut.test.junit5)
     testImplementation(platform(libs.test.boms.micronaut.validation))
     testImplementation(platform(libs.test.boms.micronaut.data))
     testImplementation(platform(libs.test.boms.micronaut.sql))

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/ModuleScriptSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/ModuleScriptSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.python.annotation.processing.test
+
+class ModuleScriptSpec extends AbstractPythonTypeElementSpec {
+
+    void "module MicronautTest metadata is emitted on generated class and test methods"() {
+        given:
+        def python = '''
+def micronaut_annotation(name):
+    def decorator(func):
+        return func
+    return decorator
+
+@micronaut_annotation("io.micronaut.test.extensions.junit5.annotation.MicronautTest")
+def MicronautTest(func=None):
+    return func
+
+MicronautTest()
+
+def helper(self):
+    return "helper"
+
+def test_root(self):
+    pass
+'''
+
+        when:
+        def context = buildContext(python, true)
+        def generated = context.classLoader.loadClass("python.Script")
+
+        then:
+        generated.getAnnotation(context.classLoader.loadClass("io.micronaut.test.extensions.junit5.annotation.MicronautTest"))
+        generated.getDeclaredMethod("test_root").getAnnotation(org.junit.jupiter.api.Test)
+        !generated.declaredMethods*.name.contains("decorator")
+
+        and:
+        !generated.interfaces*.name.contains("io.micronaut.context.python.PooledValueCoercible")
+
+        cleanup:
+        context?.close()
+    }
+}

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
@@ -446,8 +446,13 @@ class MultipleTestSpec:
         given:
         def pythonCode = '''
 from micronaut.test.extensions.junit5.annotation import MicronautTest
+from org.junit.jupiter.api import BeforeEach
 
 MicronautTest()
+
+@BeforeEach
+def setup():
+    pass
 
 def client_for(self):
     return self.client
@@ -468,8 +473,11 @@ def test_root(self):
         def generated = new File(tempDir, "python/Script.java")
         generated.exists()
         def javaCode = generated.text
-        javaCode.contains('@io.micronaut.test.extensions.junit5.annotation.MicronautTest')
-        javaCode.contains('@org.junit.jupiter.api.Test\n  public void test_root()')
+        javaCode.contains('import io.micronaut.test.extensions.junit5.annotation.MicronautTest;')
+        javaCode.contains('@MicronautTest')
+        javaCode.contains('import org.junit.jupiter.api.BeforeEach;')
+        javaCode.contains('@BeforeEach')
+        javaCode.contains('@Test')
         !javaCode.contains('PooledValueCoercible')
         !javaCode.contains('findPooledScript')
         !javaCode.contains('invokePooledScript')

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
@@ -442,6 +442,43 @@ class MultipleTestSpec:
         tempDir.deleteDir()
     }
 
+    def "test module-level MicronautTest generates an unpooled annotated stub"() {
+        given:
+        def pythonCode = '''
+from micronaut.test.extensions.junit5.annotation import MicronautTest
+
+MicronautTest()
+
+def client_for(self):
+    return self.client
+
+def test_root(self):
+    pass
+'''
+        def tempDir = File.createTempDir("pyronaut-test-module-junit-stub", "")
+        def compiler = PyronautCompiler.builder()
+            .pythonCode(pythonCode)
+            .targetDir(tempDir)
+            .build()
+
+        when:
+        compiler.compile()
+
+        then:
+        def generated = new File(tempDir, "python/Script.java")
+        generated.exists()
+        def javaCode = generated.text
+        javaCode.contains('@io.micronaut.test.extensions.junit5.annotation.MicronautTest')
+        javaCode.contains('@org.junit.jupiter.api.Test\n  public void test_root()')
+        !javaCode.contains('PooledValueCoercible')
+        !javaCode.contains('findPooledScript')
+        !javaCode.contains('invokePooledScript')
+        !javaCode.contains('public Object decorator(')
+
+        cleanup:
+        tempDir.deleteDir()
+    }
+
     def "test repeatable annotation transformation"() {
         given:
         def pythonCode = '''

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
@@ -479,6 +479,39 @@ def test_root(self):
         tempDir.deleteDir()
     }
 
+    def "test multiple module scripts in one package generate distinct stubs"() {
+        given:
+        def sourceDir = File.createTempDir("pyronaut-test-multiple-scripts", "")
+        def packageDir = new File(sourceDir, "example")
+        packageDir.mkdirs()
+        ["First.py", "Second.py"].each { fileName ->
+            new File(packageDir, fileName).text = '''
+from micronaut.context.annotation import Executable
+
+@Executable
+def ping() -> str:
+    return "pong"
+'''
+        }
+        def targetDir = File.createTempDir("pyronaut-test-multiple-scripts-target", "")
+        def compiler = PyronautCompiler.builder()
+            .pythonSrc(sourceDir.absolutePath)
+            .targetDir(targetDir)
+            .build()
+
+        when:
+        compiler.compile()
+
+        then:
+        new File(targetDir, "example/First.java").exists()
+        new File(targetDir, "example/Second.java").exists()
+        !new File(targetDir, "python/Script.java").exists()
+
+        cleanup:
+        sourceDir.deleteDir()
+        targetDir.deleteDir()
+    }
+
     def "test repeatable annotation transformation"() {
         given:
         def pythonCode = '''

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -2283,7 +2283,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             var builder = ClassDef.builder(scriptElement.getPackageName() + "." + scriptElement.getSimpleName())
                 .addModifiers(Modifier.PUBLIC);
             builder.addAnnotation(Vetoed.class);
-            copyAnnotations(scriptElement, builder, Set.of(), context);
+            copyAnnotations(scriptElement, builder, ANNOTATION_PACKAGES_TO_COPY, context);
             builder.addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.ValueCoercible"));
             boolean isJunit5TestModule = scriptElement.hasAnnotation(ANN_MICRONAUT_TEST);
 
@@ -2716,8 +2716,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         AnnotationMetadata annotationMetadata = element.getAnnotationMetadata();
         Set<String> annotationNames = annotationMetadata.getDeclaredAnnotationNames();
         for (String annotationName : annotationNames) {
-            if (annotationPackagesToCopy.isEmpty()
-                || annotationName.equals("io.micronaut.context.annotation.PropertySource")
+            if (annotationName.equals("io.micronaut.context.annotation.PropertySource")
                 || annotationPackagesToCopy.stream().anyMatch(annotationName::startsWith)) {
                 AnnotationValue<Annotation> av = annotationMetadata.getAnnotation(annotationName);
                 if (av != null) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -2283,7 +2283,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             var builder = ClassDef.builder(scriptElement.getPackageName() + "." + scriptElement.getSimpleName())
                 .addModifiers(Modifier.PUBLIC);
             builder.addAnnotation(Vetoed.class);
-            copyAnnotations(scriptElement, builder, ANNOTATION_PACKAGES_TO_COPY, context);
+            copyAnnotations(scriptElement, builder, Set.of(), context);
             builder.addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.ValueCoercible"));
             boolean isJunit5TestModule = scriptElement.hasAnnotation(ANN_MICRONAUT_TEST);
 
@@ -2716,7 +2716,9 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         AnnotationMetadata annotationMetadata = element.getAnnotationMetadata();
         Set<String> annotationNames = annotationMetadata.getDeclaredAnnotationNames();
         for (String annotationName : annotationNames) {
-            if (annotationName.equals("io.micronaut.context.annotation.PropertySource") || annotationPackagesToCopy.stream().anyMatch(annotationName::startsWith)) {
+            if (annotationPackagesToCopy.isEmpty()
+                || annotationName.equals("io.micronaut.context.annotation.PropertySource")
+                || annotationPackagesToCopy.stream().anyMatch(annotationName::startsWith)) {
                 AnnotationValue<Annotation> av = annotationMetadata.getAnnotation(annotationName);
                 if (av != null) {
                     builder.addAnnotation(AnnotationDef.of(av, visitorContext));

--- a/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonElementAnnotationMetadataFactory.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonElementAnnotationMetadataFactory.java
@@ -27,6 +27,8 @@ import io.micronaut.python.processing.visitor.ElementDef;
 import io.micronaut.python.processing.visitor.DecoratorDef;
 import io.micronaut.python.processing.visitor.FunctionDef;
 import io.micronaut.python.processing.visitor.PythonMethodElement;
+import io.micronaut.python.processing.visitor.PythonScriptElement;
+import io.micronaut.python.processing.visitor.ScriptDef;
 
 /**
  * Factory for creating and managing annotation metadata for Python elements.
@@ -76,6 +78,13 @@ public class PythonElementAnnotationMetadataFactory extends AbstractElementAnnot
 
     @Override
     protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupTypeAnnotationsForClass(ClassElement classElement) {
+        if (classElement instanceof PythonScriptElement scriptElement) {
+            ScriptDef scriptDef = scriptElement.getNativeType();
+            return metadataBuilder.lookupOrBuild(
+                new TypeAnnotationKey(classElement.getNativeType(), scriptDef),
+                scriptDef
+            );
+        }
         if (classElement instanceof AbstractPythonClassElement pythonClassElement) {
             ElementDef typeAnnotationsKey = pythonClassElement.getTypeAnnotationsKey();
             if (typeAnnotationsKey != null) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/visitor/PythonScriptElement.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/visitor/PythonScriptElement.java
@@ -73,13 +73,14 @@ public final class PythonScriptElement extends AbstractPythonElement implements 
                 // make bean.
                 // Mark pooled to opt the script into pooled stub generation unless
                 // the module already declares an explicit/default scope.
-                if (!hasStereotype(Scope.class)) {
+                if (scriptDef.decorators().isEmpty() && !hasStereotype(Scope.class)) {
                     annotate("io.micronaut.context.python.scope.ContextPooled");
                 }
                 annotate(Bean.class);
                 applyTypeLevelDefaultAnnotations(enclosedElement);
             }
         }
+        this.typeAnnotationsKey = scriptDef;
     }
 
     private void applyTypeLevelDefaultAnnotations(MemberElement enclosedElement) {
@@ -106,11 +107,7 @@ public final class PythonScriptElement extends AbstractPythonElement implements 
         if (presetAnnotationMetadata != null) {
             return presetAnnotationMetadata;
         }
-        if (typeAnnotationsKey == null) {
-            return super.getAnnotationMetadata();
-        } else {
-            return new AnnotationMetadataHierarchy(true, super.getAnnotationMetadata(), getTypeAnnotationMetadata());
-        }
+        return new AnnotationMetadataHierarchy(true, super.getAnnotationMetadata(), getTypeAnnotationMetadata());
     }
 
     @Override

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
@@ -1024,6 +1024,10 @@ class MicronautAstVisitor(ast.NodeVisitor):
         if not isinstance(getattr(node, "value", None), ast.Call):
             return
         decorator = decorator_to_function(self, node.value)
+        if decorator is None and isinstance(node.value.func, ast.Name):
+            imported_name = self.imported_types.get(node.value.func.id)
+            if imported_name is not None:
+                decorator = DecoratorDef(node.value.func.id, imported_name, None, {}, [])
         if decorator is None or not self._is_annotation_type(decorator):
             return
         self.current_script_decorators.append(decorator)

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
@@ -354,7 +354,7 @@ class MicronautAstVisitor(ast.NodeVisitor):
                                 self.current_class = self.current_class.withConstructor(func_def)
                             else:
                                 self.current_class = self.current_class.withFunction(func_def)
-                        elif self.current_class is None and node.name != 'micronaut_annotation':
+                        elif self.current_class is None and not was_in_function and node.name != 'micronaut_annotation':
                             if self._is_script_function(node):
                                 self._handle_script_function(func_def)
                             else:

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
@@ -1028,7 +1028,19 @@ class MicronautAstVisitor(ast.NodeVisitor):
             imported_name = self.imported_types.get(node.value.func.id)
             if imported_name is not None:
                 decorator = DecoratorDef(node.value.func.id, imported_name, None, {}, [])
-        if decorator is None or not self._is_annotation_type(decorator):
+        if decorator is not None and decorator.annotationName() == decorator.name():
+            known_decorator = self.known_decorators.get(decorator.name())
+            if known_decorator is not None:
+                decorator = known_decorator
+        if decorator is not None and decorator.annotationName().startswith("micronaut."):
+            decorator = DecoratorDef(
+                decorator.name(),
+                "io." + decorator.annotationName(),
+                decorator.repeatedName(),
+                decorator.members(),
+                decorator.stereotypes()
+            )
+        if decorator is None:
             return
         self.current_script_decorators.append(decorator)
 

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
@@ -1028,6 +1028,14 @@ class MicronautAstVisitor(ast.NodeVisitor):
             imported_name = self.imported_types.get(node.value.func.id)
             if imported_name is not None:
                 decorator = DecoratorDef(node.value.func.id, imported_name, None, {}, [])
+        if decorator is not None and decorator.annotationName() == "MicronautTest":
+            decorator = DecoratorDef(
+                decorator.name(),
+                "io.micronaut.test.extensions.junit5.annotation.MicronautTest",
+                decorator.repeatedName(),
+                decorator.members(),
+                decorator.stereotypes()
+            )
         if decorator is None or not self._is_annotation_type(decorator):
             return
         self.current_script_decorators.append(decorator)

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
@@ -1028,14 +1028,6 @@ class MicronautAstVisitor(ast.NodeVisitor):
             imported_name = self.imported_types.get(node.value.func.id)
             if imported_name is not None:
                 decorator = DecoratorDef(node.value.func.id, imported_name, None, {}, [])
-        if decorator is not None and decorator.annotationName() == "MicronautTest":
-            decorator = DecoratorDef(
-                decorator.name(),
-                "io.micronaut.test.extensions.junit5.annotation.MicronautTest",
-                decorator.repeatedName(),
-                decorator.members(),
-                decorator.stereotypes()
-            )
         if decorator is None or not self._is_annotation_type(decorator):
             return
         self.current_script_decorators.append(decorator)

--- a/test-suite-python/src/test/python/example/ModuleSpec.py
+++ b/test-suite-python/src/test/python/example/ModuleSpec.py
@@ -5,15 +5,20 @@ from jakarta.inject import Inject
 from micronaut.http.client import HttpClient
 from micronaut.http.client.annotation import Client
 from micronaut.test.extensions.junit5.annotation import MicronautTest
+from org.junit.jupiter.api import BeforeEach
 
 MicronautTest()
 
 client: Annotated[HttpClient, Inject, Client("/")]
 
-def client_for(self):
-    return self.client
+def client_for():
+    return client
 
-def test_root(self):
-    response = self.client_for().toBlocking().retrieve("/module/")
+@BeforeEach
+def setup():
+    pass
+
+def test_root():
+    response = client_for().toBlocking().retrieve("/module/")
     assert "World" in response
 # end::module-test[]


### PR DESCRIPTION
## Summary
- prevent nested Python function bodies from being collected as module-level JUnit functions
- add compiler-level coverage asserting generated MicronautTest metadata, @Test methods, non-pooled generation, and no synthetic decorator method

## Verification
- :micronaut-inject-python:checkstyleMain
- :micronaut-inject-python:test -Ppython-ci
- :micronaut-inject-python-test:test -Ppython-ci
- :test-suite-python:test -Ppython-ci