### PR TITLE
Allow disabling ImageSingletons lookups

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
@@ -49,6 +49,7 @@ import java.util.function.Predicate;
  */
 @Internal
 final class ServiceScanner<S> {
+    private static final String GRAALVM_IMAGESINGLETONS_ENABLED = "micronaut.graalvm.imagesingletons.enabled";
     private final ClassLoader classLoader;
     private final String serviceName;
     private final Predicate<String> lineCondition;
@@ -71,6 +72,9 @@ final class ServiceScanner<S> {
 
     @SuppressWarnings("java:S1181")
     private static boolean hasImageSingletons() {
+        if ("false".equalsIgnoreCase(System.getProperty(GRAALVM_IMAGESINGLETONS_ENABLED))) {
+            return false;
+        }
         try {
             //noinspection ConstantValue
             return ImageSingletons.class != null;

--- a/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
@@ -16,6 +16,7 @@
 package io.micronaut.core.io.service;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.NativeImageUtils;
 import org.jspecify.annotations.Nullable;
 import org.graalvm.nativeimage.ImageSingletons;
 
@@ -49,7 +50,6 @@ import java.util.function.Predicate;
  */
 @Internal
 final class ServiceScanner<S> {
-    private static final String GRAALVM_IMAGESINGLETONS_ENABLED = "micronaut.graalvm.imagesingletons.enabled";
     private final ClassLoader classLoader;
     private final String serviceName;
     private final Predicate<String> lineCondition;
@@ -63,24 +63,10 @@ final class ServiceScanner<S> {
     }
 
     static ServiceScanner.@Nullable ExclusiveStaticServiceDefinitions findStaticServiceDefinitions() {
-        if (hasImageSingletons()) {
+        if (NativeImageUtils.hasImageSingletons()) {
             return ImageSingletons.contains(ExclusiveStaticServiceDefinitions.class) ? ImageSingletons.lookup(ExclusiveStaticServiceDefinitions.class) : null;
         } else {
             return null;
-        }
-    }
-
-    @SuppressWarnings("java:S1181")
-    private static boolean hasImageSingletons() {
-        if ("false".equalsIgnoreCase(System.getProperty(GRAALVM_IMAGESINGLETONS_ENABLED))) {
-            return false;
-        }
-        try {
-            //noinspection ConstantValue
-            return ImageSingletons.class != null;
-        } catch (Throwable e) {
-            // not present or not a GraalVM JDK
-            return false;
         }
     }
 

--- a/core/src/main/java/io/micronaut/core/util/NativeImageUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/NativeImageUtils.java
@@ -103,7 +103,7 @@ public final class NativeImageUtils {
      */
     @SuppressWarnings("java:S1181")
     public static boolean hasImageSingletons() {
-        if ("false".equalsIgnoreCase(System.getProperty(GRAALVM_IMAGESINGLETONS_ENABLED))) {
+        if (StringUtils.FALSE.equalsIgnoreCase(System.getProperty(GRAALVM_IMAGESINGLETONS_ENABLED))) {
             return false;
         }
         try {

--- a/core/src/main/java/io/micronaut/core/util/NativeImageUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/NativeImageUtils.java
@@ -16,6 +16,7 @@
 package io.micronaut.core.util;
 
 import io.micronaut.core.annotation.Internal;
+import org.graalvm.nativeimage.ImageSingletons;
 
 /**
  * Utility class to retrieve information about the context in which code gets executed.
@@ -54,6 +55,8 @@ public final class NativeImageUtils {
      */
     public static final boolean JFR_AVAILABLE = !inImageCode();
 
+    private static final String GRAALVM_IMAGESINGLETONS_ENABLED = "micronaut.graalvm.imagesingletons.enabled";
+
     private NativeImageUtils() {
     }
 
@@ -85,5 +88,30 @@ public final class NativeImageUtils {
      */
     public static boolean inImageBuildtimeCode() {
         return PROPERTY_IMAGE_CODE_VALUE_BUILDTIME.equals(System.getProperty(PROPERTY_IMAGE_CODE_KEY));
+    }
+
+    /**
+     * Checks whether GraalVM {@link ImageSingletons} APIs are available and enabled.
+     *
+     * <p>When {@code micronaut.graalvm.imagesingletons.enabled} is set to
+     * {@code false}, this method returns {@code false} without attempting to
+     * access the {@link ImageSingletons} class. This is useful for runtimes
+     * where the class is available but its methods are not reachable from
+     * interpreted code.</p>
+     *
+     * @return {@code true} if ImageSingletons are available and enabled
+     */
+    @SuppressWarnings("java:S1181")
+    public static boolean hasImageSingletons() {
+        if ("false".equalsIgnoreCase(System.getProperty(GRAALVM_IMAGESINGLETONS_ENABLED))) {
+            return false;
+        }
+        try {
+            //noinspection ConstantValue
+            return ImageSingletons.class != null;
+        } catch (Throwable e) {
+            // not present or not a GraalVM JDK
+            return false;
+        }
     }
 }

--- a/core/src/test/java/io/micronaut/core/io/service/SoftServiceLoaderTest.java
+++ b/core/src/test/java/io/micronaut/core/io/service/SoftServiceLoaderTest.java
@@ -1,6 +1,7 @@
 package io.micronaut.core.io.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.module.Configuration;
@@ -13,6 +14,7 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
+import io.micronaut.core.util.NativeImageUtils;
 import io.micronaut.core.io.service.SoftServiceLoader.ServiceCollector;
 
 public class SoftServiceLoaderTest {
@@ -70,6 +72,7 @@ public class SoftServiceLoaderTest {
         try {
             System.setProperty("micronaut.graalvm.imagesingletons.enabled", "false");
             assertNull(ServiceScanner.findStaticServiceDefinitions());
+            assertFalse(NativeImageUtils.hasImageSingletons());
         } finally {
             if (previous == null) {
                 System.clearProperty("micronaut.graalvm.imagesingletons.enabled");

--- a/core/src/test/java/io/micronaut/core/io/service/SoftServiceLoaderTest.java
+++ b/core/src/test/java/io/micronaut/core/io/service/SoftServiceLoaderTest.java
@@ -1,6 +1,7 @@
 package io.micronaut.core.io.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
@@ -61,5 +62,20 @@ public class SoftServiceLoaderTest {
             SoftServiceLoader.StaticDefinition.of(PackagePrivateConstructorService.class.getName(), PackagePrivateConstructorService.class);
 
         assertEquals("fallback", serviceDefinition.load().value());
+    }
+
+    @Test
+    void imageSingletonsLookupCanBeDisabled() {
+        String previous = System.getProperty("micronaut.graalvm.imagesingletons.enabled");
+        try {
+            System.setProperty("micronaut.graalvm.imagesingletons.enabled", "false");
+            assertNull(ServiceScanner.findStaticServiceDefinitions());
+        } finally {
+            if (previous == null) {
+                System.clearProperty("micronaut.graalvm.imagesingletons.enabled");
+            } else {
+                System.setProperty("micronaut.graalvm.imagesingletons.enabled", previous);
+            }
+        }
     }
 }


### PR DESCRIPTION
Add a system property to disable optional ImageSingletons detection before calling ImageSingletons APIs.

This supports runtimes such as Crema where ImageSingletons.contains is not reachable. The default behavior is unchanged; setting `micronaut.graalvm.imagesingletons.enabled=false` skips the lookup.

Tests: `./gradlew :micronaut-core:test --tests io.micronaut.core.io.service.SoftServiceLoaderTest`