### PR TITLE
Fix FormDemuxer event loop race

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/FormDemuxer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/FormDemuxer.java
@@ -105,9 +105,18 @@ public final class FormDemuxer implements BufferConsumer {
                 this.upstream = s.primary(this);
             }
             // we delay streaming until the upstream is set, so let's do that now.
-            if (state instanceof OptimisticBufferingContent opt) {
-                opt.devolveToStreaming(false);
+            if (eventLoop.inEventLoop()) {
+                devolveIfStillBuffering();
+            } else {
+                eventLoop.execute(this::devolveIfStillBuffering);
             }
+        }
+    }
+
+    private void devolveIfStillBuffering() {
+        assert eventLoop == null || eventLoop.inEventLoop();
+        if (state instanceof OptimisticBufferingContent opt) {
+            opt.devolveToStreaming(false);
         }
     }
 


### PR DESCRIPTION
## Summary

- serialize the constructor's optimistic-buffering fix-up on the channel event loop
- recheck the demuxer state when deferred work runs, avoiding stale devolution after another state transition
- preserve the existing synchronous path when construction already occurs on the event loop

## Testing

- `./gradlew :micronaut-http-server-netty:spotlessCheck :micronaut-http-server-netty:test --tests io.micronaut.http.server.netty.multipart.FormDemuxerTest`
- 13 `FormDemuxerTest` tests passed

Resolves #12860