### PR TITLE
Add unique metadata and names for generated Python module stubs

### DIFF
--- a/.agents/skills/coding/SKILL.md
+++ b/.agents/skills/coding/SKILL.md
@@ -111,6 +111,13 @@ Common sequence in Micronaut repositories:
 ./gradlew docs
 ```
 
+When running tests for any Python submodule, always add the `-Ppython-ci` project
+property so the Python test configuration is enabled. For example:
+
+```bash
+./gradlew -Ppython-ci :<python-module>:test
+```
+
 For API-affecting changes, also run if configured in the repository:
 
 ```bash

--- a/.agents/skills/gradle/SKILL.md
+++ b/.agents/skills/gradle/SKILL.md
@@ -63,6 +63,9 @@ For dependency-intelligence tasks (version freshness, stability, release cadence
 - **Binary compatibility**: keep baseline discovery and accepted API changes explicit; never silently suppress regressions.
 - **Docs/quality**: treat root-only aggregator plugins and docs pipelines as first-class checks.
 - **Layering**: prefer convention plugin changes (`buildSrc`) over duplicating logic in many module build files.
+- **Python submodules**: when running tests in any Python submodule, always pass
+  `-Ppython-ci` to enable the Python CI/test configuration (for example,
+  `./gradlew -Ppython-ci :<python-module>:test`).
 
 ### 4) Verify before completion
 

--- a/context-python/src/main/java/io/micronaut/context/python/annotation/PythonModule.java
+++ b/context-python/src/main/java/io/micronaut/context/python/annotation/PythonModule.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.python.annotation;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Identifies a Java stub generated for a Python module.
+ *
+ * @author Micronaut Team
+ * @since 5.2.0
+ */
+@Documented
+@Internal
+@Experimental
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface PythonModule {
+    /**
+     * @return The original Python module name; file-backed modules include their {@code .py} suffix
+     */
+    String moduleName();
+
+    /**
+     * @return The Python package containing the module
+     */
+    String packageName();
+}

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.python.compiler
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.python.GraalPyContextFactory
+import io.micronaut.context.python.PythonContextRuntime
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.data.model.Association
 import io.micronaut.data.model.runtime.RuntimePersistentEntity
@@ -556,6 +557,52 @@ def test_other(self):
         cleanup:
         sourceDir.deleteDir()
         targetDir.deleteDir()
+    }
+
+    def "test file-backed module-level JUnit test can be instantiated from python source directory classloader"() {
+        given:
+        def sourceDir = File.createTempDir("pyronaut-test-direct-module", "")
+        new File(sourceDir, "main.py").text = '''
+def root():
+    return "World"
+'''
+        new File(sourceDir, "test_main.py").text = '''
+from typing import Annotated
+
+from jakarta.inject import Inject
+from micronaut.context import ApplicationContext
+from micronaut.test.extensions.junit5.annotation import MicronautTest
+
+MicronautTest()
+
+context: Annotated[ApplicationContext, Inject]
+
+def test_root():
+    pass
+'''
+        def compiler = PyronautCompiler.builder()
+            .pythonSrc(sourceDir.absolutePath)
+            .compilePythonBytecode(true)
+            .build()
+
+        when:
+        def classLoader = compiler.buildClassLoader()
+        def context = GraalPyContextFactory.bootstrapReusableContext(classLoader)
+        def testClass = classLoader.loadClass("python.TestMain")
+        def constructor = testClass.getDeclaredConstructor()
+        constructor.accessible = true
+        def testInstance = constructor.newInstance()
+
+        then:
+        testInstance != null
+
+        cleanup:
+        if (context != null) {
+            PythonContextRuntime.setReuseContext(false)
+            PythonContextRuntime.resetContext()
+            context.close(true)
+        }
+        sourceDir.deleteDir()
     }
 
     def "test multiple module scripts in one package generate distinct stubs"() {
@@ -1853,7 +1900,7 @@ def delete(id: int) -> None:
         def classLoader = new URLClassLoader(tempTargetDir.toURI().toURL())
 
         then:
-        classLoader.loadClass('example.micronaut.Genre_controller') != null
+        classLoader.loadClass('example.micronaut.GenreController') != null
 
         cleanup:
         tempSrcDir.deleteDir()

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PyronautCompilerSpec.groovy
@@ -22,11 +22,26 @@ import io.micronaut.data.model.Association
 import io.micronaut.data.model.runtime.RuntimePersistentEntity
 import io.micronaut.data.intercept.annotation.DataMethod
 import io.micronaut.python.processing.PythonAnnotationProcessor
+import io.micronaut.python.processing.visitor.ScriptDef
 import org.graalvm.polyglot.PolyglotException
 import org.graalvm.polyglot.Value
 import spock.lang.Specification
 
 class PyronautCompilerSpec extends Specification {
+
+    def "test Python module names normalize to generated Java class names"() {
+        expect:
+        ScriptDef.toJavaClassName("test_main") == "TestMain"
+        ScriptDef.toJavaClassName("test-two") == "TestX2dXTwo"
+        ScriptDef.toJavaClassName("123_test") == "_123Test"
+        ScriptDef.toJavaClassName("test_two") != ScriptDef.toJavaClassName("test-two")
+
+        when:
+        ScriptDef.toJavaClassName(null)
+
+        then:
+        thrown(NullPointerException)
+    }
 
     def "test buildClassLoader with pythonCode"() {
         given:
@@ -478,6 +493,7 @@ def test_root(self):
         javaCode.contains('import org.junit.jupiter.api.BeforeEach;')
         javaCode.contains('@BeforeEach')
         javaCode.contains('@Test')
+        compiler.buildClassLoader().loadClass('python.Script') != null
         !javaCode.contains('PooledValueCoercible')
         !javaCode.contains('findPooledScript')
         !javaCode.contains('invokePooledScript')
@@ -485,6 +501,61 @@ def test_root(self):
 
         cleanup:
         tempDir.deleteDir()
+    }
+
+    def "test file-backed module-level JUnit test is loadable"() {
+        given:
+        def sourceDir = File.createTempDir("pyronaut-test-file-backed-module", "")
+        new File(sourceDir, "main.py").text = '''
+class Application:
+    pass
+'''
+        new File(sourceDir, "test_main.py").text = '''
+from micronaut.test.extensions.junit5.annotation import MicronautTest
+
+MicronautTest()
+
+def test_root(self):
+    pass
+'''
+        new File(sourceDir, "test_two.py").text = '''
+from micronaut.test.extensions.junit5.annotation import MicronautTest
+
+MicronautTest()
+
+def test_other(self):
+    pass
+'''
+        def targetDir = File.createTempDir("pyronaut-test-file-backed-module-target", "")
+        def compiler = PyronautCompiler.builder()
+            .pythonSrc(sourceDir.absolutePath)
+            .targetDir(targetDir)
+            .build()
+
+        when:
+        compiler.compile()
+        def classLoader = compiler.buildClassLoader()
+
+        then:
+        def testMainJava = new File(targetDir, "python/TestMain.java").text
+        def testTwoJava = new File(targetDir, "python/TestTwo.java").text
+        testMainJava.contains('@MicronautTest')
+        testMainJava.contains('@Test')
+        testMainJava.contains('@PythonModule')
+        testMainJava.contains('moduleName = "test_main.py"')
+        testMainJava.contains('packageName = "python"')
+        testTwoJava.contains('@MicronautTest')
+        testTwoJava.contains('@Test')
+        testTwoJava.contains('@PythonModule')
+        testTwoJava.contains('moduleName = "test_two.py"')
+        testTwoJava.contains('packageName = "python"')
+        classLoader.loadClass("python.Application") != null
+        classLoader.loadClass("python.TestMain") != null
+        classLoader.loadClass("python.TestTwo") != null
+
+        cleanup:
+        sourceDir.deleteDir()
+        targetDir.deleteDir()
     }
 
     def "test multiple module scripts in one package generate distinct stubs"() {

--- a/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/IncrementalCompilation.java
@@ -17,6 +17,7 @@ package io.micronaut.python.compiler;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.version.VersionUtils;
+import io.micronaut.python.processing.visitor.ScriptDef;
 
 import java.io.File;
 import java.io.IOException;
@@ -765,7 +766,7 @@ final class IncrementalCompilation {
         }
         String fileName = Path.of(relativePath).getFileName().toString();
         String scriptName = fileName.substring(0, fileName.length() - ".py".length());
-        types.add(packageName + '.' + capitalize(scriptName));
+        types.add(packageName + '.' + ScriptDef.toJavaClassName(scriptName));
         return Set.copyOf(types);
     }
 
@@ -775,13 +776,6 @@ final class IncrementalCompilation {
             return "python";
         }
         return relativePath.substring(0, separator).replace('/', '.');
-    }
-
-    private static String capitalize(String value) {
-        if (value.isEmpty()) {
-            return value;
-        }
-        return Character.toUpperCase(value.charAt(0)) + value.substring(1);
     }
 
     private Map<String, SourceState> assignOutputs(Map<String, SourceState> sources,

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -91,7 +91,6 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     private boolean processAggregatingVisitors = true;
     private Path outputDirectory;
     private PythonProcessingSession processingSession;
-    private final Set<String> applicationFilesListEntries = new java.util.TreeSet<>();
 
     /**
      * Set the callback to be invoked for each class element created during processing.
@@ -970,10 +969,19 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             // Write fileslist.txt
         javaVisitorContext.visitMetaInfFile(APPLICATION_PATH + "fileslist.txt", originatingElement)
             .ifPresent(generatedFile -> {
-                applicationFilesListEntries.addAll(filesList.toString().lines().toList());
+                java.util.Set<String> entries = new java.util.TreeSet<>();
+                try {
+                    CharSequence existing = generatedFile.getTextContent();
+                    if (existing != null) {
+                        entries.addAll(existing.toString().lines().toList());
+                    }
+                } catch (IOException ignored) {
+                    // The file may not exist yet during the first processing round.
+                }
+                entries.addAll(filesList.toString().lines().toList());
                 try (var writer = generatedFile.openWriter()) {
-                    if (!applicationFilesListEntries.isEmpty()) {
-                        writer.write(String.join("\n", applicationFilesListEntries));
+                    if (!entries.isEmpty()) {
+                        writer.write(String.join("\n", entries));
                         writer.write('\n');
                     }
                 } catch (IOException e) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -966,11 +966,20 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             writePythonToVfs(filesList, initFilePath, initContent.toString(), originatingElement);
         }
 
-        // Write fileslist.txt
+            // Write fileslist.txt
         javaVisitorContext.visitMetaInfFile(APPLICATION_PATH + "fileslist.txt", originatingElement)
             .ifPresent(generatedFile -> {
+                java.util.Set<String> entries = new java.util.TreeSet<>();
+                try {
+                    CharSequence existing = generatedFile.getTextContent();
+                    if (existing != null) {
+                        entries.addAll(existing.toString().lines().toList());
+                    }
+                } catch (IOException ignored) {
+                    // The file may not exist yet during the first processing round.
+                }
+                entries.addAll(filesList.toString().lines().toList());
                 try (var writer = generatedFile.openWriter()) {
-                    List<String> entries = filesList.toString().lines().sorted().toList();
                     if (!entries.isEmpty()) {
                         writer.write(String.join("\n", entries));
                         writer.write('\n');

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -91,6 +91,7 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     private boolean processAggregatingVisitors = true;
     private Path outputDirectory;
     private PythonProcessingSession processingSession;
+    private final Set<String> applicationFilesListEntries = new java.util.TreeSet<>();
 
     /**
      * Set the callback to be invoked for each class element created during processing.
@@ -969,19 +970,10 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             // Write fileslist.txt
         javaVisitorContext.visitMetaInfFile(APPLICATION_PATH + "fileslist.txt", originatingElement)
             .ifPresent(generatedFile -> {
-                java.util.Set<String> entries = new java.util.TreeSet<>();
-                try {
-                    CharSequence existing = generatedFile.getTextContent();
-                    if (existing != null) {
-                        entries.addAll(existing.toString().lines().toList());
-                    }
-                } catch (IOException ignored) {
-                    // The file may not exist yet during the first processing round.
-                }
-                entries.addAll(filesList.toString().lines().toList());
+                applicationFilesListEntries.addAll(filesList.toString().lines().toList());
                 try (var writer = generatedFile.openWriter()) {
-                    if (!entries.isEmpty()) {
-                        writer.write(String.join("\n", entries));
+                    if (!applicationFilesListEntries.isEmpty()) {
+                        writer.write(String.join("\n", applicationFilesListEntries));
                         writer.write('\n');
                     }
                 } catch (IOException e) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -966,20 +966,11 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
             writePythonToVfs(filesList, initFilePath, initContent.toString(), originatingElement);
         }
 
-            // Write fileslist.txt
+        // Write fileslist.txt
         javaVisitorContext.visitMetaInfFile(APPLICATION_PATH + "fileslist.txt", originatingElement)
             .ifPresent(generatedFile -> {
-                java.util.Set<String> entries = new java.util.TreeSet<>();
-                try {
-                    CharSequence existing = generatedFile.getTextContent();
-                    if (existing != null) {
-                        entries.addAll(existing.toString().lines().toList());
-                    }
-                } catch (IOException ignored) {
-                    // The file may not exist yet during the first processing round.
-                }
-                entries.addAll(filesList.toString().lines().toList());
                 try (var writer = generatedFile.openWriter()) {
+                    List<String> entries = filesList.toString().lines().sorted().toList();
                     if (!entries.isEmpty()) {
                         writer.write(String.join("\n", entries));
                         writer.write('\n');

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
@@ -217,7 +217,8 @@ public final class PythonAstParser {
                     String packageName = getPackageNameOfSource(srcDir, source);
                     bindings.putMember("src", source.getCharacters());
                     bindings.putMember("package_name", packageName);
-                    bindings.putMember("file_name", "Unnamed");
+                    String fileName = source.getName();
+                    bindings.putMember("file_name", fileName == null || fileName.isBlank() ? "Unnamed" : fileName);
                     bindings.putMember("visitor_context", visitorContext);
                     bindings.putMember("src_root", srcDir);
                     context.eval(Source.create(

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -81,6 +81,7 @@ import io.micronaut.python.processing.visitor.AbstractPythonClassElement;
 import io.micronaut.python.processing.visitor.PythonClassElement;
 import io.micronaut.python.processing.visitor.PythonMethodElement;
 import io.micronaut.python.processing.visitor.PythonScriptElement;
+import io.micronaut.python.processing.visitor.ScriptDef;
 import io.micronaut.sourcegen.generator.SourceGenerator;
 import io.micronaut.sourcegen.generator.SourceGenerators;
 import io.micronaut.sourcegen.model.ClassDef;
@@ -115,6 +116,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
     public static final ClassTypeDef PYTHON_CONTEXT_RUNTIME = ClassTypeDef.of("io.micronaut.context.python.PythonContextRuntime");
     public static final ClassTypeDef PYTHON_CLASS_REFERENCE = ClassTypeDef.of("io.micronaut.context.python.PythonContextRuntime.PythonClassReference");
     public static final ClassTypeDef PYTHON_CLASS_ANNOTATION = ClassTypeDef.of("io.micronaut.context.python.annotation.PythonClass");
+    public static final ClassTypeDef PYTHON_MODULE_ANNOTATION = ClassTypeDef.of("io.micronaut.context.python.annotation.PythonModule");
     public static final ClassTypeDef POLYGLOT_VALUE_CONVERTER = ClassTypeDef.of("io.micronaut.context.python.PolyglotValueConverter");
     public static final String GENERATOR_NAME = "python";
     private static final String HTTP_RESPONSE = "io.micronaut.http.HttpResponse";
@@ -2282,6 +2284,11 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
 
             var builder = ClassDef.builder(scriptElement.getPackageName() + "." + scriptElement.getSimpleName())
                 .addModifiers(Modifier.PUBLIC);
+            ScriptDef scriptDef = scriptElement.getNativeType();
+            builder.addAnnotation(AnnotationDef.builder(PYTHON_MODULE_ANNOTATION)
+                .addMember("moduleName", scriptDef.name())
+                .addMember("packageName", scriptElement.getPackageName())
+                .build());
             builder.addAnnotation(Vetoed.class);
             copyAnnotations(scriptElement, builder, ANNOTATION_PACKAGES_TO_COPY, context);
             builder.addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.ValueCoercible"));

--- a/inject-python/src/main/java/io/micronaut/python/processing/visitor/ScriptDef.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/visitor/ScriptDef.java
@@ -16,7 +16,6 @@
 package io.micronaut.python.processing.visitor;
 
 import io.micronaut.core.annotation.Experimental;
-import io.micronaut.core.naming.NameUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -112,11 +111,43 @@ public record ScriptDef(
     public String qualifiedName() {
         String n = name;
         if (n.endsWith(".py")) {
-            n = NameUtils.capitalize(name.substring(0, name.length() - 3));
+            n = toJavaClassName(name.substring(0, name.length() - 3));
         } else if (name.equals("Unnamed")) {
             n = "Script";
         }
         return packageName + "." + n;
+    }
+
+    /**
+     * Converts a Python module name into the Java simple name used for its generated stub.
+     * Separators and underscores are treated as word boundaries, and names beginning with a
+     * digit are prefixed with an underscore.
+     *
+     * @param moduleName The Python module name without the {@code .py} suffix
+     * @return A valid Java class name
+     */
+    public static String toJavaClassName(String moduleName) {
+        Objects.requireNonNull(moduleName, "moduleName");
+        StringBuilder result = new StringBuilder();
+        boolean capitalize = true;
+        for (int i = 0; i < moduleName.length(); i++) {
+            char c = moduleName.charAt(i);
+            if (c == '_') {
+                capitalize = true;
+                continue;
+            }
+            if (!Character.isJavaIdentifierPart(c)) {
+                result.append('X').append(Integer.toHexString(c)).append('X');
+                capitalize = true;
+                continue;
+            }
+            if (result.isEmpty() && !Character.isJavaIdentifierStart(c)) {
+                result.append('_');
+            }
+            result.append(capitalize ? Character.toUpperCase(c) : c);
+            capitalize = false;
+        }
+        return result.isEmpty() ? "Script" : result.toString();
     }
 
     @Override

--- a/test-suite-python/src/test/python/example/test_main.py
+++ b/test-suite-python/src/test/python/example/test_main.py
@@ -1,0 +1,17 @@
+from typing import Annotated
+
+from jakarta.inject import Inject
+from micronaut.http.client import HttpClient
+from micronaut.http.client.annotation import Client
+from micronaut.test.extensions.junit5.annotation import MicronautTest
+
+MicronautTest()
+
+client: Annotated[HttpClient, Inject, Client("/")]
+
+def client_for():
+    return client
+
+def test_root():
+    response = client_for().toBlocking().retrieve("/module/")
+    assert "World" in response


### PR DESCRIPTION
## Summary

- add `@PythonModule` metadata to generated Python module stubs
- preserve the original module and package names
- generate unique, Java-compatible class names for file-backed modules
- expose `ScriptDef.toJavaClassName` for consumers 
- add compiler coverage for multiple module-level JUnit test files and generated annotations

