### PR TITLE
A bean introspection describes only the constructor it instantiates beans with

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -33,6 +33,7 @@ import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.annotation.AnnotationMetadataReference;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ConstructorElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.EnumConstantElement;
@@ -98,6 +99,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
     private static final String FIELD_CONSTRUCTOR_ARGUMENTS = "$CONSTRUCTOR_ARGUMENTS";
     private static final String FIELD_BEAN_PROPERTIES_REFERENCES = "$PROPERTIES_REFERENCES";
     private static final String FIELD_BEAN_METHODS_REFERENCES = "$METHODS_REFERENCES";
+    private static final String FIELD_BEAN_CONSTRUCTORS_REFERENCES = "$CONSTRUCTORS_REFERENCES";
     private static final String FIELD_ENUM_CONSTANTS_REFERENCES = "$ENUM_CONSTANTS_REFERENCES";
     private static final java.lang.reflect.Method FIND_PROPERTY_BY_INDEX_METHOD =
         ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanIntrospection.class, "getPropertyByIndex", int.class);
@@ -135,6 +137,24 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
         Argument[].class,
         AbstractInitializableBeanIntrospection.BeanPropertyRef[].class,
         AbstractInitializableBeanIntrospection.BeanMethodRef[].class
+    );
+
+    private static final java.lang.reflect.Constructor<?> INTROSPECTION_SUPER_CONSTRUCTOR_WITH_CONSTRUCTORS = ReflectionUtils.getRequiredInternalConstructor(
+        AbstractInitializableBeanIntrospectionAndReference.class,
+        Class.class,
+        AnnotationMetadata.class,
+        AnnotationMetadata.class,
+        Argument[].class,
+        AbstractInitializableBeanIntrospection.BeanPropertyRef[].class,
+        AbstractInitializableBeanIntrospection.BeanMethodRef[].class,
+        AbstractInitializableBeanIntrospection.BeanConstructorRef[].class
+    );
+
+    private static final java.lang.reflect.Constructor<?> BEAN_CONSTRUCTOR_REF_CONSTRUCTOR = ReflectionUtils.getRequiredInternalConstructor(
+        AbstractInitializableBeanIntrospection.BeanConstructorRef.class,
+        AnnotationMetadata.class,
+        Argument[].class,
+        int.class
     );
 
     private static final java.lang.reflect.Constructor<?> ENUM_INTROSPECTION_SUPER_CONSTRUCTOR = ReflectionUtils.getRequiredInternalConstructor(
@@ -184,6 +204,16 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
         "hasConstructor"
     );
 
+    private static final java.lang.reflect.Method INSTANTIATE_CONSTRUCTOR_INTERNAL_METHOD = ReflectionUtils.getRequiredInternalMethod(
+        AbstractInitializableBeanIntrospection.class,
+        "instantiateConstructorInternal", int.class, Object[].class
+    );
+
+    private static final java.lang.reflect.Method UNKNOWN_DISPATCH_AT_INDEX_METHOD = ReflectionUtils.getRequiredInternalMethod(
+        AbstractInitializableBeanIntrospection.class,
+        "unknownDispatchAtIndexException", int.class
+    );
+
     private final String introspectionName;
     private final ClassTypeDef introspectionTypeDef;
     private final Map<AnnotationWithValue, String> indexByAnnotationAndValue = new HashMap<>(2);
@@ -196,6 +226,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
 
     private final List<BeanPropertyData> beanProperties = new ArrayList<>();
     private final List<BeanMethodData> beanMethods = new ArrayList<>();
+    private final List<MethodElement> declaredConstructors = new ArrayList<>();
 
     private final DispatchWriter dispatchWriter;
     private final EvaluatedExpressionProcessor evaluatedExpressionProcessor;
@@ -671,6 +702,34 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
         } else {
             beanMethodsField = null;
         }
+        FieldDef beanConstructorsField;
+        List<MethodElement> orderedDeclaredConstructors = isEnum ? List.of() : getOrderedDeclaredConstructors();
+        if (!orderedDeclaredConstructors.isEmpty()) {
+            ClassTypeDef beanConstructorRefType = ClassTypeDef.of(AbstractInitializableBeanIntrospection.BeanConstructorRef.class);
+            List<ExpressionDef> constructorsExpressions = new ArrayList<>();
+            for (int i = 0; i < orderedDeclaredConstructors.size(); i++) {
+                MethodElement declaredConstructor = orderedDeclaredConstructors.get(i);
+                int constructorIndex = i;
+                MethodDef metadataMethod = MethodDef.builder("$constructor$" + constructorIndex + "$metadata")
+                    .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                    .returns(beanConstructorRefType)
+                    .build((aThis, methodParameters) -> newBeanConstructorRef(declaredConstructor, constructorIndex, loadClassValueExpressionFn).returning());
+                classDefBuilder.addMethod(metadataMethod);
+                constructorsExpressions.add(thisType.invokeStatic(metadataMethod));
+            }
+            beanConstructorsField = FieldDef.builder(FIELD_BEAN_CONSTRUCTORS_REFERENCES, AbstractInitializableBeanIntrospection.BeanConstructorRef[].class)
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL, Modifier.STATIC)
+                .initializer(
+                    beanConstructorRefType.array()
+                        .instantiate(
+                            constructorsExpressions
+                        )
+                )
+                .build();
+            classDefBuilder.addField(beanConstructorsField);
+        } else {
+            beanConstructorsField = null;
+        }
         if (isEnum) {
             enumsField = FieldDef.builder(FIELD_ENUM_CONSTANTS_REFERENCES, AbstractEnumBeanIntrospectionAndReference.EnumConstantDynamicRef[].class)
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL, Modifier.STATIC)
@@ -748,11 +807,18 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
                     if (enumsField != null) {
                         values.add(introspectionTypeDef.getStaticField(enumsField));
                         return aThis.superRef().invokeConstructor(ENUM_INTROSPECTION_SUPER_CONSTRUCTOR, values);
+                    } else if (beanConstructorsField != null) {
+                        values.add(introspectionTypeDef.getStaticField(beanConstructorsField));
+                        return aThis.superRef().invokeConstructor(INTROSPECTION_SUPER_CONSTRUCTOR_WITH_CONSTRUCTORS, values);
                     } else {
                         return aThis.superRef().invokeConstructor(INTROSPECTION_SUPER_CONSTRUCTOR, values);
                     }
                 })
         );
+
+        if (!orderedDeclaredConstructors.isEmpty()) {
+            classDefBuilder.addMethod(getInstantiateConstructorMethod(orderedDeclaredConstructors));
+        }
 
         MethodDef dispatchOneMethod = dispatchWriter.buildDispatchOneMethod();
         if (dispatchOneMethod != null) {
@@ -965,6 +1031,95 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
         throw new IllegalStateException("Property not found: " + propertyName + " " + beanClassElement.getName());
     }
 
