### PR TITLE
Fix Python bridge casts for response subtypes

### DIFF
--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -3871,12 +3871,12 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                             yield RUNTIME_UTIL
                                 .invokeStatic("convertHttpResponse", ClassTypeDef.OBJECT,
                                     invokedValue, CLASS_OBJECT)
-                                .cast(ClassTypeDef.of(HTTP_RESPONSE));
+                                .cast(ClassTypeDef.of(returnType));
                         }
                         yield RUNTIME_UTIL
                             .invokeStatic("convertHttpResponse", ClassTypeDef.OBJECT,
                                 invokedValue, toClassExpression(bodyType))
-                            .cast(ClassTypeDef.of(HTTP_RESPONSE));
+                            .cast(ClassTypeDef.of(returnType));
                     } else {
                         if (isGeneratedWrapperType(allClasses, returnType)) {
                             yield javaClassType(returnType)

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -62,6 +62,24 @@ final class PyronautCompilerTest {
     }
 
     @Test
+    void compilesPythonMethodsReturningHttpResponseSubtypes(@TempDir Path sourceDirectory) throws Exception {
+        Files.writeString(sourceDirectory.resolve("responses.py"), """
+            from micronaut.http import MutableHttpResponse
+
+            class Responses:
+                def response(self) -> MutableHttpResponse:
+                    return None
+            """);
+
+        ClassLoader classLoader = PyronautCompiler.builder()
+            .pythonSrc(sourceDirectory.toString())
+            .build()
+            .buildClassLoader();
+
+        assertNotNull(classLoader.loadClass("pyronaut_application.PyronautMain"));
+    }
+
+    @Test
     void optionallyIncludesPythonBytecodeInTheInMemoryVfs() throws Exception {
         ClassLoader classLoader = PyronautCompiler.builder()
             .pythonCode("answer = 42")


### PR DESCRIPTION
The Python bridge currently casts every converted HttpResponse result to HttpResponse, even when the generated override declares a subtype such as MutableHttpResponse.

This produces a generated-source compilation error in Python guides that override Micronaut handlers returning MutableHttpResponse. Cast to the resolved declared return type instead.

Validated with :micronaut-inject-python:compileJava and :micronaut-inject-python:test.