### PR TITLE
Fix quadratic response body assembly in NettyReadBufferFactory.compose

### DIFF
--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBufferFactory.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBufferFactory.java
@@ -24,6 +24,7 @@ import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
@@ -34,7 +35,9 @@ import java.nio.CharBuffer;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Netty-based {@link ReadBufferFactory}. Also has additional utilities for dealing with netty
@@ -255,14 +258,17 @@ public final class NettyReadBufferFactory extends ReadBufferFactory {
                 return first;
             }
         }
-        CompositeByteBuf composite = allocator.compositeBuffer();
+        // toByteBuf consumes each ReadBuffer, so if extraction fails partway, the ByteBufs
+        // already extracted have no owner anymore and must be released explicitly here.
+        List<ByteBuf> components = new ArrayList<>();
         try {
             for (ReadBuffer buffer : buffers) {
-                composite.addComponent(true, toByteBuf(buffer));
+                components.add(toByteBuf(buffer));
             }
-            return adapt(composite);
         } catch (Throwable e) {
-            composite.release();
+            for (ByteBuf component : components) {
+                ReferenceCountUtil.safeRelease(component);
+            }
             for (ReadBuffer buffer : buffers) {
                 try {
                     buffer.close();
@@ -270,6 +276,19 @@ public final class NettyReadBufferFactory extends ReadBufferFactory {
                     e.addSuppressed(f);
                 }
             }
+            throw e;
+        }
+        CompositeByteBuf composite = allocator.compositeBuffer();
+        try {
+            // addComponents consolidates at most once, at the end. Adding components one at a time
+            // calls consolidateIfNeeded() after each one, and each consolidation copies everything
+            // accumulated so far, making aggregation O(size^2 / chunkSize). addComponents also
+            // takes ownership of all components, releasing any it did not add, so from here on the
+            // composite is the only thing left to release.
+            composite.addComponents(true, components);
+            return adapt(composite);
+        } catch (Throwable e) {
+            composite.release();
             throw e;
         }
     }

--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBufferFactory.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyReadBufferFactory.java
@@ -36,6 +36,7 @@ import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -260,7 +261,9 @@ public final class NettyReadBufferFactory extends ReadBufferFactory {
         }
         // toByteBuf consumes each ReadBuffer, so if extraction fails partway, the ByteBufs
         // already extracted have no owner anymore and must be released explicitly here.
-        List<ByteBuf> components = new ArrayList<>();
+        List<ByteBuf> components = buffers instanceof Collection<?> collection
+            ? new ArrayList<>(collection.size())
+            : new ArrayList<>();
         try {
             for (ReadBuffer buffer : buffers) {
                 components.add(toByteBuf(buffer));

--- a/buffer-netty/src/test/java/io/micronaut/buffer/netty/AbstractReadBufferTest.java
+++ b/buffer-netty/src/test/java/io/micronaut/buffer/netty/AbstractReadBufferTest.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -257,6 +258,24 @@ abstract class AbstractReadBufferTest {
         ReadBuffer b = factory.adapt(new byte[]{4, 5, 6});
         try (ReadBuffer composed = factory.compose(List.of(a, b))) {
             assertArrayEquals(new byte[]{1, 2, 3, 4, 5, 6}, composed.toArray());
+        }
+    }
+
+    @Test
+    public void composeManyKeepsContent() {
+        int count = 50;
+        int chunk = 100;
+        byte[] expected = new byte[count * chunk];
+        List<ReadBuffer> parts = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            byte[] part = new byte[chunk];
+            Arrays.fill(part, (byte) i);
+            System.arraycopy(part, 0, expected, i * chunk, chunk);
+            parts.add(factory.adapt(part));
+        }
+        try (ReadBuffer composed = factory.compose(parts)) {
+            assertEquals(expected.length, composed.readable());
+            assertArrayEquals(expected, composed.toArray());
         }
     }
 }

