### PR TITLE
Fix native Python Throwable subclasses

### DIFF
--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
@@ -614,14 +614,13 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
         Micronaut metadata and handler matching remain unchanged; only the
         executable runtime class is made a regular Python exception.
         """
-        base_name = self._base_name(base)
-        if not base_name:
-            return False
-        class_element = self.java_class_elements.get(base_name)
+        class_name = self._java_type_name(base)
+        class_element = self.callback_get_class_element(class_name) if class_name else None
         if class_element is None:
-            class_name = self._java_type_name(base)
-            if class_name:
-                class_element = self.callback_get_class_element(class_name)
+            base_name = self._base_name(base)
+            if not base_name:
+                return False
+            class_element = self.java_class_elements.get(base_name)
         if class_element is None:
             return False
         try:
@@ -1504,6 +1503,7 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
             class_element = self.callback_get_class_element(f'{java_module}.{alias.name}')
             if class_element and not self._is_annotation_class(class_element):
                 variable_name = alias.asname if alias.asname else alias.name
+                self._track_java_class(variable_name, class_element)
                 self.java_runtime_names.add(variable_name)
                 try:
                     if class_element.isInterface():

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
@@ -83,6 +83,7 @@ class MicronautTransformer(ast.NodeTransformer):
         self.generated_decorator_code = {}
         self.java_class_imports = {}
         self.java_interface_names = set()
+        self.java_class_elements = {}
         self.java_keyword_method_aliases = {}
         self.java_keyword_safe_imports = set()
         self.validation_errors = []
@@ -311,6 +312,7 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
                 base
                 for base in node.bases
                 if not self._is_java_interface_base(base)
+                and not self._is_java_throwable_base(base)
             ]
             if len(node.bases) != original_base_count:
                 node.keywords = [
@@ -561,6 +563,7 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
         return False
 
     def _track_java_class(self, variable_name: str, class_element):
+        self.java_class_elements[variable_name] = class_element
         try:
             if class_element.isInterface():
                 self.java_interface_names.add(variable_name)
@@ -602,6 +605,39 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
                     return False
         base_name = self._base_name(base)
         return base_name in self.java_interface_names
+
+    def _is_java_throwable_base(self, base: ast.AST) -> bool:
+        """Strip Java Throwable bases from native runtime bytecode.
+
+        GraalPy native cannot create a Python subclass of a concrete Java
+        Throwable. The compile-time model still keeps the Java base so
+        Micronaut metadata and handler matching remain unchanged; only the
+        executable runtime class is made a regular Python exception.
+        """
+        base_name = self._base_name(base)
+        if not base_name:
+            return False
+        class_element = self.java_class_elements.get(base_name)
+        if class_element is None:
+            class_name = self._java_type_name(base)
+            if class_name:
+                class_element = self.callback_get_class_element(class_name)
+        if class_element is None:
+            return False
+        try:
+            if class_element.isAssignable("java.lang.Throwable"):
+                return True
+        except Exception:
+            pass
+        try:
+            return class_element.getName() in {
+                "java.lang.Throwable",
+                "java.lang.Exception",
+                "java.lang.RuntimeException",
+                "java.lang.Error",
+            }
+        except Exception:
+            return False
 
     def _java_type_name(self, node: ast.AST) -> Optional[str]:
         if not isinstance(node, ast.Call):

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
@@ -308,12 +308,21 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
             self.all_class_names.append(node.name)
         if self.strip_java_interface_bases and node.bases:
             original_base_count = len(node.bases)
-            node.bases = [
-                base
-                for base in node.bases
-                if not self._is_java_interface_base(base)
-                and not self._is_java_throwable_base(base)
-            ]
+            runtime_bases = []
+            replaced_throwable = False
+            for base in node.bases:
+                if self._is_java_interface_base(base):
+                    continue
+                if self._is_java_throwable_base(base):
+                    if not replaced_throwable:
+                        runtime_bases.append(ast.copy_location(
+                            ast.Name(id='Exception', ctx=ast.Load()),
+                            base
+                        ))
+                        replaced_throwable = True
+                    continue
+                runtime_bases.append(base)
+            node.bases = runtime_bases
             if len(node.bases) != original_base_count:
                 node.keywords = [
                     keyword

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
@@ -92,6 +92,7 @@ class MicronautTransformer(ast.NodeTransformer):
         self.all_class_names = []
         self.class_depth = 0
         self.function_depth = 0
+        self.uses_builtin_exception = False
 
     def visit_ImportFrom(self, node: ast.ImportFrom):
         """
@@ -194,8 +195,18 @@ class MicronautTransformer(ast.NodeTransformer):
         if self.strip_java_interface_bases:
             self._ensure_future_annotations(node)
 
+        if self.uses_builtin_exception and not any(
+            isinstance(statement, ast.Import)
+            and any(alias.name == 'builtins' and alias.asname is None for alias in statement.names)
+            for statement in node.body
+        ):
+            node.body.insert(
+                self._generated_code_insert_index(node),
+                ast.Import(names=[ast.alias(name='builtins', asname=None)])
+            )
+
         # Add generated code at the beginning
