### PR TITLE
Backport: Handle null instances in QueryValueArgumentBinder

### DIFF
--- a/http/src/main/java/io/micronaut/http/bind/binders/QueryValueArgumentBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/QueryValueArgumentBinder.java
@@ -197,6 +197,15 @@ public class QueryValueArgumentBinder<T> extends AbstractArgumentBinder<T> imple
 
         try {
             T instance = introspectionBuilder.build();
+
+            if (instance == null) {
+                if (argument.isNullable()) {
+                    return BindingResult.empty();
+                }
+
+                return BindingResult.unsatisfied();
+            }
+
             return () -> Optional.of(instance);
         } catch (Exception e) {
             return BindingResult.unsatisfied();

--- a/http/src/test/java/io/micronaut/http/bind/binders/QueryValueArgumentBinderTest.java
+++ b/http/src/test/java/io/micronaut/http/bind/binders/QueryValueArgumentBinderTest.java
@@ -1,0 +1,198 @@
+package io.micronaut.http.bind.binders;
+
+import io.micronaut.core.annotation.*;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.QueryValue;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueryValueArgumentBinderTest {
+    @Introspected
+    static class NullableTestType {
+        @Creator
+        public static NullableTestType getInstance() {
+            return null;
+        }
+    }
+
+    @Introspected
+    static class NonNullTestType {
+        private final String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        private NonNullTestType(String value) {
+            this.value = value;
+        }
+
+        @Creator
+        public static NonNullTestType getInstance(@NonNull String value) {
+            return new NonNullTestType(value);
+        }
+    }
+
+    QueryValueArgumentBinder<NullableTestType> nullableTestTypeQueryValueArgumentBinder =
+        new QueryValueArgumentBinder<>(ConversionService.SHARED);
+    QueryValueArgumentBinder<NonNullTestType> nonNullableTestTypeQueryValueArgumentBinder =
+        new QueryValueArgumentBinder<>(ConversionService.SHARED);
+
+    private static final AnnotationMetadata NULLABLE_ANNOTATION_METADATA = new AnnotationMetadata() {
+        @Override
+        public boolean hasStereotype(@Nullable String annotation) {
+            assert annotation != null;
+            return annotation.equals(AnnotationUtil.NULLABLE);
+        }
+
+        @Override
+        public boolean hasAnnotation(@Nullable Class<? extends Annotation> annotation) {
+            assert annotation != null;
+            return annotation.equals(QueryValue.class);
+        }
+    };
+    private static final AnnotationMetadata NON_NULLABLE_ANNOTATION_METADATA = new AnnotationMetadata() {
+        @Override
+        public boolean hasAnnotation(@Nullable Class<? extends Annotation> annotation) {
+            assert annotation != null;
+            return annotation.equals(QueryValue.class);
+        }
+    };
+
+    @Test
+    void shouldBindEmptyWhenInstanceCreatedByIntrospectionIsNullAndArgumentIsNullable() {
+        var context = new ArgumentConversionContext<NullableTestType>() {
+            @Override
+            @NonNull
+            public Argument<NullableTestType> getArgument() {
+                return Argument.of(NullableTestType.class, NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var source = get("/");
+
+
+        var bound = nullableTestTypeQueryValueArgumentBinder.bind(context, source);
+
+        assertTrue(bound.isSatisfied());
+        assertFalse(bound.getValue().isPresent());
+    }
+
+    @Test
+    void shouldBindUnsatisfiedWhenInstanceCreatedByIntrospectionIsNullAndArgumentIsNotNullable() {
+        var context = new ArgumentConversionContext<NullableTestType>() {
+            @Override
+            @NonNull
+            public Argument<NullableTestType> getArgument() {
+                return Argument.of(NullableTestType.class, NON_NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var source = get("/");
+
+
+        var bound = nullableTestTypeQueryValueArgumentBinder.bind(context, source);
+
+
+        assertFalse(bound.isSatisfied());
+        assertFalse(bound.getValue().isPresent());
+    }
+
+
+    @Test
+    void shouldBindWithValueWhenInstanceCreatedByIntrospectionIsNotNullAndArgumentIsNullableAndCreatorSucceeds() {
+        var context = new ArgumentConversionContext<NonNullTestType>() {
+            @Override
+            @NonNull
+            public Argument<NonNullTestType> getArgument() {
+                return Argument.of(NonNullTestType.class, NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var expected = "test-value";
+        var source = get("/", Map.of("value", expected));
+
+        var bound = nonNullableTestTypeQueryValueArgumentBinder.bind(context, source);
+
+
+        assertTrue(bound.isSatisfied());
+        assertTrue(bound.isPresentAndSatisfied());
+        assertEquals(expected, bound.get().getValue());
+    }
+
+    @Test
+    void shouldBindWithValueWhenInstanceCreatedByIntrospectionIsNotNullAndArgumentIsNotNullableAndCreatorSucceeds() {
+        var context = new ArgumentConversionContext<NonNullTestType>() {
+            @Override
+            @NonNull
+            public Argument<NonNullTestType> getArgument() {
+                return Argument.of(NonNullTestType.class, NON_NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var expected = "test-value";
+        var source = get("/", Map.of("value", expected));
+
+
+        var bound = nonNullableTestTypeQueryValueArgumentBinder.bind(context, source);
+
+
+        assertTrue(bound.isSatisfied());
+        assertTrue(bound.isPresentAndSatisfied());
+        assertEquals(expected, bound.get().getValue());
+    }
+
+    @Test
+    void shouldBindUnsatisfiedWhenInstanceCreatedByIntrospectionIsNotNullAndArgumentIsNullableAndCreatorFails() {
+        var context = new ArgumentConversionContext<NonNullTestType>() {
+            @Override
+            @NonNull
+            public Argument<NonNullTestType> getArgument() {
+                return Argument.of(NonNullTestType.class, NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var source = get("/");
+
+
+        var bound = nonNullableTestTypeQueryValueArgumentBinder.bind(context, source);
+
+
+        assertFalse(bound.isSatisfied());
+        assertFalse(bound.getValue().isPresent());
+    }
+
+    @Test
+    void shouldBindUnsatisfiedWhenInstanceCreatedByIntrospectionIsNotNullAndArgumentIsNotNullableAndCreatorFails() {
+        var context = new ArgumentConversionContext<NonNullTestType>() {
+            @Override
+            @NonNull
+            public Argument<NonNullTestType> getArgument() {
+                return Argument.of(NonNullTestType.class, NON_NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var source = get("/");
+
+
+        var bound = nonNullableTestTypeQueryValueArgumentBinder.bind(context, source);
+
+
+        assertFalse(bound.isSatisfied());
+        assertFalse(bound.getValue().isPresent());
+    }
+
+    HttpRequest<?> get(String uri) {
+        return get(uri, Collections.emptyMap());
+    }
+
+    HttpRequest<?> get(String uri, Map<String, String> queryParams) {
+        var request = HttpRequest.GET(uri);
+        var params = request.getParameters();
+        queryParams.forEach(params::add);
+
+        return request;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
@@ -434,6 +434,8 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
             }
         } else if (bindingResult.isPresentAndSatisfied()) {
             value = bindingResult.get();
+        } else if (argument.isNullable() && bindingResult.isSatisfied()) {
+            value = null;
         } else {
             return false;
         }


### PR DESCRIPTION
Mostly just a cherrypick of #12759 to 4.10.x branch; the only manual change was to remove the jspecify annotations which aren't in 4.10.x.
Closes #12667 for 4.10.x (previously closed for 5.1.x)
Handle null instances created by the creator in `QueryValueArgumentBinder` explicitly. Error if the argument is not marked `@Nullable` and forward null if it is.