+    /**
+     * Orders the visited declared constructors so that the constructor described by
+     * {@link BeanIntrospection#getConstructor()} comes first, per the contract of
+     * {@link BeanIntrospection#getConstructors()}.
+     */
+    private List<MethodElement> getOrderedDeclaredConstructors() {
+        if (declaredConstructors.isEmpty()) {
+            return List.of();
+        }
+        List<MethodElement> ordered = new ArrayList<>(declaredConstructors);
+        MethodElement instantiatingConstructor = constructor != null ? constructor : defaultConstructor;
+        if (instantiatingConstructor != null) {
+            MethodElement match = instantiatingConstructor instanceof ConstructorElement
+                ? ordered.stream().filter(candidate -> isSameConstructor(candidate, instantiatingConstructor)).findFirst().orElse(null)
+                : null;
+            if (match != null) {
+                ordered.remove(match);
+                ordered.add(0, match);
+            } else {
+                // a static creator, or a constructor that was not visited as a declared one
+                ordered.add(0, instantiatingConstructor);
+            }
+        }
+        return ordered;
+    }
+
+    private static boolean isSameConstructor(MethodElement a, MethodElement b) {
+        if (a == b) {
+            return true;
+        }
+        ParameterElement[] parameters1 = a.getParameters();
+        ParameterElement[] parameters2 = b.getParameters();
+        if (parameters1.length != parameters2.length) {
+            return false;
+        }
+        for (int i = 0; i < parameters1.length; i++) {
+            if (!parameters1[i].getType().getName().equals(parameters2[i].getType().getName())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private ExpressionDef newBeanConstructorRef(MethodElement declaredConstructor,
+                                                int constructorIndex,
+                                                Function<String, ExpressionDef> loadClassValueExpressionFn) {
+        return ClassTypeDef.of(AbstractInitializableBeanIntrospection.BeanConstructorRef.class)
+            .instantiate(
+                BEAN_CONSTRUCTOR_REF_CONSTRUCTOR,
+
+                // 1: annotation metadata
+                getAnnotationMetadataExpression(declaredConstructor.getAnnotationMetadata(), loadClassValueExpressionFn),
+                // 2: arguments
+                ArrayUtils.isEmpty(declaredConstructor.getParameters()) ? ExpressionDef.nullValue() : ArgumentExpUtils.pushBuildArgumentsForMethod(
+                    annotationMetadata,
+                    declaredConstructor.getOwningType(),
+                    introspectionTypeDef,
+                    Arrays.asList(declaredConstructor.getParameters()),
+                    loadClassValueExpressionFn
+                ),
+                // 3: instantiate dispatch index
+                ExpressionDef.constant(constructorIndex)
+            );
+    }
+
+    private MethodDef getInstantiateConstructorMethod(List<MethodElement> orderedDeclaredConstructors) {
+        return MethodDef.override(INSTANTIATE_CONSTRUCTOR_INTERNAL_METHOD)
+            .build((aThis, methodParameters) -> {
+                Map<ExpressionDef.Constant, StatementDef> switchCases = new LinkedHashMap<>();
+                for (int i = 0; i < orderedDeclaredConstructors.size(); i++) {
+                    MethodElement declaredConstructor = orderedDeclaredConstructors.get(i);
+                    List<StatementDef> statements = new ArrayList<>();
+                    List<ExpressionDef> values = IntStream.range(0, declaredConstructor.getParameters().length)
+                        .<ExpressionDef>mapToObj(index -> methodParameters.get(1).arrayElement(index))
+                        .toList();
+                    statements.add(
+                        MethodGenUtils.invokeBeanConstructor(ClassElement.of(introspectionName), declaredConstructor, true, values, statements)
+                            .returning()
+                    );
+                    switchCases.put(ExpressionDef.constant(i), StatementDef.multi(statements));
+                }
+                return methodParameters.get(0).asStatementSwitch(
+                    TypeDef.OBJECT,
+                    switchCases,
+                    aThis.invoke(UNKNOWN_DISPATCH_AT_INDEX_METHOD, methodParameters.get(0)).doThrow()
+                );
+            });
+    }
+
     private MethodDef getInstantiateMethod(MethodElement constructor, Method method) {
         return MethodDef.override(method)
             .build((aThis, methodParameters) -> {
@@ -1032,6 +1187,17 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
      */
     void visitDefaultConstructor(MethodElement constructor) {
         this.defaultConstructor = constructor;
+        processConstructorEvaluatedMetadata(constructor);
+    }
+
+    /**
+     * Visit a declared constructor that should be described by the introspection and exposed via
+     * {@link BeanIntrospection#getConstructors()}.
+     *
+     * @param constructor The constructor
+     */
+    void visitDeclaredConstructor(MethodElement constructor) {
+        declaredConstructors.add(constructor);
         processConstructorEvaluatedMetadata(constructor);
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -101,6 +101,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
     private static final String FIELD_BEAN_METHODS_REFERENCES = "$METHODS_REFERENCES";
     private static final String FIELD_BEAN_CONSTRUCTORS_REFERENCES = "$CONSTRUCTORS_REFERENCES";
     private static final String FIELD_ENUM_CONSTANTS_REFERENCES = "$ENUM_CONSTANTS_REFERENCES";
+    private static final String METADATA_METHOD_SUFFIX = "$metadata";
     private static final java.lang.reflect.Method FIND_PROPERTY_BY_INDEX_METHOD =
         ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanIntrospection.class, "getPropertyByIndex", int.class);
 
@@ -638,7 +639,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
             ClassTypeDef beanPropertyRefType = ClassTypeDef.of(AbstractInitializableBeanIntrospection.BeanPropertyRef.class);
             List<ExpressionDef> propsExpressions = new ArrayList<>();
             for (BeanPropertyData beanProperty : beanProperties) {
-                MethodDef metadataMethod = MethodDef.builder("$property$" + beanProperty.name + "$metadata")
+                MethodDef metadataMethod = MethodDef.builder("$property$" + beanProperty.name + METADATA_METHOD_SUFFIX)
                     .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
                     .returns(beanPropertyRefType)
                     .build((aThis, methodParameters) -> {
@@ -677,7 +678,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
                 while (!usedNames.add(methodName)) {
                     methodName += index++;
                 }
-                MethodDef metadataMethod = MethodDef.builder("$method$" + methodName + "$metadata")
+                MethodDef metadataMethod = MethodDef.builder("$method$" + methodName + METADATA_METHOD_SUFFIX)
                     .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
                     .returns(beanMethodRefType)
                     .build((aThis, methodParameters) -> newBeanMethodRef(beanMethod, loadClassValueExpressionFn).returning());
@@ -710,7 +711,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
             for (int i = 0; i < orderedDeclaredConstructors.size(); i++) {
                 MethodElement declaredConstructor = orderedDeclaredConstructors.get(i);
                 int constructorIndex = i;
-                MethodDef metadataMethod = MethodDef.builder("$constructor$" + constructorIndex + "$metadata")
+                MethodDef metadataMethod = MethodDef.builder("$constructor$" + constructorIndex + METADATA_METHOD_SUFFIX)
                     .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
                     .returns(beanConstructorRefType)
                     .build((aThis, methodParameters) -> newBeanConstructorRef(declaredConstructor, constructorIndex, loadClassValueExpressionFn).returning());
@@ -806,12 +807,12 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
 
                     if (enumsField != null) {
                         values.add(introspectionTypeDef.getStaticField(enumsField));
-                        return aThis.superRef().invokeConstructor(ENUM_INTROSPECTION_SUPER_CONSTRUCTOR, values);
+                        return aThis.superRef().invokeSuperConstructor(ENUM_INTROSPECTION_SUPER_CONSTRUCTOR, values);
                     } else if (beanConstructorsField != null) {
                         values.add(introspectionTypeDef.getStaticField(beanConstructorsField));
-                        return aThis.superRef().invokeConstructor(INTROSPECTION_SUPER_CONSTRUCTOR_WITH_CONSTRUCTORS, values);
+                        return aThis.superRef().invokeSuperConstructor(INTROSPECTION_SUPER_CONSTRUCTOR_WITH_CONSTRUCTORS, values);
                     } else {
-                        return aThis.superRef().invokeConstructor(INTROSPECTION_SUPER_CONSTRUCTOR, values);
+                        return aThis.superRef().invokeSuperConstructor(INTROSPECTION_SUPER_CONSTRUCTOR, values);
                     }
                 })
         );

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -171,6 +171,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     getExternalPropertyElementQuery(element, ce, ignoreSettersWithDifferingType),
                     ce,
                     writer,
+                    isDescribeConstructors(ce, introspected),
                     context
                 );
             });
@@ -203,6 +204,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                             getExternalPropertyElementQuery(element, classElement, ignoreSettersWithDifferingType),
                             classElement,
                             writer,
+                            isDescribeConstructors(classElement, introspected),
                             context);
                     }
                 }
@@ -230,8 +232,12 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     context
                 );
             }
-            processElement(metadata, indexedAnnotations, element, writer, ignoreSettersWithDifferingType, context);
+            processElement(metadata, indexedAnnotations, element, writer, ignoreSettersWithDifferingType, isDescribeConstructors(element, introspected), context);
         }
+    }
+
+    private static boolean isDescribeConstructors(ClassElement ce, AnnotationValue<Introspected> introspected) {
+        return ce.findAnnotation(Introspected.class).orElse(introspected).booleanValue("constructors").orElse(false);
     }
 
     private void processBuilderDefinition(ClassElement element, VisitorContext context, AnnotationValue<Introspected> introspected, int index, String targetPackage, boolean useLongBuilderName) {
@@ -387,6 +393,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                                 ClassElement ce,
                                 BeanIntrospectionWriter writer,
                                 boolean ignoreSettersWithDifferingType,
+                                boolean describeConstructors,
                                 VisitorContext visitorContext) {
 
         processElement(metadata,
@@ -394,6 +401,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             PropertyElementQuery.of(ce).ignoreSettersWithDifferingType(ignoreSettersWithDifferingType),
             ce,
             writer,
+            describeConstructors,
             visitorContext
         );
     }
@@ -507,6 +515,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                                 PropertyElementQuery propertyElementQuery,
                                 ClassElement ce,
                                 BeanIntrospectionWriter writer,
+                                boolean describeConstructors,
                                 VisitorContext context) {
         if (isAlreadyWritten(ce, writer)) {
             processed.add(ce.getName());
@@ -522,6 +531,14 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             }
         });
         ce.getDefaultConstructor().ifPresent(writer::visitDefaultConstructor);