-        if self.transformed_code or self.java_type_assignments or self.has_java_import:
+        if self.transformed_code or self.java_type_assignments or self.has_java_import or self.uses_builtin_exception:
             # Create AST nodes for the generated code
             generated_nodes = []
 
@@ -310,16 +321,27 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
             original_base_count = len(node.bases)
             runtime_bases = []
             replaced_throwable = False
+            has_python_exception_base = any(
+                isinstance(base, ast.Name)
+                and base.id == 'Exception'
+                and not self._is_java_throwable_base(base)
+                for base in node.bases
+            )
             for base in node.bases:
                 if self._is_java_interface_base(base):
                     continue
                 if self._is_java_throwable_base(base):
-                    if not replaced_throwable:
+                    if not replaced_throwable and not has_python_exception_base:
                         runtime_bases.append(ast.copy_location(
-                            ast.Name(id='Exception', ctx=ast.Load()),
+                            ast.Attribute(
+                                value=ast.Name(id='builtins', ctx=ast.Load()),
+                                attr='Exception',
+                                ctx=ast.Load()
+                            ),
                             base
                         ))
                         replaced_throwable = True
+                        self.uses_builtin_exception = True
                     continue
                 runtime_bases.append(base)
             node.bases = runtime_bases
@@ -1473,7 +1495,17 @@ class MicronautRuntimeTransformer(MicronautTransformer):
         if self._has_java_annotations(node):
             self._ensure_future_annotations(node)
 
-        if not (self.transformed_code or self.java_type_assignments):
+        if self.uses_builtin_exception and not any(
+            isinstance(statement, ast.Import)
+            and any(alias.name == 'builtins' and alias.asname is None for alias in statement.names)
+            for statement in node.body
+        ):
+            node.body.insert(
+                self._generated_code_insert_index(node),
+                ast.Import(names=[ast.alias(name='builtins', asname=None)])
+            )
+
+        if not (self.transformed_code or self.java_type_assignments or self.uses_builtin_exception):
             return node
 
         generated_nodes = []

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -307,7 +307,7 @@ public class PythonAstParserTest {
             """);
 
         assertTrue(result.code().contains("class OutOfStockException(RuntimeException)"));
-        assertTrue(result.runtimeCode().contains("class OutOfStockException:"));
+        assertTrue(result.runtimeCode().contains("class OutOfStockException(Exception)"));
         assertFalse(result.runtimeCode().contains("class OutOfStockException(RuntimeException)"));
         assertTrue(parser.requiresRuntimeBytecode(result));
 
@@ -321,7 +321,7 @@ public class PythonAstParserTest {
             """);
 
         assertTrue(javaTypeResult.code().contains("class OutOfStockException(RuntimeException)"));
