### PR TITLE
[5.1.x] Update netty-tcnative to 2.0.81.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,7 @@ managed-kotlin = "2.3.21"
 managed-kotlin-coroutines = "1.10.2"
 managed-methvin-directory-watcher = "0.19.1"
 managed-netty = "4.2.17.Final"
-managed-netty-tcnative = "2.0.80.Final"
+managed-netty-tcnative = "2.0.81.Final"
 managed-netty-contrib-multipart = "1.0.0.Final"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM


### PR DESCRIPTION
Backport of #12889 to the 5.1.x release line.

Netty 4.2.17 calls `SSL.getGroupName(long)`, which was introduced in netty-tcnative 2.0.81. Keeping tcnative at 2.0.80 causes a `NoSuchMethodError` during OpenSSL ALPN negotiation and leaves HTTP/2 tests waiting indefinitely.

## Verification

- `GracefulShutdownSpec`
- `Http2StaticResourceCacheSpec`
- `Http2ServerPushSpec`
- Oracle GraalVM 25.1.3

Resolves #12887