### PR TITLE
Add a reflection bridge: Micronaut metadata over java.lang.reflect

### DIFF
--- a/inject/src/main/java/io/micronaut/context/AnnotationReflectionUtils.java
+++ b/inject/src/main/java/io/micronaut/context/AnnotationReflectionUtils.java
@@ -18,7 +18,7 @@ package io.micronaut.context;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.reflect.ClassUtils;
-import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.inject.annotation.ReflectionAnnotationMetadataBuilder;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
@@ -31,8 +31,11 @@ import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.AnnotatedWildcardType;
 import java.lang.reflect.Array;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -95,6 +98,99 @@ public final class AnnotationReflectionUtils {
      * @param superType The supertype that we want to get the type information for
      * @return The annotated generic supertype, with the same raw type as {@code superType}
      */
+    /**
+     * Converts an annotated type to an {@link Argument}: the raw type, the type arguments recursively, and the
+     * type-use annotations of each level as metadata built by
+     * {@link io.micronaut.inject.annotation.ReflectionAnnotationMetadataBuilder}.
+     *
+     * @param annotatedType The annotated type
+     * @return The argument
+     * @since 5.1
+     */
+    public static Argument<?> argumentOf(AnnotatedType annotatedType) {
+        return toArgument(null, annotatedType, Map.of());
+    }
+
+    /**
+     * Converts an annotated type to a named {@link Argument}.
+     *
+     * @param name          The name of the argument, can be {@code null}
+     * @param annotatedType The annotated type
+     * @return The argument
+     * @since 5.1
+     */
+    public static Argument<?> argumentOf(@Nullable String name, AnnotatedType annotatedType) {
+        return toArgument(name, annotatedType, Map.of());
+    }
+
+    /**
+     * Converts a parameter to an {@link Argument} named after it, whose metadata holds the annotations of the
+     * parameter and the type-use annotations of its type.
+     *
+     * @param parameter The parameter
+     * @return The argument
+     * @since 5.1
+     */
+    public static Argument<?> argumentOf(Parameter parameter) {
+        return withElementAnnotations(toArgument(parameter.getName(), parameter.getAnnotatedType(), Map.of()), parameter);
+    }
+
+    /**
+     * Converts a field to an {@link Argument} named after it, whose metadata holds the annotations of the
+     * field and the type-use annotations of its type.
+     *
+     * @param field The field
+     * @return The argument
+     * @since 5.1
+     */
+    public static Argument<?> argumentOf(Field field) {
+        return withElementAnnotations(toArgument(field.getName(), field.getAnnotatedType(), Map.of()), field);
+    }
+
+    /**
+     * Converts the parameters of a method or constructor to {@link Argument}s.
+     *
+     * @param executable The method or constructor
+     * @return The arguments, in the order of the parameters
+     * @since 5.1
+     */
+    public static Argument<?>[] argumentsOf(Executable executable) {
+        Parameter[] parameters = executable.getParameters();
+        if (parameters.length == 0) {
+            return Argument.ZERO_ARGUMENTS;
+        }
+        Argument<?>[] arguments = new Argument[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            arguments[i] = argumentOf(parameters[i]);
+        }
+        return arguments;
+    }
+
+    /**
+     * Converts the return type of a method to an {@link Argument} carrying the type-use annotations of the
+     * return type. The annotations of the method itself belong to the method, not to its return type.
+     *
+     * @param method The method
+     * @return The argument
+     * @since 5.1
+     */
+    public static Argument<?> returnArgumentOf(Method method) {
+        return toArgument(null, method.getAnnotatedReturnType(), Map.of());
+    }
+
+    private static Argument<?> withElementAnnotations(Argument<?> argument, AnnotatedElement element) {
+        AnnotationMetadata own = ReflectionAnnotationMetadataBuilder.build(element);
+        if (own == AnnotationMetadata.EMPTY_METADATA) {
+            return argument;
+        }
+        return Argument.of(
+            argument.getType(),
+            argument.getName(),
+            combine(argument.getAnnotationMetadata(), own),
+            argument.getTypeParameters()
+        );
+    }
+
     @Nullable
     private static AnnotatedType findAnnotatedSupertype(AnnotatedType subType, Class<?> superType) {
         Class<?> raw = getRawType(subType.getType());
@@ -179,27 +275,7 @@ public final class AnnotationReflectionUtils {
     }
 
     private static AnnotationMetadata annotationMetadataOf(AnnotatedElement annotatedElement) {
-        Annotation[] annotations = annotatedElement.getAnnotations();
-        if (annotations.length == 0) {
-            return AnnotationMetadata.EMPTY_METADATA;
-        }
-        MutableAnnotationMetadata mutableAnnotationMetadata = new MutableAnnotationMetadata();
-        for (Annotation annotation : annotations) {
-            Map<CharSequence, Object> values = new LinkedHashMap<>();
-            Class<? extends Annotation> annotationType = annotation.annotationType();
-            Method[] methods = annotationType.getMethods();
-            for (Method method : methods) {
-                if (!method.getDeclaringClass().equals(annotationType)) {
-                    continue;
-                }
-                Object value = ReflectionUtils.invokeMethod(annotation, method);
-                if (value != null) {
-                    values.put(method.getName(), value);
-                }
-            }
-            mutableAnnotationMetadata.addAnnotation(annotationType.getName(), values);
-        }
-        return mutableAnnotationMetadata;
+        return ReflectionAnnotationMetadataBuilder.build(annotatedElement);
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -355,7 +355,14 @@ public final class AnnotationMetadataSupport {
     static Optional<Class<? extends Annotation>> getAnnotationType(String name, ClassLoader classLoader) {
         final Class<? extends Annotation> type = ANNOTATION_TYPES.get(name);
         if (type != null) {
-            return Optional.of(type);
+            if (type.getClassLoader() == null || type.getClassLoader() == classLoader) {
+                return Optional.of(type);
+            }
+            // the registered type was loaded by another class loader: the caller's loader may define its own
+            // copy — a child-first deployment loader does — and that copy is the one the caller compares with
+            @SuppressWarnings("unchecked") final Class<? extends Annotation> own =
+                (Class<? extends Annotation>) ClassUtils.forName(name, classLoader).orElse(null);
+            return Optional.of(own != null && Annotation.class.isAssignableFrom(own) ? own : type);
         } else {
             // last resort, try dynamic load, shouldn't normally happen.
             @SuppressWarnings("unchecked") final Class<? extends Annotation> aClass =

--- a/inject/src/main/java/io/micronaut/inject/annotation/ReflectionAnnotationCustomizer.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/ReflectionAnnotationCustomizer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Indexed;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+/**
+ * The runtime counterpart of the annotation mappers, transformers and remappers of the annotation
+ * processors, for the metadata {@link ReflectionAnnotationMetadataBuilder} builds reflectively.
+ *
+ * <p>A processor extension that derives a member from the annotation type — the validator classes a
+ * constraint is validated by, copied from its {@code @Constraint} meta-annotation — has to be applied to the
+ * reflective metadata too, or the code reading the member behaves differently for a type the processor never
+ * saw. An implementation is registered as a service and receives every annotation the builder converts,
+ * stereotypes included, with a mutable copy of its values.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+@Experimental
+@Indexed(ReflectionAnnotationCustomizer.class)
+public interface ReflectionAnnotationCustomizer {
+
+    /**
+     * @param annotationType The annotation type
+     * @return Whether {@link #customize(Annotation, Map)} is to be called for the annotations of the type
+     */
+    default boolean supports(Class<? extends Annotation> annotationType) {
+        return true;
+    }
+
+    /**
+     * Customizes the values of an annotation before they enter the metadata.
+     *
+     * @param annotation The annotation
+     * @param values     The values, as {@link ReflectionAnnotationMetadataBuilder#values(Annotation)} converts
+     *                   them, to add to, replace or remove from
+     */
+    void customize(Annotation annotation, Map<CharSequence, Object> values);
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/ReflectionAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/ReflectionAnnotationMetadataBuilder.java
@@ -1,0 +1,453 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueProvider;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.io.service.SoftServiceLoader;
+import io.micronaut.core.reflect.ReflectionUtils;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Repeatable;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Builds {@link AnnotationMetadata} from the annotations read reflectively from an
+ * {@link AnnotatedElement}, in the shape the annotation processors give the metadata they generate at
+ * compilation time.
+ *
+ * <p>Code written against generated metadata then works unchanged for an element that has none:</p>
+ * <ul>
+ *     <li>the meta-annotations of an annotation are its stereotypes, recursively, with their values;</li>
+ *     <li>a repeatable annotation is filed under its container, whether it was written once, several times or
+ *     inside the container, and the container is registered with {@link AnnotationMetadataSupport} so that
+ *     {@link AnnotationMetadata#getAnnotationValuesByType(Class)} finds it;</li>
+ *     <li>the defaults of the members are registered and reachable through
+ *     {@link AnnotationMetadata#getDefaultValues(String)} and the value accessors;</li>
+ *     <li>a class value is an {@link AnnotationClassValue}, an enum value is its name, a nested annotation is an
+ *     {@link AnnotationValue};</li>
+ *     <li>an annotation inherited by a class through {@link java.lang.annotation.Inherited} is present but not
+ *     declared.</li>
+ * </ul>
+ *
+ * <p>An annotation instance does not say which members were written, so a member whose value equals its
+ * default is not part of the values of the annotation; it is served by the defaults, as a member that was not
+ * written is at compilation time.</p>
+ *
+ * <p>The annotation mappers, transformers and remappers of the annotation processors are not applied: they
+ * are part of {@code micronaut-core-processor} and are not on a runtime classpath. The
+ * {@link ReflectionAnnotationCustomizer} services are their runtime counterpart, and receive the values of
+ * every annotation the builder converts.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+@Experimental
+public final class ReflectionAnnotationMetadataBuilder {
+
+    private static final String JAVA_LANG_ANNOTATION = "java.lang.annotation.";
+    private static final String KOTLIN = "kotlin.";
+    private static final List<ReflectionAnnotationCustomizer> CUSTOMIZERS =
+        SoftServiceLoader.load(ReflectionAnnotationCustomizer.class).collectAll();
+
+    private ReflectionAnnotationMetadataBuilder() {
+    }
+
+    /**
+     * Builds the metadata of an element.
+     *
+     * @param element The element
+     * @return The metadata, {@link AnnotationMetadata#EMPTY_METADATA} when the element has no annotation
+     */
+    public static AnnotationMetadata build(AnnotatedElement element) {
+        MutableAnnotationMetadata metadata = new MutableAnnotationMetadata();
+        add(metadata, element);
+        return metadata.isEmpty() ? AnnotationMetadata.EMPTY_METADATA : metadata;
+    }
+
+    /**
+     * Builds the metadata of several elements merged, the first element first: the field, the getter and the
+     * setter of a property, or a parameter and its type.
+     *
+     * @param elements The elements
+     * @return The metadata, {@link AnnotationMetadata#EMPTY_METADATA} when none of the elements has an annotation
+     */
+    public static AnnotationMetadata build(AnnotatedElement... elements) {
+        MutableAnnotationMetadata metadata = new MutableAnnotationMetadata();
+        for (AnnotatedElement element : elements) {
+            if (element != null) {
+                add(metadata, element);
+            }
+        }
+        return metadata.isEmpty() ? AnnotationMetadata.EMPTY_METADATA : metadata;
+    }
+
+    /**
+     * Adds the annotations of an element to a metadata under construction.
+     *
+     * @param metadata The metadata
+     * @param element  The element
+     */
+    public static void add(MutableAnnotationMetadata metadata, AnnotatedElement element) {
+        Annotation[] declared = element.getDeclaredAnnotations();
+        for (Annotation annotation : declared) {
+            addAnnotation(metadata, annotation, true);
+        }
+        if (element instanceof Class<?>) {
+            Set<Annotation> declaredSet = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+            declaredSet.addAll(Arrays.asList(declared));
+            for (Annotation annotation : element.getAnnotations()) {
+                if (!declaredSet.contains(annotation)) {
+                    addAnnotation(metadata, annotation, false);
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds one annotation instance to a metadata under construction, as {@link #add(MutableAnnotationMetadata, AnnotatedElement)}
+     * adds every annotation of an element: a caller keeping only some annotations of an element — the
+     * constraints, the qualifiers — filters the instances and adds the ones it keeps.
+     *
+     * @param metadata   The metadata
+     * @param annotation The annotation
+     * @param declared   Whether the annotation is declared on the element rather than inherited
+     */
+    public static void add(MutableAnnotationMetadata metadata, Annotation annotation, boolean declared) {
+        addAnnotation(metadata, annotation, declared);
+    }
+
+    /**
+     * The annotations a repeatable container holds.
+     *
+     * @param annotation The annotation
+     * @return The contained annotations, empty when the annotation is not the container of a repeatable
+     * annotation
+     */
+    public static List<Annotation> contained(Annotation annotation) {
+        Annotation[] contained = containedAnnotations(annotation);
+        return contained == null ? List.of() : List.of(contained);
+    }
+
+    /**
+     * The values of the members of an annotation, as the metadata stores them: the members whose value is the
+     * default of the member are left out, a class is an {@link AnnotationClassValue}, an enum constant is its
+     * name and a nested annotation is an {@link AnnotationValue}.
+     *
+     * @param annotation The annotation
+     * @return The values
+     */
+    public static Map<CharSequence, Object> values(Annotation annotation) {
+        Map<CharSequence, Object> values = new LinkedHashMap<>();
+        Class<? extends Annotation> type = annotation.annotationType();
+        for (Method member : members(type)) {
+            Object value = ReflectionUtils.invokeMethod(annotation, member);
+            Object defaultValue = member.getDefaultValue();
+            if (value == null || (defaultValue != null && Objects.deepEquals(value, defaultValue))) {
+                continue;
+            }
+            values.put(member.getName(), convert(value));
+        }
+        for (ReflectionAnnotationCustomizer customizer : CUSTOMIZERS) {
+            if (customizer.supports(type)) {
+                customizer.customize(annotation, values);
+            }
+        }
+        return values;
+    }
+
+    /**
+     * The defaults of the members of an annotation type, converted as {@link #values(Annotation)} converts
+     * the values.
+     *
+     * @param annotationType The annotation type
+     * @return The defaults
+     */
+    public static Map<CharSequence, Object> defaultValues(Class<? extends Annotation> annotationType) {
+        Map<CharSequence, Object> defaults = new LinkedHashMap<>();
+        for (Method member : members(annotationType)) {
+            Object defaultValue = member.getDefaultValue();
+            if (defaultValue != null) {
+                defaults.put(member.getName(), convert(defaultValue));
+            }
+        }
+        return defaults;
+    }
+
+    /**
+     * The annotation value of an annotation instance, carrying its defaults. An instance that is an
+     * {@link AnnotationValueProvider} — a synthetic annotation built from a value — returns that value.
+     *
+     * @param annotation The annotation
+     * @param <A>        The annotation type
+     * @return The annotation value
+     */
+    public static <A extends Annotation> AnnotationValue<A> annotationValue(A annotation) {
+        return annotationValue(annotation, null);
+    }
+
+    /**
+     * The annotation value of an annotation instance, carrying its defaults, with its values customized.
+     *
+     * @param annotation The annotation
+     * @param customizer The customizer of the values, receiving a mutable copy, can be {@code null}
+     * @param <A>        The annotation type
+     * @return The annotation value
+     */
+    @SuppressWarnings("unchecked")
+    public static <A extends Annotation> AnnotationValue<A> annotationValue(A annotation,
+                                                                          @Nullable Consumer<Map<CharSequence, Object>> customizer) {
+        if (customizer == null && annotation instanceof AnnotationValueProvider<?> provider) {
+            return (AnnotationValue<A>) provider.annotationValue();
+        }
+        Class<A> type = (Class<A>) annotation.annotationType();
+        Map<CharSequence, Object> values = values(annotation);
+        if (customizer != null) {
+            customizer.accept(values);
+        }
+        return new AnnotationValue<>(type.getName(), values, defaultValues(type));
+    }
+
+    private static void addAnnotation(MutableAnnotationMetadata metadata, Annotation annotation, boolean declared) {
+        Class<? extends Annotation> type = annotation.annotationType();
+        if (isIgnored(type)) {
+            return;
+        }
+        Annotation[] contained = containedAnnotations(annotation);
+        if (contained != null) {
+            for (Annotation repeated : contained) {
+                addRepeated(metadata, repeated, type, declared);
+            }
+            return;
+        }
+        Repeatable repeatable = type.getAnnotation(Repeatable.class);
+        if (repeatable != null) {
+            addRepeated(metadata, annotation, repeatable.value(), declared);
+            return;
+        }
+        register(metadata, type);
+        String name = type.getName();
+        if (declared) {
+            metadata.addDeclaredAnnotation(name, values(annotation));
+        } else {
+            metadata.addAnnotation(name, values(annotation));
+        }
+        addStereotypes(metadata, type, List.of(name), declared);
+    }
+
+    private static void addRepeated(MutableAnnotationMetadata metadata,
+                                    Annotation annotation,
+                                    Class<? extends Annotation> container,
+                                    boolean declared) {
+        Class<? extends Annotation> type = annotation.annotationType();
+        register(metadata, type);
+        register(metadata, container);
+        AnnotationMetadataSupport.registerRepeatableAnnotation(type.getName(), container.getName());
+        AnnotationValue<?> value = annotationValue(annotation);
+        if (declared) {
+            metadata.addDeclaredRepeatable(container.getName(), value);
+        } else {
+            metadata.addRepeatable(container.getName(), value);
+        }
+        addStereotypes(metadata, type, List.of(type.getName()), declared);
+    }
+
+    /**
+     * Adds the meta-annotations of an annotation type as stereotypes of the given parents, recursively. The
+     * parents are the chain from the annotation on the element down to the current type, and a type already
+     * in the chain is a cycle, which is skipped.
+     */
+    private static void addStereotypes(MutableAnnotationMetadata metadata,
+                                       Class<? extends Annotation> type,
+                                       List<String> parents,
+                                       boolean declared) {
+        for (Annotation meta : type.getDeclaredAnnotations()) {
+            Class<? extends Annotation> metaType = meta.annotationType();
+            if (isIgnored(metaType) || parents.contains(metaType.getName())) {
+                continue;
+            }
+            Annotation[] contained = containedAnnotations(meta);
+            if (contained != null) {
+                for (Annotation repeated : contained) {
+                    addRepeatedStereotype(metadata, repeated, metaType, parents, declared);
+                }
+                continue;
+            }
+            Repeatable repeatable = metaType.getAnnotation(Repeatable.class);
+            if (repeatable != null) {
+                addRepeatedStereotype(metadata, meta, repeatable.value(), parents, declared);
+                continue;
+            }
+            register(metadata, metaType);
+            if (declared) {
+                metadata.addDeclaredStereotype(parents, metaType.getName(), values(meta));
+            } else {
+                metadata.addStereotype(parents, metaType.getName(), values(meta));
+            }
+            addStereotypes(metadata, metaType, chain(parents, metaType), declared);
+        }
+    }
+
+    private static void addRepeatedStereotype(MutableAnnotationMetadata metadata,
+                                              Annotation meta,
+                                              Class<? extends Annotation> container,
+                                              List<String> parents,
+                                              boolean declared) {
+        Class<? extends Annotation> metaType = meta.annotationType();
+        if (parents.contains(metaType.getName())) {
+            return;
+        }
+        register(metadata, metaType);
+        register(metadata, container);
+        AnnotationMetadataSupport.registerRepeatableAnnotation(metaType.getName(), container.getName());
+        AnnotationValue<?> value = annotationValue(meta);
+        if (declared) {
+            metadata.addDeclaredRepeatableStereotype(parents, container.getName(), value);
+        } else {
+            metadata.addRepeatableStereotype(parents, container.getName(), value);
+        }
+        addStereotypes(metadata, metaType, chain(parents, metaType), declared);
+    }
+
+    private static List<String> chain(List<String> parents, Class<? extends Annotation> type) {
+        List<String> chain = new ArrayList<>(parents.size() + 1);
+        chain.addAll(parents);
+        chain.add(type.getName());
+        return chain;
+    }
+
+    /**
+     * Registers the defaults of an annotation type, both in the metadata under construction and in the
+     * shared registry the value accessors consult. The registry is keyed by name and the annotation type
+     * itself is not registered: a type loaded by several class loaders — the same annotation in several
+     * deployments — must resolve to the class of the loader asking for it, not to the first one seen.
+     */
+    private static void register(MutableAnnotationMetadata metadata, Class<? extends Annotation> type) {
+        Map<CharSequence, Object> defaults = defaultValues(type);
+        AnnotationMetadataSupport.registerDefaultValues(type.getName(), defaults);
+        if (!defaults.isEmpty()) {
+            metadata.addDefaultAnnotationValues(type.getName(), defaults);
+        }
+    }
+
+    /**
+     * @return The annotations a repeatable container holds, or {@code null} when the annotation is not a container;
+     * a container is the {@link Repeatable} one or a nested {@code List} of its enclosing annotation
+     */
+    private static Annotation @Nullable [] containedAnnotations(Annotation annotation) {
+        Class<? extends Annotation> type = annotation.annotationType();
+        Method value;
+        try {
+            value = type.getDeclaredMethod(AnnotationMetadata.VALUE_MEMBER);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+        Class<?> returnType = value.getReturnType();
+        if (!returnType.isArray() || !returnType.getComponentType().isAnnotation()) {
+            return null;
+        }
+        Class<?> contained = returnType.getComponentType();
+        Repeatable repeatable = contained.getAnnotation(Repeatable.class);
+        if (repeatable == null || repeatable.value() != type) {
+            // a nested `List` of its enclosing annotation is a container by convention even without @Repeatable:
+            // Bean Validation declared its constraint containers that way before Java had repeatable annotations
+            if (!("List".equals(type.getSimpleName()) && type.getEnclosingClass() == contained)) {
+                return null;
+            }
+        }
+        value.trySetAccessible();
+        return (Annotation[]) ReflectionUtils.invokeMethod(annotation, value);
+    }
+
+    private static List<Method> members(Class<? extends Annotation> type) {
+        List<Method> members = new ArrayList<>();
+        for (Method method : type.getDeclaredMethods()) {
+            if (!Modifier.isStatic(method.getModifiers()) && !method.isSynthetic() && method.getParameterCount() == 0) {
+                // the annotation type may not be public, its members are read all the same
+                method.trySetAccessible();
+                members.add(method);
+            }
+        }
+        members.sort(Comparator.comparing(Method::getName));
+        return members;
+    }
+
+    private static Object convert(Object value) {
+        if (value instanceof Class<?> type) {
+            return new AnnotationClassValue<>(type);
+        }
+        if (value instanceof Enum<?> constant) {
+            return constant.name();
+        }
+        if (value instanceof Annotation annotation) {
+            return annotationValue(annotation);
+        }
+        if (value instanceof Class<?>[] types) {
+            AnnotationClassValue<?>[] converted = new AnnotationClassValue[types.length];
+            for (int i = 0; i < types.length; i++) {
+                converted[i] = new AnnotationClassValue<>(types[i]);
+            }
+            return converted;
+        }
+        if (value instanceof Enum<?>[] constants) {
+            String[] converted = new String[constants.length];
+            for (int i = 0; i < constants.length; i++) {
+                converted[i] = constants[i].name();
+            }
+            return converted;
+        }
+        if (value instanceof Annotation[] annotations) {
+            AnnotationValue<?>[] converted = new AnnotationValue[annotations.length];
+            for (int i = 0; i < annotations.length; i++) {
+                converted[i] = annotationValue(annotations[i]);
+            }
+            return converted;
+        }
+        if (value.getClass().isArray() && !value.getClass().getComponentType().isPrimitive()) {
+            // an array of strings, kept as it is, copied so that the annotation instance is not shared
+            int length = Array.getLength(value);
+            Object copy = Array.newInstance(value.getClass().getComponentType(), length);
+            System.arraycopy(value, 0, copy, 0, length);
+            return copy;
+        }
+        return value;
+    }
+
+    private static boolean isIgnored(Class<? extends Annotation> type) {
+        String name = type.getName();
+        return name.startsWith(JAVA_LANG_ANNOTATION)
+            || name.startsWith(KOTLIN)
+            || AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(name);
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/reflection/IntrospectedExecutableMethod.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/IntrospectedExecutableMethod.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.reflection;
+
+import io.micronaut.context.AbstractExecutableMethod;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.beans.BeanMethod;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.reflect.Method;
+
+/**
+ * An {@link io.micronaut.inject.ExecutableMethod} over the {@link BeanMethod} of a bean introspection, for a
+ * specification API that names a method by its {@link Method}: the arguments and the metadata are the ones
+ * the introspection carries, generated or reflective, and the method itself is the one the caller gave.
+ *
+ * @param <T> The declaring type
+ * @param <R> The return type
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+@Experimental
+public final class IntrospectedExecutableMethod<T, R> extends AbstractExecutableMethod<T, R> {
+
+    private final BeanMethod<T, R> beanMethod;
+    private final Method method;
+
+    /**
+     * @param declaringType The type declaring the method
+     * @param beanMethod    The method of the introspection of that type
+     * @param method        The method the caller named
+     */
+    public IntrospectedExecutableMethod(Class<T> declaringType, BeanMethod<T, R> beanMethod, Method method) {
+        super(declaringType, beanMethod.getName(), beanMethod.getReturnType().asArgument(), beanMethod.getArguments());
+        this.beanMethod = beanMethod;
+        this.method = method;
+    }
+
+    @Override
+    @SuppressWarnings("NullAway") // a method can return null
+    protected R invokeInternal(T instance, @Nullable Object[] arguments) {
+        return beanMethod.invoke(instance, arguments);
+    }
+
+    @Override
+    protected Method resolveTargetMethod() {
+        return method;
+    }
+
+    @Override
+    protected AnnotationMetadata resolveAnnotationMetadata() {
+        return beanMethod.getAnnotationMetadata();
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/reflection/MethodHierarchy.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/MethodHierarchy.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.reflection;
+
+import io.micronaut.context.AnnotationReflectionUtils;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.core.beans.BeanMethod;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ReturnType;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.annotation.ReflectionAnnotationMetadataBuilder;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * What a method hierarchy declares: the method as a caller names it, what its declaring type itself declares,
+ * the declarations it overrides or implements, and the three merged into one view.
+ *
+ * <p>A specification that describes a method — the constraint metadata of Jakarta Validation, the resource
+ * metadata of JAX-RS — reads a method together with the methods it overrides, and has rules about which level
+ * of the hierarchy may declare what. Answering those rules needs the levels apart, not merged: this type
+ * resolves them.</p>
+ *
+ * <p>The hierarchy is read from the bean introspections of the super types, so it is as complete as the
+ * introspections are. A {@link ReflectiveIntrospection} tells which annotations a type itself declares, and its
+ * declarations are marked {@link Declaration#exact() exact}; a generated introspection reports the metadata of
+ * a method with the annotations of the methods it overrides already merged in, so its declarations are not.</p>
+ *
+ * @param local              The method as the caller names it
+ * @param declared           What the declaring type itself declares, {@code local} when that is not known apart
+ * @param inherited          The declarations the method overrides or implements, the nearest first
+ * @param annotationMetadata The annotations of every level merged, the local one winning
+ * @param arguments          The parameters of every level merged, the local one winning
+ * @param returnArgument     The return value of every level merged, the local one winning
+ * @author Denis Stepanov
+ * @since 5.2
+ */
+@Experimental
+public record MethodHierarchy(Declaration local,
+                              Declaration declared,
+                              List<Declaration> inherited,
+                              AnnotationMetadata annotationMetadata,
+                              Argument<?>[] arguments,
+                              Argument<?> returnArgument) {
+
+    /**
+     * Resolves the hierarchy of a method named by a {@link Method}.
+     *
+     * @param introspector The introspector of the types of the hierarchy
+     * @param method       The method
+     * @return The hierarchy
+     */
+    public static MethodHierarchy resolve(BeanIntrospector introspector, Method method) {
+        return resolve(introspector, method.getDeclaringClass(), method.getName(), method.getParameterTypes());
+    }
+
+    /**
+     * Resolves the hierarchy of a method named by the type reading it, which is the type declaring it or one
+     * inheriting it.
+     *
+     * @param introspector   The introspector of the types of the hierarchy
+     * @param type           The type reading the method
+     * @param name           The method name
+     * @param parameterTypes The parameter types
+     * @return The hierarchy
+     * @throws IllegalArgumentException When the type has no such method
+     */
+    public static MethodHierarchy resolve(BeanIntrospector introspector,
+                                          Class<?> type,
+                                          String name,
+                                          Class<?>... parameterTypes) {
+        Declaration local = declaredBy(introspector, type, name, parameterTypes)
+            .or(() -> findMethod(type, name, parameterTypes).map(Declaration::of))
+            .orElseThrow(() -> new IllegalArgumentException(
+                "No method " + name + Arrays.toString(parameterTypes) + " on type " + type.getName()));
+        return resolve(introspector, local, name);
+    }
+
+    /**
+     * Resolves the hierarchy of a method already read as a declaration, the walk starting at the type
+     * declaring it.
+     *
+     * @param introspector The introspector of the types of the hierarchy
+     * @param local        The method as the caller names it
+     * @param name         The method name
+     * @return The hierarchy
+     */
+    public static MethodHierarchy resolve(BeanIntrospector introspector, Declaration local, String name) {
+        Class<?>[] parameterTypes = Argument.toClassArray(local.arguments());
+        Declaration declared = declaredBy(introspector, local.declaringType(), name, parameterTypes)
+            .filter(Declaration::exact)
+            .orElse(local);
+        List<Declaration> inherited = inherited(introspector, local.declaringType(), name, parameterTypes);
+        if (inherited.isEmpty()) {
+            return new MethodHierarchy(local, declared, inherited, local.annotationMetadata(), local.arguments(), local.returnArgument());
+        }
+        // the farthest declaration first, the local one last: it wins where the same annotation is repeated
+        List<Declaration> levels = new ArrayList<>(inherited);
+        Collections.reverse(levels);
+        levels.add(local);
+        Argument<?>[] arguments = new Argument[local.arguments().length];
+        for (int i = 0; i < arguments.length; i++) {
+            int index = i;
+            arguments[i] = mergeArgument(levels.stream().map(level -> level.arguments()[index]).toList());
+        }
+        return new MethodHierarchy(local,
+            declared,
+            inherited,
+            mergeMetadata(levels.stream().map(Declaration::annotationMetadata).toList()),
+            arguments,
+            mergeArgument(levels.stream().map(Declaration::returnArgument).toList()));
+    }
+
+    /**
+     * The declaration of a method by a type itself, read from the introspection of that type.
+     *
+     * <p>A {@link ReflectiveIntrospection} answers whether the type declares the method, and its declaration
+     * is {@link Declaration#exact() exact}. A generated introspection is asked for the bean method of that
+     * name declared by the type; its metadata merges the annotations of the methods it overrides, so the
+     * declaration it yields is not exact. Once a generated introspection reports the annotations a method
+     * declares apart from the ones it inherits, that branch answers exactly too, and the declaring type
+     * filter it applies here becomes redundant rather than wrong.</p>
+     *
+     * @param introspector   The introspector
+     * @param type           The type
+     * @param name           The method name
+     * @param parameterTypes The parameter types
+     * @return The declaration, empty when the type has no introspection or the introspection does not
+     * describe the method
+     */
+    @SuppressWarnings("unchecked")
+    public static Optional<Declaration> declaredBy(BeanIntrospector introspector,
+                                                   Class<?> type,
+                                                   String name,
+                                                   Class<?>... parameterTypes) {
+        BeanIntrospection<Object> introspection = introspector.findIntrospection((Class<Object>) type).orElse(null);
+        if (introspection == null) {
+            return Optional.empty();
+        }
+        if (introspection instanceof ReflectiveIntrospection<Object> reflective) {
+            return reflective.findDeclaredMethod(name, parameterTypes).map(method -> Declaration.of(method, true));
+        }
+        return introspection.getBeanMethods().stream()
+            .filter(method -> method.getName().equals(name)
+                && method.getDeclaringType() == type
+                && Arrays.equals(Argument.toClassArray(method.getArguments()), parameterTypes))
+            .findFirst()
+            .map(method -> Declaration.of(method, false));
+    }
+
+    /**
+     * Merges the annotations of the levels of an argument, its type arguments included, the last level winning.
+     *
+     * @param levels The levels, the local one last
+     * @return The merged argument
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static Argument<?> mergeArgument(List<Argument<?>> levels) {
+        Argument<?> local = levels.get(levels.size() - 1);
+        Argument<?>[] localTypeParameters = local.getTypeParameters();
+        Argument<?>[] typeParameters = new Argument[localTypeParameters.length];
+        for (int i = 0; i < typeParameters.length; i++) {
+            int index = i;
+            typeParameters[i] = mergeArgument(levels.stream()
+                .filter(level -> level.getTypeParameters().length == localTypeParameters.length)
+                .map(level -> level.getTypeParameters()[index])
+                .toList());
+        }
+        return Argument.of((Class) local.getType(),
+            local.getName(),
+            mergeMetadata(levels.stream().map(Argument::getAnnotationMetadata).toList()),
+            typeParameters);
+    }
+
+    /**
+     * Merges the levels of metadata of a hierarchy into one, every annotation of it declared.
+     *
+     * @param levels The levels, the one to win last
+     * @return The merged metadata
+     */
+    public static AnnotationMetadata mergeMetadata(List<AnnotationMetadata> levels) {
+        List<AnnotationMetadata> present = levels.stream().filter(level -> !level.isEmpty()).toList();
+        if (present.isEmpty()) {
+            return AnnotationMetadata.EMPTY_METADATA;
+        }
+        if (present.size() == 1) {
+            return present.get(0);
+        }
+        // a hierarchy reads the levels as they are: the generated metadata of a type is shared, copying it into
+        // a mutable metadata would share and then alter its annotation values
+        return new AnnotationMetadataHierarchy(true, present.toArray(AnnotationMetadata[]::new));
+    }
+
+    /**
+     * Whether the method is declared in parallel branches of the hierarchy. Each declaration is read from the
+     * introspection of the type declaring it, so a type that merely inherits the method does not count as a
+     * declaration of its own.
+     *
+     * @return Whether more than one type of the hierarchy declares the method
+     */
+    public boolean parallel() {
+        return inherited.size() > 1;
+    }
+
+    /**
+     * The declarations the method overrides or implements: the ones of the super classes, then of all the
+     * interfaces, each interface visited once.
+     */
+    private static List<Declaration> inherited(BeanIntrospector introspector, Class<?> declaringType, String name, Class<?>[] parameterTypes) {
+        List<Declaration> declarations = new ArrayList<>();
+        Set<Class<?>> visitedInterfaces = new HashSet<>();
+        for (Class<?> current = declaringType.getSuperclass(); current != null && current != Object.class; current = current.getSuperclass()) {
+            declaredBy(introspector, current, name, parameterTypes).ifPresent(declarations::add);
+            collectInterfaceDeclarations(introspector, current, name, parameterTypes, visitedInterfaces, declarations);
+        }
+        collectInterfaceDeclarations(introspector, declaringType, name, parameterTypes, visitedInterfaces, declarations);
+        return List.copyOf(declarations);
+    }
+
+    private static void collectInterfaceDeclarations(BeanIntrospector introspector,
+                                                     Class<?> type,
+                                                     String name,
+                                                     Class<?>[] parameterTypes,
+                                                     Set<Class<?>> visitedInterfaces,
+                                                     List<Declaration> declarations) {
+        for (Class<?> interfaceType : type.getInterfaces()) {
+            if (visitedInterfaces.add(interfaceType)) {
+                declaredBy(introspector, interfaceType, name, parameterTypes).ifPresent(declarations::add);
+                collectInterfaceDeclarations(introspector, interfaceType, name, parameterTypes, visitedInterfaces, declarations);
+            }
+        }
+    }
+
+    /**
+     * The method a type reads under a name, whether the type declares it or inherits it from a super class or
+     * an interface, of any visibility.
+     */
+    private static Optional<Method> findMethod(Class<?> type, String name, Class<?>[] parameterTypes) {
+        for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+            Optional<Method> declared = declaredMethod(current, name, parameterTypes);
+            if (declared.isPresent()) {
+                return declared;
+            }
+        }
+        Set<Class<?>> visitedInterfaces = new HashSet<>();
+        for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+            Optional<Method> declared = interfaceMethod(current, name, parameterTypes, visitedInterfaces);
+            if (declared.isPresent()) {
+                return declared;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Method> interfaceMethod(Class<?> type, String name, Class<?>[] parameterTypes, Set<Class<?>> visitedInterfaces) {
+        for (Class<?> interfaceType : type.getInterfaces()) {
+            if (visitedInterfaces.add(interfaceType)) {
+                Optional<Method> declared = declaredMethod(interfaceType, name, parameterTypes)
+                    .or(() -> interfaceMethod(interfaceType, name, parameterTypes, visitedInterfaces));
+                if (declared.isPresent()) {
+                    return declared;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Method> declaredMethod(Class<?> type, String name, Class<?>[] parameterTypes) {
+        try {
+            return Optional.of(type.getDeclaredMethod(name, parameterTypes));
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof MethodHierarchy other
+            && local.equals(other.local)
+            && declared.equals(other.declared)
+            && inherited.equals(other.inherited)
+            && annotationMetadata.equals(other.annotationMetadata)
+            && Arrays.equals(arguments, other.arguments)
+            && returnArgument.equals(other.returnArgument);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Objects.hash(local, declared, inherited, annotationMetadata, returnArgument) + Arrays.hashCode(arguments);
+    }
+
+    @Override
+    public String toString() {
+        return "MethodHierarchy{local=" + local + ", inherited=" + inherited + "}";
+    }
+
+    /**
+     * One declaration of a method by one type of a hierarchy.
+     *
+     * @param declaringType      The type declaring it
+     * @param annotationMetadata The annotations of the method, without the ones of its declaring type
+     * @param arguments          The parameters
+     * @param returnArgument     The return value
+     * @param exact              Whether the annotations are the ones of this declaration only: a generated
+     *                           introspection merges the annotations of the overridden methods into them
+     */
+    public record Declaration(Class<?> declaringType,
+                              AnnotationMetadata annotationMetadata,
+                              Argument<?>[] arguments,
+                              Argument<?> returnArgument,
+                              boolean exact) {
+
+        /**
+         * The declaration an executable method reports. The metadata of an executable method merges the
+         * annotations of the methods it overrides, so the declaration is not {@link #exact()}.
+         *
+         * @param method The method
+         * @return The declaration
+         */
+        public static Declaration of(ExecutableMethod<?, ?> method) {
+            return new Declaration(method.getDeclaringType(),
+                declaredOf(method.getAnnotationMetadata()),
+                method.getArguments(),
+                returnArgumentOf(method.getReturnType()),
+                false);
+        }
+
+        /**
+         * The declaration a bean method reports.
+         *
+         * @param method The method
+         * @param exact  Whether the introspection reporting it tells the annotations of this declaration apart
+         *               from the ones of the methods it overrides
+         * @return The declaration
+         */
+        public static Declaration of(BeanMethod<?, ?> method, boolean exact) {
+            return new Declaration(method.getDeclaringType(),
+                declaredOf(method.getAnnotationMetadata()),
+                method.getArguments(),
+                returnArgumentOf(method.getReturnType()),
+                exact);
+        }
+
+        /**
+         * The declaration read from a {@link Method} itself. Java reflection does not inherit the annotations
+         * of a method, so the declaration is {@link #exact()}.
+         *
+         * @param method The method
+         * @return The declaration
+         */
+        public static Declaration of(Method method) {
+            return new Declaration(method.getDeclaringClass(),
+                ReflectionAnnotationMetadataBuilder.build(method),
+                AnnotationReflectionUtils.argumentsOf(method),
+                AnnotationReflectionUtils.returnArgumentOf(method),
+                true);
+        }
+
+        /**
+         * The annotations declared on an executable, without the ones of its class: the executable methods of
+         * beans carry both. A metadata that is not a hierarchy is returned as is, {@code getDeclaredMetadata()}
+         * would drop the repeated annotations.
+         *
+         * @param annotationMetadata The metadata
+         * @return The metadata of the executable alone
+         */
+        public static AnnotationMetadata declaredOf(AnnotationMetadata annotationMetadata) {
+            if (annotationMetadata instanceof AnnotationMetadataHierarchy hierarchy) {
+                AnnotationMetadata declared = hierarchy.getDeclaredMetadata();
+                return declared instanceof AnnotationMetadataHierarchy
+                    ? new AnnotationMetadataHierarchy(hierarchy.getRootMetadata(), declared.getDeclaredMetadata())
+                    : declared;
+            }
+            return annotationMetadata;
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private static Argument<?> returnArgumentOf(ReturnType<?> returnType) {
+            return Argument.of((Class) returnType.getType(),
+                declaredOf(returnType.asArgument().getAnnotationMetadata()),
+                returnType.getTypeParameters());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof Declaration other
+                && declaringType == other.declaringType
+                && exact == other.exact
+                && annotationMetadata.equals(other.annotationMetadata)
+                && Arrays.equals(arguments, other.arguments)
+                && returnArgument.equals(other.returnArgument);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * Objects.hash(declaringType, annotationMetadata, returnArgument, exact) + Arrays.hashCode(arguments);
+        }
+
+        @Override
+        public String toString() {
+            return declaringType.getName() + (exact ? " (declared)" : "");
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/reflection/ReflectionBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/ReflectionBeanIntrospection.java
@@ -314,8 +314,8 @@ public final class ReflectionBeanIntrospection<T> implements ReflectiveIntrospec
         Map<String, PropertyMembers> members = propertyMembers;
         for (Class<?> type = beanType; type != null && type != Object.class; type = type.getSuperclass()) {
             for (Method method : type.getDeclaredMethods()) {
-                if (!Modifier.isPublic(method.getModifiers()) || Modifier.isStatic(method.getModifiers())
-                    || method.isSynthetic() || method.isBridge()) {
+                // an accessor of any visibility is a member of the property: what it declares holds
+                if (Modifier.isStatic(method.getModifiers()) || method.isSynthetic() || method.isBridge()) {
                     continue;
                 }
                 String name = method.getName();

--- a/inject/src/main/java/io/micronaut/inject/reflection/ReflectionBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/ReflectionBeanIntrospection.java
@@ -666,8 +666,16 @@ public final class ReflectionBeanIntrospection<T> implements ReflectiveIntrospec
             this.field = members.field();
             this.getter = members.getter();
             this.setter = members.setter();
+            // a member of a type that is not public is reachable all the same: what it declares is what the
+            // property carries, and the accessor is the only way to the value
             if (field != null) {
                 field.trySetAccessible();
+            }
+            if (getter != null) {
+                getter.trySetAccessible();
+            }
+            if (setter != null) {
+                setter.trySetAccessible();
             }
         }
 

--- a/inject/src/main/java/io/micronaut/inject/reflection/ReflectionBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/ReflectionBeanIntrospection.java
@@ -1,0 +1,830 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.reflection;
+
+import io.micronaut.context.AnnotationReflectionUtils;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Creator;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.beans.AbstractBeanConstructor;
+import io.micronaut.core.beans.AbstractBeanMethod;
+import io.micronaut.core.beans.AbstractBeanProperty;
+import io.micronaut.core.beans.BeanConstructor;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanMethod;
+import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.core.reflect.exception.InstantiationException;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.annotation.MutableAnnotationMetadata;
+import io.micronaut.inject.annotation.ReflectionAnnotationMetadataBuilder;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A {@link BeanIntrospection} over a {@link Class}, with the properties, the constructor and the methods a
+ * generated introspection would have.
+ *
+ * <p>A property is a field, a getter or a setter of the type or of its super classes, merged by name: it is
+ * read through the getter when there is one and through the field otherwise, written through the setter when
+ * there is one and through a non-final field otherwise, and its metadata holds the annotations of all three
+ * together with the type-use annotations of the property type. A bean method is a public instance method of
+ * the type or of its super classes, {@link Object} excluded. The constructor is the one annotated
+ * {@link Creator}, else the only public one, else the public one with no parameter, else the declared one
+ * with the most parameters.</p>
+ *
+ * @param <T> The bean type
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+@Experimental
+public final class ReflectionBeanIntrospection<T> implements ReflectiveIntrospection<T> {
+
+    private final Class<T> beanType;
+    private final AnnotationMetadata annotationMetadata;
+    private final @Nullable Constructor<T> constructor;
+    private final Argument<?>[] constructorArguments;
+    private final BeanConstructor<T> beanConstructor;
+    private final Map<String, PropertyMembers> propertyMembers = new LinkedHashMap<>();
+    private final List<BeanProperty<T, Object>> properties;
+    private final List<BeanMethod<T, Object>> methods;
+
+    private ReflectionBeanIntrospection(Class<T> beanType) {
+        this.beanType = beanType;
+        this.annotationMetadata = ReflectionAnnotationMetadataBuilder.build(beanType);
+        this.constructor = selectConstructor(beanType);
+        this.constructorArguments = constructor == null ? Argument.ZERO_ARGUMENTS : AnnotationReflectionUtils.argumentsOf(constructor);
+        this.beanConstructor = new ReflectionBeanConstructor();
+        this.properties = Collections.unmodifiableList(discoverProperties());
+        this.methods = Collections.unmodifiableList(discoverMethods());
+    }
+
+    /**
+     * Introspects a type.
+     *
+     * @param beanType The type
+     * @param <T>      The type
+     * @return The introspection
+     * @throws IllegalArgumentException When the type cannot be introspected, see {@link #isIntrospectable(Class)}
+     */
+    public static <T> ReflectionBeanIntrospection<T> of(Class<T> beanType) {
+        if (!isIntrospectable(beanType)) {
+            throw new IllegalArgumentException("The type " + beanType.getName() + " cannot be introspected reflectively");
+        }
+        return new ReflectionBeanIntrospection<>(beanType);
+    }
+
+    /**
+     * @param type The type
+     * @return Whether the type is a class a reflective introspection can describe: not a primitive, an array,
+     * an interface, an annotation, an enum or a type of the JDK
+     */
+    public static boolean isIntrospectable(Class<?> type) {
+        // an interface is introspected for its declarations, it cannot be instantiated
+        return !type.isPrimitive()
+            && !type.isArray()
+            && !type.isAnnotation()
+            && !type.isEnum()
+            && !type.getName().startsWith("java.")
+            && !type.getName().startsWith("javax.")
+            && !type.getName().startsWith("jdk.");
+    }
+
+    @Override
+    public Class<T> getBeanType() {
+        return beanType;
+    }
+
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        return annotationMetadata;
+    }
+
+    @Override
+    public Collection<BeanProperty<T, Object>> getBeanProperties() {
+        return properties;
+    }
+
+    @Override
+    public Collection<BeanMethod<T, Object>> getBeanMethods() {
+        return methods;
+    }
+
+    @Override
+    public Optional<BeanMethod<T, Object>> findDeclaredMethod(String name, Class<?>... parameterTypes) {
+        for (BeanMethod<T, Object> method : methods) {
+            if (method.getDeclaringType() == beanType
+                && method.getName().equals(name)
+                && Arrays.equals(Argument.toClassArray(method.getArguments()), parameterTypes)) {
+                return Optional.of(method);
+            }
+        }
+        // the accessors are properties, not bean methods, yet they are declarations of the type all the same
+        try {
+            Method declared = beanType.getDeclaredMethod(name, parameterTypes);
+            if (Modifier.isStatic(declared.getModifiers()) || declared.isSynthetic()) {
+                return Optional.empty();
+            }
+            declared.trySetAccessible();
+            return Optional.of(new ReflectionMethod<>(this, new ReflectionExecutableMethod<>(beanType, declared)));
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Argument<?>[] getConstructorArguments() {
+        return constructorArguments;
+    }
+
+    @Override
+    public BeanConstructor<T> getConstructor() {
+        return beanConstructor;
+    }
+
+    /**
+     * Every constructor of the type, the selected one first. An introspection describes one constructor;
+     * a specification that names constructors by their parameter types needs the others too.
+     *
+     * @return The constructors
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<BeanConstructor<T>> getConstructors() {
+        List<BeanConstructor<T>> constructors = new ArrayList<>();
+        constructors.add(beanConstructor);
+        for (Constructor<?> declared : beanType.getDeclaredConstructors()) {
+            if (declared.isSynthetic() || declared.equals(constructor)) {
+                continue;
+            }
+            declared.trySetAccessible();
+            constructors.add(new ReflectionBeanConstructor((Constructor<T>) declared));
+        }
+        return Collections.unmodifiableList(constructors);
+    }
+
+    @Override
+    public Collection<BeanProperty<T, Object>> getIndexedProperties(Class<? extends Annotation> annotationType) {
+        List<BeanProperty<T, Object>> indexed = new ArrayList<>(2);
+        for (BeanProperty<T, Object> property : properties) {
+            if (property.getAnnotationMetadata().hasStereotype(annotationType)) {
+                indexed.add(property);
+            }
+        }
+        return indexed;
+    }
+
+    @Override
+    public Optional<BeanProperty<T, Object>> getIndexedProperty(Class<? extends Annotation> annotationType, String annotationValue) {
+        for (BeanProperty<T, Object> property : properties) {
+            if (annotationValue.equals(property.getAnnotationMetadata().stringValue(annotationType).orElse(null))) {
+                return Optional.of(property);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public T instantiate() throws InstantiationException {
+        return instantiate(true, Argument.ZERO_ARGUMENTS);
+    }
+
+    @Override
+    public T instantiate(boolean strictNullable, @Nullable Object... arguments) throws InstantiationException {
+        if (constructor == null) {
+            throw new InstantiationException("The type " + beanType.getName() + " declares no constructor a reflective introspection can invoke");
+        }
+        Object[] values = arguments == null ? new Object[0] : arguments;
+        if (values.length != constructorArguments.length) {
+            throw new InstantiationException("The constructor of " + beanType.getName() + " expects "
+                + constructorArguments.length + " argument(s), " + values.length + " given");
+        }
+        if (strictNullable) {
+            for (int i = 0; i < values.length; i++) {
+                if (values[i] == null && !constructorArguments[i].isNullable()) {
+                    throw new InstantiationException("Null argument specified for [" + constructorArguments[i].getName()
+                        + "] of " + beanType.getName());
+                }
+            }
+        }
+        try {
+            return constructor.newInstance(values);
+        } catch (InvocationTargetException e) {
+            throw new InstantiationException("Cannot instantiate " + beanType.getName() + ": " + e.getTargetException().getMessage(), e.getTargetException());
+        } catch (ReflectiveOperationException | IllegalArgumentException e) {
+            throw new InstantiationException("Cannot instantiate " + beanType.getName() + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean isBuildable() {
+        return constructor != null;
+    }
+
+    @Override
+    public Builder<T> builder() {
+        return new ReflectionBuilder();
+    }
+
+    @Override
+    public String toString() {
+        return "ReflectionBeanIntrospection(" + beanType.getName() + ")";
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> @Nullable Constructor<T> selectConstructor(Class<T> beanType) {
+        Constructor<?>[] declared = beanType.getDeclaredConstructors();
+        Constructor<?> selected = null;
+        for (Constructor<?> candidate : declared) {
+            if (candidate.isAnnotationPresent(Creator.class)) {
+                selected = candidate;
+                break;
+            }
+        }
+        if (selected == null) {
+            List<Constructor<?>> visible = new ArrayList<>(declared.length);
+            for (Constructor<?> candidate : declared) {
+                if (Modifier.isPublic(candidate.getModifiers()) && !candidate.isSynthetic()) {
+                    visible.add(candidate);
+                }
+            }
+            if (visible.size() == 1) {
+                selected = visible.get(0);
+            } else {
+                for (Constructor<?> candidate : visible) {
+                    if (candidate.getParameterCount() == 0) {
+                        selected = candidate;
+                        break;
+                    }
+                }
+            }
+        }
+        if (selected == null) {
+            for (Constructor<?> candidate : declared) {
+                if (!candidate.isSynthetic() && (selected == null || candidate.getParameterCount() > selected.getParameterCount())) {
+                    selected = candidate;
+                }
+            }
+        }
+        if (selected != null) {
+            selected.trySetAccessible();
+        }
+        return (Constructor<T>) selected;
+    }
+
+    @Override
+    public List<PropertyMember> getPropertyMembers(String propertyName) {
+        PropertyMembers members = propertyMembers.get(propertyName);
+        return members == null ? List.of() : members.members();
+    }
+
+    private List<BeanProperty<T, Object>> discoverProperties() {
+        Map<String, PropertyMembers> members = propertyMembers;
+        for (Class<?> type = beanType; type != null && type != Object.class; type = type.getSuperclass()) {
+            for (Method method : type.getDeclaredMethods()) {
+                if (!Modifier.isPublic(method.getModifiers()) || Modifier.isStatic(method.getModifiers())
+                    || method.isSynthetic() || method.isBridge()) {
+                    continue;
+                }
+                String name = method.getName();
+                int parameters = method.getParameterCount();
+                if (parameters == 0 && method.getReturnType() != void.class) {
+                    String property = accessorProperty(name, method.getReturnType());
+                    if (property != null) {
+                        members.computeIfAbsent(property, PropertyMembers::new).addGetter(method);
+                    }
+                } else if (parameters == 1 && name.startsWith("set") && name.length() > 3 && Character.isUpperCase(name.charAt(3))) {
+                    String property = decapitalize(name.substring(3));
+                    members.computeIfAbsent(property, PropertyMembers::new).addSetter(method);
+                }
+            }
+            for (Field field : type.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers()) || field.isSynthetic()) {
+                    continue;
+                }
+                members.computeIfAbsent(field.getName(), PropertyMembers::new).addField(field);
+            }
+        }
+        // the getters of the interfaces, which declare the type-use annotations of the implementations' properties
+        for (Class<?> anInterface : allInterfaces(beanType)) {
+            for (Method method : anInterface.getDeclaredMethods()) {
+                if (Modifier.isStatic(method.getModifiers()) || method.isSynthetic() || method.getParameterCount() != 0
+                    || method.getReturnType() == void.class) {
+                    continue;
+                }
+                String property = accessorProperty(method.getName(), method.getReturnType());
+                if (property != null) {
+                    members.computeIfAbsent(property, PropertyMembers::new).addGetter(method);
+                }
+            }
+        }
+        List<BeanProperty<T, Object>> discovered = new ArrayList<>(members.size());
+        for (PropertyMembers property : members.values()) {
+            if (property.getter() == null && property.field() == null && property.setter() == null) {
+                continue;
+            }
+            discovered.add(new ReflectionProperty<>(this, property));
+        }
+        return discovered;
+    }
+
+    @Nullable
+    private static String accessorProperty(String name, Class<?> returnType) {
+        if (name.startsWith("get") && name.length() > 3 && Character.isUpperCase(name.charAt(3))) {
+            return decapitalize(name.substring(3));
+        }
+        if (name.startsWith("is") && name.length() > 2 && Character.isUpperCase(name.charAt(2))
+            && (returnType == boolean.class || returnType == Boolean.class)) {
+            return decapitalize(name.substring(2));
+        }
+        return null;
+    }
+
+    private static List<Class<?>> allInterfaces(Class<?> type) {
+        List<Class<?>> interfaces = new ArrayList<>();
+        for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
+            collectInterfaces(current, interfaces);
+        }
+        return interfaces;
+    }
+
+    private static void collectInterfaces(Class<?> type, List<Class<?>> interfaces) {
+        for (Class<?> anInterface : type.getInterfaces()) {
+            if (!interfaces.contains(anInterface)) {
+                interfaces.add(anInterface);
+                collectInterfaces(anInterface, interfaces);
+            }
+        }
+    }
+
+    /**
+     * Merges the metadata of the type arguments of two arguments of the same type, the first argument
+     * winning the type and the names.
+     *
+     * @param first  The first argument
+     * @param second The second argument
+     * @return The merged argument
+     */
+    static Argument<?> mergeTypeArguments(Argument<?> first, Argument<?> second) {
+        if (first.getType() != second.getType()) {
+            return first;
+        }
+        Argument<?>[] firstParameters = first.getTypeParameters();
+        Argument<?>[] secondParameters = second.getTypeParameters();
+        if (firstParameters.length == 0 || firstParameters.length != secondParameters.length) {
+            return mergeMetadata(first, second.getAnnotationMetadata(), firstParameters);
+        }
+        Argument<?>[] merged = new Argument[firstParameters.length];
+        for (int i = 0; i < merged.length; i++) {
+            merged[i] = mergeTypeArguments(firstParameters[i], secondParameters[i]);
+        }
+        return mergeMetadata(first, second.getAnnotationMetadata(), merged);
+    }
+
+    /**
+     * Merges two argument arrays of the same arity pairwise.
+     *
+     * @param first  The first arguments
+     * @param second The second arguments
+     * @return The merged arguments, the first ones when the arities differ
+     */
+    static Argument<?>[] mergeArguments(Argument<?>[] first, Argument<?>[] second) {
+        if (first.length != second.length) {
+            return first;
+        }
+        Argument<?>[] merged = new Argument[first.length];
+        for (int i = 0; i < merged.length; i++) {
+            merged[i] = mergeTypeArguments(first[i], second[i]);
+        }
+        return merged;
+    }
+
+    /**
+     * The metadata of the first argument wins when it has any: the second completes a type argument the
+     * first left bare, it does not repeat the annotations the first already carries.
+     */
+    private static Argument<?> mergeMetadata(Argument<?> argument, AnnotationMetadata additional, Argument<?>[] typeParameters) {
+        AnnotationMetadata metadata = argument.getAnnotationMetadata();
+        if (metadata.isEmpty() && !additional.isEmpty()) {
+            metadata = additional;
+        }
+        return Argument.of(argument.getType(), argument.getName(), metadata, typeParameters);
+    }
+
+    private static String decapitalize(String name) {
+        if (name.length() > 1 && Character.isUpperCase(name.charAt(1))) {
+            return name;
+        }
+        return Character.toLowerCase(name.charAt(0)) + name.substring(1);
+    }
+
+    private List<BeanMethod<T, Object>> discoverMethods() {
+        Map<String, Method> bySignature = new LinkedHashMap<>();
+        for (Class<?> type = beanType; type != null && type != Object.class; type = type.getSuperclass()) {
+            for (Method method : type.getDeclaredMethods()) {
+                if (!Modifier.isPublic(method.getModifiers()) || Modifier.isStatic(method.getModifiers())
+                    || method.isSynthetic() || method.isBridge()) {
+                    continue;
+                }
+                bySignature.putIfAbsent(signature(method), method);
+            }
+        }
+        List<BeanMethod<T, Object>> discovered = new ArrayList<>(bySignature.size());
+        for (Method method : bySignature.values()) {
+            discovered.add(new ReflectionMethod<>(this, new ReflectionExecutableMethod<>(beanType, method)));
+        }
+        return discovered;
+    }
+
+    private static String signature(Method method) {
+        StringBuilder signature = new StringBuilder(method.getName()).append('(');
+        for (Class<?> parameterType : method.getParameterTypes()) {
+            signature.append(parameterType.getName()).append(',');
+        }
+        return signature.append(')').toString();
+    }
+
+    /**
+     * The members a property is made of, the most specific first: a field can be shadowed in a sub class and
+     * a getter overridden, and the constraints of every declaration apply.
+     */
+    private static final class PropertyMembers {
+
+        private final String name;
+        private final List<Field> fields = new ArrayList<>(1);
+        private final List<Method> getters = new ArrayList<>(1);
+        private final List<Method> setters = new ArrayList<>(1);
+
+        PropertyMembers(String name) {
+            this.name = name;
+        }
+
+        void addField(Field field) {
+            fields.add(field);
+        }
+
+        void addGetter(Method getter) {
+            getters.add(getter);
+        }
+
+        void addSetter(Method setter) {
+            setters.add(setter);
+        }
+
+        @Nullable Field field() {
+            return fields.isEmpty() ? null : fields.get(0);
+        }
+
+        @Nullable Method getter() {
+            return getters.isEmpty() ? null : getters.get(0);
+        }
+
+        @Nullable Method setter() {
+            return setters.isEmpty() ? null : setters.get(0);
+        }
+
+        /**
+         * The argument of the property: its type and type arguments with their type-use annotations. Every
+         * declaration can annotate the type arguments — {@code List<@Size String>} on the field, on the
+         * return type of the getter of an interface — so the arguments of all of them are merged.
+         */
+        Argument<?> argument() {
+            Argument<?> merged = null;
+            for (AnnotatedType annotatedType : annotatedTypes()) {
+                Argument<?> argument = AnnotationReflectionUtils.argumentOf(name, annotatedType);
+                merged = merged == null ? argument : mergeTypeArguments(merged, argument);
+            }
+            if (merged == null) {
+                throw new IllegalStateException("The property '" + name + "' has no member");
+            }
+            return merged;
+        }
+
+        private List<AnnotatedType> annotatedTypes() {
+            List<AnnotatedType> types = new ArrayList<>(3);
+            for (Field field : fields) {
+                types.add(field.getAnnotatedType());
+            }
+            for (Method getter : getters) {
+                types.add(getter.getAnnotatedReturnType());
+            }
+            for (Method setter : setters) {
+                types.add(setter.getAnnotatedParameterTypes()[0]);
+            }
+            return types;
+        }
+
+        /**
+         * The members with their own metadata, the most specific first.
+         */
+        List<PropertyMember> members() {
+            List<PropertyMember> members = new ArrayList<>(fields.size() + getters.size() + setters.size());
+            for (Field field : fields) {
+                members.add(new PropertyMember(ElementType.FIELD, field.getDeclaringClass(),
+                    withType(ReflectionAnnotationMetadataBuilder.build(field), field.getAnnotatedType()),
+                    AnnotationReflectionUtils.argumentOf(name, field.getAnnotatedType()),
+                    field));
+            }
+            for (Method getter : getters) {
+                members.add(new PropertyMember(ElementType.METHOD, getter.getDeclaringClass(),
+                    withType(ReflectionAnnotationMetadataBuilder.build(getter), getter.getAnnotatedReturnType()),
+                    AnnotationReflectionUtils.argumentOf(name, getter.getAnnotatedReturnType()),
+                    getter));
+            }
+            for (Method setter : setters) {
+                members.add(new PropertyMember(ElementType.METHOD, setter.getDeclaringClass(),
+                    ReflectionAnnotationMetadataBuilder.build(setter, setter.getParameters()[0]),
+                    AnnotationReflectionUtils.argumentOf(name, setter.getAnnotatedParameterTypes()[0]),
+                    setter));
+            }
+            return members;
+        }
+
+        private static AnnotationMetadata withType(AnnotationMetadata member, AnnotatedType type) {
+            AnnotationMetadata typeMetadata = ReflectionAnnotationMetadataBuilder.build(type);
+            if (typeMetadata.isEmpty()) {
+                return member;
+            }
+            return member.isEmpty() ? typeMetadata : new AnnotationMetadataHierarchy(true, member, typeMetadata);
+        }
+
+        private static Argument<?> mergeTypeArguments(Argument<?> first, Argument<?> second) {
+            return ReflectionBeanIntrospection.mergeTypeArguments(first, second);
+        }
+
+        /**
+         * The metadata of the property: every member, the most specific first, and the type-use annotations
+         * of its type.
+         */
+        AnnotationMetadata annotationMetadata(Argument<?> typed) {
+            MutableAnnotationMetadata metadata = new MutableAnnotationMetadata();
+            for (Field field : fields) {
+                ReflectionAnnotationMetadataBuilder.add(metadata, field);
+            }
+            for (Method getter : getters) {
+                ReflectionAnnotationMetadataBuilder.add(metadata, getter);
+            }
+            for (Method setter : setters) {
+                ReflectionAnnotationMetadataBuilder.add(metadata, setter);
+                ReflectionAnnotationMetadataBuilder.add(metadata, setter.getParameters()[0]);
+            }
+            AnnotationMetadata typeMetadata = typed.getAnnotationMetadata();
+            if (typeMetadata.isEmpty()) {
+                return metadata.isEmpty() ? AnnotationMetadata.EMPTY_METADATA : metadata;
+            }
+            return metadata.isEmpty() ? typeMetadata : new AnnotationMetadataHierarchy(true, metadata, typeMetadata);
+        }
+    }
+
+    /**
+     * A constructor with its annotation metadata: a constraint or a cascade declared on the constructor
+     * itself is read from here.
+     */
+    private final class ReflectionBeanConstructor extends AbstractBeanConstructor<T> {
+
+        private final @Nullable Constructor<T> target;
+
+        ReflectionBeanConstructor() {
+            super(beanType,
+                constructor == null ? AnnotationMetadata.EMPTY_METADATA : ReflectionAnnotationMetadataBuilder.build(constructor),
+                constructorArguments);
+            this.target = constructor;
+        }
+
+        ReflectionBeanConstructor(Constructor<T> target) {
+            super(beanType, ReflectionAnnotationMetadataBuilder.build(target), AnnotationReflectionUtils.argumentsOf(target));
+            this.target = target;
+        }
+
+        @Override
+        public T instantiate(@Nullable Object... parameterValues) {
+            if (target == null || target == constructor) {
+                return ReflectionBeanIntrospection.this.instantiate(true, parameterValues);
+            }
+            try {
+                return target.newInstance(parameterValues == null ? new Object[0] : parameterValues);
+            } catch (InvocationTargetException e) {
+                throw new InstantiationException("Cannot instantiate " + beanType.getName() + ": " + e.getTargetException().getMessage(), e.getTargetException());
+            } catch (ReflectiveOperationException | IllegalArgumentException e) {
+                throw new InstantiationException("Cannot instantiate " + beanType.getName() + ": " + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * A property read and written through its members.
+     *
+     * @param <B> The bean type
+     * @param <P> The property type
+     */
+    private static final class ReflectionProperty<B, P> extends AbstractBeanProperty<B, P> {
+
+        private final @Nullable Field field;
+        private final @Nullable Method getter;
+        private final @Nullable Method setter;
+
+        @SuppressWarnings("unchecked")
+        ReflectionProperty(BeanIntrospection<B> introspection, PropertyMembers members) {
+            this(introspection, members, members.argument());
+        }
+
+        @SuppressWarnings("unchecked")
+        private ReflectionProperty(BeanIntrospection<B> introspection, PropertyMembers members, Argument<?> typed) {
+            super(introspection, (Class<P>) typed.getType(), members.name, members.annotationMetadata(typed), typed.getTypeParameters());
+            this.field = members.field();
+            this.getter = members.getter();
+            this.setter = members.setter();
+            if (field != null) {
+                field.trySetAccessible();
+            }
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return setter == null && (field == null || Modifier.isFinal(field.getModifiers()));
+        }
+
+        @Override
+        public boolean isWriteOnly() {
+            return getter == null && field == null;
+        }
+
+        @Override
+        @SuppressWarnings({"unchecked", "NullAway"}) // a property value can be null, the declaration of readInternal predates the nullness annotations
+        protected P readInternal(B bean) {
+            if (getter != null) {
+                return ReflectionUtils.invokeMethod(bean, getter);
+            }
+            if (field == null) {
+                throw new UnsupportedOperationException("The property '" + getName() + "' of " + getDeclaringType().getName() + " is write only");
+            }
+            try {
+                return (P) field.get(bean);
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Cannot read the field '" + getName() + "' of " + getDeclaringType().getName(), e);
+            }
+        }
+
+        @Override
+        protected void writeInternal(B bean, @Nullable P value) {
+            if (setter != null) {
+                ReflectionUtils.invokeMethod(bean, setter, value);
+                return;
+            }
+            if (field == null || Modifier.isFinal(field.getModifiers())) {
+                throw new UnsupportedOperationException("The property '" + getName() + "' of " + getDeclaringType().getName() + " is read only");
+            }
+            try {
+                field.set(bean, value);
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Cannot write the field '" + getName() + "' of " + getDeclaringType().getName(), e);
+            }
+        }
+    }
+
+    /**
+     * A bean method dispatching to a {@link ReflectionExecutableMethod}.
+     *
+     * @param <B> The bean type
+     * @param <R> The return type
+     */
+    private static final class ReflectionMethod<B, R> extends AbstractBeanMethod<B, R> {
+
+        private final ReflectionExecutableMethod<B, R> executable;
+
+        ReflectionMethod(BeanIntrospection<B> introspection, ReflectionExecutableMethod<B, R> executable) {
+            super(introspection,
+                executable.getReturnType().asArgument(),
+                executable.getMethodName(),
+                executable.getAnnotationMetadata(),
+                executable.getArguments());
+            this.executable = executable;
+        }
+
+        /**
+         * The class declaring the method, which is a super class for an inherited method: the bean type is
+         * {@link #getDeclaringBean()}.
+         */
+        @Override
+        @SuppressWarnings("unchecked")
+        public Class<B> getDeclaringType() {
+            return (Class<B>) executable.getMethod().getDeclaringClass();
+        }
+
+        /**
+         * @return The method
+         */
+        public Method getMethod() {
+            return executable.getMethod();
+        }
+
+        @Override
+        @SuppressWarnings("NullAway") // a method can return null, the declaration of invokeInternal predates the nullness annotations
+        protected R invokeInternal(B instance, @Nullable Object... arguments) {
+            return executable.invoke(instance, arguments);
+        }
+    }
+
+    /**
+     * A builder collecting the constructor arguments by name or index.
+     */
+    private final class ReflectionBuilder implements Builder<T> {
+
+        private final Object[] values = new Object[constructorArguments.length];
+
+        @Override
+        public Argument<?>[] getBuilderArguments() {
+            return constructorArguments;
+        }
+
+        @Override
+        public Argument<?>[] getBuildMethodArguments() {
+            return Argument.ZERO_ARGUMENTS;
+        }
+
+        @Override
+        public int indexOf(String name) {
+            for (int i = 0; i < constructorArguments.length; i++) {
+                if (constructorArguments[i].getName().equals(name)) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public Builder<T> with(String name, @Nullable Object value) {
+            int index = indexOf(name);
+            if (index == -1) {
+                throw new IllegalArgumentException("No constructor argument named '" + name + "' in " + beanType.getName());
+            }
+            values[index] = value;
+            return this;
+        }
+
+        @Override
+        public Builder<T> with(T existing) {
+            for (BeanProperty<T, Object> property : properties) {
+                int index = indexOf(property.getName());
+                if (index != -1 && !property.isWriteOnly()) {
+                    values[index] = property.get(existing);
+                }
+            }
+            return this;
+        }
+
+        @Override
+        public <A> Builder<T> with(int index, Argument<A> argument, @Nullable A value) {
+            values[index] = value;
+            return this;
+        }
+
+        @Override
+        public <A> Builder<T> convert(int index, ArgumentConversionContext<A> argument, @Nullable Object value, ConversionService conversionService) {
+            values[index] = conversionService.convertRequired(value, argument);
+            return this;
+        }
+
+        @Override
+        public T build() {
+            return instantiate(false, values);
+        }
+
+        @Override
+        public T build(Object... buildMethodArguments) {
+            return build();
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/reflection/ReflectionBeanIntrospector.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/ReflectionBeanIntrospector.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.reflection;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanIntrospectionReference;
+import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.core.reflect.ClassUtils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+
+/**
+ * A {@link BeanIntrospector} that serves the generated introspections of another introspector first, and a
+ * {@link ReflectionBeanIntrospection} for a type that has none.
+ *
+ * <p>The reflective introspections cannot be enumerated, so {@link #findIntrospections(Predicate)} and
+ * {@link #findIntrospectedTypes(Predicate)} return what the delegate returns.</p>
+ *
+ * <p>This introspector is for the code paths a specification requires to handle any class; it is not a
+ * replacement of {@link BeanIntrospector#SHARED}, whose callers expect a missing introspection to mean that
+ * a type was not meant to be introspected.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+@Experimental
+public final class ReflectionBeanIntrospector implements BeanIntrospector {
+
+    private final BeanIntrospector delegate;
+    private final Predicate<Class<?>> reflective;
+    private final boolean supplementing;
+    private final Map<Class<?>, Optional<BeanIntrospection<?>>> reflected = new ConcurrentHashMap<>();
+
+    /**
+     * Creates an introspector reflecting over every type the delegate does not know.
+     *
+     * @param delegate The introspector consulted first
+     */
+    public ReflectionBeanIntrospector(BeanIntrospector delegate) {
+        this(delegate, type -> true, false);
+    }
+
+    /**
+     * @param delegate   The introspector consulted first
+     * @param reflective The types a reflective introspection may be created for
+     */
+    public ReflectionBeanIntrospector(BeanIntrospector delegate, Predicate<Class<?>> reflective) {
+        this(delegate, reflective, false);
+    }
+
+    /**
+     * @param delegate      The introspector consulted first
+     * @param reflective    The types a reflective introspection may be created for
+     * @param supplementing Whether a generated introspection is completed with the executables the
+     *                      processor left out, as a {@link SupplementedBeanIntrospection}
+     */
+    public ReflectionBeanIntrospector(BeanIntrospector delegate, Predicate<Class<?>> reflective, boolean supplementing) {
+        this.delegate = delegate;
+        this.reflective = reflective;
+        this.supplementing = supplementing;
+    }
+
+    @Override
+    public Collection<BeanIntrospection<Object>> findIntrospections(Predicate<? super BeanIntrospectionReference<?>> filter) {
+        return delegate.findIntrospections(filter);
+    }
+
+    @Override
+    public Collection<Class<?>> findIntrospectedTypes(Predicate<? super BeanIntrospectionReference<?>> filter) {
+        return delegate.findIntrospectedTypes(filter);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Optional<BeanIntrospection<T>> findIntrospection(Class<T> beanType) {
+        Optional<BeanIntrospection<T>> generated = delegate.findIntrospection(beanType);
+        boolean introspectable = ReflectionBeanIntrospection.isIntrospectable(beanType) && reflective.test(beanType);
+        if (generated.isPresent() && (!supplementing || !introspectable)) {
+            return generated;
+        }
+        if (!introspectable) {
+            return Optional.empty();
+        }
+        return (Optional<BeanIntrospection<T>>) (Optional<?>) reflected.computeIfAbsent(beanType, type -> {
+            ReflectionBeanIntrospection<T> reflection = ReflectionBeanIntrospection.of(beanType);
+            if (generated.isPresent()) {
+                return Optional.of(new SupplementedBeanIntrospection<>(generated.get(), reflection));
+            }
+            if (ClassUtils.REFLECTION_LOGGER.isDebugEnabled()) {
+                ClassUtils.REFLECTION_LOGGER.debug("Reflectively introspecting '{}', which has no generated BeanIntrospection", type.getName());
+            }
+            return Optional.of(reflection);
+        });
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/reflection/ReflectionExecutableMethod.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/ReflectionExecutableMethod.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.reflection;
+
+import io.micronaut.context.AbstractExecutableMethod;
+import io.micronaut.context.AnnotationReflectionUtils;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.annotation.ReflectionAnnotationMetadataBuilder;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.reflect.Method;
+
+/**
+ * An {@link io.micronaut.inject.ExecutableMethod} over a {@link Method}, with the arguments, the return type
+ * and the annotation metadata a generated executable method would have.
+ *
+ * @param <T> The declaring type
+ * @param <R> The return type
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+@Experimental
+public final class ReflectionExecutableMethod<T, R> extends AbstractExecutableMethod<T, R> {
+
+    private final Method method;
+    private volatile @Nullable AnnotationMetadata annotationMetadata;
+
+    /**
+     * @param declaringType The type the method is invoked on, which may inherit the method
+     * @param method        The method
+     */
+    @SuppressWarnings("unchecked")
+    public ReflectionExecutableMethod(Class<T> declaringType, Method method) {
+        super(declaringType,
+            method.getName(),
+            (Argument<R>) AnnotationReflectionUtils.returnArgumentOf(method),
+            AnnotationReflectionUtils.argumentsOf(method));
+        this.method = method;
+        method.trySetAccessible();
+    }
+
+    /**
+     * @return The method
+     */
+    public Method getMethod() {
+        return method;
+    }
+
+    @Override
+    @SuppressWarnings("NullAway") // a method can return null, the declaration of invokeInternal predates the nullness annotations
+    protected R invokeInternal(T instance, @Nullable Object[] arguments) {
+        return ReflectionUtils.invokeMethod(instance, method, arguments);
+    }
+
+    @Override
+    protected Method resolveTargetMethod() {
+        return method;
+    }
+
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        // the base class resolves the metadata while constructing, before the method is known: read it lazily instead
+        AnnotationMetadata metadata = annotationMetadata;
+        if (metadata == null) {
+            metadata = ReflectionAnnotationMetadataBuilder.build(method);
+            annotationMetadata = metadata;
+        }
+        return metadata;
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/reflection/ReflectionExecutables.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/ReflectionExecutables.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.reflection;
+
+import io.micronaut.context.AnnotationReflectionUtils;
+import io.micronaut.context.ExecutionHandleLocator;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.beans.AbstractBeanConstructor;
+import io.micronaut.core.beans.BeanConstructor;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.core.beans.BeanMethod;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.annotation.ReflectionAnnotationMetadataBuilder;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The adapters of a specification API that names an executable by its {@link Method} or
+ * {@link Constructor}: the generated metadata is used when it describes the named executable, and the
+ * reflective metadata of this package otherwise — the one reflective step an API defined on
+ * {@code java.lang.reflect} imposes.
+ *
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+@Experimental
+public final class ReflectionExecutables {
+
+    private ReflectionExecutables() {
+    }
+
+    /**
+     * The arguments of the constructor named by the caller. An introspection describes one constructor;
+     * when the caller names another one of the type, its arguments are read from the constructor itself.
+     *
+     * @param introspection The introspection of the declaring type
+     * @param constructor   The constructor
+     * @return The arguments
+     */
+    public static Argument<?>[] constructorArguments(BeanIntrospection<?> introspection, Constructor<?> constructor) {
+        Argument<?>[] arguments = introspection.getConstructorArguments();
+        Class<?>[] parameterTypes = constructor.getParameterTypes();
+        if (arguments.length == parameterTypes.length) {
+            boolean same = true;
+            for (int i = 0; i < arguments.length; i++) {
+                if (arguments[i].getType() != parameterTypes[i]) {
+                    same = false;
+                    break;
+                }
+            }
+            if (same) {
+                return arguments;
+            }
+        }
+        return AnnotationReflectionUtils.argumentsOf(constructor);
+    }
+
+    /**
+     * The constructor named by the caller, with its arguments and its annotation metadata: the one the
+     * introspection describes when it is that constructor, another one a {@link ReflectiveIntrospection}
+     * knows, else one read from the constructor itself.
+     *
+     * @param introspection The introspection of the declaring type, can be {@code null}
+     * @param constructor   The constructor
+     * @param <T>           The declaring type
+     * @return The bean constructor
+     */
+    public static <T> BeanConstructor<T> beanConstructor(@Nullable BeanIntrospection<T> introspection, Constructor<T> constructor) {
+        Class<?>[] parameterTypes = constructor.getParameterTypes();
+        if (introspection != null) {
+            List<BeanConstructor<T>> known = introspection instanceof ReflectiveIntrospection<T> reflective
+                ? reflective.getConstructors()
+                : List.of(introspection.getConstructor());
+            for (BeanConstructor<T> candidate : known) {
+                if (Arrays.equals(Argument.toClassArray(candidate.getArguments()), parameterTypes)) {
+                    return candidate;
+                }
+            }
+        }
+        constructor.trySetAccessible();
+        return new AbstractBeanConstructor<T>(constructor.getDeclaringClass(),
+            ReflectionAnnotationMetadataBuilder.build(constructor),
+            AnnotationReflectionUtils.argumentsOf(constructor)) {
+            @Override
+            public T instantiate(@Nullable Object... parameterValues) {
+                try {
+                    return constructor.newInstance(parameterValues == null ? new Object[0] : parameterValues);
+                } catch (ReflectiveOperationException e) {
+                    throw new IllegalStateException("Cannot instantiate " + constructor.getDeclaringClass().getName(), e);
+                }
+            }
+        };
+    }
+
+    /**
+     * The executable method of the method named by the caller: the one of the bean definition when the
+     * declaring type is a bean, else the one of the bean introspection, generated or reflective, else one
+     * read from the method itself.
+     *
+     * @param locator      The locator of the executable methods of the beans
+     * @param introspector The introspector
+     * @param method       The method
+     * @param <T>          The declaring type
+     * @return The executable method
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> ExecutableMethod<T, Object> executableMethod(ExecutionHandleLocator locator,
+                                                                   BeanIntrospector introspector,
+                                                                   Method method) {
+        Class<T> declaringType = (Class<T>) method.getDeclaringClass();
+        Optional<ExecutableMethod<T, Object>> found = locator.findExecutableMethod(
+            declaringType, method.getName(), method.getParameterTypes());
+        // the locator answers for any bean of the type, a sub type overriding the method included: only the bean
+        // declared by the type of the method is the method named
+        if (found.isPresent() && found.get().getDeclaringType() == declaringType) {
+            return found.get();
+        }
+        BeanIntrospection<T> introspection = introspector.findIntrospection(declaringType).orElse(null);
+        if (introspection != null) {
+            for (BeanMethod<T, Object> beanMethod : introspection.getBeanMethods()) {
+                if (beanMethod.getName().equals(method.getName())
+                    && Arrays.equals(Argument.toClassArray(beanMethod.getArguments()), method.getParameterTypes())) {
+                    return new IntrospectedExecutableMethod<>(declaringType, beanMethod, method);
+                }
+            }
+        }
+        return new ReflectionExecutableMethod<>(declaringType, method);
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/reflection/ReflectiveIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/ReflectiveIntrospection.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.reflection;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.beans.BeanConstructor;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanMethod;
+import io.micronaut.core.type.Argument;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.ElementType;
+import java.lang.reflect.Method;
+import java.lang.reflect.Field;
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * What a reflective introspection knows beyond the {@link BeanIntrospection} contract: every constructor of
+ * the type, and the members a property is made of, each with the class declaring it and its own metadata.
+ *
+ * <p>A specification that describes a type — the constraint metadata of Jakarta Validation, for instance —
+ * names constructors by their parameter types and distinguishes the constraints declared on a field from the
+ * ones declared on a getter, or in the type from the ones inherited from a super type. A generated
+ * introspection merges the members of a property into one metadata; this contract keeps them apart.</p>
+ *
+ * @param <T> The bean type
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+@Experimental
+public interface ReflectiveIntrospection<T> extends BeanIntrospection<T> {
+
+    /**
+     * @return Every constructor of the type, {@link #getConstructor()} first
+     */
+    List<BeanConstructor<T>> getConstructors();
+
+    /**
+     * @param propertyName The property name
+     * @return The members of the property, the most specific first: the fields declaring it in the type
+     * and its super classes, its getters and its setters, each with its own metadata
+     */
+    List<PropertyMember> getPropertyMembers(String propertyName);
+
+    /**
+     * Finds the method the introspected type itself declares, with the annotations of that declaration only:
+     * the generated metadata of a method merges the annotations of the methods it overrides.
+     *
+     * @param name           The method name
+     * @param parameterTypes The parameter types
+     * @return The method declared by the type, empty when the type inherits it
+     */
+    Optional<BeanMethod<T, Object>> findDeclaredMethod(String name, Class<?>... parameterTypes);
+
+    /**
+     * A member of a property.
+     *
+     * @param elementType        {@link ElementType#FIELD} for a field, {@link ElementType#METHOD} for a getter or a setter
+     * @param declaringType      The class or interface declaring the member
+     * @param annotationMetadata The metadata of the member, the type-use annotations of its type included
+     * @param argument           The type of the member as it declares it — an interface getter can declare
+     *                           {@code Iterable<@NotNull String>} where the implementation returns a sub type —
+     *                           with the type-use annotations of its type arguments
+     * @param member             The field or method
+     */
+    record PropertyMember(ElementType elementType,
+                          Class<?> declaringType,
+                          AnnotationMetadata annotationMetadata,
+                          Argument<?> argument,
+                          AnnotatedElement member) {
+
+        /**
+         * @return Whether the member yields the property value: a field or a getter, not a setter
+         */
+        public boolean isReadable() {
+            return member instanceof Field || member instanceof Method method && method.getParameterCount() == 0;
+        }
+
+        /**
+         * Reads the value of the member on a bean: the field or the getter, the way the constraints declared
+         * on each are validated against what that member holds.
+         *
+         * @param bean The bean
+         * @return The value
+         * @throws IllegalStateException When the member is not readable or fails
+         */
+        @Nullable
+        public Object read(Object bean) {
+            try {
+                if (member instanceof Field field) {
+                    field.trySetAccessible();
+                    return field.get(bean);
+                }
+                if (member instanceof Method method && method.getParameterCount() == 0) {
+                    method.trySetAccessible();
+                    return method.invoke(bean);
+                }
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException("Cannot read " + member + " of " + bean.getClass().getName(), e);
+            }
+            throw new IllegalStateException("The member " + member + " does not yield the property value");
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/reflection/ReflectiveIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/ReflectiveIntrospection.java
@@ -49,6 +49,7 @@ public interface ReflectiveIntrospection<T> extends BeanIntrospection<T> {
     /**
      * @return Every constructor of the type, {@link #getConstructor()} first
      */
+    @Override
     List<BeanConstructor<T>> getConstructors();
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/reflection/SupplementedBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/SupplementedBeanIntrospection.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.reflection;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.beans.BeanConstructor;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanMethod;
+import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.reflect.exception.InstantiationException;
+import io.micronaut.core.type.Argument;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A generated {@link BeanIntrospection} completed by a reflective one: the properties, the constructor and
+ * the methods the processor generated are served as generated, and the executables it left out — the
+ * methods that are not {@code @Executable}, the other constructors — come from reflection.
+ *
+ * <p>A processor generates what the application needs; a specification describing the type needs all of
+ * it. This keeps one introspection per type, generated where it exists.</p>
+ *
+ * @param <T> The bean type
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+@Experimental
+public final class SupplementedBeanIntrospection<T> implements ReflectiveIntrospection<T> {
+
+    private final BeanIntrospection<T> generated;
+    private final ReflectionBeanIntrospection<T> reflected;
+    private final List<BeanMethod<T, Object>> methods;
+
+    /**
+     * @param generated The generated introspection
+     * @param reflected The reflective introspection of the same type
+     */
+    public SupplementedBeanIntrospection(BeanIntrospection<T> generated, ReflectionBeanIntrospection<T> reflected) {
+        this.generated = generated;
+        this.reflected = reflected;
+        List<BeanMethod<T, Object>> merged = new ArrayList<>();
+        for (BeanMethod<T, Object> method : generated.getBeanMethods()) {
+            // the generated method, with the class the reflection knows declares it
+            BeanMethod<T, Object> reflectedMethod = findMethod(new ArrayList<>(reflected.getBeanMethods()), method.getName(), Argument.toClassArray(method.getArguments()));
+            merged.add(reflectedMethod == null ? method : new DeclaredBeanMethod<>(method, reflectedMethod.getDeclaringType()));
+        }
+        for (BeanMethod<T, Object> method : reflected.getBeanMethods()) {
+            if (findMethod(merged, method.getName(), Argument.toClassArray(method.getArguments())) == null) {
+                merged.add(method);
+            }
+        }
+        this.methods = Collections.unmodifiableList(merged);
+    }
+
+    /**
+     * @return The generated introspection
+     */
+    public BeanIntrospection<T> getGenerated() {
+        return generated;
+    }
+
+    @Override
+    public Class<T> getBeanType() {
+        return generated.getBeanType();
+    }
+
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        return generated.getAnnotationMetadata();
+    }
+
+    @Override
+    public Collection<BeanProperty<T, Object>> getIndexedProperties(Class<? extends Annotation> annotationType) {
+        return generated.getIndexedProperties(annotationType);
+    }
+
+    @Override
+    public Optional<BeanProperty<T, Object>> getIndexedProperty(Class<? extends Annotation> annotationType, String annotationValue) {
+        return generated.getIndexedProperty(annotationType, annotationValue);
+    }
+
+    @Override
+    public Collection<BeanMethod<T, Object>> getBeanMethods() {
+        return methods;
+    }
+
+    @Override
+    public Optional<BeanMethod<T, Object>> findDeclaredMethod(String name, Class<?>... parameterTypes) {
+        return reflected.findDeclaredMethod(name, parameterTypes);
+    }
+
+    @Override
+    public Argument<?>[] getConstructorArguments() {
+        return generated.getConstructorArguments();
+    }
+
+    /**
+     * The generated constructor, with the metadata the reflection reads from the constructor when the
+     * generated one carries none: a generated introspection instantiates, it does not describe.
+     */
+    @Override
+    public BeanConstructor<T> getConstructor() {
+        BeanConstructor<T> constructor = generated.getConstructor();
+        if (!constructor.getAnnotationMetadata().isEmpty()) {
+            return constructor;
+        }
+        Class<?>[] generatedTypes = Argument.toClassArray(generated.getConstructorArguments());
+        for (BeanConstructor<T> reflectedConstructor : reflected.getConstructors()) {
+            if (Arrays.equals(Argument.toClassArray(reflectedConstructor.getArguments()), generatedTypes)) {
+                return new DescribedBeanConstructor<>(constructor, reflectedConstructor);
+            }
+        }
+        return constructor;
+    }
+
+    @Override
+    public List<BeanConstructor<T>> getConstructors() {
+        List<BeanConstructor<T>> constructors = new ArrayList<>();
+        constructors.add(getConstructor());
+        Class<?>[] generatedTypes = Argument.toClassArray(generated.getConstructorArguments());
+        for (BeanConstructor<T> constructor : reflected.getConstructors()) {
+            if (!Arrays.equals(Argument.toClassArray(constructor.getArguments()), generatedTypes)) {
+                constructors.add(constructor);
+            }
+        }
+        return Collections.unmodifiableList(constructors);
+    }
+
+    /**
+     * The generated properties, each with the type arguments the reflection reads from every member:
+     * the getter of an interface can declare {@code Map<String, @NotBlank String>} where the field is a
+     * plain {@code Map<String, String>}.
+     */
+    @Override
+    public Collection<BeanProperty<T, Object>> getBeanProperties() {
+        List<BeanProperty<T, Object>> properties = new ArrayList<>();
+        for (BeanProperty<T, Object> property : generated.getBeanProperties()) {
+            BeanProperty<T, Object> reflectedProperty = reflected.getProperty(property.getName()).orElse(null);
+            properties.add(reflectedProperty == null ? property : new DescribedBeanProperty<>(property, reflectedProperty.asArgument()));
+        }
+        return Collections.unmodifiableList(properties);
+    }
+
+    @Override
+    public Optional<BeanProperty<T, Object>> getProperty(String name) {
+        for (BeanProperty<T, Object> property : getBeanProperties()) {
+            if (property.getName().equals(name)) {
+                return Optional.of(property);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<PropertyMember> getPropertyMembers(String propertyName) {
+        return reflected.getPropertyMembers(propertyName);
+    }
+
+    @Override
+    public T instantiate() throws InstantiationException {
+        return generated.instantiate();
+    }
+
+    @Override
+    public T instantiate(boolean strictNullable, @Nullable Object... arguments) throws InstantiationException {
+        return generated.instantiate(strictNullable, arguments);
+    }
+
+    @Override
+    public boolean isBuildable() {
+        return generated.isBuildable();
+    }
+
+    @Override
+    public boolean hasBuilder() {
+        return generated.hasBuilder();
+    }
+
+    @Override
+    public Builder<T> builder() {
+        return generated.builder();
+    }
+
+    @Override
+    public String toString() {
+        return "SupplementedBeanIntrospection(" + generated + ")";
+    }
+
+    /**
+     * A generated constructor with the metadata of the reflective one.
+     *
+     * @param <B> The bean type
+     */
+    private static final class DescribedBeanConstructor<B> implements BeanConstructor<B> {
+
+        private final BeanConstructor<B> generated;
+        private final BeanConstructor<B> reflected;
+
+        DescribedBeanConstructor(BeanConstructor<B> generated, BeanConstructor<B> reflected) {
+            this.generated = generated;
+            this.reflected = reflected;
+        }
+
+        @Override
+        public Class<B> getDeclaringBeanType() {
+            return generated.getDeclaringBeanType();
+        }
+
+        @Override
+        public Argument<?>[] getArguments() {
+            return ReflectionBeanIntrospection.mergeArguments(generated.getArguments(), reflected.getArguments());
+        }
+
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return reflected.getAnnotationMetadata();
+        }
+
+        @Override
+        public B instantiate(@Nullable Object... parameterValues) {
+            return generated.instantiate(parameterValues);
+        }
+    }
+
+    /**
+     * A generated property with the type arguments the reflection reads.
+     *
+     * @param <B> The bean type
+     * @param <P> The property type
+     */
+    private static final class DescribedBeanProperty<B, P> implements BeanProperty<B, P> {
+
+        private final BeanProperty<B, P> generated;
+        private final Argument<P> argument;
+
+        @SuppressWarnings("unchecked")
+        DescribedBeanProperty(BeanProperty<B, P> generated, Argument<?> reflectedArgument) {
+            this.generated = generated;
+            this.argument = (Argument<P>) ReflectionBeanIntrospection.mergeTypeArguments(generated.asArgument(), reflectedArgument);
+        }
+
+        @Override
+        public BeanIntrospection<B> getDeclaringBean() {
+            return generated.getDeclaringBean();
+        }
+
+        @Override
+        @SuppressWarnings("NullAway") // a property value can be null
+        public P get(B bean) {
+            return generated.get(bean);
+        }
+
+        @Override
+        public B withValue(B bean, @Nullable P value) {
+            return generated.withValue(bean, value);
+        }
+
+        @Override
+        public void set(B bean, @Nullable P value) {
+            generated.set(bean, value);
+        }
+
+        @Override
+        public Class<P> getType() {
+            return generated.getType();
+        }
+
+        @Override
+        public Argument<P> asArgument() {
+            return argument;
+        }
+
+        @Override
+        public String getName() {
+            return generated.getName();
+        }
+
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return generated.getAnnotationMetadata();
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return generated.isReadOnly();
+        }
+
+        @Override
+        public boolean isWriteOnly() {
+            return generated.isWriteOnly();
+        }
+
+        @Override
+        public boolean hasSetterOrConstructorArgument() {
+            return generated.hasSetterOrConstructorArgument();
+        }
+    }
+
+    /**
+     * A generated bean method reporting the class the reflection knows declares it.
+     *
+     * @param <B> The bean type
+     * @param <R> The return type
+     */
+    private static final class DeclaredBeanMethod<B, R> implements BeanMethod<B, R> {
+
+        private final BeanMethod<B, R> delegate;
+        private final Class<B> declaringType;
+
+        DeclaredBeanMethod(BeanMethod<B, R> delegate, Class<B> declaringType) {
+            this.delegate = delegate;
+            this.declaringType = declaringType;
+        }
+
+        @Override
+        public BeanIntrospection<B> getDeclaringBean() {
+            return delegate.getDeclaringBean();
+        }
+
+        @Override
+        public Class<B> getDeclaringType() {
+            return declaringType;
+        }
+
+        @Override
+        public io.micronaut.core.type.ReturnType<R> getReturnType() {
+            return delegate.getReturnType();
+        }
+
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return delegate.getAnnotationMetadata();
+        }
+
+        @Override
+        public String getName() {
+            return delegate.getName();
+        }
+
+        @Override
+        public Argument<?>[] getArguments() {
+            return delegate.getArguments();
+        }
+
+        @Override
+        @SuppressWarnings("NullAway") // a method can return null
+        public R invoke(B instance, @Nullable Object... arguments) {
+            return delegate.invoke(instance, arguments);
+        }
+    }
+
+    @Nullable
+    private static <T> BeanMethod<T, Object> findMethod(List<BeanMethod<T, Object>> methods, String name, Class<?>[] parameterTypes) {
+        for (BeanMethod<T, Object> method : methods) {
+            if (method.getName().equals(name) && Arrays.equals(Argument.toClassArray(method.getArguments()), parameterTypes)) {
+                return method;
+            }
+        }
+        return null;
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/reflection/package-info.java
+++ b/inject/src/main/java/io/micronaut/inject/reflection/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Reflective implementations of the metadata the annotation processors generate: an
+ * {@link io.micronaut.inject.ExecutableMethod} over a {@link java.lang.reflect.Method} and a
+ * {@link io.micronaut.core.beans.BeanIntrospection} over a {@link java.lang.Class}, for the types that were
+ * not processed at compilation time and that a specification requires to be handled anyway.
+ *
+ * @since 5.1
+ */
+package io.micronaut.inject.reflection;

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationTypeClassLoaderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationTypeClassLoaderSpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.inject.reflection.Portable
+import spock.lang.Specification
+
+class AnnotationTypeClassLoaderSpec extends Specification {
+
+    void "a registered annotation type is resolved again through the class loader of the caller"() {
+        given: "a loader defining its own copy of the annotation, as a child-first deployment loader does"
+        def child = new OwnCopy()
+        def own = child.define(Portable.name)
+
+        and: "the type registered by an earlier resolution, from the application loader"
+        AnnotationMetadataSupport.getAnnotationType(Portable.name, Portable.classLoader).get().is(Portable)
+
+        when: "the same name is resolved for the other loader"
+        def resolved = AnnotationMetadataSupport.getAnnotationType(Portable.name, child)
+
+        then: "the copy that loader defines is the one returned: it is the one the caller compares with"
+        resolved.get().is(own)
+        !resolved.get().is(Portable)
+        resolved.get().name == Portable.name
+
+        and: "the registered type is still served to a caller of the loader that registered it"
+        AnnotationMetadataSupport.getAnnotationType(Portable.name, Portable.classLoader).get().is(Portable)
+    }
+
+    void "a loader that has no copy of its own falls back to the registered type"() {
+        given: "a loader that defines nothing"
+        def empty = new OwnCopy()
+
+        expect:
+        AnnotationMetadataSupport.getAnnotationType(Portable.name, empty).get().is(Portable)
+    }
+
+    void "an annotation type of the JDK is served whatever the loader asks"() {
+        expect: "a type the bootstrap loader defines cannot be shadowed"
+        Deprecated.classLoader == null
+        AnnotationMetadataSupport.getAnnotationType(Deprecated.name, Deprecated.classLoader).get().is(Deprecated)
+        AnnotationMetadataSupport.getAnnotationType(Deprecated.name, new OwnCopy()).get().is(Deprecated)
+    }
+
+    /**
+     * A loader defining the classes it is asked for itself, rather than delegating to the loader that
+     * already defines them.
+     */
+    static class OwnCopy extends ClassLoader {
+
+        OwnCopy() {
+            super(ClassLoader.platformClassLoader)
+        }
+
+        Class<?> define(String name) {
+            def bytes = AnnotationTypeClassLoaderSpec.classLoader
+                    .getResourceAsStream(name.replace('.' as char, '/' as char) + ".class").bytes
+            defineClass(name, bytes, 0, bytes.length)
+        }
+    }
+}

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/ReflectionAnnotationCustomizerSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/ReflectionAnnotationCustomizerSpec.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.inject.reflection.Customized
+import io.micronaut.inject.reflection.Tag
+import spock.lang.Specification
+
+class ReflectionAnnotationCustomizerSpec extends Specification {
+
+    void "a registered customizer derives a member of the annotation it supports"() {
+        when: "an annotation the customizer supports"
+        def metadata = ReflectionAnnotationMetadataBuilder.build(Marked.getDeclaredField("named"))
+
+        then: "the derived member is in the metadata, next to the declared one"
+        metadata.stringValue(Customized, "value").get() == "one"
+        metadata.stringValue(Customized, "derived").get() == "from-one"
+    }
+
+    void "the customizer sees the values as the builder converts them, defaults included"() {
+        when: "the member the customizer derives from is left at its default, so it is not a value"
+        def metadata = ReflectionAnnotationMetadataBuilder.build(Marked.getDeclaredField("bare"))
+
+        then: "it derives from what it was given, which is nothing"
+        metadata.stringValue(Customized, "derived").get() == "from-nothing"
+    }
+
+    void "an annotation the customizer does not support is untouched"() {
+        when:
+        def metadata = ReflectionAnnotationMetadataBuilder.build(Marked.getDeclaredField("tagged"))
+
+        then:
+        metadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["plain"]
+        metadata.getAnnotationValuesByType(Tag)[0].stringValue("derived").empty
+    }
+
+    static class Marked {
+
+        @Customized("one")
+        String named
+
+        @Customized
+        String bare
+
+        @Tag("plain")
+        String tagged
+    }
+}

--- a/inject/src/test/groovy/io/micronaut/inject/reflection/MethodHierarchySpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/reflection/MethodHierarchySpec.groovy
@@ -1,0 +1,261 @@
+package io.micronaut.inject.reflection
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Executable
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.core.beans.BeanIntrospector
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MethodHierarchySpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(["spec.name": "MethodHierarchySpec"])
+
+    @Shared
+    BeanIntrospector reflective = new ReflectionBeanIntrospector(BeanIntrospector.SHARED)
+
+    private static List<String> tags(metadata) {
+        metadata.getAnnotationValuesByType(Tag).collect { it.stringValue().get() }
+    }
+
+    void "a method of a reflective hierarchy reports the declaration of every level, the nearest first"() {
+        when:
+        def hierarchy = MethodHierarchy.resolve(reflective, Reservation, "reserve", String)
+
+        then: "the super classes first, then the interfaces of each level"
+        hierarchy.local().declaringType() == Reservation
+        hierarchy.inherited()*.declaringType() == [AbstractReservation, Reservable, Auditable]
+
+        and: "every declaration is exact: reflection reads the annotations of that method alone"
+        hierarchy.local().exact()
+        hierarchy.inherited().every { it.exact() }
+        tags(hierarchy.local().annotationMetadata()) == ["reservation"]
+        hierarchy.inherited().collect { tags(it.annotationMetadata()) } == [["abstract"], ["reservable"], ["auditable"]]
+
+        and: "the declaring type declares the method itself, so that is the exact declaration"
+        hierarchy.declared().is(hierarchy.local()) || hierarchy.declared().declaringType() == Reservation
+        hierarchy.declared().exact()
+    }
+
+    void "the merged views hold every level, the local declaration winning"() {
+        when:
+        def hierarchy = MethodHierarchy.resolve(reflective, Reservation, "reserve", String)
+
+        then: "the method annotations of the whole hierarchy, the farthest first"
+        tags(hierarchy.annotationMetadata()) as Set == ["reservable", "auditable", "abstract", "reservation"] as Set
+
+        and: "the parameter annotations of the whole hierarchy"
+        hierarchy.arguments().length == 1
+        tags(hierarchy.arguments()[0].getAnnotationMetadata()) as Set ==
+                ["reservable-param", "auditable-param", "abstract-param", "reservation-param"] as Set
+
+        and: "the type-use annotations of the return type arguments, merged level by level"
+        hierarchy.returnArgument().type == List
+        tags(hierarchy.returnArgument().typeParameters[0].getAnnotationMetadata()) as Set ==
+                ["reservable-item", "auditable-item", "abstract-item", "reservation-item"] as Set
+    }
+
+    void "a type declaring the method in more than one branch is parallel"() {
+        expect:
+        MethodHierarchy.resolve(reflective, Reservation, "reserve", String).parallel()
+        !MethodHierarchy.resolve(reflective, AbstractReservation, "reserve", String).parallel()
+    }
+
+    void "a type that inherits a method without overriding it reads the declaration of the type declaring it"() {
+        when: "the type declares nothing of its own"
+        def hierarchy = MethodHierarchy.resolve(reflective, InheritedReservation, "reserve", String)
+
+        then: "the local declaration is the one of the super class actually declaring the method"
+        hierarchy.local().declaringType() == AbstractReservation
+        tags(hierarchy.local().annotationMetadata()) == ["abstract"]
+
+        and: "and the walk starts there: the interface the sub type does not implement is not reported"
+        hierarchy.inherited()*.declaringType() == [Reservable]
+    }
+
+    void "an interface reached by two branches is reported once"() {
+        when:
+        def hierarchy = MethodHierarchy.resolve(reflective, Diamond.Both, "reserve", String)
+
+        then:
+        hierarchy.local().declaringType() == Diamond.Both
+        hierarchy.inherited()*.declaringType() == [Reservable]
+        !hierarchy.parallel()
+    }
+
+    void "a method a class inherits as an interface default is found on the interface declaring it"() {
+        when:
+        def hierarchy = MethodHierarchy.resolve(reflective, Defaulting, "label", new Class[0])
+
+        then:
+        hierarchy.local().declaringType() == Labelled
+        tags(hierarchy.local().annotationMetadata()) == ["labelled"]
+        hierarchy.inherited().isEmpty()
+    }
+
+    void "a hierarchy of an interface only reports what the interface declares"() {
+        when:
+        def hierarchy = MethodHierarchy.resolve(reflective, Reservable, "reserve", String)
+
+        then:
+        hierarchy.local().declaringType() == Reservable
+        hierarchy.inherited().isEmpty()
+        hierarchy.annotationMetadata().is(hierarchy.local().annotationMetadata())
+        hierarchy.arguments().is(hierarchy.local().arguments())
+    }
+
+    void "a method named by a java.lang.reflect handle resolves against the type declaring it"() {
+        given:
+        def method = Reservation.getMethod("reserve", String)
+
+        expect:
+        MethodHierarchy.resolve(reflective, method).inherited()*.declaringType() ==
+                [AbstractReservation, Reservable, Auditable]
+    }
+
+    void "a type with no such method is rejected"() {
+        when:
+        MethodHierarchy.resolve(reflective, Reservation, "cancel", String)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("No method cancel")
+        e.message.contains(Reservation.name)
+    }
+
+    void "a declaration of a generated introspection is not exact, so the declared view falls back to the local one"() {
+        given: "the shared introspector, which serves generated introspections only"
+        def introspection = BeanIntrospection.getIntrospection(GeneratedChild)
+        def beanMethod = introspection.beanMethods.find { it.name == "describe" }
+
+        when:
+        def hierarchy = MethodHierarchy.resolve(BeanIntrospector.SHARED,
+                MethodHierarchy.Declaration.of(beanMethod, false), "describe")
+
+        then: "a generated introspection does not tell the annotations of a declaration apart from the ones \
+it merges from the methods it overrides, so the declaration is not exact and the declared view falls back"
+        !hierarchy.local().exact()
+        hierarchy.declared().is(hierarchy.local())
+
+        and: "the parent is introspected too, so its declaration is read as its own level"
+        hierarchy.inherited()*.declaringType() == [GeneratedParent]
+        !hierarchy.inherited()[0].exact()
+
+        and: "the merged view holds both levels all the same"
+        tags(hierarchy.annotationMetadata()) as Set == ["parent", "child"] as Set
+    }
+
+    void "a generated introspection completed reflectively tells the declarations apart"() {
+        given: "the same types, introspected reflectively on top of the generated introspections"
+        def supplementing = new ReflectionBeanIntrospector(BeanIntrospector.SHARED, { true }, true)
+
+        when:
+        def hierarchy = MethodHierarchy.resolve(supplementing, GeneratedChild, "describe", String)
+
+        then: "the child declares only its own annotation"
+        hierarchy.declared().exact()
+        tags(hierarchy.declared().annotationMetadata()) == ["child"]
+
+        and: "the parent declaration is a level of its own"
+        hierarchy.inherited()*.declaringType() == [GeneratedParent]
+        tags(hierarchy.inherited()[0].annotationMetadata()) == ["parent"]
+    }
+
+    void "a method of a bean definition resolves through its executable method"() {
+        given:
+        def executable = context.getExecutableMethod(CountingChild, "count", String)
+
+        when:
+        def hierarchy = MethodHierarchy.resolve(reflective,
+                MethodHierarchy.Declaration.of(executable), executable.methodName)
+
+        then: "the annotations of the class are not read as annotations of the method"
+        hierarchy.local().declaringType() == CountingChild
+        tags(hierarchy.local().annotationMetadata()) == ["counting-child"]
+
+        and:
+        hierarchy.inherited()*.declaringType() == [CountingParent]
+        tags(hierarchy.annotationMetadata()) as Set == ["counting-parent", "counting-child"] as Set
+    }
+
+    void "the metadata of an executable method is read without the metadata of its class"() {
+        given:
+        def executable = context.getExecutableMethod(CountingChild, "count", String)
+
+        expect: "the executable method carries both, the declaration only the method annotations"
+        executable.annotationMetadata.hasAnnotation(Singleton)
+        !MethodHierarchy.Declaration.declaredOf(executable.annotationMetadata).hasAnnotation(Singleton)
+        tags(MethodHierarchy.Declaration.declaredOf(executable.annotationMetadata)) == ["counting-child"]
+    }
+
+    void "a type with no introspection declares nothing"() {
+        expect:
+        MethodHierarchy.declaredBy(BeanIntrospector.SHARED, Reservation, "reserve", String).isEmpty()
+        MethodHierarchy.declaredBy(reflective, Reservation, "reserve", String).isPresent()
+    }
+
+    void "merging one level returns that level as it is"() {
+        given:
+        def only = BeanIntrospection.getIntrospection(GeneratedParent).beanMethods[0].annotationMetadata
+
+        expect:
+        MethodHierarchy.mergeMetadata([]).isEmpty()
+        MethodHierarchy.mergeMetadata([only]).is(only)
+    }
+
+    interface Labelled {
+        @Tag("labelled")
+        default String label() {
+            "labelled"
+        }
+    }
+
+    static class Defaulting implements Labelled {
+    }
+
+    @Introspected
+    static class GeneratedParent {
+        @Executable
+        @Tag("parent")
+        String describe(String value) {
+            "parent:$value"
+        }
+    }
+
+    @Introspected
+    static class GeneratedChild extends GeneratedParent {
+        @Override
+        @Executable
+        @Tag("child")
+        String describe(String value) {
+            "child:$value"
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "MethodHierarchySpec")
+    static class CountingParent {
+        @Executable
+        @Tag("counting-parent")
+        int count(String value) {
+            value.length()
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "MethodHierarchySpec")
+    static class CountingChild extends CountingParent {
+        @Override
+        @Executable
+        @Tag("counting-child")
+        int count(String value) {
+            super.count(value) * 2
+        }
+    }
+}

--- a/inject/src/test/groovy/io/micronaut/inject/reflection/ReflectionArgumentFactoriesSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/reflection/ReflectionArgumentFactoriesSpec.groovy
@@ -1,0 +1,82 @@
+package io.micronaut.inject.reflection
+
+import io.micronaut.context.AnnotationReflectionUtils
+import spock.lang.Specification
+
+class ReflectionArgumentFactoriesSpec extends Specification {
+
+    private static List<String> tags(def argument) {
+        argument.annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get()
+    }
+
+    void "the argument of a field is named after it and carries the type-use annotations of every level"() {
+        when:
+        def argument = AnnotationReflectionUtils.argumentOf(Factories.getDeclaredField("nested"))
+
+        then:
+        argument.name == "nested"
+        argument.type == Map
+
+        and: "the annotation on the value type, and the one nested inside it"
+        tags(argument.typeParameters[0]) == []
+        tags(argument.typeParameters[1]) == ["mapValue"]
+        tags(argument.typeParameters[1].typeParameters[0]) == ["deep"]
+    }
+
+    void "the argument of a parameter is named after it and carries its annotations and its type-use ones"() {
+        given:
+        def method = Factories.getMethod("produce", Map)
+
+        when:
+        def argument = AnnotationReflectionUtils.argumentOf(method.parameters[0])
+
+        then: "the annotation declared on the parameter"
+        argument.name == "input"
+        argument.type == Map
+        tags(argument) == ["param"]
+
+        and: "and the one declared on its type argument"
+        tags(argument.typeParameters[1]) == ["arg"]
+    }
+
+    void "the arguments of a method and of a constructor are the arguments of their parameters"() {
+        expect:
+        AnnotationReflectionUtils.argumentsOf(Factories.getMethod("produce", Map))*.name == ["input"]
+        AnnotationReflectionUtils.argumentsOf(Factories.getMethod("consume", String))*.type == [String]
+
+        and: "a constructor is read the same way"
+        def constructor = AnnotationReflectionUtils.argumentsOf(Factories.getConstructor(String, List))
+        tags(constructor[0]) == ["ctorParam"]
+        tags(constructor[1].typeParameters[0]) == ["ctorElem"]
+
+        and: "an executable with no parameter has no argument"
+        AnnotationReflectionUtils.argumentsOf(Factories.getConstructor()).length == 0
+        AnnotationReflectionUtils.argumentsOf(Factories.getConstructor()).is(io.micronaut.core.type.Argument.ZERO_ARGUMENTS)
+    }
+
+    void "the return argument of a method is the annotated return type, not the method"() {
+        when:
+        def argument = AnnotationReflectionUtils.returnArgumentOf(Factories.getMethod("produce", Map))
+
+        then: "the type-use annotation of the returned type argument"
+        argument.type == List
+        tags(argument.typeParameters[0]) == ["returned"]
+
+        and: "an annotation written before the return type whose target includes TYPE_USE is one of that type too, the way the compiler records it"
+        tags(argument) == ["method"]
+
+        and: "a void method returns a void argument"
+        AnnotationReflectionUtils.returnArgumentOf(Factories.getMethod("consume", String)).type == void
+    }
+
+    void "an argument can be named by the caller rather than by the member"() {
+        when:
+        def named = AnnotationReflectionUtils.argumentOf("chosen", Factories.getDeclaredField("plain").annotatedType)
+        def anonymous = AnnotationReflectionUtils.argumentOf(Factories.getDeclaredField("plain").annotatedType)
+
+        then:
+        named.name == "chosen"
+        named.type == String
+        anonymous.type == String
+    }
+}

--- a/inject/src/test/groovy/io/micronaut/inject/reflection/ReflectionBeanIntrospectionSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/reflection/ReflectionBeanIntrospectionSpec.groovy
@@ -1,0 +1,203 @@
+package io.micronaut.inject.reflection
+
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.convert.ConversionContext
+import io.micronaut.core.reflect.exception.InstantiationException
+import io.micronaut.core.type.Argument
+import spock.lang.Specification
+
+import java.lang.annotation.ElementType
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+class ReflectionBeanIntrospectionSpec extends Specification {
+
+    void "the constructor is selected the way the processor selects it"() {
+        expect:
+        ReflectionBeanIntrospection.of(type).constructorArguments*.type == arguments
+
+        where:
+        type                              || arguments
+        Constructors.Annotated            || [String, int]   // @Creator wins, though it is not public
+        Constructors.OnlyPublic           || [String, int]   // the only public one
+        Constructors.NoArgAmongMany       || []              // among several public ones, the no-arg one
+        Constructors.NonePublic           || [String, int]   // none public: the widest declared one
+    }
+
+    void "every declared constructor is listed, the selected one first"() {
+        when:
+        def constructors = ReflectionBeanIntrospection.of(Constructors.Annotated).constructors
+
+        then: "the selected one, then the others, without repeating it"
+        constructors*.arguments*.type == [[String, int], [], [String]]
+    }
+
+    void "instantiation reports what it cannot do"() {
+        given:
+        def introspection = ReflectionBeanIntrospection.of(Book)
+
+        expect:
+        introspection.isBuildable()
+
+        when: "the wrong number of arguments"
+        introspection.instantiate("only")
+
+        then:
+        def wrongCount = thrown(InstantiationException)
+        wrongCount.message.contains("expects 2 argument(s), 1 given")
+
+        when: "null for an argument that is not nullable, checked strictly"
+        introspection.instantiate(true, null, 1)
+
+        then:
+        thrown(InstantiationException)
+
+        when: "the same, not checked strictly, reaches the constructor"
+        def book = introspection.instantiate(false, null, 1)
+
+        then:
+        book.pages == 1
+    }
+
+    void "an interface declares no constructor a reflective introspection can invoke"() {
+        given:
+        def introspection = ReflectionBeanIntrospection.of(Shelf)
+
+        expect:
+        !introspection.isBuildable()
+
+        when:
+        introspection.instantiate()
+
+        then:
+        def e = thrown(InstantiationException)
+        e.message.contains("declares no constructor")
+    }
+
+    void "the types a reflective introspection describes"() {
+        expect:
+        ReflectionBeanIntrospection.isIntrospectable(Book)
+        ReflectionBeanIntrospection.isIntrospectable(Shelf)          // an interface, for its declarations
+        !ReflectionBeanIntrospection.isIntrospectable(int)
+        !ReflectionBeanIntrospection.isIntrospectable(String[])
+        !ReflectionBeanIntrospection.isIntrospectable(Level)          // an enum
+        !ReflectionBeanIntrospection.isIntrospectable(Tag)            // an annotation
+        !ReflectionBeanIntrospection.isIntrospectable(String)         // java.
+        !ReflectionBeanIntrospection.isIntrospectable(List)           // java.
+    }
+
+    void "the properties are indexed by the stereotypes and the values of their annotations"() {
+        given:
+        def introspection = ReflectionBeanIntrospection.of(Shadowed)
+
+        expect: "every property whose metadata carries the stereotype"
+        introspection.getIndexedProperties(Stereo)*.name == ["value"]
+        introspection.getIndexedProperties(Hidden)*.name == ["marked"]
+        introspection.getIndexedProperties(Shape).isEmpty()
+
+        and: "the property whose annotation holds the value"
+        introspection.getIndexedProperty(Hidden, "indexed").get().name == "marked"
+        introspection.getIndexedProperty(Hidden, "absent").empty
+    }
+
+    void "a property is made of every member declaring it, the most specific first"() {
+        given:
+        def introspection = ReflectionBeanIntrospection.of(Shadowed)
+
+        when:
+        def members = introspection.getPropertyMembers("value")
+
+        then: "the shadowed field of the super class is a member too, after the one of the type"
+        members.findAll { it.member instanceof Field }*.declaringType == [Shadowed, ShadowedBase]
+        members.findAll { it.member instanceof Field }*.annotationMetadata
+                *.getAnnotationValuesByType(Tag)*.collect { it.stringValue().get() } == [["sub"], ["super"]]
+
+        and: "the getter and the setter, each with its own metadata and element type"
+        def getter = members.find { it.member instanceof Method && ((Method) it.member).parameterCount == 0 }
+        def setter = members.find { it.member instanceof Method && ((Method) it.member).parameterCount == 1 }
+        getter.elementType == ElementType.METHOD
+        getter.annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["getter"]
+        setter.elementType == ElementType.METHOD
+        members.findAll { it.member instanceof Field }*.elementType.every { it == ElementType.FIELD }
+
+        and: "a field and a getter yield the property value, a setter does not"
+        getter.readable
+        !setter.readable
+        members.findAll { it.member instanceof Field }.every { it.readable }
+
+        and: "an unknown property has no member"
+        introspection.getPropertyMembers("missing").isEmpty()
+    }
+
+    void "a member reads the value it holds, and says so when it cannot"() {
+        given:
+        def introspection = ReflectionBeanIntrospection.of(Shadowed)
+        def bean = new Shadowed("own")
+        def members = introspection.getPropertyMembers("value")
+
+        expect: "the field of the type and its getter read the value of the type"
+        members.find { it.member instanceof Field && it.declaringType == Shadowed }.read(bean) == "own"
+        members.find { it.member instanceof Method && ((Method) it.member).parameterCount == 0 }.read(bean) == "own"
+
+        and: "the shadowed field of the super class reads what that field holds"
+        members.find { it.member instanceof Field && it.declaringType == ShadowedBase }.read(bean) == "inherited"
+
+        when: "a setter is asked for the value"
+        members.find { it.member instanceof Method && ((Method) it.member).parameterCount == 1 }.read(bean)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.contains("does not yield the property value")
+    }
+
+    void "the builder sets the constructor arguments by name, by index, from an existing bean and by conversion"() {
+        given:
+        def introspection = ReflectionBeanIntrospection.of(Book)
+
+        expect: "the arguments it builds from, and their positions"
+        introspection.builder().builderArguments*.type == [String, int]
+        introspection.builder().buildMethodArguments.length == 0
+        introspection.builder().indexOf("title") == 0
+        introspection.builder().indexOf("pages") == 1
+        introspection.builder().indexOf("missing") == -1
+
+        when: "by name"
+        def built = introspection.builder().with("title", "Named").with("pages", 5).build()
+
+        then:
+        built.title == "Named"
+        built.pages == 5
+
+        when: "an argument that does not exist"
+        introspection.builder().with("missing", "x")
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("No constructor argument named 'missing'")
+
+        when: "from an existing bean, then overridden by index"
+        def copied = introspection.builder()
+                .with(new Book("Existing", 9))
+                .with(0, Argument.of(String, "title"), "Overridden")
+                .build()
+
+        then:
+        copied.title == "Overridden"
+        copied.pages == 9
+
+        when: "by conversion"
+        def converted = introspection.builder()
+                .with("title", "Converted")
+                .convert(1, ConversionContext.of(Argument.of(int, "pages")), "12", ConversionService.SHARED)
+                .build()
+
+        then:
+        converted.pages == 12
+
+        and: "an argument left unset is null, which build does not check"
+        introspection.builder().with("pages", 1).build().title == null
+
+        and: "build with method arguments builds the same bean: there is no build method"
+        introspection.builder().with("title", "Same").with("pages", 2).build("ignored").title == "Same"
+    }
+}

--- a/inject/src/test/groovy/io/micronaut/inject/reflection/ReflectionBridgeSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/reflection/ReflectionBridgeSpec.groovy
@@ -1,0 +1,205 @@
+package io.micronaut.inject.reflection
+
+import io.micronaut.context.AnnotationReflectionUtils
+import io.micronaut.core.annotation.AnnotationClassValue
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.beans.BeanIntrospector
+import io.micronaut.inject.annotation.ReflectionAnnotationMetadataBuilder
+import spock.lang.Specification
+
+class ReflectionBridgeSpec extends Specification {
+
+    void "the metadata of a class has its declared annotations, their stereotypes, the repeated ones and the inherited ones"() {
+        when:
+        def metadata = ReflectionAnnotationMetadataBuilder.build(Book)
+
+        then: "the annotations composing another annotation are flattened next to the declared one, as the generated metadata does"
+        metadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["entity", "first", "second"]
+        metadata.getAnnotationNamesByStereotype(Stereo).contains(Tag.name)
+
+        and: "the meta-annotation of the annotation is a stereotype with its values"
+        metadata.hasStereotype(Stereo)
+        metadata.stringValue(Stereo, "kind").get() == "tag"
+
+        and: "an annotation inherited from the super class is present but not declared"
+        metadata.hasAnnotation(Shape)
+        !metadata.hasDeclaredAnnotation(Shape)
+        metadata.stringValue(Shape).get() == "base"
+
+        and: "the annotations composing an annotation are its stereotypes, repeated ones included; a stereotype lists the annotation carrying it directly, as the generated metadata does"
+        metadata.hasDeclaredAnnotation(Composed)
+        metadata.getAnnotationNamesByStereotype(Tags).contains(Composed.name)
+        metadata.getAnnotationNamesByStereotype(Stereo) == [Tag.name]
+
+        and: "the defaults of the members are known"
+        metadata.getDefaultValues(Tag.name).get("priority") == 1
+        metadata.getDefaultValues(Tag.name).get("level") == "LOW"
+    }
+
+    void "a repeated annotation keeps every occurrence with its values and its defaults"() {
+        when:
+        def metadata = ReflectionAnnotationMetadataBuilder.build(Book.getDeclaredField("title"))
+        def tags = metadata.getAnnotationValuesByType(Tag)
+
+        then: "a member equal to its default is not a value, the defaults are carried separately, as the generated metadata does"
+        tags*.stringValue()*.get() == ["title", "name"]
+        !tags[0].values.containsKey("priority")
+        tags[0].defaultValues.get("priority") == 1
+        tags[1].intValue("priority").get() == 2
+        !metadata.hasAnnotation(Shape)
+    }
+
+    void "class, enum and nested annotation members are stored as the generated metadata stores them"() {
+        when:
+        def metadata = ReflectionAnnotationMetadataBuilder.build(Book.getMethod("discount", double))
+        def tag = metadata.getAnnotationValuesByType(Tag)[0]
+
+        then: "a repeatable annotation written once is served as a repeated one, under its container"
+        metadata.getAnnotationValuesByType(Tag).size() == 1
+
+        and: "the members of a package-private annotation type are read"
+        metadata.stringValue(Hidden).get() == "secret"
+        tag.enumValue("level", Level).get() == Level.HIGH
+        tag.classValue("type").get() == Number
+        tag.getValues().get("type") instanceof AnnotationClassValue
+        tag.getAnnotation("nested", Stereo).get().stringValue("kind").get() == "inner"
+        tag.getValues().get("level") == "HIGH"
+    }
+
+    void "a member whose value is its default is served by the defaults, not stored"() {
+        when:
+        def metadata = ReflectionAnnotationMetadataBuilder.build(Book)
+        def tag = metadata.getAnnotationValuesByType(Tag)[0]
+
+        then:
+        !tag.getValues().containsKey("priority")
+        tag.defaultValues.get("priority") == 1
+        tag.defaultValues.get("level") == "LOW"
+        metadata.getDefaultValues(Tag.name).get("priority") == 1
+    }
+
+    void "the argument of a field carries the type-use annotations of its type arguments"() {
+        when:
+        def argument = AnnotationReflectionUtils.argumentOf(Book.getDeclaredField("tags"))
+
+        then:
+        argument.name == "tags"
+        argument.type == List
+        argument.typeParameters.length == 1
+        argument.typeParameters[0].type == String
+        argument.typeParameters[0].annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["elem"]
+    }
+
+    void "the arguments of a method carry the annotations of the parameters"() {
+        when:
+        def arguments = AnnotationReflectionUtils.argumentsOf(Book.getMethod("discount", double))
+
+        then:
+        arguments.length == 1
+        arguments[0].type == double
+        arguments[0].annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["pct"]
+    }
+
+    void "an executable method invokes the method and exposes its metadata"() {
+        given:
+        def method = Book.getMethod("discount", double)
+        def executable = new ReflectionExecutableMethod<Book, Double>(Book, method)
+
+        expect:
+        executable.methodName == "discount"
+        executable.declaringType == Book
+        executable.targetMethod == method
+        executable.returnType.type == double
+        executable.arguments*.type == [double]
+        executable.annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["disc"]
+        executable.invoke(new Book("EL", 200), 10d) == 180d
+    }
+
+    void "a reflective introspection exposes the properties, the constructor and the methods"() {
+        given:
+        def introspection = ReflectionBeanIntrospection.of(Book)
+        def book = new Book("EL", 200)
+
+        expect: "the properties of the type and of its super class, with their metadata"
+        introspection.propertyNames.toList().containsAll(["title", "pages", "tags", "published", "baseName"])
+        introspection.getRequiredProperty("title", String).get(book) == "EL"
+        introspection.getRequiredProperty("title", String).annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["title", "name"]
+        introspection.getRequiredProperty("pages", int).get(book) == 200
+        introspection.getRequiredProperty("published", boolean).get(book) == false
+        introspection.getRequiredProperty("baseName", String).get(book) == "base"
+
+        and: "a property is written through its setter, a final field without a setter is read only"
+        introspection.getRequiredProperty("title", String).set(book, "Expression")
+        book.title == "Expression"
+        introspection.getRequiredProperty("tags", List).readOnly
+        introspection.getRequiredProperty("tags", List).asArgument().typeParameters[0].annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["elem"]
+
+        and: "the type metadata"
+        introspection.annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["entity", "first", "second"]
+        introspection.hasStereotype(Stereo)
+
+        and: "the constructor, with its metadata"
+        introspection.constructorArguments*.type == [String, int]
+        introspection.constructor.arguments*.type == [String, int]
+        introspection.constructor.annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["ctor"]
+        introspection.constructor.instantiate("Made", 4).pages == 4
+        introspection.constructors*.arguments*.length == [2, 0]
+        introspection.constructors[1].instantiate().pages == 0
+
+        and: "an inherited method declares the class that declares it"
+        introspection.beanMethods.find { it.name == "setBaseName" }.declaringType == Base
+        introspection.beanMethods.find { it.name == "discount" }.declaringType == Book
+        introspection.instantiate("Compiled", 3).title == "Compiled"
+        introspection.builder().with(0, introspection.constructorArguments[0], "Built").with(1, introspection.constructorArguments[1], 7).build().pages == 7
+
+        and: "the methods, without those of Object"
+        introspection.beanMethods*.name.containsAll(["discount", "describe", "getTitle", "setBaseName"])
+        !introspection.beanMethods*.name.contains("hashCode")
+        introspection.beanMethods.find { it.name == "discount" }.invoke(book, 50d) == 100d
+        introspection.beanMethods.find { it.name == "discount" }.annotationMetadata.getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["disc"]
+    }
+
+    void "the reflective introspector serves the generated introspections first and reflects only for the others"() {
+        given:
+        def introspector = new ReflectionBeanIntrospector(BeanIntrospector.SHARED)
+
+        expect:
+        !(introspector.findIntrospection(Generated).get() instanceof ReflectionBeanIntrospection)
+        introspector.findIntrospection(Book).get() instanceof ReflectionBeanIntrospection
+        introspector.findIntrospection(Book).get().is(introspector.findIntrospection(Book).get())
+        introspector.findIntrospection(String).empty
+        introspector.findIntrospection(Level).empty
+        introspector.findIntrospection(Runnable).empty
+        !new ReflectionBeanIntrospector(BeanIntrospector.SHARED, { false }).findIntrospection(Book).present
+    }
+
+    @Introspected
+    static class Generated {
+        String name
+    }
+
+    void "an executable method read reflectively carries the annotations of the method"() {
+        when:
+        def executable = new ReflectionExecutableMethod<>(Book, Book.getMethod("discount", double))
+
+        then:
+        executable.annotationMetadata.getAnnotationValuesByType(Tag).size() == 1
+        executable.arguments.length == 1
+    }
+
+    void "an interface is introspected for its declarations and cannot be instantiated"() {
+        when:
+        def introspection = ReflectionBeanIntrospection.of(Shelf)
+
+        then:
+        introspection.findDeclaredMethod("getTitle").present
+        introspection.findDeclaredMethod("getTitle").get().annotationMetadata.getAnnotationValuesByType(Tag).size() == 1
+        introspection.findDeclaredMethod("missing").empty
+
+        when:
+        introspection.instantiate()
+
+        then:
+        thrown(io.micronaut.core.reflect.exception.InstantiationException)
+    }
+}

--- a/inject/src/test/groovy/io/micronaut/inject/reflection/ReflectionExecutablesSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/reflection/ReflectionExecutablesSpec.groovy
@@ -1,0 +1,211 @@
+package io.micronaut.inject.reflection
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Executable
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.beans.AbstractBeanConstructor
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.core.beans.BeanIntrospector
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ReflectionExecutablesSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(["spec.name": "ReflectionExecutablesSpec"])
+
+    void "a method of a type with a bean definition resolves to the executable method of that definition"() {
+        given:
+        def method = Counted.getMethod("count", String)
+
+        when:
+        def executable = ReflectionExecutables.executableMethod(context, BeanIntrospector.SHARED, method)
+
+        then: "the generated executable method, not a reflective one"
+        !(executable instanceof ReflectionExecutableMethod)
+        !(executable instanceof IntrospectedExecutableMethod)
+        executable.declaringType == Counted
+        executable.invoke(context.getBean(Counted), "abc") == 3
+    }
+
+    void "a method of an introspected type without a bean definition resolves through the bean method"() {
+        given:
+        def method = Described.getMethod("describe", String)
+
+        when:
+        def executable = ReflectionExecutables.executableMethod(context, BeanIntrospector.SHARED, method)
+
+        then:
+        executable instanceof IntrospectedExecutableMethod
+        executable.declaringType == Described
+        executable.getAnnotationMetadata().hasAnnotation(Executable)
+        executable.invoke(new Described(), "x") == "described x"
+    }
+
+    void "a method of a type with neither a bean definition nor an introspection resolves reflectively"() {
+        given:
+        def method = Plain.getMethod("shout", String)
+
+        when:
+        def executable = ReflectionExecutables.executableMethod(context, BeanIntrospector.SHARED, method)
+
+        then:
+        executable instanceof ReflectionExecutableMethod
+        executable.declaringType == Plain
+        executable.invoke(new Plain(), "hi") == "HI"
+    }
+
+    void "a method declared by a super type resolves against the type declaring it, not against a sub type bean overriding it"() {
+        given: "the method as the super type declares it, while only the sub type overriding it is a bean"
+        def method = Greeter.getMethod("greet", String)
+
+        expect: "the locator does answer for the super type, with the executable method of the overriding sub type"
+        context.findExecutableMethod(Greeter, "greet", String).get().declaringType == LoudGreeter
+
+        when:
+        def executable = ReflectionExecutables.executableMethod(context, BeanIntrospector.SHARED, method)
+
+        then: "that answer is rejected: the method named is the one the super type declares"
+        executable.declaringType == Greeter
+        executable.invoke(new Greeter(), "sam") == "hello sam"
+    }
+
+    void "a constructor of an introspected type resolves to the bean constructor of the introspection"() {
+        given:
+        def introspection = BeanIntrospection.getIntrospection(Described)
+
+        when:
+        def constructor = ReflectionExecutables.beanConstructor(introspection, Described.getConstructor())
+
+        then:
+        constructor.is(introspection.constructor)
+    }
+
+    void "a constructor of a type with no introspection resolves to a bean constructor over the reflective metadata"() {
+        given:
+        def ctor = Plain.getConstructor()
+
+        when:
+        def constructor = ReflectionExecutables.beanConstructor(null, ctor)
+
+        then:
+        constructor instanceof AbstractBeanConstructor
+        constructor.declaringBeanType == Plain
+        constructor.arguments.length == 0
+        constructor.instantiate() instanceof Plain
+    }
+
+    void "a constructor the introspection does not describe is read from the constructor itself"() {
+        given: "the introspection describes the two argument constructor"
+        def introspection = BeanIntrospection.getIntrospection(Pair)
+        def other = Pair.getConstructor(String)
+
+        expect:
+        introspection.constructorArguments.length == 2
+
+        when:
+        def constructor = ReflectionExecutables.beanConstructor(introspection, other)
+
+        then: "the one the introspection describes is not returned for another constructor"
+        !constructor.is(introspection.constructor)
+        constructor.arguments*.type == [String]
+        constructor.instantiate("only").first == "only"
+
+        and: "the arguments of a described constructor are the ones of the introspection, of another one the reflective ones"
+        ReflectionExecutables.constructorArguments(introspection, Pair.getConstructor(String, String))
+                .is(introspection.constructorArguments)
+        ReflectionExecutables.constructorArguments(introspection, other)*.type == [String]
+    }
+
+    void "a constructor a reflective introspection knows is one of its own bean constructors"() {
+        given: "a reflective introspection, which describes every constructor of the type"
+        def introspection = new ReflectionBeanIntrospector(BeanIntrospector.SHARED)
+                .getIntrospection(Untouched)
+        def other = Untouched.getConstructor(String)
+
+        expect: "the introspection selects the two argument constructor, as the processor would"
+        introspection.constructorArguments.length == 2
+
+        when:
+        def constructor = ReflectionExecutables.beanConstructor(introspection, other)
+
+        then: "the other constructor is one the introspection carries, not one built over the raw metadata"
+        constructor.class in introspection.constructors*.class
+        !constructor.class.anonymousClass
+        constructor.arguments*.type == [String]
+        constructor.instantiate("only").first == "only"
+    }
+
+    static class Plain {
+        String shout(String value) {
+            value.toUpperCase()
+        }
+    }
+
+    static class Greeter {
+        @Executable
+        String greet(String name) {
+            "hello $name"
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "ReflectionExecutablesSpec")
+    static class LoudGreeter extends Greeter {
+        @Override
+        @Executable
+        String greet(String name) {
+            super.greet(name).toUpperCase()
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "ReflectionExecutablesSpec")
+    static class Counted {
+        @Executable
+        int count(String value) {
+            value.length()
+        }
+    }
+
+    @Introspected
+    static class Described {
+        @Executable
+        String describe(String value) {
+            "described $value"
+        }
+    }
+
+    static class Untouched {
+        final String first
+        final String second
+
+        Untouched(String first, String second) {
+            this.first = first
+            this.second = second
+        }
+
+        Untouched(String only) {
+            this(only, null)
+        }
+    }
+
+    @Introspected
+    static class Pair {
+        final String first
+        final String second
+
+        Pair(String first, String second) {
+            this.first = first
+            this.second = second
+        }
+
+        Pair(String only) {
+            this(only, null)
+        }
+    }
+}

--- a/inject/src/test/groovy/io/micronaut/inject/reflection/Shelf.java
+++ b/inject/src/test/groovy/io/micronaut/inject/reflection/Shelf.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.reflection;
+
+interface Shelf {
+
+    @Tag("shelf")
+    String getTitle();
+}

--- a/inject/src/test/groovy/io/micronaut/inject/reflection/SupplementedBeanIntrospectionSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/reflection/SupplementedBeanIntrospectionSpec.groovy
@@ -1,0 +1,219 @@
+package io.micronaut.inject.reflection
+
+import io.micronaut.context.annotation.Executable
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.core.beans.BeanIntrospector
+import spock.lang.Specification
+
+@Introspected(classes = [Ledger])
+class SupplementedBeanIntrospectionSpec extends Specification {
+
+    private static <T> SupplementedBeanIntrospection<T> supplemented(Class<T> type) {
+        new SupplementedBeanIntrospection<T>(BeanIntrospection.getIntrospection(type), ReflectionBeanIntrospection.of(type))
+    }
+
+    void "the type, the metadata and the indexed properties are the ones of the generated introspection"() {
+        given:
+        def introspection = supplemented(Catalogue)
+
+        expect:
+        introspection.beanType == Catalogue
+        introspection.generated.is(BeanIntrospection.getIntrospection(Catalogue))
+        introspection.annotationMetadata.hasAnnotation(Introspected)
+        introspection.toString().startsWith("SupplementedBeanIntrospection(")
+    }
+
+    void "a method the processor generated is served as generated, with the class reflection knows declares it"() {
+        given:
+        def introspection = supplemented(Catalogue)
+
+        when: "the method the processor generated, which an interface declares"
+        def described = introspection.beanMethods.find { it.name == "describe" }
+
+        then: "it is the generated method, not a reflective one"
+        !(described instanceof ReflectionBeanIntrospection.ReflectionMethod)
+        described.annotationMetadata.hasAnnotation(Executable)
+        described.invoke(new Catalogue("art", ["a"])) == "catalogue:art"
+    }
+
+    void "a method the processor left out comes from reflection"() {
+        given:
+        def introspection = supplemented(Catalogue)
+
+        expect: "the generated introspection describes only the @Executable method"
+        BeanIntrospection.getIntrospection(Catalogue).beanMethods*.name == ["describe"]
+
+        when:
+        def names = introspection.beanMethods*.name
+
+        then: "the public method that is not @Executable is there too, once"
+        names.contains("describe")
+        names.contains("omitted")
+        names.count { it == "describe" } == 1
+
+        and:
+        introspection.beanMethods.find { it.name == "omitted" }.invoke(new Catalogue("art", [])) == "omitted"
+    }
+
+    void "findDeclaredMethod answers from reflection, which the generated introspection cannot"() {
+        given:
+        def introspection = supplemented(Catalogue)
+
+        expect: "a method the type declares, with the annotations of that declaration only"
+        introspection.findDeclaredMethod("omitted").present
+        introspection.findDeclaredMethod("describe").present
+        introspection.findDeclaredMethod("missing").empty
+    }
+
+    void "the generated constructor is served as generated when the processor described it"() {
+        given:
+        def introspection = supplemented(Catalogue)
+
+        expect: "the processor does record the annotations of a constructor it sees"
+        BeanIntrospection.getIntrospection(Catalogue).constructor.annotationMetadata
+                .getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["ctor"]
+
+        when:
+        def constructor = introspection.constructor
+
+        then: "so the supplemented introspection returns it untouched"
+        constructor.is(BeanIntrospection.getIntrospection(Catalogue).constructor)
+        constructor.declaringBeanType == Catalogue
+        constructor.arguments*.type == [String, List]
+        constructor.instantiate("art", ["a"]).name == "art"
+    }
+
+    void "a constructor the processor described with no metadata gains the arguments reflection reads"() {
+        given: "a constructor carrying no annotation of its own, whose parameter declares a type-use one"
+        def generated = BeanIntrospection.getIntrospection(Ledger)
+        def introspection = new SupplementedBeanIntrospection<Ledger>(generated, ReflectionBeanIntrospection.of(Ledger))
+
+        expect: "the generated constructor has no metadata and drops the type-use annotation"
+        generated.constructor.annotationMetadata.isEmpty()
+        generated.constructorArguments[0].typeParameters[0].annotationMetadata
+                .getAnnotationValuesByType(Tag).isEmpty()
+
+        when:
+        def constructor = introspection.constructor
+
+        then: "the supplemented one merges the arguments reflection read"
+        constructor.arguments[0].typeParameters[0].annotationMetadata
+                .getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["entry"]
+
+        and: "and still instantiates through the generated introspection"
+        constructor.declaringBeanType == Ledger
+        constructor.instantiate(["a", "b"]).entries == ["a", "b"]
+    }
+
+    void "every constructor of the type is listed, the generated one first"() {
+        given:
+        def introspection = supplemented(Catalogue)
+
+        expect: "the generated introspection describes one constructor"
+        introspection.constructorArguments*.type == [String, List]
+
+        when:
+        def constructors = introspection.constructors
+
+        then: "the generated one first, then the one the processor did not select"
+        constructors.size() == 2
+        constructors[0].arguments*.type == [String, List]
+        constructors[1].arguments*.type == [String]
+        constructors[1].instantiate("solo").entries == []
+    }
+
+    void "a generated property carries the type arguments reflection reads from every member"() {
+        given:
+        def introspection = supplemented(Catalogue)
+
+        expect: "the generated property has no type-use annotation: the processor read the field"
+        BeanIntrospection.getIntrospection(Catalogue).getRequiredProperty("entries", List)
+                .asArgument().typeParameters[0].annotationMetadata.getAnnotationValuesByType(Tag).isEmpty()
+
+        when:
+        def property = introspection.getProperty("entries").get()
+
+        then: "the supplemented one carries the annotation the interface declares on the type argument"
+        property.asArgument().typeParameters[0].annotationMetadata
+                .getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["elem"]
+
+        and: "while the property itself is still the generated one, read and written through it"
+        property.name == "entries"
+        property.type == List
+        property.get(new Catalogue("art", ["a", "b"])) == ["a", "b"]
+        !property.readOnly
+        introspection.getProperty("missing").empty
+    }
+
+    void "the members a property is made of come from reflection"() {
+        given:
+        def introspection = supplemented(Catalogue)
+
+        when:
+        def members = introspection.getPropertyMembers("name")
+
+        then: "the field and its accessors, each with the class declaring it"
+        members*.declaringType.every { it == Catalogue }
+        members.any { it.member instanceof java.lang.reflect.Field }
+        members.find { it.member instanceof java.lang.reflect.Field }.read(new Catalogue("art", [])) == "art"
+
+        and:
+        introspection.getPropertyMembers("missing").isEmpty()
+    }
+
+    void "instantiation and building are delegated to the generated introspection"() {
+        given:
+        def introspection = supplemented(Catalogue)
+
+        expect:
+        introspection.isBuildable() == BeanIntrospection.getIntrospection(Catalogue).isBuildable()
+        introspection.hasBuilder() == BeanIntrospection.getIntrospection(Catalogue).hasBuilder()
+        introspection.instantiate(false, "art", ["a"]).name == "art"
+    }
+
+    void "the reflective introspector supplements a generated introspection when it is asked to"() {
+        given:
+        def plain = new ReflectionBeanIntrospector(BeanIntrospector.SHARED)
+        def supplementing = new ReflectionBeanIntrospector(BeanIntrospector.SHARED, { true }, true)
+
+        expect: "without supplementing, a generated introspection is served untouched"
+        !(plain.findIntrospection(Catalogue).get() instanceof SupplementedBeanIntrospection)
+
+        and: "with it, the generated introspection is completed by the reflective one"
+        supplementing.findIntrospection(Catalogue).get() instanceof SupplementedBeanIntrospection
+        supplementing.findIntrospection(Catalogue).get().beanMethods*.name.contains("omitted")
+
+        and: "a type the processor never saw is reflective either way, not supplemented"
+        supplementing.findIntrospection(Book).get() instanceof ReflectionBeanIntrospection
+        !(supplementing.findIntrospection(Book).get() instanceof SupplementedBeanIntrospection)
+    }
+
+    @Introspected
+    static class Catalogue implements Catalogued {
+
+        @Tag("name")
+        String name
+
+        List<String> entries
+
+        @Tag("ctor")
+        Catalogue(String name, List<String> entries) {
+            this.name = name
+            this.entries = entries
+        }
+
+        protected Catalogue(String name) {
+            this(name, [])
+        }
+
+        @Executable
+        String describe() {
+            "catalogue:$name"
+        }
+
+        String omitted() {
+            "omitted"
+        }
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/annotation/DerivingCustomizer.java
+++ b/inject/src/test/java/io/micronaut/inject/annotation/DerivingCustomizer.java
@@ -1,0 +1,24 @@
+package io.micronaut.inject.annotation;
+
+import io.micronaut.inject.reflection.Customized;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+/**
+ * A customizer deriving a member from the value of the annotation, the way a processor extension derives the
+ * validator classes of a constraint. It supports one annotation type so that registering it as a service
+ * leaves the metadata of every other annotation of the test module untouched.
+ */
+public final class DerivingCustomizer implements ReflectionAnnotationCustomizer {
+
+    @Override
+    public boolean supports(Class<? extends Annotation> annotationType) {
+        return annotationType == Customized.class;
+    }
+
+    @Override
+    public void customize(Annotation annotation, Map<CharSequence, Object> values) {
+        values.put("derived", "from-" + values.getOrDefault("value", "nothing"));
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/AbstractReservation.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/AbstractReservation.java
@@ -1,0 +1,12 @@
+package io.micronaut.inject.reflection;
+
+import java.util.List;
+
+public abstract class AbstractReservation implements Reservable {
+
+    @Override
+    @Tag("abstract")
+    public List<@Tag("abstract-item") String> reserve(@Tag("abstract-param") String name) {
+        return List.of("abstract:" + name);
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Auditable.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Auditable.java
@@ -1,0 +1,13 @@
+package io.micronaut.inject.reflection;
+
+import java.util.List;
+
+/**
+ * A second, parallel declaration of the method {@link Reservable} declares: a type implementing both
+ * inherits the method from two branches that know nothing of each other.
+ */
+public interface Auditable {
+
+    @Tag("auditable")
+    List<@Tag("auditable-item") String> reserve(@Tag("auditable-param") String name);
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Base.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Base.java
@@ -1,0 +1,15 @@
+package io.micronaut.inject.reflection;
+
+@Shape("base")
+public class Base {
+
+    private String baseName = "base";
+
+    public String getBaseName() {
+        return baseName;
+    }
+
+    public void setBaseName(String baseName) {
+        this.baseName = baseName;
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Book.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Book.java
@@ -1,0 +1,67 @@
+package io.micronaut.inject.reflection;
+
+import java.util.List;
+
+@Tag("entity")
+@Composed
+public class Book extends Base {
+
+    @Tag("title")
+    @Tag(value = "name", priority = 2)
+    private String title;
+
+    private int pages;
+
+    private final List<@Tag("elem") String> tags;
+
+    private boolean published;
+
+    Book() {
+        this("", 0);
+    }
+
+    @Tag("ctor")
+    public Book(String title, int pages) {
+        this.title = title;
+        this.pages = pages;
+        this.tags = List.of("a", "b");
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public int getPages() {
+        return pages;
+    }
+
+    public void setPages(int pages) {
+        this.pages = pages;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public boolean isPublished() {
+        return published;
+    }
+
+    public void setPublished(boolean published) {
+        this.published = published;
+    }
+
+    @Hidden("secret")
+    @Tag(value = "disc", level = Level.HIGH, type = Number.class, nested = @Stereo(kind = "inner"))
+    public double discount(@Tag("pct") double percent) {
+        return pages * (1 - percent / 100);
+    }
+
+    public String describe(Level level) {
+        return title + ":" + level;
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Catalogued.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Catalogued.java
@@ -1,0 +1,12 @@
+package io.micronaut.inject.reflection;
+
+import java.util.List;
+
+/**
+ * An interface declaring the type-use annotations the implementation drops: a generated introspection reads
+ * the field, so only reflection over the hierarchy sees them.
+ */
+public interface Catalogued {
+
+    List<@Tag("elem") String> getEntries();
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Composed.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Composed.java
@@ -1,0 +1,16 @@
+package io.micronaut.inject.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation composed of two repeated {@link Tag}s, the way a custom constraint composes constraints.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+@Tag("first")
+@Tag(value = "second", priority = 2)
+public @interface Composed {
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Constructors.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Constructors.java
@@ -1,0 +1,63 @@
+package io.micronaut.inject.reflection;
+
+import io.micronaut.core.annotation.Creator;
+
+/**
+ * The four rules a reflective introspection selects a constructor by.
+ */
+public final class Constructors {
+
+    private Constructors() {
+    }
+
+    /**
+     * A {@link Creator} wins, even on a constructor that is not public.
+     */
+    public static class Annotated {
+        public Annotated() {
+        }
+
+        public Annotated(String only) {
+        }
+
+        @Creator
+        Annotated(String first, int second) {
+        }
+    }
+
+    /**
+     * With no {@link Creator}, the only public constructor.
+     */
+    public static class OnlyPublic {
+        OnlyPublic(String only) {
+        }
+
+        public OnlyPublic(String first, int second) {
+        }
+    }
+
+    /**
+     * Among several public ones, the one taking no parameter.
+     */
+    public static class NoArgAmongMany {
+        public NoArgAmongMany(String only) {
+        }
+
+        public NoArgAmongMany(String first, int second) {
+        }
+
+        public NoArgAmongMany() {
+        }
+    }
+
+    /**
+     * With none public, the declared one taking the most parameters.
+     */
+    public static class NonePublic {
+        NonePublic(String only) {
+        }
+
+        private NonePublic(String first, int second) {
+        }
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Customized.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Customized.java
@@ -1,0 +1,18 @@
+package io.micronaut.inject.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation a {@link io.micronaut.inject.annotation.ReflectionAnnotationCustomizer} derives a member of.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+public @interface Customized {
+
+    String value() default "";
+
+    String derived() default "";
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Diamond.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Diamond.java
@@ -1,0 +1,25 @@
+package io.micronaut.inject.reflection;
+
+import java.util.List;
+
+/**
+ * Two branches reaching the same interface: {@link Reservable} is a super interface of both {@link Left} and
+ * {@link Right}, and the walk reports its declaration once.
+ */
+public interface Diamond {
+
+    interface Left extends Reservable {
+    }
+
+    interface Right extends Reservable {
+    }
+
+    class Both implements Left, Right {
+
+        @Override
+        @Tag("both")
+        public List<String> reserve(String name) {
+            return List.of("both:" + name);
+        }
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Factories.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Factories.java
@@ -1,0 +1,29 @@
+package io.micronaut.inject.reflection;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The shapes the {@code AnnotationReflectionUtils} argument factories are read from.
+ */
+public class Factories {
+
+    private Map<String, @Tag("mapValue") List<@Tag("deep") String>> nested;
+
+    private String plain;
+
+    public Factories(@Tag("ctorParam") String plain, List<@Tag("ctorElem") String> more) {
+        this.plain = plain;
+    }
+
+    public Factories() {
+    }
+
+    @Tag("method")
+    public List<@Tag("returned") String> produce(@Tag("param") Map<String, @Tag("arg") Integer> input) {
+        return List.of();
+    }
+
+    public void consume(String value) {
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Hidden.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Hidden.java
@@ -1,0 +1,15 @@
+package io.micronaut.inject.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A package-private annotation type: its members are still read.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+@interface Hidden {
+    String value() default "hidden";
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/InheritedReservation.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/InheritedReservation.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.reflection;
+
+/**
+ * A type that declares nothing of its own: it reads the method of {@link AbstractReservation}.
+ */
+public class InheritedReservation extends AbstractReservation {
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Ledger.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Ledger.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.reflection;
+
+import java.util.List;
+
+/**
+ * A class whose constructor carries no annotation of its own, but whose parameter declares a type-use one:
+ * the generated introspection reads neither, so only reflection describes it.
+ */
+public class Ledger {
+
+    private final List<String> entries;
+
+    public Ledger(List<@Tag("entry") String> entries) {
+        this.entries = entries;
+    }
+
+    public List<String> getEntries() {
+        return entries;
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Level.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Level.java
@@ -1,0 +1,5 @@
+package io.micronaut.inject.reflection;
+
+public enum Level {
+    LOW, HIGH
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Portable.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Portable.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation with no member, so that another class loader can define its own copy of it.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+public @interface Portable {
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Reservable.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Reservable.java
@@ -1,0 +1,12 @@
+package io.micronaut.inject.reflection;
+
+import java.util.List;
+
+/**
+ * The root of the method hierarchy the {@code MethodHierarchySpec} walks.
+ */
+public interface Reservable {
+
+    @Tag("reservable")
+    List<@Tag("reservable-item") String> reserve(@Tag("reservable-param") String name);
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Reservation.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Reservation.java
@@ -1,0 +1,12 @@
+package io.micronaut.inject.reflection;
+
+import java.util.List;
+
+public class Reservation extends AbstractReservation implements Auditable {
+
+    @Override
+    @Tag("reservation")
+    public List<@Tag("reservation-item") String> reserve(@Tag("reservation-param") String name) {
+        return List.of("reservation:" + name);
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Shadowed.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Shadowed.java
@@ -1,0 +1,31 @@
+package io.micronaut.inject.reflection;
+
+/**
+ * A field shadowing the one of a super class, with a getter and a setter of its own: every declaration is a
+ * member of the property, and each carries its own annotations.
+ */
+public class Shadowed extends ShadowedBase {
+
+    @Tag("sub")
+    private String value;
+
+    @Hidden("indexed")
+    private String marked = "here";
+
+    public Shadowed(String value) {
+        this.value = value;
+    }
+
+    @Tag("getter")
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(@Tag("param") String value) {
+        this.value = value;
+    }
+
+    public String getMarked() {
+        return marked;
+    }
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/ShadowedBase.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/ShadowedBase.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.reflection;
+
+class ShadowedBase {
+
+    @Tag("super")
+    String value = "inherited";
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Shape.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Shape.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface Shape {
+    String value();
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Stereo.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Stereo.java
@@ -1,0 +1,12 @@
+package io.micronaut.inject.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE_USE})
+public @interface Stereo {
+    String kind() default "any";
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Tag.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Tag.java
@@ -1,0 +1,23 @@
+package io.micronaut.inject.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Repeatable(Tags.class)
+@Stereo(kind = "tag")
+public @interface Tag {
+    String value();
+
+    int priority() default 1;
+
+    Class<?> type() default Object.class;
+
+    Level level() default Level.LOW;
+
+    Stereo nested() default @Stereo;
+}

--- a/inject/src/test/java/io/micronaut/inject/reflection/Tags.java
+++ b/inject/src/test/java/io/micronaut/inject/reflection/Tags.java
@@ -1,0 +1,12 @@
+package io.micronaut.inject.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE_USE})
+public @interface Tags {
+    Tag[] value();
+}

--- a/inject/src/test/resources/META-INF/services/io.micronaut.inject.annotation.ReflectionAnnotationCustomizer
+++ b/inject/src/test/resources/META-INF/services/io.micronaut.inject.annotation.ReflectionAnnotationCustomizer
@@ -1,0 +1,1 @@
+io.micronaut.inject.annotation.DerivingCustomizer


### PR DESCRIPTION
## What this is

A specification that has to handle any class — Jakarta Validation, Jakarta REST, CDI — ends up reading annotations, parameters and properties reflectively for the types the annotation processors never saw. micronaut-validation, micronaut-jaxrs and ODI each wrote that conversion themselves, and each wrote it differently: one adds stereotypes, another none, one expands repeatable containers, another does not, and none of them serves defaults the way the generated metadata does.

This is one implementation in `micronaut-inject`, shaped like the metadata the processors generate, so that code written against generated metadata also works for a type that has none. Everything is `@Experimental`.

| Class | Lines | What it is |
| --- | ---: | --- |
| `inject/annotation/ReflectionAnnotationMetadataBuilder` | 453 | `AnnotationMetadata` from an `AnnotatedElement` |
| `inject/annotation/ReflectionAnnotationCustomizer` | 57 | the runtime counterpart of the processors' mappers and transformers |
| `context/AnnotationReflectionUtils` | +120 | the `Argument` factories over `AnnotatedType`, `Parameter`, `Field`, `Executable` |
| `inject/reflection/ReflectionBeanIntrospection` | 838 | a `BeanIntrospection` over a `Class` |
| `inject/reflection/SupplementedBeanIntrospection` | 382 | a generated introspection completed by a reflective one |
| `inject/reflection/ReflectionBeanIntrospector` | 113 | generated introspections first, reflection only for the rest |
| `inject/reflection/ReflectiveIntrospection` | 120 | what a reflective introspection knows beyond the contract |
| `inject/reflection/ReflectionExecutableMethod` | 86 | an `ExecutableMethod` over a `Method` |
| `inject/reflection/ReflectionExecutables` | 149 | `Method`/`Constructor` → the best metadata available |
| `inject/reflection/IntrospectedExecutableMethod` | 68 | an `ExecutableMethod` over a `BeanMethod` |
| `inject/reflection/MethodHierarchy` | 429 | what each level of a method hierarchy declares, apart and merged |
| `inject/annotation/AnnotationMetadataSupport` | +9 | a registered annotation type resolved through the caller's loader |

`MethodHierarchy` answers the question every consumer asks straight after "describe this class". A specification that describes a method reads it together with the methods it overrides, and has rules about which level may declare what — so it needs the levels **apart**, not merged. The walk asks each level's introspection what that level declares itself (`findDeclaredMethod` on a `ReflectiveIntrospection`, the bean method filtered by declaring type on a generated one) and returns the local declaration, the exact one where a level can be told apart, the inherited ones nearest first, and the three merged into one view of the annotations, the parameters and the return type.

A declaration read reflectively is `exact`: Java reflection does not inherit the annotations of a method. One read from a generated introspection is not, because that metadata already merges what the method overrides. When #12917 lands that branch answers exactly too and nothing else moves — the declaring-type filter it applies becomes redundant rather than wrong.

The annotation mappers, transformers and remappers of the processors are **not** applied: they live in `micronaut-core-processor`, which is not on a runtime classpath. `ReflectionAnnotationCustomizer` is the runtime hook for the extensions that need one — a processor extension deriving a member from the annotation type, such as the validator classes copied from a `@Constraint` meta-annotation, has to be applied to the reflective metadata too, or code reading the member behaves differently for a type the processor never saw.

`BeanIntrospector.SHARED` is unchanged. `ReflectionBeanIntrospector` serves the generated introspections of a delegate first and reflects only for the others, so a caller opts into reflection explicitly.

## Why

Two consumers are waiting on it:

- **micronaut-validation** deletes its `validation-reflection` module — `ReflectionValidator` and eleven supporting classes, 9852 deletions — and runs one `DefaultValidator` over a supplementing `ReflectionBeanIntrospector`. The Jakarta Validation TCK passes on that branch: `jakartaTck` 1054, `jakartaTckIntrospection` 961, `jakartaTckReflection` 1019, no failures.
  It also drops the three classes it wrote in core types with no validation concept in them: `ReflectiveExecutables` (147 lines, now `ReflectionExecutables`), `IntrospectedExecutableMethod` (63, now the copy here) and the traversal half of `ExecutableHierarchy` (~180 of 486, now `MethodHierarchy`). What stays there is the Jakarta declaration rules over the levels this PR resolves.
- **micronaut-jaxrs** needs the same thing for its reflective path (micronaut-jaxrs#641). Three sites in `jaxrs-reflection` reflect over methods and constructors directly today and would otherwise reimplement `ReflectionExecutables`.

## Tests

68 cases in `micronaut-inject`, all green; the module's suite is 380.

| Spec | Cases | Covers |
| --- | ---: | --- |
| `ReflectionBridgeSpec` | 11 | the metadata builder and a walk through each class |
| `ReflectionArgumentFactoriesSpec` | 5 | the six `AnnotationReflectionUtils` factories |
| `ReflectionBeanIntrospectionSpec` | 12 | constructor selection, instantiation, property members, the builder |
| `SupplementedBeanIntrospectionSpec` | 11 | generated-plus-reflective merging |
| `ReflectionExecutablesSpec` | 8 | the resolution strategy |
| `MethodHierarchySpec` | 15 | the levels of a method hierarchy |
| `ReflectionAnnotationCustomizerSpec` | 3 | the service hook |
| `AnnotationTypeClassLoaderSpec` | 3 | the annotation-type/class-loader fix |

Each case asserts the reflective metadata is shaped **like the generated metadata**, which is the point of the whole thing: code written against one has to work against the other.

<details>
<summary>The cases in full</summary>

**The metadata builder** — a class's declared annotations, their stereotypes, the repeated ones and the inherited ones; annotations composing another flattened next to the declared one; a meta-annotation as a stereotype with its values; a super class's annotation present but not *declared*; every occurrence of a repeated annotation with its values; a member equal to its default carried in the defaults rather than stored; class, enum and nested annotation members stored as `AnnotationClassValue`, the enum name and a nested `AnnotationValue`; a package-private annotation type's members still read.

**The argument factories** — `argumentOf(Field)` carrying the type-use annotations of *every* level, so `Map<String, @Tag List<@Tag String>>` keeps both; `argumentOf(Parameter)` carrying the parameter's own annotations and those of its type arguments; `argumentsOf(Executable)` over methods and constructors alike, returning `Argument.ZERO_ARGUMENTS` for an executable with no parameter; `returnArgumentOf(Method)` reading the annotated return type; `argumentOf(name, AnnotatedType)` letting the caller name the argument.

**The reflective introspection** — constructor selection following the processor's four rules, one case each (a `@Creator` wins even when not public; else the only public constructor; else the no-arg one among several public; else the widest declared one); every declared constructor listed, the selected one first; what instantiation refuses (wrong argument count, a null for a non-nullable argument checked strictly) and what it lets through; an interface having no constructor to invoke; `isIntrospectable` accepting a class and an interface, refusing a primitive, an array, an enum, an annotation and anything under `java.`; the indexed properties by stereotype and by annotation value; a property made of every member declaring it, most specific first, so a field shadowing a super class's field yields both with their own annotations; a member reading the value it holds, and a setter throwing because it yields none; the builder by name, by index, from an existing bean and by conversion.

**Generated plus reflective** — the type, metadata and indexed properties coming from the generated introspection; a generated method served as generated but reporting the class reflection knows declares it; a method the processor left out (public but not `@Executable`) coming from reflection, and a method on both sides appearing once; `findDeclaredMethod` answering what one level declared, which a generated introspection cannot because it merges the annotations of the methods a method overrides; a described constructor returned untouched; a constructor described with no metadata gaining the arguments reflection read; every constructor listed, the generated one first; a generated property carrying the type arguments reflection reads from every member, so an interface getter declaring `List<@Tag String>` over a plain `List<String>` field keeps the annotation; the property members and the supplementing introspector.

**The resolution strategy** — a method of a type with a bean definition resolving to that definition's `ExecutableMethod`; one of an introspected type without a bean definition resolving through the `BeanMethod`; one of a type with neither resolving to `ReflectionExecutableMethod`; a method declared by a super type resolving against the type declaring it rather than against a sub type bean overriding it; a constructor of an introspected type resolving to the introspection's `BeanConstructor`; one of a non-introspected type to a constructor over the reflective metadata; a constructor the introspection does not describe read from the constructor itself; one a `ReflectiveIntrospection` knows coming from its `getConstructors()`.

**The method hierarchy** — a reflective hierarchy reporting every level nearest first, super classes before the interfaces of each level, every declaration exact; the merged views holding the method annotations, the parameter annotations and the type-use annotations of the return type arguments of all four levels, the local one winning; a type declaring the method in two branches being `parallel` while one with a single super declaration is not; a type that inherits without overriding reading the declaration of the type that declares it, and the walk starting *there*, so an interface the sub type does not implement is not reported; an interface reached by two branches reported once; a method inherited as an interface default found on the interface declaring it; an interface hierarchy reporting only what the interface declares, returning the local metadata and arguments identically rather than merging one level; a `java.lang.reflect.Method` resolving against the type declaring it; a type with no such method rejected; a generated introspection's declaration **not** exact, so the declared view falls back to the local one while the merged view still holds both levels; the same types under a supplementing introspector telling the declarations apart, the child carrying only its own annotation; a bean definition's `ExecutableMethod` read without the annotations of its class; `declaredBy` empty for a type the shared introspector does not know and present for one the reflective introspector does.

**The service hook** — a registered customizer deriving a member of the annotation it supports; seeing the values as the builder converts them, so a member left at its default is not among them; an unsupported annotation untouched. The customizer is registered as a real service in the test module and supports exactly one annotation type, so it changes nothing else in the suite.

**The class-loader fix** — `AnnotationMetadataSupport.getAnnotationType` caches annotation types by name. A child-first deployment loader defines its own copy of the same annotation and the caller compares against *that* copy, so returning the cached one silently fails every comparison. Once registered from one loader, asking with a loader that defines its own copy returns that loader's copy while the original loader still gets the original; a loader with no copy falls back to the registered type; a type the bootstrap loader defines cannot be shadowed.

</details>

### Verified, not assumed

The class-loader case was checked against a reverted fix: it fails without the nine-line change, so it is a regression test rather than a description.

Two shapes are worth a reviewer's attention, because the obvious test passes vacuously for both:

- `SupplementedBeanIntrospection.DescribedBeanConstructor` engages only when the generated constructor's metadata is empty, and the processor records constructor annotations whenever it sees them — including for `@Introspected(classes = …)`. Its value is therefore not the metadata it substitutes (empty on both sides in that case) but the **arguments** it merges: the type-use annotations on constructor parameters that the generated introspection drops. The test is built on exactly that shape.
- An inherited, non-overridden method already reports the super type as its `getDeclaringType()`, so only an **overriding** sub type exercises the declaring-type guard in `ReflectionExecutables.executableMethod`. A fixture that merely inherits proves nothing.

### One known javadoc slip

`ReflectionBeanIntrospection.isIntrospectable`'s javadoc says the type must not be "a primitive, an array, an interface, an annotation, an enum or a type of the JDK", but interfaces are deliberately allowed — the comment on the line below says so, and an interface is introspected for its declarations. The javadoc should drop "an interface". Left as is pending review.

## How to run

```
./gradlew :micronaut-inject:test \
  --tests 'io.micronaut.inject.reflection.*' \
  --tests '*ReflectionAnnotationCustomizer*' --tests '*AnnotationTypeClassLoader*'
```

## Rebased onto 5.2.x

`BeanIntrospection.getConstructors()` landed in 5.2.x (#12909), so `ReflectiveIntrospection` now narrows it rather than declaring it — one `@Override`, in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

