### PR TITLE
Diagnose concrete Java inheritance in native Python

### DIFF
--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_transformer.py
@@ -343,6 +343,21 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
                         replaced_throwable = True
                         self.uses_builtin_exception = True
                     continue
+                java_class_name = self._java_class_name(base)
+                if java_class_name:
+                    node.body.insert(0, ast.Raise(
+                        exc=ast.Call(
+                            func=ast.Name(id='RuntimeError', ctx=ast.Load()),
+                            args=[ast.Constant(
+                                f"Native Python mode does not support Python class [{node.name}] "
+                                f"extending Java class [{java_class_name}]; "
+                                "use composition or a Java interface instead."
+                            )],
+                            keywords=[]
+                        ),
+                        cause=None
+                    ))
+                    continue
                 runtime_bases.append(base)
             node.bases = runtime_bases
             if len(node.bases) != original_base_count:
@@ -668,6 +683,19 @@ def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
             }
         except Exception:
             return False
+
+    def _java_class_name(self, base: ast.AST) -> Optional[str]:
+        class_name = self._java_type_name(base)
+        class_element = self.callback_get_class_element(class_name) if class_name else None
+        if class_element is None:
+            base_name = self._base_name(base)
+            class_element = self.java_class_elements.get(base_name) if base_name else None
+        if class_element is None:
+            return None
+        try:
+            return None if class_element.isInterface() or class_element.isAbstract() else class_element.getName()
+        except Exception:
+            return None
 
     def _java_type_name(self, node: ast.AST) -> Optional[str]:
         if not isinstance(node, ast.Call):

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -353,6 +353,60 @@ public class PythonAstParserTest {
     }
 
     @Test
+    void testRuntimeTransformDiagnosesConcreteJavaClassInheritance() {
+        PythonAstParser parser = new PythonAstParser();
+        VisitorContext visitorContext = (VisitorContext) Proxy.newProxyInstance(
+            VisitorContext.class.getClassLoader(),
+            new Class<?>[] { VisitorContext.class },
+            (proxy, method, args) -> {
+                if ("getClassElement".equals(method.getName()) && args != null && args.length == 1) {
+                    return switch ((String) args[0]) {
+                        case "java.lang.Thread" -> Optional.of(ClassElement.of(Thread.class));
+                        case "java.lang.Runnable" -> Optional.of(ClassElement.of(Runnable.class));
+                        default -> Optional.empty();
+                    };
+                }
+                if ("getClassElements".equals(method.getName())) {
+                    return ClassElement.ZERO_CLASS_ELEMENTS;
+                }
+                if (Optional.class.equals(method.getReturnType())) {
+                    return Optional.empty();
+                }
+                if (method.getReturnType().equals(boolean.class)) {
+                    return false;
+                }
+                if (method.getReturnType().equals(int.class)) {
+                    return 0;
+                }
+                return null;
+            }
+        );
+
+        PythonAstParser.TransformResult result = parser.transform(visitorContext, """
+            from java.lang import Thread
+
+            class Worker(Thread):
+                pass
+            """);
+
+        assertTrue(result.code().contains("class Worker(Thread)"));
+        assertTrue(result.runtimeCode().contains("Native Python mode does not support Python class [Worker]"));
+        assertTrue(result.runtimeCode().contains("Java class [java.lang.Thread]"));
+        assertTrue(parser.requiresRuntimeBytecode(result));
+
+        PythonAstParser.TransformResult interfaceResult = parser.transform(visitorContext, """
+            from java.lang import Runnable
+
+            class Worker(Runnable):
+                pass
+            """);
+
+        assertFalse(interfaceResult.runtimeCode().contains("does not support Python class"));
+        assertTrue(interfaceResult.runtimeCode().contains("class Worker:"));
+        assertTrue(parser.requiresRuntimeBytecode(interfaceResult));
+    }
+
+    @Test
     void testTransformKeepsFutureImportsBeforeGeneratedCode() {
         PythonAstParser pythonProcessor = new PythonAstParser();
         VisitorContext visitorContext = (VisitorContext) Proxy.newProxyInstance(


### PR DESCRIPTION
## Summary
- emit a clear native-runtime error before GraalPy attempts to subclass a concrete Java class
- retain supported Java-interface adaptation and existing Throwable handling
- add parser coverage for concrete Java classes and interfaces

## Validation
- `:micronaut-inject-python:compileTestJava`
- `:micronaut-inject-python:test --tests io.micronaut.python.processing.PythonAstParserTest` (task is disabled by this checkout; Gradle build succeeds)