+
+        if (!ce.isEnum()) {
+            for (MethodElement declaredConstructor : ce.getEnclosedElements(ElementQuery.CONSTRUCTORS)) {
+                if (describeConstructors || declaredConstructor.hasDeclaredStereotype(Executable.class)) {
+                    writer.visitDeclaredConstructor(declaredConstructor);
+                }
+            }
+        }
 
         for (PropertyElement beanProperty : beanProperties) {
             if (beanProperty.isExcluded()) {

--- a/core/src/main/java/io/micronaut/core/annotation/Introspected.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Introspected.java
@@ -206,6 +206,20 @@ public @interface Introspected {
     IntrospectionBuilder builder() default @IntrospectionBuilder();
 
     /**
+     * Whether every declared constructor of the type should be described by the introspection and
+     * exposed via {@link io.micronaut.core.beans.BeanIntrospection#getConstructors()}, including
+     * each constructor's annotation metadata and the annotation metadata of its parameters.
+     *
+     * <p>The default is {@code false} so that only the constructor used to instantiate beans is
+     * described. Individual constructors can also be opted in by annotating them with
+     * {@code io.micronaut.context.annotation.Executable}.</p>
+     *
+     * @return True if all declared constructors should be described
+     * @since 5.2.0
+     */
+    boolean constructors() default false;
+
+    /**
      * Configuration for an introspection builder.
      */
     @Documented

--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
@@ -386,6 +386,23 @@ public interface BeanIntrospection<T> extends AnnotationMetadataDelegate, BeanIn
     }
 
     /**
+     * Returns the constructors this introspection describes.
+     *
+     * <p>By default an introspection only describes the constructor used to instantiate beans, in
+     * which case this method returns a singleton list containing {@link #getConstructor()}. When the
+     * introspected type opts in via {@link io.micronaut.core.annotation.Introspected#constructors()},
+     * or by annotating individual constructors with {@code io.micronaut.context.annotation.Executable},
+     * every described constructor is returned, including its own annotation metadata and the
+     * annotation metadata of its parameters.</p>
+     *
+     * @return Every described constructor of the type, {@link #getConstructor()} first
+     * @since 5.2.0
+     */
+    default List<BeanConstructor<T>> getConstructors() {
+        return List.of(getConstructor());
+    }
+
+    /**
      * Obtains an introspection from the default {@link BeanIntrospector}.
      *
      * @param type The type

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2645,4 +2645,70 @@ class Test extends MySuperclass {
         and: 'the package private superclass property is introspected, as we are in the same package'
         introspection.getProperty("packagePrivateProperty").orElse(null)
     }
+
+    void "every declared constructor is described"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(constructors = true)
+class Order {
+    String name
+    int quantity
+
+    Order() {}
+    Order(String name) { this.name = name }
+    Order(String name, int quantity) { this.name = name; this.quantity = quantity }
+}
+''')
+
+        then:
+        introspection.getConstructors().size() == 3
+        introspection.getConstructors()[0].arguments.length == introspection.constructor.arguments.length
+        introspection.getConstructors()*.arguments*.length.toSorted() == [0, 1, 2]
+    }
+
+    void "instantiating through a described constructor works"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(constructors = true)
+class Order {
+    String name
+
+    Order() { this.name = "none" }
+    Order(String name) { this.name = name }
+}
+''')
+        def order = introspection.getConstructors().find { it.arguments.length == 1 }.instantiate("abc")
+
+        then:
+        introspection.getRequiredProperty("name", String).get(order) == "abc"
+    }
+
+    void "an introspection that did not ask for constructors keeps describing one"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Order {
+    String name
+
+    Order() {}
+    Order(String name) { this.name = name }
+}
+''')
+
+        then:
+        introspection.getConstructors().size() == 1
+        introspection.getConstructors()[0].arguments.length == introspection.constructor.arguments.length
+    }
 }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -37,6 +37,7 @@ import jakarta.validation.Constraint
 import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import spock.lang.Issue
 
@@ -6189,6 +6190,166 @@ class SharedBuilder {
 
         cleanup:
         context?.close()
+    }
+
+    void "every declared constructor is described"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.NotNull;
+
+@Introspected(constructors = true)
+class Order {
+    Order() {}
+    Order(@NotNull String name) {}
+    Order(String name, int quantity) {}
+}
+''')
+
+        when:
+        def constructors = introspection.getConstructors()
+
+        then:
+        constructors.size() == 3
+        // getConstructor() first, per the contract
+        constructors[0].arguments.length == introspection.constructor.arguments.length
+        constructors*.arguments*.length.toSorted() == [0, 1, 2]
+    }
+
+    void "a constructor carries the annotations of its parameters"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+@Introspected(constructors = true)
+class Order {
+    Order() {}
+    Order(@NotNull String name, List<@Valid Line> lines) {}
+}
+
+class Line {}
+''')
+
+        when:
+        def constructor = introspection.getConstructors().find { it.arguments.length == 2 }
+
+        then:
+        constructor.arguments[0].annotationMetadata.hasAnnotation(NotNull)
+        constructor.arguments[1].typeParameters[0].annotationMetadata.hasAnnotation('jakarta.validation.Valid')
+    }
+
+    void "a constructor carries its own annotations"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(constructors = true)
+class Order {
+    Order() {}
+    @Deprecated Order(String name) {}
+}
+''')
+
+        expect:
+        introspection.getConstructors().find { it.arguments.length == 1 }.annotationMetadata.hasAnnotation(Deprecated)
+    }
+
+    void "an introspection that did not ask for constructors keeps describing one"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class Order {
+    Order() {}
+    Order(String name) {}
+}
+''')
+
+        expect:
+        introspection.getConstructors().size() == 1
+        introspection.getConstructors()[0].arguments.length == introspection.constructor.arguments.length
+    }
+
+    void "a constructor annotated as executable is described"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected
+class Order {
+    Order() {}
+    @Executable Order(String name) {}
+    Order(String name, int quantity) {}
+}
+''')
+
+        when:
+        def constructors = introspection.getConstructors()
+
+        then:
+        // the bean instantiating constructor, plus the one asked for by @Executable
+        constructors.size() == 2
+        constructors[0].arguments.length == introspection.constructor.arguments.length
+        constructors[1].arguments.length == 1
+    }
+
+    void "instantiating through a described constructor works"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(constructors = true)
+class Order {
+    final String name;
+    Order() { this.name = "none"; }
+    Order(String name) { this.name = name; }
+    public String getName() { return name; }
+}
+''')
+
+        when:
+        def order = introspection.getConstructors().find { it.arguments.length == 1 }.instantiate("abc")
+
+        then:
+        introspection.getRequiredProperty("name", String).get(order) == "abc"
+    }
+
+    void "type level executable does not sweep in every constructor"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected
+@Executable
+class Order {
+    Order() {}
+    Order(String name) {}
+    Order(String name, int quantity) {}
+}
+''')
+
+        expect:
+        introspection.getConstructors().size() == 1
     }
 
     @Override

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -6807,6 +6807,137 @@ class Order {
     }
 
 
+    void "a constructor described via @Executable does not become a bean method"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected
+class Order {
+    Order() {}
+
+    @Executable
+    Order(String name) {}
+}
+''')
+
+        expect: 'the constructor is described as a constructor'
+        introspection.getConstructors().size() == 2
+
+        and: 'and does not show up among the bean methods'
+        introspection.getBeanMethods().isEmpty()
+        introspection.getBeanMethods().every { it.name != '<init>' }
+    }
+
+    void "constructors = true does not add anything to the bean methods"() {
+        given: 'the same type built with and without the member'
+        def source = '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected(%s)
+class Order {
+    private String name;
+
+    Order() {}
+    Order(String name) { this.name = name; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    @Executable
+    public String describe() { return "order:" + name; }
+}
+'''
+        def baseline = buildBeanIntrospection('test.Order', String.format(source, ''))
+        def described = buildBeanIntrospection('test.Order', String.format(source, 'constructors = true'))
+
+        expect: 'the bean methods are untouched'
+        described.getBeanMethods().size() == baseline.getBeanMethods().size()
+        described.getBeanMethods()*.name.toSorted() == baseline.getBeanMethods()*.name.toSorted()
+        described.getBeanMethods()*.name == ['describe']
+
+        and: 'only the described constructors grew'
+        baseline.getConstructors().size() == 1
+        described.getConstructors().size() == 2
+
+        and: 'a bean method still works on an instance built through a described constructor'
+        described.getBeanMethods()[0].invoke(
+            described.getConstructors().find { it.arguments.length == 1 }.instantiate("abc")
+        ) == 'order:abc'
+    }
+
+    void "an @Executable method does not become a described constructor"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected(constructors = true)
+class Order {
+    Order() {}
+    Order(String name) {}
+
+    @Executable
+    public String describe() { return "described"; }
+
+    @Executable
+    public String describe(String prefix) { return prefix; }
+}
+''')
+
+        expect: 'the constructors are exactly the declared ones, not the methods'
+        introspection.getConstructors().size() == 2
+        introspection.getConstructors()*.arguments*.length.toSorted() == [0, 1]
+
+        and: 'the methods are exactly the executable ones'
+        introspection.getBeanMethods()*.name.toSorted() == ['describe', 'describe']
+    }
+
+    void "an @Executable constructor and an @Executable method land in their own buckets"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected
+class Order {
+    private String name;
+
+    Order() {}
+
+    @Executable
+    Order(String name) { this.name = name; }
+
+    public String getName() { return name; }
+
+    @Executable
+    public String describe() { return "order:" + name; }
+}
+''')
+
+        expect: 'the constructor bucket holds only constructors'
+        introspection.getConstructors().size() == 2
+        introspection.getConstructors().every { it.declaringBeanType.simpleName == 'Order' }
+
+        and: 'the method bucket holds only the method'
+        introspection.getBeanMethods().size() == 1
+        introspection.getBeanMethods()[0].name == 'describe'
+
+        and: 'both are usable through their own API'
+        introspection.getConstructors().find { it.arguments.length == 1 }.instantiate("abc") != null
+        introspection.getBeanMethods()[0].invoke(introspection.instantiate()) == 'order:null'
+    }
+
     @Override
     protected JavaParser newJavaParser() {
         return new JavaParser() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -6352,6 +6352,181 @@ class Order {
         introspection.getConstructors().size() == 1
     }
 
+    void "@Executable on a secondary constructor does not change the constructor beans are built with"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected
+class Order {
+    private final String name;
+
+    public Order() { this.name = "default-ctor"; }
+
+    @Executable
+    public Order(String name) { this.name = name; }
+
+    public String getName() { return name; }
+}
+''')
+
+        expect: 'the default constructor is still the one that builds beans'
+        introspection.constructor.arguments.length == 0
+        introspection.constructorArguments.length == 0
+        introspection.getRequiredProperty("name", String).get(introspection.instantiate()) == "default-ctor"
+
+        and: 'it is still described first, and the @Executable one is described too'
+        introspection.getConstructors().size() == 2
+        introspection.getConstructors()[0].arguments.length == 0
+        introspection.getConstructors()[1].arguments.length == 1
+    }
+
+    void "@Executable on a non-primary constructor does not change the primary constructor"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected
+class Order {
+    private final String name;
+    private final int quantity;
+
+    public Order(String name) { this.name = name; this.quantity = 0; }
+
+    @Executable
+    public Order(String name, int quantity) { this.name = name; this.quantity = quantity; }
+
+    public String getName() { return name; }
+    public int getQuantity() { return quantity; }
+}
+''')
+
+        expect: 'the first public constructor is still the primary one'
+        introspection.constructor.arguments.length == 1
+        introspection.constructorArguments.length == 1
+        introspection.getRequiredProperty("quantity", int).get(introspection.instantiate("abc")) == 0
+
+        and: 'the primary constructor is described first even though the other one asked to be described'
+        introspection.getConstructors()[0].arguments.length == 1
+    }
+
+    void "@Executable on a constructor does not override an explicit @Creator"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Creator;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected
+class Order {
+    private final String name;
+    private final int quantity;
+
+    @Executable
+    public Order(String name, int quantity) { this.name = name; this.quantity = quantity; }
+
+    @Creator
+    public Order(String name) { this.name = name; this.quantity = 42; }
+
+    public String getName() { return name; }
+    public int getQuantity() { return quantity; }
+}
+''')
+
+        expect: '@Creator still wins as the bean instantiating constructor'
+        introspection.constructor.arguments.length == 1
+        introspection.getRequiredProperty("quantity", int).get(introspection.instantiate("abc")) == 42
+
+        and: 'and is described first'
+        introspection.getConstructors()[0].arguments.length == 1
+    }
+
+    void "constructors = true does not change the constructor beans are built with"() {
+        given: 'the same type built with and without the member'
+        def source = '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(%s)
+class Order {
+    private final String name;
+    private final int quantity;
+
+    // declared first, but not public, so not the primary constructor
+    Order(String name, int quantity) { this.name = name; this.quantity = quantity; }
+
+    public Order() { this.name = "default-ctor"; this.quantity = 0; }
+    public Order(String name) { this.name = name; this.quantity = 0; }
+
+    public String getName() { return name; }
+    public int getQuantity() { return quantity; }
+}
+'''
+        def baseline = buildBeanIntrospection('test.Order', String.format(source, ''))
+        def described = buildBeanIntrospection('test.Order', String.format(source, 'constructors = true'))
+
+        expect: 'the instantiating constructor is unchanged'
+        described.constructor.arguments.length == baseline.constructor.arguments.length
+        described.constructorArguments.length == baseline.constructorArguments.length
+        described.isBuildable() == baseline.isBuildable()
+
+        and: 'instantiate() still runs the same constructor'
+        described.getRequiredProperty("name", String).get(described.instantiate()) ==
+            baseline.getRequiredProperty("name", String).get(baseline.instantiate())
+        described.getRequiredProperty("name", String).get(described.instantiate()) == "default-ctor"
+
+        and: 'only the described set grew'
+        baseline.getConstructors().size() == 1
+        described.getConstructors().size() == 3
+        described.getConstructors()[0].arguments.length == baseline.constructor.arguments.length
+    }
+
+    void "constructors = true does not change a primary constructor that takes arguments"() {
+        given:
+        def source = '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(%s)
+class Order {
+    private final String name;
+    private final int quantity;
+
+    // declared first, but not public, so not the primary constructor
+    Order(String name, int quantity) { this.name = name; this.quantity = quantity; }
+
+    public Order(String name) { this.name = name; this.quantity = 7; }
+
+    public String getName() { return name; }
+    public int getQuantity() { return quantity; }
+}
+'''
+        def baseline = buildBeanIntrospection('test.Order', String.format(source, ''))
+        def described = buildBeanIntrospection('test.Order', String.format(source, 'constructors = true'))
+
+        expect: 'the same single-argument constructor still builds beans'
+        baseline.constructor.arguments.length == 1
+        described.constructor.arguments.length == 1
+        described.getRequiredProperty("quantity", int).get(described.instantiate("abc")) ==
+            baseline.getRequiredProperty("quantity", int).get(baseline.instantiate("abc"))
+        described.getRequiredProperty("quantity", int).get(described.instantiate("abc")) == 7
+
+        and: 'and is described first, ahead of the constructor declared before it'
+        described.getConstructors().size() == 2
+        described.getConstructors()[0].arguments.length == 1
+        described.getConstructors()[1].arguments.length == 2
+    }
+
     @Override
     protected JavaParser newJavaParser() {
         return new JavaParser() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -6527,6 +6527,286 @@ class Order {
         described.getConstructors()[1].arguments.length == 2
     }
 
+    void "a described constructor preserves annotation values and stereotypes"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@interface Marker {}
+
+@Marker
+@Retention(RUNTIME)
+@Target(CONSTRUCTOR)
+@interface OrderCreator {
+    String value();
+    int max() default 5;
+}
+
+@Introspected(constructors = true)
+class Order {
+    Order() {}
+
+    @OrderCreator(value = "explicit", max = 10)
+    Order(String name) {}
+
+    @OrderCreator("only-value")
+    Order(String name, int quantity) {}
+}
+''')
+
+        when:
+        def oneArg = introspection.getConstructors().find { it.arguments.length == 1 }
+        def twoArg = introspection.getConstructors().find { it.arguments.length == 2 }
+
+        then: 'explicitly set members keep their values'
+        oneArg.annotationMetadata.hasAnnotation('test.OrderCreator')
+        oneArg.annotationMetadata.stringValue('test.OrderCreator').get() == 'explicit'
+        oneArg.annotationMetadata.intValue('test.OrderCreator', 'max').getAsInt() == 10
+
+        and: 'a member set on one constructor is not seen on the other'
+        twoArg.annotationMetadata.stringValue('test.OrderCreator').get() == 'only-value'
+        twoArg.annotationMetadata.intValue('test.OrderCreator', 'max').isEmpty()
+
+        and: 'meta annotations are resolved as stereotypes'
+        oneArg.annotationMetadata.hasStereotype('test.Marker')
+        twoArg.annotationMetadata.hasStereotype('test.Marker')
+    }
+
+    void "a described constructor carries the same metadata the constructor path already produced"() {
+        given: 'the same annotated constructor, once as the only described one and once as a described set'
+        def source = '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.Size;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@interface Marker {}
+
+@Marker
+@Retention(RUNTIME)
+@Target(CONSTRUCTOR)
+@interface OrderCreator {
+    String value();
+    int max() default 5;
+}
+
+@Introspected(%s)
+class Order {
+    @OrderCreator(value = "explicit", max = 10)
+    public Order(@Size(min = 1, max = 10) String name) {}
+}
+'''
+        def baseline = buildBeanIntrospection('test.Order', String.format(source, ''))
+        def described = buildBeanIntrospection('test.Order', String.format(source, 'constructors = true'))
+
+        expect: 'the described constructor reports exactly what getConstructor() reports'
+        def expected = baseline.constructor.annotationMetadata
+        def actual = described.getConstructors()[0].annotationMetadata
+
+        actual.stringValue('test.OrderCreator') == expected.stringValue('test.OrderCreator')
+        actual.intValue('test.OrderCreator', 'max') == expected.intValue('test.OrderCreator', 'max')
+        actual.hasStereotype('test.Marker') == expected.hasStereotype('test.Marker')
+        actual.annotationNames.toSorted() == expected.annotationNames.toSorted()
+
+        and: 'and so do its parameters'
+        described.getConstructors()[0].arguments[0].annotationMetadata.intValue(Size, "min") ==
+            baseline.constructorArguments[0].annotationMetadata.intValue(Size, "min")
+        described.getConstructors()[0].arguments[0].annotationMetadata.intValue(Size, "max") ==
+            baseline.constructorArguments[0].annotationMetadata.intValue(Size, "max")
+
+        and: 'sanity: the values really are there rather than both being empty'
+        actual.stringValue('test.OrderCreator').get() == 'explicit'
+        described.getConstructors()[0].arguments[0].annotationMetadata.intValue(Size, "max").getAsInt() == 10
+    }
+
+    void "annotations on one described constructor do not leak onto another"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@interface First {}
+
+@Retention(RUNTIME)
+@interface Second {}
+
+@Introspected(constructors = true)
+class Order {
+    @First
+    Order() {}
+
+    @Second
+    Order(String name) {}
+
+    Order(String name, int quantity) {}
+}
+''')
+
+        when:
+        def noArg = introspection.getConstructors().find { it.arguments.length == 0 }
+        def oneArg = introspection.getConstructors().find { it.arguments.length == 1 }
+        def twoArg = introspection.getConstructors().find { it.arguments.length == 2 }
+
+        then: 'each constructor carries only its own annotations'
+        noArg.annotationMetadata.hasAnnotation('test.First')
+        !noArg.annotationMetadata.hasAnnotation('test.Second')
+
+        oneArg.annotationMetadata.hasAnnotation('test.Second')
+        !oneArg.annotationMetadata.hasAnnotation('test.First')
+
+        and: 'an unannotated constructor carries neither'
+        !twoArg.annotationMetadata.hasAnnotation('test.First')
+        !twoArg.annotationMetadata.hasAnnotation('test.Second')
+    }
+
+    void "a described constructor does not inherit the annotations of its declaring type"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@interface OnType {}
+
+@Retention(RUNTIME)
+@interface OnConstructor {}
+
+@OnType
+@Introspected(constructors = true)
+class Order {
+    @OnConstructor
+    Order() {}
+
+    Order(String name) {}
+}
+''')
+
+        expect: 'the type level annotation is not reported on the constructors'
+        introspection.getConstructors().every { !it.annotationMetadata.hasAnnotation('test.OnType') }
+        !introspection.getConstructors()[0].annotationMetadata.hasStereotype(Introspected)
+
+        and: 'the constructor level one still is'
+        introspection.getConstructors().find { it.arguments.length == 0 }
+            .annotationMetadata.hasAnnotation('test.OnConstructor')
+    }
+
+    void "a described constructor preserves the annotation values of its parameters"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+@Introspected(constructors = true)
+class Order {
+    Order() {}
+
+    Order(@Size(min = 1, max = 10) String name, @Min(5) int quantity) {}
+}
+''')
+
+        when:
+        def constructor = introspection.getConstructors().find { it.arguments.length == 2 }
+
+        then: 'each parameter keeps its own annotation and its member values'
+        constructor.arguments[0].annotationMetadata.intValue(Size, "min").getAsInt() == 1
+        constructor.arguments[0].annotationMetadata.intValue(Size, "max").getAsInt() == 10
+        constructor.arguments[1].annotationMetadata.intValue(Min).getAsInt() == 5
+
+        and: 'stereotypes of the parameter annotations are resolved'
+        constructor.arguments[0].annotationMetadata.hasStereotype(Constraint)
+        constructor.arguments[1].annotationMetadata.hasStereotype(Constraint)
+
+        and: 'annotations do not leak between parameters'
+        !constructor.arguments[0].annotationMetadata.hasAnnotation(Min)
+        !constructor.arguments[1].annotationMetadata.hasAnnotation(Size)
+    }
+
+    void "a described constructor preserves type use annotations on parameter type arguments"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.Min;
+import java.util.List;
+
+@Introspected(constructors = true)
+class Order {
+    Order() {}
+
+    Order(List<@Min(10) Long> quantities) {}
+}
+''')
+
+        when:
+        def typeArgument = introspection.getConstructors()
+            .find { it.arguments.length == 1 }
+            .arguments[0].typeParameters[0]
+
+        then:
+        typeArgument.annotationMetadata.hasAnnotation(Min)
+        typeArgument.annotationMetadata.intValue(Min).getAsInt() == 10
+        typeArgument.annotationMetadata.hasStereotype(Constraint)
+    }
+
+    void "a constructor described via @Executable preserves its other annotations"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+import jakarta.validation.constraints.Size;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@interface OrderCreator {
+    String value() default "fallback";
+}
+
+@Introspected
+class Order {
+    Order() {}
+
+    @Executable
+    @OrderCreator("named")
+    Order(@Size(max = 3) String name) {}
+}
+''')
+
+        when:
+        def constructor = introspection.getConstructors().find { it.arguments.length == 1 }
+
+        then: 'the gating annotation is preserved alongside the others'
+        constructor.annotationMetadata.hasAnnotation(Executable)
+        constructor.annotationMetadata.stringValue('test.OrderCreator').get() == 'named'
+        constructor.arguments[0].annotationMetadata.intValue(Size, "max").getAsInt() == 3
+    }
+
+
     @Override
     protected JavaParser newJavaParser() {
         return new JavaParser() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
@@ -502,5 +502,39 @@ class MyBean  {
         definition != null
         definition.findMethod("run").isPresent()
     }
-}
 
+    void "test @Executable on a constructor does not produce an executable method"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.ExecutableConstructorBean','''\
+package test;
+
+import io.micronaut.context.annotation.Executable;
+import jakarta.inject.Singleton;
+
+@Singleton
+class ExecutableConstructorBean {
+
+    private final String name;
+
+    @Executable
+    ExecutableConstructorBean() {
+        this.name = "none";
+    }
+
+    @Executable
+    public String describe() {
+        return name;
+    }
+}
+''')
+        expect: 'the executable method is the method, not the constructor'
+        definition != null
+        definition.executableMethods.size() == 1
+        definition.executableMethods[0].methodName == 'describe'
+
+        and: 'no executable method was produced for the constructor'
+        definition.executableMethods.every { it.methodName != '<init>' }
+        definition.findMethod('<init>').isEmpty()
+        definition.findMethod('describe').isPresent()
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -2563,6 +2563,81 @@ class MyMessage: Message()
         noExceptionThrown()
     }
 
+    void "constructors = true does not change the constructor beans are built with"() {
+        when: 'the same type is built with and without the member'
+        def source = '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(%s)
+class Order(val name: String, val quantity: Int) {
+    constructor() : this("default-ctor", 0)
+    constructor(name: String) : this(name, 7)
+}
+'''
+        def baseline = buildBeanIntrospection('test.Order', String.format(source, ''))
+        def described = buildBeanIntrospection('test.Order', String.format(source, 'constructors = true'))
+
+        then: 'the instantiating constructor is unchanged'
+        described.constructor.arguments.length == baseline.constructor.arguments.length
+        described.constructorArguments.length == baseline.constructorArguments.length
+        described.isBuildable() == baseline.isBuildable()
+
+        and: 'instantiate still runs the same constructor'
+        described.getRequiredProperty("name", String).get(described.instantiate("abc", 1)) ==
+            baseline.getRequiredProperty("name", String).get(baseline.instantiate("abc", 1))
+
+        and: 'only the described set grew'
+        baseline.getConstructors().size() == 1
+        described.getConstructors().size() == 3
+        described.getConstructors()[0].arguments.length == baseline.constructor.arguments.length
+    }
+
+    void "a secondary constructor annotated as executable does not change the primary constructor"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.context.annotation.Executable
+
+@Introspected
+class Order(val name: String, val quantity: Int) {
+    @Executable constructor(name: String) : this(name, 7)
+}
+''')
+
+        then: 'the Kotlin primary constructor still builds beans'
+        introspection.constructor.arguments.length == 2
+        introspection.getRequiredProperty("quantity", int).get(introspection.instantiate("abc", 1)) == 1
+
+        and: 'and is described first, ahead of the secondary one'
+        introspection.getConstructors().size() == 2
+        introspection.getConstructors()[0].arguments.length == 2
+        introspection.getConstructors()[1].arguments.length == 1
+    }
+
+    void "constructors = true does not change a constructor with default parameter values"() {
+        when:
+        def source = '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(%s)
+class Order(val name: String = "default-ctor", val quantity: Int = 7)
+'''
+        def baseline = buildBeanIntrospection('test.Order', String.format(source, ''))
+        def described = buildBeanIntrospection('test.Order', String.format(source, 'constructors = true'))
+
+        then: 'the instantiating constructor is unchanged and defaults still apply'
+        described.constructor.arguments.length == baseline.constructor.arguments.length
+        described.getRequiredProperty("name", String).get(described.instantiate()) ==
+            baseline.getRequiredProperty("name", String).get(baseline.instantiate())
+        described.getRequiredProperty("name", String).get(described.instantiate()) == "default-ctor"
+    }
+
     void "every declared constructor is described including secondary constructors"() {
         when:
         def introspection = buildBeanIntrospection('test.Order', '''

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -2562,4 +2562,76 @@ class MyMessage: Message()
         then:
         noExceptionThrown()
     }
+
+    void "every declared constructor is described including secondary constructors"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(constructors = true)
+class Order(val name: String, val quantity: Int) {
+    constructor() : this("none", 0)
+    constructor(name: String) : this(name, 0)
+}
+''')
+
+        then:
+        introspection.getConstructors().size() == 3
+        introspection.getConstructors()[0].arguments.length == introspection.constructor.arguments.length
+        introspection.getConstructors()*.arguments*.length.toSorted() == [0, 1, 2]
+    }
+
+    void "instantiating through a described constructor works"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(constructors = true)
+class Order(val name: String) {
+    constructor() : this("none")
+}
+''')
+        def order = introspection.getConstructors().find { it.arguments.length == 1 }.instantiate("abc")
+
+        then:
+        introspection.getRequiredProperty("name", String).get(order) == "abc"
+    }
+
+    void "a data class describes its constructor"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(constructors = true)
+data class Order(val name: String, val quantity: Int)
+''')
+
+        then:
+        introspection.getConstructors().size() == 1
+        introspection.getConstructors()[0].arguments.length == 2
+    }
+
+    void "an introspection that did not ask for constructors keeps describing one"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Order', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Order(val name: String) {
+    constructor() : this("none")
+}
+''')
+
+        then:
+        introspection.getConstructors().size() == 1
+        introspection.getConstructors()[0].arguments.length == introspection.constructor.arguments.length
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/annotation/Executable.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/Executable.java
@@ -29,6 +29,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * <p>When applied to a type all public methods will be considered executable and the necessary metadata produced</p>
  *
+ * <p>When applied to a constructor of an {@link io.micronaut.core.annotation.Introspected} type, the
+ * constructor is described by the generated introspection and exposed via
+ * {@link io.micronaut.core.beans.BeanIntrospection#getConstructors()}.</p>
+ *
  * <p>This annotation can be used as a meta annotation</p>
  *
  * @author Graeme Rocher
@@ -36,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Inherited
 public @interface Executable {
 

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -88,7 +88,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
     private final List<BeanMethod<B, Object>> beanMethodsList;
     private final StringIntMap beanPropertyIndex;
 
-    private final BeanConstructorRef<B> @Nullable [] constructorsRefs;
+    private final BeanConstructorRef @Nullable [] constructorsRefs;
 
     @Nullable
     private BeanConstructor<B> beanConstructor;
@@ -126,7 +126,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
                                                      @Nullable Argument<?>[] constructorArguments,
                                                      @Nullable BeanPropertyRef<Object>[] propertiesRefs,
                                                      @Nullable BeanMethodRef<Object>[] methodsRefs,
-                                                     BeanConstructorRef<B> @Nullable [] constructorsRefs) {
+                                                     BeanConstructorRef @Nullable [] constructorsRefs) {
         this.constructorsRefs = constructorsRefs;
         this.beanType = beanType;
         this.annotationMetadata = annotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : EvaluatedAnnotationMetadata.wrapIfNecessary(annotationMetadata);
@@ -908,7 +908,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
         List<BeanConstructor<B>> constructors = beanConstructorsList;
         if (constructors == null) {
             List<BeanConstructor<B>> newConstructors = new ArrayList<>(constructorsRefs.length);
-            for (BeanConstructorRef<B> constructorRef : constructorsRefs) {
+            for (BeanConstructorRef constructorRef : constructorsRefs) {
                 newConstructors.add(new BeanConstructorImpl(constructorRef));
             }
             constructors = Collections.unmodifiableList(newConstructors);
@@ -1865,9 +1865,9 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
      */
     private final class BeanConstructorImpl implements BeanConstructor<B> {
 
-        private final BeanConstructorRef<B> ref;
+        private final BeanConstructorRef ref;
 
-        private BeanConstructorImpl(BeanConstructorRef<B> ref) {
+        private BeanConstructorImpl(BeanConstructorRef ref) {
             this.ref = ref;
         }
 
@@ -2083,7 +2083,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
      */
     @Internal
     @UsedByGeneratedCode
-    public static final class BeanConstructorRef<B> {
+    public static final class BeanConstructorRef {
         final AnnotationMetadata annotationMetadata;
         final Argument<?>[] arguments;
 

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -88,8 +88,13 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
     private final List<BeanMethod<B, Object>> beanMethodsList;
     private final StringIntMap beanPropertyIndex;
 
+    private final BeanConstructorRef<B> @Nullable [] constructorsRefs;
+
     @Nullable
     private BeanConstructor<B> beanConstructor;
+
+    @Nullable
+    private List<BeanConstructor<B>> beanConstructorsList;
 
     @Nullable
     private IntrospectionBuilderData builderData;
@@ -100,6 +105,29 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
                                                      @Nullable Argument<?>[] constructorArguments,
                                                      @Nullable BeanPropertyRef<Object>[] propertiesRefs,
                                                      @Nullable BeanMethodRef<Object>[] methodsRefs) {
+        this(beanType, annotationMetadata, constructorAnnotationMetadata, constructorArguments, propertiesRefs, methodsRefs, null);
+    }
+
+    /**
+     * Constructor variant used by generated introspections that describe all of their declared constructors.
+     *
+     * @param beanType The bean type
+     * @param annotationMetadata The annotation metadata
+     * @param constructorAnnotationMetadata The constructor annotation metadata
+     * @param constructorArguments The constructor arguments
+     * @param propertiesRefs The property references
+     * @param methodsRefs The method references
+     * @param constructorsRefs The declared constructor references, the bean instantiating constructor first
+     * @since 5.2.0
+     */
+    protected AbstractInitializableBeanIntrospection(Class<B> beanType,
+                                                     @Nullable AnnotationMetadata annotationMetadata,
+                                                     @Nullable AnnotationMetadata constructorAnnotationMetadata,
+                                                     @Nullable Argument<?>[] constructorArguments,
+                                                     @Nullable BeanPropertyRef<Object>[] propertiesRefs,
+                                                     @Nullable BeanMethodRef<Object>[] methodsRefs,
+                                                     BeanConstructorRef<B> @Nullable [] constructorsRefs) {
+        this.constructorsRefs = constructorsRefs;
         this.beanType = beanType;
         this.annotationMetadata = annotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : EvaluatedAnnotationMetadata.wrapIfNecessary(annotationMetadata);
         this.constructorAnnotationMetadata = constructorAnnotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : EvaluatedAnnotationMetadata.wrapIfNecessary(constructorAnnotationMetadata);
@@ -870,6 +898,39 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
             };
         }
         return beanConstructor;
+    }
+
+    @Override
+    public List<BeanConstructor<B>> getConstructors() {
+        if (constructorsRefs == null) {
+            return List.of(getConstructor());
+        }
+        List<BeanConstructor<B>> constructors = beanConstructorsList;
+        if (constructors == null) {
+            List<BeanConstructor<B>> newConstructors = new ArrayList<>(constructorsRefs.length);
+            for (BeanConstructorRef<B> constructorRef : constructorsRefs) {
+                newConstructors.add(new BeanConstructorImpl(constructorRef));
+            }
+            constructors = Collections.unmodifiableList(newConstructors);
+            beanConstructorsList = constructors;
+        }
+        return constructors;
+    }
+
+    /**
+     * Reflection free instantiation implementation for a declared constructor described by
+     * {@link #getConstructors()}. Generated introspections override this method with a switch
+     * over the described constructors.
+     *
+     * @param index     The constructor index
+     * @param arguments The arguments
+     * @return The bean
+     * @since 5.2.0
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected B instantiateConstructorInternal(int index, @Nullable Object @Nullable [] arguments) {
+        throw unknownDispatchAtIndexException(index);
     }
 
     @Override
@@ -1800,6 +1861,57 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
     }
 
     /**
+     * Implementation of {@link BeanConstructor} that is using {@link BeanConstructorRef} and constructor dispatch.
+     */
+    private final class BeanConstructorImpl implements BeanConstructor<B> {
+
+        private final BeanConstructorRef<B> ref;
+
+        private BeanConstructorImpl(BeanConstructorRef<B> ref) {
+            this.ref = ref;
+        }
+
+        @Override
+        public Class<B> getDeclaringBeanType() {
+            return beanType;
+        }
+
+        @Override
+        public Argument<?>[] getArguments() {
+            return ref.arguments;
+        }
+
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return ref.annotationMetadata;
+        }
+
+        @Override
+        public B instantiate(@Nullable Object... parameterValues) {
+            ArgumentUtils.requireNonNull("parameterValues", parameterValues);
+            Argument<?>[] arguments = ref.arguments;
+            if (arguments.length != parameterValues.length) {
+                throw new InstantiationException("Argument count [" + parameterValues.length + "] doesn't match required argument count: " + arguments.length);
+            }
+            for (int i = 0; i < arguments.length; i++) {
+                Argument<?> argument = arguments[i];
+                final Object specified = parameterValues[i];
+                if (specified == null) {
+                    if (argument.isDeclaredNullable()) {
+                        continue;
+                    } else {
+                        throw new InstantiationException("Null argument specified for [" + argument.getName() + "]. If this argument is allowed to be null annotate it with @Nullable");
+                    }
+                }
+                if (!ReflectionUtils.getWrapperType(argument.getType()).isInstance(specified)) {
+                    throw new InstantiationException("Invalid argument [" + specified + "] specified for argument: " + argument);
+                }
+            }
+            return instantiateConstructorInternal(ref.instantiateIndex, parameterValues);
+        }
+    }
+
+    /**
      * Implementation of {@link BeanMethod} that is using {@link BeanMethodRef} and method dispatch.
      *
      * @param <P> The property type
@@ -1960,6 +2072,29 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
             this.annotationMetadata = EvaluatedAnnotationMetadata.wrapIfNecessary(annotationMetadata);
             this.arguments = arguments;
             this.methodIndex = methodIndex;
+        }
+    }
+
+    /**
+     * Bean constructor compile-time data container.
+     *
+     * @param <B> The bean type.
+     * @since 5.2.0
+     */
+    @Internal
+    @UsedByGeneratedCode
+    public static final class BeanConstructorRef<B> {
+        final AnnotationMetadata annotationMetadata;
+        final Argument<?>[] arguments;
+
+        final int instantiateIndex;
+
+        public BeanConstructorRef(@Nullable AnnotationMetadata annotationMetadata,
+                                  Argument<?> @Nullable [] arguments,
+                                  int instantiateIndex) {
+            this.annotationMetadata = annotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : EvaluatedAnnotationMetadata.wrapIfNecessary(annotationMetadata);
+            this.arguments = arguments == null ? Argument.ZERO_ARGUMENTS : arguments;
+            this.instantiateIndex = instantiateIndex;
         }
     }
 

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospectionAndReference.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospectionAndReference.java
@@ -56,7 +56,7 @@ public abstract class AbstractInitializableBeanIntrospectionAndReference<B> exte
                                                                  Argument<?>[] constructorArguments,
                                                                  BeanPropertyRef<Object>[] propertiesRefs,
                                                                  BeanMethodRef<Object>[] methodsRefs,
-                                                                 BeanConstructorRef<B>[] constructorsRefs) {
+                                                                 BeanConstructorRef[] constructorsRefs) {
         super(beanType, annotationMetadata, constructorAnnotationMetadata, constructorArguments, propertiesRefs, methodsRefs, constructorsRefs);
     }
 

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospectionAndReference.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospectionAndReference.java
@@ -38,6 +38,28 @@ public abstract class AbstractInitializableBeanIntrospectionAndReference<B> exte
         super(beanType, annotationMetadata, constructorAnnotationMetadata, constructorArguments, propertiesRefs, methodsRefs);
     }
 
