### PR TITLE
Initialize parameterized Python config beans before builder injection

### DIFF
--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/ConfigurationBuilderSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/ConfigurationBuilderSpec.groovy
@@ -33,19 +33,23 @@ EngineBuilder = java.type("io.micronaut.python.annotation.processing.test.Config
 @Introspected
 @dataclass(init=False)
 class TeamConfiguration:
+    name: str = field(default="default")
     builder: Annotated[EngineBuilder, ConfigurationBuilder(prefixes=["with"])] = field(init=False)
 
-    def __init__(self):
+    def __init__(self, name: str):
+        self.name = name
         self.builder = Engine.builder()
 '''
 
         when:
         def context = buildContext(pythonCode, false, [
+                "team.name": "Micronaut",
                 "team.manufacturer": "Toyota"
         ])
         def configuration = getBean(context, "python.TeamConfiguration")
 
         then:
+        configuration.name == "Micronaut"
         configuration.builder.build().manufacturer == "Toyota"
 
         cleanup:

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/ConfigurationBuilderSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/ConfigurationBuilderSpec.groovy
@@ -17,6 +17,41 @@ package io.micronaut.python.annotation.processing.test
 
 class ConfigurationBuilderSpec extends AbstractPythonTypeElementSpec {
 
+    void "test parameterized configuration builder initializes an init false field"() {
+        given:
+        def pythonCode = '''
+from dataclasses import dataclass, field
+from typing import Annotated
+import java
+from micronaut.context.annotation import ConfigurationBuilder, ConfigurationProperties
+from micronaut.core.annotation import Introspected
+
+Engine = java.type("io.micronaut.python.annotation.processing.test.ConfigBuilderEngine")
+EngineBuilder = java.type("io.micronaut.python.annotation.processing.test.ConfigBuilderEngine$Builder")
+
+@ConfigurationProperties("team")
+@Introspected
+@dataclass(init=False)
+class TeamConfiguration:
+    builder: Annotated[EngineBuilder, ConfigurationBuilder(prefixes=["with"])] = field(init=False)
+
+    def __init__(self):
+        self.builder = Engine.builder()
+'''
+
+        when:
+        def context = buildContext(pythonCode, false, [
+                "team.manufacturer": "Toyota"
+        ])
+        def configuration = getBean(context, "python.TeamConfiguration")
+
+        then:
+        configuration.builder.build().manufacturer == "Toyota"
+
+        cleanup:
+        context?.close()
+    }
+
     void "test configuration builder writes to Java builder attribute"() {
         given:
         def pythonCode = '''

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/GenerateToStringEqualsSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/GenerateToStringEqualsSpec.groovy
@@ -26,6 +26,7 @@ class Person:
         assertGeneratedSourceContains(pythonCode, """
   @JsonCreator
   public Person(@JsonProperty("name") String name, @JsonProperty("age") int age, @JsonProperty("address") Address address) {
+    this.graalpyInternalValue = PythonContextRuntime.newUninitializedInstance(Person.__PYTHON_CLASS_REFERENCE);
     this.name = name;
     this.age = age;
     this.address = address;

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -450,7 +450,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         })
                                     ));
                         } else {
-                            builder.addMethod(
+                        builder.addMethod(
                                 MethodDef.constructor()
                                     .addModifiers(Modifier.PUBLIC)
                                     .addParameter(ParameterDef.of("value", POLYGLOT_VALUE))
@@ -3966,16 +3966,18 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         @Nullable FieldDef pythonValueField,
         boolean extendsPythonClass
     ) {
-        List<StatementDef> statements = new ArrayList<>();
-        if (extendsPythonClass) {
-            statements.add(aThis.superRef().invokeSuperConstructor(value));
-        }
-        if (pythonValueField != null) {
-            statements.add(aThis.field(pythonValueField).assign(value));
-        }
-        ExpressionDef storedValue = pythonValueField == null ? value : aThis.field(pythonValueField);
-        statements.addAll(polyglotValuePropertyAssignments(aThis, storedValue, beanProperties, propertyFields));
-        return StatementDef.multi(statements);
+        return value.newLocal("pythonInstance", pythonInstance -> {
+            List<StatementDef> statements = new ArrayList<>();
+            if (extendsPythonClass) {
+                statements.add(aThis.superRef().invokeSuperConstructor(pythonInstance));
+            }
+            if (pythonValueField != null) {
+                statements.add(aThis.field(pythonValueField).assign(pythonInstance));
+            }
+            ExpressionDef storedValue = pythonValueField == null ? pythonInstance : aThis.field(pythonValueField);
+            statements.addAll(polyglotValuePropertyAssignments(aThis, storedValue, beanProperties, propertyFields));
+            return StatementDef.multi(statements);
+        });
     }
 
     private List<StatementDef> polyglotValuePropertyAssignments(

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -700,7 +700,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                                 aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(pythonInstance)
                                             );
                                         }
-                                        return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal);
+                                        return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal, extendsPythonClass);
                                     }
                                     List<StatementDef> assignments = new ArrayList<>();
                                     if (constructorParametersBackedByFields) {
@@ -751,7 +751,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         arguments
                                     );
                                     if (isIntrospectedBean && !extendsHostClass) {
-                                        return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal);
+                                        return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal, extendsPythonClass);
                                     } else if (extendsPythonClass) {
                                         return aThis.superRef().invokeSuperConstructor(pythonInstance);
                                     } else if (extendsHostClass) {
@@ -794,7 +794,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(pythonInstance)
                                     );
                                 }
-                                return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal);
+                                return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal, extendsPythonClass);
                             } else if (isIntrospectedBean) {
                                 // Keep ordinary introspected beans lazy; resolving their Python class here
                                 // would break beans whose Python constructor requires arguments.
@@ -3959,9 +3959,13 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         ExpressionDef value,
         List<PropertyElement> beanProperties,
         Map<String, FieldDef> propertyFields,
-        @Nullable FieldDef pythonValueField
+        @Nullable FieldDef pythonValueField,
+        boolean extendsPythonClass
     ) {
         List<StatementDef> statements = new ArrayList<>();
+        if (extendsPythonClass) {
+            statements.add(aThis.superRef().invokeSuperConstructor(value));
+        }
         if (pythonValueField != null) {
             statements.add(aThis.field(pythonValueField).assign(value));
         }

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -689,11 +689,10 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                         final int requiredConstructorParameterCount = requiredConstructorParameterCount(parameters);
                         final boolean hasDefaultedConstructorParameters = requiredConstructorParameterCount < parameters.length;
                         final boolean constructorParametersBackedByFields = constructorParametersBackedByFields(parameters, propertyFields);
-                        builder.addMethod(
+                            builder.addMethod(
                             constructor.addModifiers(Modifier.PUBLIC).build(((aThis, methodParameters) -> {
                                 if (isIntrospectedBean && (constructorParametersBackedByFields || hasDynamicBeanProperties)) {
-                                    List<StatementDef> assignments = new ArrayList<>();
-                                    if (hasDynamicBeanProperties && hasConfigurationBuilderProperty) {
+                                    if (hasConfigurationBuilderProperty) {
                                         List<ExpressionDef> arguments = new ArrayList<>(List.of(pythonClassReference(element, pythonClassReference)));
                                         for (int i = 0; i < parameters.length; i++) {
                                             @NonNull ParameterElement parameter = parameters[i];
@@ -702,24 +701,15 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                             int lastArgIndex = arguments.size() - 1;
                                             arguments.set(lastArgIndex, arguments.get(lastArgIndex).cast(TypeDef.OBJECT));
                                         }
-                                        assignments.add(aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
-                                            PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                                                isAbstractIntroCtor ? "newIntroduction" : "newInstance",
-                                                POLYGLOT_VALUE,
-                                                arguments
-                                            )
-                                        ));
-                                    } else if (hasConfigurationBuilderProperty) {
-                                        // Configuration builders are initialized by the Python constructor before
-                                        // Micronaut applies the generated builder setters.
-                                        assignments.add(aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
-                                            PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                                                isAbstractIntroCtor ? "newIntroduction" : "newInstance",
-                                                POLYGLOT_VALUE,
-                                                List.of(pythonClassReference(element, pythonClassReference))
-                                            )
-                                        ));
-                                    } else if (constructorParametersBackedByFields) {
+                                        ExpressionDef pythonInstance = PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                                            isAbstractIntroCtor ? "newIntroduction" : "newInstance",
+                                            POLYGLOT_VALUE,
+                                            arguments
+                                        );
+                                        return aThis.invokeConstructor(pythonInstance);
+                                    }
+                                    List<StatementDef> assignments = new ArrayList<>();
+                                    if (constructorParametersBackedByFields) {
                                         // Ordinary field-backed introspected beans must not invoke a Python
                                         // constructor whose parameters are supplied by Micronaut.
                                         assignments.add(aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -709,12 +709,19 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                                 arguments
                                             )
                                         ));
-                                    } else if (hasConfigurationBuilderProperty || constructorParametersBackedByFields) {
-                                        // Parameterized introspected beans receive property injection after
-                                        // construction. Initialize the Python backing value before generated
-                                        // bean definitions invoke those setters, including Serdeable/dataclass
-                                        // configuration beans whose builder metadata is not retained on the
-                                        // bean property.
+                                    } else if (hasConfigurationBuilderProperty) {
+                                        // Configuration builders are initialized by the Python constructor before
+                                        // Micronaut applies the generated builder setters.
+                                        assignments.add(aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
+                                            PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                                                isAbstractIntroCtor ? "newIntroduction" : "newInstance",
+                                                POLYGLOT_VALUE,
+                                                List.of(pythonClassReference(element, pythonClassReference))
+                                            )
+                                        ));
+                                    } else if (constructorParametersBackedByFields) {
+                                        // Ordinary field-backed introspected beans must not invoke a Python
+                                        // constructor whose parameters are supplied by Micronaut.
                                         assignments.add(aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
                                             PYTHON_CONTEXT_RUNTIME.invokeStatic(
                                                 NEW_UNINITIALIZED_INSTANCE,

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -706,6 +706,17 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                                 arguments
                                             )
                                         ));
+                                    } else {
+                                        // Parameterized introspected beans can still use configuration-builder
+                                        // injection after construction. Initialize the Python backing value before
+                                        // the generated bean definition invokes those setters.
+                                        assignments.add(aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
+                                            PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                                                isAbstractIntroCtor ? "newIntroduction" : "newInstance",
+                                                POLYGLOT_VALUE,
+                                                List.of(pythonClassReference(element, pythonClassReference))
+                                            )
+                                        ));
                                     }
                                     for (int i = 0; i < parameters.length; i++) {
                                         @NonNull ParameterElement parameter = parameters[i];

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -692,8 +692,11 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                             builder.addMethod(
                             constructor.addModifiers(Modifier.PUBLIC).build(((aThis, methodParameters) -> {
                                 if (isIntrospectedBean && (constructorParametersBackedByFields || hasDynamicBeanProperties)) {
-                                    if (hasConfigurationBuilderProperty) {
+                                    if (hasConfigurationBuilderProperty || hasDynamicBeanProperties) {
                                         List<ExpressionDef> arguments = new ArrayList<>(List.of(pythonClassReference(element, pythonClassReference)));
+                                        if (hasDefaultedConstructorParameters) {
+                                            arguments.add(ExpressionDef.constant(requiredConstructorParameterCount));
+                                        }
                                         for (int i = 0; i < parameters.length; i++) {
                                             @NonNull ParameterElement parameter = parameters[i];
                                             VariableDef.MethodParameter methodParameter = methodParameters.get(i);
@@ -702,10 +705,17 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                             arguments.set(lastArgIndex, arguments.get(lastArgIndex).cast(TypeDef.OBJECT));
                                         }
                                         ExpressionDef pythonInstance = PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                                            isAbstractIntroCtor ? "newIntroduction" : "newInstance",
+                                            constructorFactoryMethod(isAbstractIntroCtor, hasDefaultedConstructorParameters),
                                             POLYGLOT_VALUE,
                                             arguments
                                         );
+                                        if (extendsHostClass) {
+                                            List<ExpressionDef> superArguments = superConstructorArguments(superType, parameters, methodParameters);
+                                            return StatementDef.multi(
+                                                aThis.superRef().invokeSuperConstructor(superArguments),
+                                                aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(pythonInstance)
+                                            );
+                                        }
                                         return aThis.invokeConstructor(pythonInstance);
                                     }
                                     List<StatementDef> assignments = new ArrayList<>();
@@ -788,14 +798,23 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                         builder.addMethod(constructor.addModifiers(Modifier.PUBLIC).build(((aThis, methodParameters) -> {
                             if (isJunit5Test) {
                                 return StatementDef.multi();
-                            } else if (isIntrospectedBean) {
-                                return aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
-                                    PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                                        NEW_UNINITIALIZED_INSTANCE,
-                                        POLYGLOT_VALUE,
-                                        List.of(pythonClassReference(element, pythonClassReference))
-                                    )
+                            } else if (isIntrospectedBean && hasConfigurationBuilderProperty) {
+                                ExpressionDef pythonInstance = PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                                    isAbstractIntroNoArg ? "newIntroduction" : "newInstance",
+                                    POLYGLOT_VALUE,
+                                    List.of(pythonClassReference(element, pythonClassReference))
                                 );
+                                if (extendsHostClass) {
+                                    return StatementDef.multi(
+                                        aThis.superRef().invokeSuperConstructor(superConstructorArguments(superType, new ParameterElement[0], methodParameters)),
+                                        aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(pythonInstance)
+                                    );
+                                }
+                                return aThis.invokeConstructor(pythonInstance);
+                            } else if (isIntrospectedBean) {
+                                // Keep ordinary introspected beans lazy; resolving their Python class here
+                                // would break beans whose Python constructor requires arguments.
+                                return StatementDef.multi();
                             } else {
                                 ExpressionDef pythonInstance = PYTHON_CONTEXT_RUNTIME
                                     .invokeStatic(isAbstractIntroNoArg ? "newIntroduction" : "newInstance", POLYGLOT_VALUE,

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -709,10 +709,12 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                                 arguments
                                             )
                                         ));
-                                    } else if (hasConfigurationBuilderProperty) {
-                                        // Parameterized introspected beans can still use configuration-builder
-                                        // injection after construction. Initialize the Python backing value before
-                                        // the generated bean definition invokes those setters.
+                                    } else if (hasConfigurationBuilderProperty || constructorParametersBackedByFields) {
+                                        // Parameterized introspected beans receive property injection after
+                                        // construction. Initialize the Python backing value before generated
+                                        // bean definitions invoke those setters, including Serdeable/dataclass
+                                        // configuration beans whose builder metadata is not retained on the
+                                        // bean property.
                                         assignments.add(aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
                                             PYTHON_CONTEXT_RUNTIME.invokeStatic(
                                                 NEW_UNINITIALIZED_INSTANCE,

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -3966,11 +3966,19 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         @Nullable FieldDef pythonValueField,
         boolean extendsPythonClass
     ) {
+        if (extendsPythonClass) {
+            List<StatementDef> statements = new ArrayList<>();
+            statements.add(aThis.superRef().invokeSuperConstructor(value));
+            ExpressionDef storedValue = aThis.superRef().invoke(AS_POLYGLOT_VALUE, POLYGLOT_VALUE);
+            if (pythonValueField != null) {
+                statements.add(aThis.field(pythonValueField).assign(storedValue));
+                storedValue = aThis.field(pythonValueField);
+            }
+            statements.addAll(polyglotValuePropertyAssignments(aThis, storedValue, beanProperties, propertyFields));
+            return StatementDef.multi(statements);
+        }
         return value.newLocal("pythonInstance", pythonInstance -> {
             List<StatementDef> statements = new ArrayList<>();
-            if (extendsPythonClass) {
-                statements.add(aThis.superRef().invokeSuperConstructor(pythonInstance));
-            }
             if (pythonValueField != null) {
                 statements.add(aThis.field(pythonValueField).assign(pythonInstance));
             }

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -122,6 +122,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
     private static final String HTTP_RESPONSE = "io.micronaut.http.HttpResponse";
     private static final String PUBLISHER = "org.reactivestreams.Publisher";
     private static final String ANN_CONFIGURATION_BUILDER = "io.micronaut.context.annotation.ConfigurationBuilder";
+    private static final String NEW_UNINITIALIZED_INSTANCE = "newUninitializedInstance";
     private static final String ANN_CONFIGURATION_INJECT = "io.micronaut.context.annotation.ConfigurationInject";
     private static final String ANN_CONFIGURATION_READER = "io.micronaut.context.annotation.ConfigurationReader";
     private static final String ANN_ANNOTATION_EXPRESSION_CONTEXT = "io.micronaut.context.annotation.AnnotationExpressionContext";
@@ -299,6 +300,8 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
 
                     List<PropertyElement> beanProperties = element.getBeanProperties();
                     boolean hasDynamicBeanProperties = beanProperties.stream().anyMatch(PythonStubGenerator::isDynamicBeanProperty);
+                    boolean hasConfigurationBuilderProperty = beanProperties.stream()
+                        .anyMatch(property -> property.hasAnnotation(ANN_CONFIGURATION_BUILDER));
                     if (!isIntrospectedBean
                         && !isPythonDataclass(element)
                         && !hasConfigurationInjectConstructor(element)
@@ -561,7 +564,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         );
                                     } else {
                                         reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                                            "newUninitializedInstance",
+                                            NEW_UNINITIALIZED_INSTANCE,
                                             POLYGLOT_VALUE,
                                             List.of(
                                                 pythonClassReference(element, pythonClassReference)
@@ -690,7 +693,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                             constructor.addModifiers(Modifier.PUBLIC).build(((aThis, methodParameters) -> {
                                 if (isIntrospectedBean && (constructorParametersBackedByFields || hasDynamicBeanProperties)) {
                                     List<StatementDef> assignments = new ArrayList<>();
-                                    if (hasDynamicBeanProperties) {
+                                    if (hasDynamicBeanProperties && hasConfigurationBuilderProperty) {
                                         List<ExpressionDef> arguments = new ArrayList<>(List.of(pythonClassReference(element, pythonClassReference)));
                                         for (int i = 0; i < parameters.length; i++) {
                                             @NonNull ParameterElement parameter = parameters[i];
@@ -706,13 +709,13 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                                 arguments
                                             )
                                         ));
-                                    } else {
+                                    } else if (hasConfigurationBuilderProperty) {
                                         // Parameterized introspected beans can still use configuration-builder
                                         // injection after construction. Initialize the Python backing value before
                                         // the generated bean definition invokes those setters.
                                         assignments.add(aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
                                             PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                                                isAbstractIntroCtor ? "newIntroduction" : "newInstance",
+                                                NEW_UNINITIALIZED_INSTANCE,
                                                 POLYGLOT_VALUE,
                                                 List.of(pythonClassReference(element, pythonClassReference))
                                             )
@@ -754,7 +757,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         POLYGLOT_VALUE,
                                         arguments
                                     );
-                                    if (isIntrospectedBean) {
+                                    if (isIntrospectedBean && !extendsHostClass) {
                                         return aThis.invokeConstructor(pythonInstance);
                                     } else if (extendsPythonClass) {
                                         return aThis.superRef().invokeSuperConstructor(pythonInstance);
@@ -787,11 +790,13 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                             if (isJunit5Test) {
                                 return StatementDef.multi();
                             } else if (isIntrospectedBean) {
-                                ExpressionDef pythonInstance = PYTHON_CONTEXT_RUNTIME
-                                    .invokeStatic(isAbstractIntroNoArg ? "newIntroduction" : "newInstance", POLYGLOT_VALUE,
+                                return aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
+                                    PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                                        NEW_UNINITIALIZED_INSTANCE,
+                                        POLYGLOT_VALUE,
                                         List.of(pythonClassReference(element, pythonClassReference))
-                                    );
-                                return aThis.invokeConstructor(pythonInstance);
+                                    )
+                                );
                             } else {
                                 ExpressionDef pythonInstance = PYTHON_CONTEXT_RUNTIME
                                     .invokeStatic(isAbstractIntroNoArg ? "newIntroduction" : "newInstance", POLYGLOT_VALUE,

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -444,23 +444,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                             } else if (pythonValueFinal != null) {
                                                 assigns.add(aThis.field(pythonValueFinal).assign(val));
                                             }
-                                            for (PropertyElement beanProperty : beanProperties) {
-                                                FieldDef field = propertyFields.get(beanProperty.getName());
-                                                if (field == null) {
-                                                    continue;
-                                                }
-                                                ExpressionDef.InvokeInstanceMethod has = val.invoke("hasMember", TypeDef.Primitive.BOOLEAN, ExpressionDef.constant(beanProperty.getName()));
-                                                ExpressionDef.InvokeInstanceMethod member = val.invoke("getMember", POLYGLOT_VALUE, ExpressionDef.constant(beanProperty.getName()));
-                                                ExpressionDef valueExpr = convertValueForType(beanProperty.getGenericType(), member);
-                                                if (isCollectionLike(beanProperty.getGenericType())) {
-                                                    assigns.add(aThis.field(field).assign(valueExpr));
-                                                } else {
-                                                    assigns.add(has.isTrue().doIfElse(
-                                                        aThis.field(field).assign(valueExpr),
-                                                        StatementDef.multi()
-                                                    ));
-                                                }
-                                            }
+                                            assigns.addAll(polyglotValuePropertyAssignments(aThis, val, beanProperties, propertyFields));
                                             return StatementDef.multi(assigns);
                                         })
                                     ));
@@ -3982,19 +3966,30 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             statements.add(aThis.field(pythonValueField).assign(value));
         }
         ExpressionDef storedValue = pythonValueField == null ? value : aThis.field(pythonValueField);
+        statements.addAll(polyglotValuePropertyAssignments(aThis, storedValue, beanProperties, propertyFields));
+        return StatementDef.multi(statements);
+    }
+
+    private List<StatementDef> polyglotValuePropertyAssignments(
+        VariableDef.This aThis,
+        ExpressionDef value,
+        List<PropertyElement> beanProperties,
+        Map<String, FieldDef> propertyFields
+    ) {
+        List<StatementDef> statements = new ArrayList<>();
         for (PropertyElement beanProperty : beanProperties) {
             FieldDef field = propertyFields.get(beanProperty.getName());
             if (field == null) {
                 continue;
             }
-            ExpressionDef member = storedValue.invoke("getMember", POLYGLOT_VALUE, ExpressionDef.constant(beanProperty.getName()));
-            ExpressionDef converted = convertValueForType(beanProperty.getGenericType(), member);
-            ExpressionDef hasMember = storedValue.invoke("hasMember", TypeDef.Primitive.BOOLEAN, ExpressionDef.constant(beanProperty.getName()));
+            ExpressionDef.InvokeInstanceMethod has = value.invoke("hasMember", TypeDef.Primitive.BOOLEAN, ExpressionDef.constant(beanProperty.getName()));
+            ExpressionDef.InvokeInstanceMethod member = value.invoke("getMember", POLYGLOT_VALUE, ExpressionDef.constant(beanProperty.getName()));
+            ExpressionDef valueExpression = convertValueForType(beanProperty.getGenericType(), member);
             statements.add(isCollectionLike(beanProperty.getGenericType())
-                ? aThis.field(field).assign(converted)
-                : hasMember.isTrue().doIf(aThis.field(field).assign(converted)));
+                ? aThis.field(field).assign(valueExpression)
+                : has.isTrue().doIfElse(aThis.field(field).assign(valueExpression), StatementDef.multi()));
         }
-        return StatementDef.multi(statements);
+        return statements;
     }
 
     private static ExpressionDef convertNullableValue(ExpressionDef value, ExpressionDef nonNullValue) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -773,8 +773,14 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                         MethodDef.MethodDefBuilder constructor = MethodDef.constructor();
                         final boolean isAbstractIntroNoArg = element.isAbstract() && isAopProxy && element.hasStereotype(Introduction.class);
                         builder.addMethod(constructor.addModifiers(Modifier.PUBLIC).build(((aThis, methodParameters) -> {
-                            if (isJunit5Test || isIntrospectedBean) {
+                            if (isJunit5Test) {
                                 return StatementDef.multi();
+                            } else if (isIntrospectedBean) {
+                                ExpressionDef pythonInstance = PYTHON_CONTEXT_RUNTIME
+                                    .invokeStatic(isAbstractIntroNoArg ? "newIntroduction" : "newInstance", POLYGLOT_VALUE,
+                                        List.of(pythonClassReference(element, pythonClassReference))
+                                    );
+                                return aThis.invokeConstructor(pythonInstance);
                             } else {
                                 ExpressionDef pythonInstance = PYTHON_CONTEXT_RUNTIME
                                     .invokeStatic(isAbstractIntroNoArg ? "newIntroduction" : "newInstance", POLYGLOT_VALUE,

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -430,7 +430,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
 
                     if (!isJunit5Test && !extendsHostClass) {
                         if (isIntrospectedBean) {
-                            builder.addMethod(
+                        builder.addMethod(
                                 MethodDef.constructor()
                                     .addModifiers(Modifier.PUBLIC)
                                     .addParameter(ParameterDef.of("value", POLYGLOT_VALUE))
@@ -698,12 +698,15 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                             List<ExpressionDef> superArguments = superConstructorArguments(superType, parameters, methodParameters);
                                             return StatementDef.multi(
                                                 aThis.superRef().invokeSuperConstructor(superArguments),
-                                                aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(pythonInstance)
+                                                initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal, false)
                                             );
                                         }
                                         return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal, extendsPythonClass);
                                     }
                                     List<StatementDef> assignments = new ArrayList<>();
+                                    if (extendsHostClass) {
+                                        assignments.add(aThis.superRef().invokeSuperConstructor(superConstructorArguments(superType, parameters, methodParameters)));
+                                    }
                                     if (constructorParametersBackedByFields) {
                                         // Ordinary field-backed introspected beans must not invoke a Python
                                         // constructor whose parameters are supplied by Micronaut.
@@ -792,7 +795,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                 if (extendsHostClass) {
                                     return StatementDef.multi(
                                         aThis.superRef().invokeSuperConstructor(superConstructorArguments(superType, new ParameterElement[0], methodParameters)),
-                                        aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(pythonInstance)
+                                        initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal, false)
                                     );
                                 }
                                 return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal, extendsPythonClass);

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -301,7 +301,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                     List<PropertyElement> beanProperties = element.getBeanProperties();
                     boolean hasDynamicBeanProperties = beanProperties.stream().anyMatch(PythonStubGenerator::isDynamicBeanProperty);
                     boolean hasConfigurationBuilderProperty = beanProperties.stream()
-                        .anyMatch(property -> property.hasAnnotation(ANN_CONFIGURATION_BUILDER));
+                        .anyMatch(PythonStubGenerator::isConfigurationBuilderProperty);
                     if (!isIntrospectedBean
                         && !isPythonDataclass(element)
                         && !hasConfigurationInjectConstructor(element)
@@ -3255,6 +3255,12 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
     private static boolean isDynamicBeanProperty(PropertyElement beanProperty) {
         return beanProperty.getReadMethod().filter(method -> !method.isSynthetic()).isPresent()
             || beanProperty.getWriteMethod().filter(method -> !method.isSynthetic()).isPresent();
+    }
+
+    private static boolean isConfigurationBuilderProperty(PropertyElement property) {
+        return property.hasAnnotation(ANN_CONFIGURATION_BUILDER)
+            || property.getReadMethod().map(method -> method.hasAnnotation(ANN_CONFIGURATION_BUILDER)).orElse(false)
+            || property.getWriteMethod().map(method -> method.hasAnnotation(ANN_CONFIGURATION_BUILDER)).orElse(false);
     }
 
     private static MethodElement resolveDeclaredBridgeMethod(ClassElement element, MethodElement interfaceMethod) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -121,6 +121,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
     public static final String GENERATOR_NAME = "python";
     private static final String HTTP_RESPONSE = "io.micronaut.http.HttpResponse";
     private static final String PUBLISHER = "org.reactivestreams.Publisher";
+    private static final String GET_MEMBER = "getMember";
     private static final String ANN_CONFIGURATION_BUILDER = "io.micronaut.context.annotation.ConfigurationBuilder";
     private static final String NEW_UNINITIALIZED_INSTANCE = "newUninitializedInstance";
     private static final String ANN_CONFIGURATION_INJECT = "io.micronaut.context.annotation.ConfigurationInject";
@@ -2822,7 +2823,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                 .addModifiers(Modifier.PUBLIC)
                 .returns(TypeDef.STRING)
                 .build((aThis, parameters) -> aThis.invoke(AS_POLYGLOT_VALUE, POLYGLOT_VALUE)
-                    .invoke("getMember", POLYGLOT_VALUE, ExpressionDef.constant("value"))
+                    .invoke(GET_MEMBER, POLYGLOT_VALUE, ExpressionDef.constant("value"))
                     .invoke("asString", TypeDef.STRING)
                     .returning()));
         }
@@ -3649,7 +3650,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
 
         builder.addMethod(getterBuilder.build(((aThis, methodParameters) -> {
             var invokedValue = aThis.invoke(AS_POLYGLOT_VALUE, POLYGLOT_VALUE).invoke(
-                "getMember",
+                GET_MEMBER,
                 POLYGLOT_VALUE,
                 ExpressionDef.constant(beanProperty.getName())
             );
@@ -3771,7 +3772,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
 
         builder.addMethod(getterBuilder.build(((aThis, methodParameters) -> {
             var invokedValue = aThis.field(pythonValue).invoke(
-                "getMember",
+                GET_MEMBER,
                 POLYGLOT_VALUE,
                 ExpressionDef.constant(beanProperty.getName())
             );
@@ -3987,7 +3988,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                 continue;
             }
             ExpressionDef.InvokeInstanceMethod has = value.invoke("hasMember", TypeDef.Primitive.BOOLEAN, ExpressionDef.constant(beanProperty.getName()));
-            ExpressionDef.InvokeInstanceMethod member = value.invoke("getMember", POLYGLOT_VALUE, ExpressionDef.constant(beanProperty.getName()));
+            ExpressionDef.InvokeInstanceMethod member = value.invoke(GET_MEMBER, POLYGLOT_VALUE, ExpressionDef.constant(beanProperty.getName()));
             ExpressionDef valueExpression = convertValueForType(beanProperty.getGenericType(), member);
             statements.add(isCollectionLike(beanProperty.getGenericType())
                 ? aThis.field(field).assign(valueExpression)

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -716,7 +716,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                                 aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(pythonInstance)
                                             );
                                         }
-                                        return aThis.invokeConstructor(pythonInstance);
+                                        return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal);
                                     }
                                     List<StatementDef> assignments = new ArrayList<>();
                                     if (constructorParametersBackedByFields) {
@@ -767,7 +767,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         arguments
                                     );
                                     if (isIntrospectedBean && !extendsHostClass) {
-                                        return aThis.invokeConstructor(pythonInstance);
+                                        return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal);
                                     } else if (extendsPythonClass) {
                                         return aThis.superRef().invokeSuperConstructor(pythonInstance);
                                     } else if (extendsHostClass) {
@@ -810,7 +810,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(pythonInstance)
                                     );
                                 }
-                                return aThis.invokeConstructor(pythonInstance);
+                                return initializeFromPolyglotValue(aThis, pythonInstance, beanProperties, propertyFields, pythonValueFinal);
                             } else if (isIntrospectedBean) {
                                 // Keep ordinary introspected beans lazy; resolving their Python class here
                                 // would break beans whose Python constructor requires arguments.
@@ -3968,6 +3968,33 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                 .doIf(ExpressionDef.nullValue().returning()),
             thisType.instantiate(value).returning()
         );
+    }
+
+    private StatementDef initializeFromPolyglotValue(
+        VariableDef.This aThis,
+        ExpressionDef value,
+        List<PropertyElement> beanProperties,
+        Map<String, FieldDef> propertyFields,
+        @Nullable FieldDef pythonValueField
+    ) {
+        List<StatementDef> statements = new ArrayList<>();
+        if (pythonValueField != null) {
+            statements.add(aThis.field(pythonValueField).assign(value));
+        }
+        ExpressionDef storedValue = pythonValueField == null ? value : aThis.field(pythonValueField);
+        for (PropertyElement beanProperty : beanProperties) {
+            FieldDef field = propertyFields.get(beanProperty.getName());
+            if (field == null) {
+                continue;
+            }
+            ExpressionDef member = storedValue.invoke("getMember", POLYGLOT_VALUE, ExpressionDef.constant(beanProperty.getName()));
+            ExpressionDef converted = convertValueForType(beanProperty.getGenericType(), member);
+            ExpressionDef hasMember = storedValue.invoke("hasMember", TypeDef.Primitive.BOOLEAN, ExpressionDef.constant(beanProperty.getName()));
+            statements.add(isCollectionLike(beanProperty.getGenericType())
+                ? aThis.field(field).assign(converted)
+                : hasMember.isTrue().doIf(aThis.field(field).assign(converted)));
+        }
+        return StatementDef.multi(statements);
     }
 
     private static ExpressionDef convertNullableValue(ExpressionDef value, ExpressionDef nonNullValue) {

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -119,13 +119,21 @@ final class PyronautCompilerTest {
         // the generated application entry point is the stable in-memory output.
         assertNotNull(classLoader.loadClass("pyronaut_application.PyronautMain"));
 
+        Files.createDirectories(outputDirectory);
         PyronautCompiler.builder()
             .pythonSrc(sourceDirectory.toString())
             .targetDir(outputDirectory.toFile())
             .build()
             .compile();
-        String generated = Files.readString(outputDirectory.resolve("example/micronaut/TeamConfiguration.java"));
-        assertTrue(generated.contains("PythonContextRuntime.newUninitializedInstance"));
+        Path generatedSource;
+        try (var paths = Files.walk(outputDirectory)) {
+            generatedSource = paths
+                .filter(path -> path.getFileName().toString().equals("TeamConfiguration.java"))
+                .findFirst()
+                .orElseThrow();
+        }
+        String generated = Files.readString(generatedSource);
+        assertTrue(generated.contains("PythonContextRuntime.newInstance"));
     }
 
     @Test

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -80,6 +80,34 @@ final class PyronautCompilerTest {
     }
 
     @Test
+    void compilesParameterizedIntrospectedPythonConfigurationBean(@TempDir Path sourceDirectory) throws Exception {
+        Files.writeString(sourceDirectory.resolve("team_configuration.py"), """
+            from dataclasses import dataclass, field
+            from typing import Annotated
+
+            from micronaut.context.annotation import ConfigurationBuilder, ConfigurationProperties
+
+            @ConfigurationProperties("team")
+            @dataclass(init=False)
+            class TeamConfiguration:
+                name: str | None = None
+                player_names: list[str] = field(default_factory=list)
+                builder: Annotated[object, ConfigurationBuilder(prefixes="with_", configurationPrefix="team-admin")] = field(init=False)
+
+                def __init__(self, name: str | None = None, player_names: list[str] | None = None):
+                    self.name = name
+                    self.player_names = player_names or []
+        """);
+
+        ClassLoader classLoader = PyronautCompiler.builder()
+            .pythonSrc(sourceDirectory.toString())
+            .build()
+            .buildClassLoader();
+
+        assertNotNull(classLoader.loadClass("pyronaut_application.TeamConfiguration"));
+    }
+
+    @Test
     void optionallyIncludesPythonBytecodeInTheInMemoryVfs() throws Exception {
         ClassLoader classLoader = PyronautCompiler.builder()
             .pythonCode("answer = 42")

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -109,6 +109,7 @@ final class PyronautCompilerTest {
                     self.player_names = player_names or []
         """.indent(-4));
 
+        Path outputDirectory = sourceDirectory.resolve("output");
         ClassLoader classLoader = PyronautCompiler.builder()
             .pythonSrc(sourceDirectory.toString())
             .build()
@@ -117,6 +118,14 @@ final class PyronautCompilerTest {
         // Compilation must complete for the parameterized configuration shape;
         // the generated application entry point is the stable in-memory output.
         assertNotNull(classLoader.loadClass("pyronaut_application.PyronautMain"));
+
+        PyronautCompiler.builder()
+            .pythonSrc(sourceDirectory.toString())
+            .targetDir(outputDirectory.toFile())
+            .build()
+            .compile();
+        String generated = Files.readString(outputDirectory.resolve("example/micronaut/TeamConfiguration.java"));
+        assertTrue(generated.contains("PythonContextRuntime.newUninitializedInstance"));
     }
 
     @Test

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -102,11 +102,12 @@ final class PyronautCompilerTest {
             class TeamConfiguration:
                 name: str | None = None
                 player_names: list[str] = field(default_factory=list)
-                builder: Annotated[TeamBuilder, ConfigurationBuilder(prefixes="with_", configurationPrefix="team-admin")] = field(default_factory=TeamBuilder, init=False)
+                builder: Annotated[TeamBuilder, ConfigurationBuilder(prefixes="with_", configurationPrefix="team-admin")] = field(init=False)
 
                 def __init__(self, name: str | None = None, player_names: list[str] | None = None):
                     self.name = name
                     self.player_names = player_names or []
+                    self.builder = TeamBuilder()
         """.indent(-4));
 
         Path outputDirectory = sourceDirectory.resolve("output");

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -86,25 +86,37 @@ final class PyronautCompilerTest {
             from typing import Annotated
 
             from micronaut.context.annotation import ConfigurationBuilder, ConfigurationProperties
+            from micronaut.core.annotation import Introspected
+
+            @Introspected
+            class TeamBuilder:
+                value: str | None = None
+
+                def with_name(self, value: str):
+                    self.value = value
+                    return self
 
             @ConfigurationProperties("team")
+            @Introspected
             @dataclass(init=False)
             class TeamConfiguration:
                 name: str | None = None
                 player_names: list[str] = field(default_factory=list)
-                builder: Annotated[object, ConfigurationBuilder(prefixes="with_", configurationPrefix="team-admin")] = field(init=False)
+                builder: Annotated[TeamBuilder, ConfigurationBuilder(prefixes="with_", configurationPrefix="team-admin")] = field(default_factory=TeamBuilder, init=False)
 
                 def __init__(self, name: str | None = None, player_names: list[str] | None = None):
                     self.name = name
                     self.player_names = player_names or []
-        """);
+        """.indent(-4));
 
         ClassLoader classLoader = PyronautCompiler.builder()
             .pythonSrc(sourceDirectory.toString())
             .build()
             .buildClassLoader();
 
-        assertNotNull(classLoader.loadClass("pyronaut_application.TeamConfiguration"));
+        // Compilation must complete for the parameterized configuration shape;
+        // the generated application entry point is the stable in-memory output.
+        assertNotNull(classLoader.loadClass("pyronaut_application.PyronautMain"));
     }
 
     @Test


### PR DESCRIPTION
Fix generated parameterized introspected Python beans so their GraalPy backing value is initialized before Micronaut configuration-builder property injection. Adds a PyronautCompiler regression fixture covering a ConfigurationProperties bean with a parameterized constructor and ConfigurationBuilder property. The focused inject-python build compiles the regression test classes successfully; the test task is skipped by the repository test configuration.