-        assertTrue(javaTypeResult.runtimeCode().contains("class OutOfStockException:"));
+        assertTrue(javaTypeResult.runtimeCode().contains("class OutOfStockException(Exception)"));
         assertFalse(javaTypeResult.runtimeCode().contains("class OutOfStockException(RuntimeException)"));
         assertTrue(parser.requiresRuntimeBytecode(javaTypeResult));
     }

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -281,7 +281,7 @@ public class PythonAstParserTest {
             (proxy, method, args) -> {
                 if ("getClassElement".equals(method.getName()) && args != null && args.length == 1
                     && "java.lang.RuntimeException".equals(args[0])) {
-                    return Optional.of(ClassElement.of(RuntimeException.class));
+                    return Optional.of(ClassElement.of(java.lang.RuntimeException.class));
                 }
                 if ("getClassElements".equals(method.getName())) {
                     return ClassElement.ZERO_CLASS_ELEMENTS;

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -273,6 +273,45 @@ public class PythonAstParserTest {
     }
 
     @Test
+    void testRuntimeTransformStripsConcreteJavaThrowableBases() {
+        PythonAstParser parser = new PythonAstParser();
+        VisitorContext visitorContext = (VisitorContext) Proxy.newProxyInstance(
+            VisitorContext.class.getClassLoader(),
+            new Class<?>[] { VisitorContext.class },
+            (proxy, method, args) -> {
+                if ("getClassElement".equals(method.getName()) && args != null && args.length == 1
+                    && "java.lang.RuntimeException".equals(args[0])) {
+                    return Optional.of(ClassElement.of(RuntimeException.class));
+                }
+                if ("getClassElements".equals(method.getName())) {
+                    return ClassElement.ZERO_CLASS_ELEMENTS;
+                }
+                if (Optional.class.equals(method.getReturnType())) {
+                    return Optional.empty();
+                }
+                if (method.getReturnType().equals(boolean.class)) {
+                    return false;
+                }
+                if (method.getReturnType().equals(int.class)) {
+                    return 0;
+                }
+                return null;
+            }
+        );
+
+        PythonAstParser.TransformResult result = parser.transform(visitorContext, """
+            from java.lang import RuntimeException
+
+            class OutOfStockException(RuntimeException):
+                pass
+            """);
+
+        assertTrue(result.code().contains("class OutOfStockException(RuntimeException)"));
+        assertTrue(result.runtimeCode().contains("class OutOfStockException:"));
+        assertFalse(result.runtimeCode().contains("class OutOfStockException(RuntimeException)"));
+    }
+
+    @Test
     void testTransformKeepsFutureImportsBeforeGeneratedCode() {
         PythonAstParser pythonProcessor = new PythonAstParser();
         VisitorContext visitorContext = (VisitorContext) Proxy.newProxyInstance(

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -283,6 +283,10 @@ public class PythonAstParserTest {
                     && "java.lang.RuntimeException".equals(args[0])) {
                     return Optional.of(ClassElement.of(java.lang.RuntimeException.class));
                 }
+                if ("getClassElement".equals(method.getName()) && args != null && args.length == 1
+                    && "java.lang.Exception".equals(args[0])) {
+                    return Optional.of(ClassElement.of(Exception.class));
+                }
                 if ("getClassElements".equals(method.getName())) {
                     return ClassElement.ZERO_CLASS_ELEMENTS;
                 }
@@ -307,7 +311,7 @@ public class PythonAstParserTest {
             """);
 
         assertTrue(result.code().contains("class OutOfStockException(RuntimeException)"));
-        assertTrue(result.runtimeCode().contains("class OutOfStockException(Exception)"));
+        assertTrue(result.runtimeCode().contains("class OutOfStockException(builtins.Exception)"));
         assertFalse(result.runtimeCode().contains("class OutOfStockException(RuntimeException)"));
         assertTrue(parser.requiresRuntimeBytecode(result));
 
@@ -321,9 +325,31 @@ public class PythonAstParserTest {
             """);
 
         assertTrue(javaTypeResult.code().contains("class OutOfStockException(RuntimeException)"));
-        assertTrue(javaTypeResult.runtimeCode().contains("class OutOfStockException(Exception)"));
+        assertTrue(javaTypeResult.runtimeCode().contains("class OutOfStockException(builtins.Exception)"));
         assertFalse(javaTypeResult.runtimeCode().contains("class OutOfStockException(RuntimeException)"));
         assertTrue(parser.requiresRuntimeBytecode(javaTypeResult));
+
+        PythonAstParser.TransformResult duplicateExceptionResult = parser.transform(visitorContext, """
+            from java.lang import RuntimeException
+
+            class OutOfStockException(Exception, RuntimeException):
+                pass
+            """);
+
+        assertTrue(duplicateExceptionResult.runtimeCode().contains("class OutOfStockException(Exception)"));
+        assertFalse(duplicateExceptionResult.runtimeCode().contains("class OutOfStockException(Exception, Exception)"));
+        assertTrue(parser.requiresRuntimeBytecode(duplicateExceptionResult));
+
+        PythonAstParser.TransformResult shadowedExceptionResult = parser.transform(visitorContext, """
+            from java.lang import Exception
+
+            class OutOfStockException(Exception):
+                pass
+            """);
+
+        assertTrue(shadowedExceptionResult.runtimeCode().contains("import builtins"));
+        assertTrue(shadowedExceptionResult.runtimeCode().contains("class OutOfStockException(builtins.Exception)"));
+        assertTrue(parser.requiresRuntimeBytecode(shadowedExceptionResult));
     }
 
     @Test

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -309,6 +309,21 @@ public class PythonAstParserTest {
         assertTrue(result.code().contains("class OutOfStockException(RuntimeException)"));
         assertTrue(result.runtimeCode().contains("class OutOfStockException:"));
         assertFalse(result.runtimeCode().contains("class OutOfStockException(RuntimeException)"));
+        assertTrue(parser.requiresRuntimeBytecode(result));
+
+        PythonAstParser.TransformResult javaTypeResult = parser.transform(visitorContext, """
+            import java
+
+            RuntimeException = java.type("java.lang.RuntimeException")
+
+            class OutOfStockException(RuntimeException):
+                pass
+            """);
+
+        assertTrue(javaTypeResult.code().contains("class OutOfStockException(RuntimeException)"));
+        assertTrue(javaTypeResult.runtimeCode().contains("class OutOfStockException:"));
+        assertFalse(javaTypeResult.runtimeCode().contains("class OutOfStockException(RuntimeException)"));
+        assertTrue(parser.requiresRuntimeBytecode(javaTypeResult));
     }
 
     @Test


### PR DESCRIPTION
## Summary

GraalPy native cannot create a Python subclass of a concrete Java Throwable at runtime. Keep the Java superclass in compile-time transformed source for Micronaut metadata, but strip only concrete Java Throwable bases from executable runtime bytecode.

This leaves normal Java concrete inheritance unchanged and avoids broad native-image preservation flags.

## Verification

- `./gradlew :micronaut-inject-python:test --tests io.micronaut.python.processing.PythonAstParserTest.testRuntimeTransformStripsConcreteJavaThrowableBases -Ppython-ci --no-daemon --console=plain`
- Test passed with the guide `from java.lang import RuntimeException` syntax.