+    /**
+     * Constructor variant used by generated introspections that describe all of their declared constructors.
+     *
+     * @param beanType The bean type
+     * @param annotationMetadata The annotation metadata
+     * @param constructorAnnotationMetadata The constructor annotation metadata
+     * @param constructorArguments The constructor arguments
+     * @param propertiesRefs The property references
+     * @param methodsRefs The method references
+     * @param constructorsRefs The declared constructor references, the bean instantiating constructor first
+     * @since 5.2.0
+     */
+    protected AbstractInitializableBeanIntrospectionAndReference(Class<B> beanType,
+                                                                 AnnotationMetadata annotationMetadata,
+                                                                 AnnotationMetadata constructorAnnotationMetadata,
+                                                                 Argument<?>[] constructorArguments,
+                                                                 BeanPropertyRef<Object>[] propertiesRefs,
+                                                                 BeanMethodRef<Object>[] methodsRefs,
+                                                                 BeanConstructorRef<B>[] constructorsRefs) {
+        super(beanType, annotationMetadata, constructorAnnotationMetadata, constructorArguments, propertiesRefs, methodsRefs, constructorsRefs);
+    }
+
     @Override
     public BeanIntrospection<B> load() {
         return this;

--- a/src/main/docs/guide/ioc/introspection/introspectionConstructors.adoc
+++ b/src/main/docs/guide/ioc/introspection/introspectionConstructors.adoc
@@ -1,0 +1,24 @@
+A api:core.beans.BeanIntrospection[] describes the constructor it instantiates beans with, which is the one returned by `getConstructor` and used by `instantiate`. By default that is the only constructor described, so `getConstructors` returns a single-element list.
+
+To describe every declared constructor instead, set the `constructors` member of the ann:core.annotation.Introspected[] annotation to `true`:
+
+snippet::io.micronaut.docs.ioc.beans.Shipment[tags="class"]
+
+<1> Every declared constructor of the class is described
+<2> The ann:core.annotation.Creator[] annotation still selects the constructor used to instantiate beans
+
+Each described constructor is a api:core.beans.BeanConstructor[] carrying its own annotation metadata and the annotation metadata of its parameters, and each one can instantiate the type:
+
+snippet::io.micronaut.docs.ioc.beans.IntrospectionSpec[tags="constructors", indent=0]
+
+<1> `getConstructors` returns every described constructor, the one returned by `getConstructor` first
+<2> Constructors are told apart by their arguments
+<3> Any described constructor can instantiate the type
+
+To describe one particular constructor rather than all of them, annotate that constructor with ann:context.annotation.Executable[]:
+
+snippet::io.micronaut.docs.ioc.beans.Delivery[tags="class"]
+
+<1> This constructor is described in addition to the one beans are instantiated with
+
+NOTE: Describing constructors does not change how beans of the type are built. The constructor returned by `getConstructor` is the same either way, and a constructor annotated with ann:context.annotation.Executable[] does not become an executable method of the bean.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -53,6 +53,7 @@ ioc:
     introspectedProperty: Explicit Bean Properties
     atCreator: Constructor Methods
     staticAtCreator: Static Creator Methods
+    introspectionConstructors: Describing Constructors
     introspectionBuilders: Builders
     introspectionEnums: Introspect Enums
     introspectedAnnotationOnAConfigurationClass: Use the @Introspected Annotation on a Configuration Class

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/beans/Delivery.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/beans/Delivery.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.beans
+
+// tag::class[]
+import io.micronaut.context.annotation.Executable
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Delivery {
+
+    String address = "unknown"
+
+    Delivery() {
+    }
+
+    @Executable // <1>
+    Delivery(String address) {
+        this.address = address
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/beans/IntrospectionSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/beans/IntrospectionSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.docs.ioc.beans
 
+import io.micronaut.core.beans.BeanConstructor
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.core.beans.BeanProperty
 import io.micronaut.core.beans.BeanWrapper
@@ -71,5 +72,35 @@ class IntrospectionSpec extends Specification {
 
         then:
         user.age == 23
+    }
+
+    void testShipmentConstructors() {
+        when:
+        // tag::constructors[]
+        BeanIntrospection<Shipment> introspection = BeanIntrospection.getIntrospection(Shipment)
+
+        List<BeanConstructor<Shipment>> constructors = introspection.getConstructors() // <1>
+
+        BeanConstructor<Shipment> byItem = constructors.find { it.arguments.length == 1 } // <2>
+
+        Shipment shipment = byItem.instantiate("book") // <3>
+        // end::constructors[]
+
+        then:
+        constructors.size() == 2
+        constructors[0].arguments.length == introspection.constructor.arguments.length
+        shipment.item == "book"
+        shipment.quantity == 1
+    }
+
+    void testDeliveryExecutableConstructor() {
+        when:
+        BeanIntrospection<Delivery> introspection = BeanIntrospection.getIntrospection(Delivery)
+        List<BeanConstructor<Delivery>> constructors = introspection.getConstructors()
+        Delivery delivery = constructors.find { it.arguments.length == 1 }.instantiate("Main Street")
+
+        then:
+        constructors.size() == 2
+        delivery.address == "Main Street"
     }
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/beans/Shipment.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/beans/Shipment.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.beans
+
+// tag::class[]
+import io.micronaut.core.annotation.Creator
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(constructors = true) // <1>
+class Shipment {
+
+    final String item
+    final int quantity
+
+    Shipment(String item) {
+        this(item, 1)
+    }
+
+    @Creator // <2>
+    Shipment(String item, int quantity) {
+        this.item = item
+        this.quantity = quantity
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/beans/Delivery.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/beans/Delivery.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.beans
+
+// tag::class[]
+import io.micronaut.context.annotation.Executable
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Delivery() {
+
+    var address: String = "unknown"
+
+    @Executable // <1>
+    constructor(address: String) : this() {
+        this.address = address
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/beans/IntrospectionSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/beans/IntrospectionSpec.kt
@@ -65,4 +65,32 @@ class IntrospectionSpec {
         val business = introspection.instantiate("Apple")
         assertEquals("Apple", business.name)
     }
+
+    @Test
+    fun testShipmentConstructors() {
+        // tag::constructors[]
+        val introspection = BeanIntrospection.getIntrospection(Shipment::class.java)
+
+        val constructors = introspection.constructors // <1>
+
+        val byItem = constructors.first { it.arguments.size == 1 } // <2>
+
+        val shipment = byItem.instantiate("book") // <3>
+        // end::constructors[]
+
+        assertEquals(2, constructors.size)
+        assertEquals(introspection.constructor.arguments.size, constructors[0].arguments.size)
+        assertEquals("book", shipment.item)
+        assertEquals(1, shipment.quantity)
+    }
+
+    @Test
+    fun testDeliveryExecutableConstructor() {
+        val introspection = BeanIntrospection.getIntrospection(Delivery::class.java)
+        val constructors = introspection.constructors
+        val delivery = constructors.first { it.arguments.size == 1 }.instantiate("Main Street")
+
+        assertEquals(2, constructors.size)
+        assertEquals("Main Street", delivery.address)
+    }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/beans/Shipment.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/beans/Shipment.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.beans
+
+// tag::class[]
+import io.micronaut.core.annotation.Creator
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(constructors = true) // <1>
+class Shipment @Creator constructor(val item: String, val quantity: Int) { // <2>
+
+    constructor(item: String) : this(item, 1)
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/beans/Delivery.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/beans/Delivery.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.beans;
+
+// tag::class[]
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class Delivery {
+
+    private String address = "unknown";
+
+    public Delivery() {
+    }
+
+    @Executable // <1>
+    public Delivery(String address) {
+        this.address = address;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/beans/IntrospectionSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/beans/IntrospectionSpec.java
@@ -15,10 +15,13 @@
  */
 package io.micronaut.docs.ioc.beans;
 
+import io.micronaut.core.beans.BeanConstructor;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanProperty;
 import io.micronaut.core.beans.BeanWrapper;
 import junit.framework.TestCase;
+
+import java.util.List;
 
 public class IntrospectionSpec extends TestCase {
 
@@ -84,5 +87,39 @@ public class IntrospectionSpec extends TestCase {
         assertEquals(2, introspection.getBeanProperties().size());
         introspection.getRequiredProperty("age", int.class).set(user, 23);
         assertEquals(23, user.age);
+    }
+
+    public void testShipmentConstructors() {
+        // tag::constructors[]
+        final BeanIntrospection<Shipment> introspection = BeanIntrospection.getIntrospection(Shipment.class);
+
+        List<BeanConstructor<Shipment>> constructors = introspection.getConstructors(); // <1>
+
+        BeanConstructor<Shipment> byItem = constructors.stream()
+                .filter(constructor -> constructor.getArguments().length == 1)
+                .findFirst()
+                .orElseThrow(); // <2>
+
+        Shipment shipment = byItem.instantiate("book"); // <3>
+        // end::constructors[]
+
+        assertEquals(2, constructors.size());
+        assertEquals(introspection.getConstructor().getArguments().length, constructors.get(0).getArguments().length);
+        assertEquals("book", shipment.getItem());
+        assertEquals(1, shipment.getQuantity());
+    }
+
+    public void testDeliveryExecutableConstructor() {
+        final BeanIntrospection<Delivery> introspection = BeanIntrospection.getIntrospection(Delivery.class);
+
+        List<BeanConstructor<Delivery>> constructors = introspection.getConstructors();
+
+        assertEquals(2, constructors.size());
+        Delivery delivery = constructors.stream()
+                .filter(constructor -> constructor.getArguments().length == 1)
+                .findFirst()
+                .orElseThrow()
+                .instantiate("Main Street");
+        assertEquals("Main Street", delivery.getAddress());
     }
 }

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/beans/Shipment.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/beans/Shipment.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.ioc.beans;
+
+// tag::class[]
+import io.micronaut.core.annotation.Creator;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(constructors = true) // <1>
+public class Shipment {
+
+    private final String item;
+    private final int quantity;
+
+    public Shipment(String item) {
+        this(item, 1);
+    }
+
+    @Creator // <2>
+    public Shipment(String item, int quantity) {
+        this.item = item;
+        this.quantity = quantity;
+    }
+
+    public String getItem() {
+        return item;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+}
+// end::class[]


### PR DESCRIPTION
## What

`BeanIntrospection` exposes one constructor. Everything a caller can learn about the constructors of an introspected type comes from `getConstructor()`, which is synthesised from `getConstructorArguments()` and describes the single constructor the introspection instantiates beans with. Nothing in a generated introspection carries the annotations of any other constructor, or the annotations of its parameters.

A specification that *describes* a type rather than instantiating it needs all of them. Jakarta Validation names a constructor by its parameter types and describes each one: its parameters, its cross-parameter constraints, its return value, and the group conversions on both. `jakarta.validation.metadata.BeanDescriptor` has `getConstrainedConstructors()` and `getConstraintsForConstructor(Class<?>...)`; with one constructor available the validator returns `null` for any constructor the introspection did not pick, and the TCK then fails with a `NullPointerException` on `ConstructorDescriptor`.

This adds `BeanIntrospection.getConstructors()`, returning every described constructor with `getConstructor()` first:

```java
/**
 * @return Every described constructor of the type, getConstructor() first
 */
default List<BeanConstructor<T>> getConstructors() {
    return List.of(getConstructor());
}
```

The `default` implementation keeps every existing introspection valid, and callers that do not opt in see no change.

## Opting in

Writing every constructor of every introspected type is not free, so it is gated. There are two ways in, and they compose:

**Per constructor, with `@Executable`** — the annotation now accepts `ElementType.CONSTRUCTOR`, so a single constructor can ask to be described:

```java
@Introspected
class Order {
    Order() {}
    @Executable Order(String name) {}   // described
    Order(String name, int quantity) {} // not described
}
```

The gate reads a *declared* stereotype, so a type-level `@Executable` — which means "all public methods are executable" — does not sweep every constructor into the introspection. There is a test pinning that.

**Per type, with `@Introspected(constructors = true)`** — describes every declared constructor. This is what a module that needs the full picture (the validation processor, via `IntrospectedValidationIndexesVisitor`) asks for, and nobody else pays for it.

## How it works

- **API** — `getConstructors()` on `BeanIntrospection`, and the `constructors()` member on `@Introspected`.
- **Runtime** — a `BeanConstructorRef` holder in `AbstractInitializableBeanIntrospection` carrying annotation metadata, arguments and a dispatch index, mirroring the existing `BeanMethodRef` pattern, plus an `instantiateConstructorInternal(int, Object[])` hook that generated code overrides with a switch. `BeanConstructor` already had everything else needed, so no new type was introduced.
- **Writer** — `BeanIntrospectionWriter` emits one `BeanConstructorRef` per described constructor, each with its own `AnnotationMetadata` and its own `Argument[]`, built through the same `pushBuildArgumentsForMethod` path bean properties already use so parameter and type-use annotations survive.
- **Cost when unused** — when nothing opts in the writer emits no extra field, no extra methods, and calls the original super constructor. The generated bytecode is byte-for-byte what it was.

## Ordering

`getConstructor()` comes first, per the contract. When the introspection is built from a static creator rather than a constructor, that creator is prepended so the contract still holds there too.

## Reviewer notes

**The opt-in is purely additive metadata.** The risk worth reviewing is whether describing extra constructors could shift which constructor the introspection actually builds beans with. The second commit pins that it does not: each test builds the same type twice, with and without the opt-in, and asserts `getConstructor()`, `getConstructorArguments()`, `isBuildable()` and the result of `instantiate()` are identical. The `instantiate()` check reads a property off the constructed object, so it proves the right constructor body ran rather than only that the metadata looks unchanged. Covered for an explicit `@Creator`, a Kotlin secondary constructor, and Kotlin default parameter values.

**The tests were checked for teeth.** I temporarily broke the ordering logic in the writer and re-ran: all five Java invariance tests failed, along with one earlier test. Two "described first" assertions were also vacuous on first writing — the instantiating constructor happened to be first in declaration order anyway — so those types now declare a non-public constructor first, and the primary genuinely has to be moved to the front for the assertion to hold.

**`@since` tags** are set to `5.2.0` based on the current branch version. If this lands in a different release they need updating in three places: `BeanIntrospection.getConstructors()`, `Introspected.constructors()`, and the new `AbstractInitializableBeanIntrospection` members.

**Out of scope.** `ReflectiveIntrospection` — which already carries this exact contract on the reflective side of the bridge — does not exist on this branch, so the two micronaut-validation special cases (`IntrospectedBeanDescriptor.constructors()` and `ReflectiveExecutables.beanConstructor`) are downstream of this change rather than part of it.

## Tests

Java, Groovy and Kotlin, covering: every declared constructor described; a constructor carrying its own annotations; a constructor carrying its parameters' annotations, including type-use annotations on type arguments; instantiating through a described constructor; an introspection that did not opt in still describing exactly one; the `@Executable` gate and the type-level `@Executable` non-regression; and the constructor-selection invariance above. Kotlin adds secondary constructors, data classes and default parameter values; Groovy adds its own constructor shapes.

Full rerun across `core`, `inject`, `inject-java`, `inject-java-test`, `inject-groovy` and `inject-kotlin`: 14,621 tests, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)