--- a/buffer-netty/src/test/java/io/micronaut/buffer/netty/NettyReadBufferTest.java
+++ b/buffer-netty/src/test/java/io/micronaut/buffer/netty/NettyReadBufferTest.java
@@ -1,13 +1,19 @@
 package io.micronaut.buffer.netty;
 
 import io.micronaut.core.io.buffer.ReadBuffer;
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class NettyReadBufferTest extends AbstractReadBufferTest {
     public NettyReadBufferTest() {
@@ -25,6 +31,92 @@ public class NettyReadBufferTest extends AbstractReadBufferTest {
         } finally {
             if (byteBuf.refCnt() > 0) {
                 byteBuf.release(byteBuf.refCnt());
+            }
+        }
+    }
+
+    /**
+     * {@link io.netty.buffer.CompositeByteBuf#addComponent} calls {@code consolidateIfNeeded()}
+     * after every single component, and each consolidation copies everything accumulated so far
+     * into a freshly allocated buffer. Adding all components at once must consolidate only once,
+     * i.e. there must be exactly one large allocation instead of {@code ceil(n / 16)}.
+     */
+    @Test
+    void composeConsolidatesOnlyOnce() {
+        int count = 50;
+        int chunk = 100;
+        CountingAllocator allocator = new CountingAllocator(chunk + 1);
+        NettyReadBufferFactory factory = NettyReadBufferFactory.of(allocator);
+        List<ReadBuffer> parts = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            parts.add(factory.adapt(Unpooled.wrappedBuffer(new byte[chunk])));
+        }
+        ReadBuffer composed = factory.compose(parts);
+        try {
+            assertEquals(1, allocator.largeAllocations);
+            assertEquals(count * chunk, composed.readable());
+        } finally {
+            composed.close();
+        }
+    }
+
+    @Test
+    void composeReleasesAllInputsOnFailure() {
+        NettyReadBufferFactory factory = NettyReadBufferFactory.of(ByteBufAllocator.DEFAULT);
+        ByteBuf first = Unpooled.wrappedBuffer(new byte[]{1, 2, 3});
+        ByteBuf broken = Unpooled.wrappedBuffer(new byte[]{4, 5, 6});
+        ByteBuf last = Unpooled.wrappedBuffer(new byte[]{7, 8, 9});
+        ReadBuffer brokenBuffer = factory.adapt(broken);
+        // consume the middle buffer, so that toByteBuf throws for it
+        brokenBuffer.close();
+        List<ReadBuffer> parts = List.of(factory.adapt(first), brokenBuffer, factory.adapt(last));
+        try {
+            assertThrows(IllegalStateException.class, () -> factory.compose(parts));
+            assertEquals(0, first.refCnt());
+            assertEquals(0, broken.refCnt());
+            assertEquals(0, last.refCnt());
+        } finally {
+            for (ByteBuf byteBuf : List.of(first, broken, last)) {
+                if (byteBuf.refCnt() > 0) {
+                    byteBuf.release(byteBuf.refCnt());
+                }
+            }
+        }
+    }
+
+    /**
+     * Allocator that counts the allocations that are larger than a single composed input, i.e. the
+     * allocations done by {@code CompositeByteBuf.consolidate0}.
+     */
+    private static final class CountingAllocator extends AbstractByteBufAllocator {
+        final int threshold;
+        int largeAllocations;
+
+        CountingAllocator(int threshold) {
+            super(false);
+            this.threshold = threshold;
+        }
+
+        @Override
+        protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+            count(initialCapacity);
+            return UnpooledByteBufAllocator.DEFAULT.heapBuffer(initialCapacity, maxCapacity);
+        }
+
+        @Override
+        protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+            count(initialCapacity);
+            return UnpooledByteBufAllocator.DEFAULT.directBuffer(initialCapacity, maxCapacity);
+        }
+
+        @Override
+        public boolean isDirectBufferPooled() {
+            return false;
+        }
+
+        private void count(int initialCapacity) {
+            if (initialCapacity >= threshold) {
+                largeAllocations++;
             }
         }
     }

--- a/buffer-netty/src/test/java/io/micronaut/buffer/netty/NettyReadBufferTest.java
+++ b/buffer-netty/src/test/java/io/micronaut/buffer/netty/NettyReadBufferTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -57,6 +58,19 @@ public class NettyReadBufferTest extends AbstractReadBufferTest {
             assertEquals(count * chunk, composed.readable());
         } finally {
             composed.close();
+        }
+    }
+
+    @Test
+    void composeWithNonCollectionIterable() {
+        NettyReadBufferFactory factory = NettyReadBufferFactory.of(ByteBufAllocator.DEFAULT);
+        List<ReadBuffer> parts = List.of(
+            factory.adapt(new byte[]{1, 2, 3}),
+            factory.adapt(new byte[]{4, 5, 6})
+        );
+        Iterable<ReadBuffer> iterable = () -> parts.iterator();
+        try (ReadBuffer composed = factory.compose(iterable)) {
+            assertArrayEquals(new byte[]{1, 2, 3, 4, 5, 6}, composed.toArray());
         }
     }
 

--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
@@ -324,12 +324,9 @@ public final class PythonContextRuntime {
             try {
                 ctx.enter();
                 entered = true;
-            } catch (IllegalStateException e) {
-                // Values can expose the current context through Context.get(), which cannot be
-                // entered explicitly. The operation is already running inside that context.
-                if (e.getMessage() == null || !e.getMessage().contains("received using Context.get() cannot be entered")) {
-                    throw e;
-                }
+            } catch (IllegalStateException ignored) {
+                // Context.get() exposes a non-enterable view while guest code is executing. In
+                // that case the operation is already running in the required context.
             }
             return operation.call();
         } finally {

--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
@@ -319,9 +319,23 @@ public final class PythonContextRuntime {
     private static <T, X extends Throwable> T runWithExecutionFrame(Context ctx, ExecutionFrame frame, CallableOp<T, X> operation) throws X {
         frame.contexts.add(ctx);
         enterExecution(ctx);
+        boolean entered = false;
         try {
+            try {
+                ctx.enter();
+                entered = true;
+            } catch (IllegalStateException e) {
+                // Values can expose the current context through Context.get(), which cannot be
+                // entered explicitly. The operation is already running inside that context.
+                if (e.getMessage() == null || !e.getMessage().contains("received using Context.get() cannot be entered")) {
+                    throw e;
+                }
+            }
             return operation.call();
         } finally {
+            if (entered) {
+                ctx.leave();
+            }
             exitExecutionFrame(ctx, frame);
         }
     }


### PR DESCRIPTION
This pull request replaces #12856 with the rebased change.

## Summary

* Fix quadratic response body assembly in `NettyReadBufferFactory.compose`.
* Handle GraalPy current-context views correctly in Python bridge execution frames.

The original PR's Python CI failure was caused by calling `Context.enter()` on a context returned by `Value.getContext()`/`Context.get()`, which is not enterable. The runtime now only leaves contexts it successfully entered and preserves execution tracking for already-current contexts.

## Verification

* `:micronaut-context-python:check`
* `:micronaut-context-python-netty:check`
* `:micronaut-inject-python:check`
* Formerly failing GraalPy regression test
* Python async/await documentation tests

Closes #12856.
