### PR TITLE
Extend @AliasFor to support OverridesAttribute-style member overrides

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -86,6 +86,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private static final List<AnnotationRemapper> ALL_ANNOTATION_REMAPPERS = new ArrayList<>(5);
     private static final Map<Object, CachedAnnotationMetadata> MUTATED_ANNOTATION_METADATA = new HashMap<>(100);
     private static final Map<String, Map<CharSequence, Object>> ANNOTATION_DEFAULTS = new HashMap<>(20);
+    private static final Map<String, List<AnnotationValue<AliasFor>>> APPLY_DEFAULT_MEMBER_ALIASES = new HashMap<>(20);
 
     static {
         ClassLoader classLoader = resolveServiceClassLoader();
@@ -836,7 +837,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private void processAnnotationAlias(Map<CharSequence, Object> annotationValues,
                                         Object annotationValue,
                                         AnnotationValue<AliasFor> aliasForAnnotation,
-                                        List<ProcessedAnnotation> introducedAnnotations) {
+                                        List<IntroducedAlias> introducedAnnotations) {
         Optional<String> aliasAnnotation = aliasForAnnotation.stringValue("annotation");
         Optional<String> aliasAnnotationName = aliasForAnnotation.stringValue("annotationName");
         Optional<String> aliasMember = aliasForAnnotation.stringValue("member");
@@ -847,15 +848,21 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 aliasedAnnotation = aliasAnnotation.orElseGet(aliasAnnotationName::get);
                 String aliasedMemberName = aliasMember.get();
                 if (annotationValue != null) {
+                    int aliasIndex = aliasForAnnotation.intValue("index").orElse(-1);
                     ProcessedAnnotation newAnnotation = toProcessedAnnotation(
                             AnnotationValue.builder(aliasedAnnotation, getRetentionPolicy(aliasedAnnotation))
                                     .members(Collections.singletonMap(aliasedMemberName, annotationValue))
                                     .build()
                     );
-                    introducedAnnotations.add(newAnnotation);
+                    introducedAnnotations.add(new IntroducedAlias(newAnnotation, aliasIndex));
                     ProcessedAnnotation newNewAnnotation = processAliases(newAnnotation, introducedAnnotations);
                     if (newNewAnnotation != newAnnotation) {
-                        introducedAnnotations.set(introducedAnnotations.indexOf(newAnnotation), newNewAnnotation);
+                        for (int i = 0; i < introducedAnnotations.size(); i++) {
+                            if (introducedAnnotations.get(i).getAnnotation() == newAnnotation) {
+                                introducedAnnotations.set(i, new IntroducedAlias(newNewAnnotation, aliasIndex));
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -1063,7 +1070,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                        Map<CharSequence, Object> annotationValues,
                                        T annotationMember,
                                        Object annotationValue,
-                                       List<ProcessedAnnotation> introducedAnnotations) {
+                                       List<IntroducedAlias> introducedAnnotations) {
         Optional<AnnotationValue<Aliases>> aliases = getAnnotationValues(originatingElement, annotationMember, Aliases.class);
         if (aliases.isPresent()) {
             for (AnnotationValue<AliasFor> av : aliases.get().<AliasFor>getAnnotations(AnnotationMetadata.VALUE_MEMBER)) {
@@ -1252,39 +1259,24 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         processedAnnotation = addDefaults(processedAnnotation);
         // Check if the annotation has the stereotypes set manually, before adding alias stereotypes
         boolean stereotypesProvided = annotationValue.getStereotypes() != null;
-        // First we need to process aliases, those contribute stereotypes with higher priority
-        processedAnnotation = processAliases(context, processedAnnotation);
+        // First we need to process aliases; those either override declared stereotype members
+        // or contribute stereotypes with higher priority
+        List<IntroducedAlias> introducedAliases = new ArrayList<>(3);
+        processedAnnotation = processAliases(processedAnnotation, introducedAliases);
 
         // The next invocation will invoke current method recursively till the stereotypes are processed.
         // That will build an annotation value tree with annotations and it's stereotypes.
-        processedAnnotation = addStereotypes(context, processedAnnotation, stereotypesProvided);
+        processedAnnotation = addStereotypes(context, processedAnnotation, stereotypesProvided, introducedAliases);
         // Next step is transforming, starting from the stereotypes moving up in the hierarchy.
         return transform(context, processedAnnotation)
                 .flatMap(this::flattenRepeatable)
                 .map(this::addDefaults);
     }
 
-    private ProcessedAnnotation processAliases(ProcessingContext context,
-                                               ProcessedAnnotation processedAnnotation) {
-        // Aliases produces by the annotations are added to the stereotypes collection
-        List<ProcessedAnnotation> introducedAliasForAnnotations = new ArrayList<>();
-        ProcessedAnnotation newAnn = processAliases(processedAnnotation, introducedAliasForAnnotations);
-        if (!introducedAliasForAnnotations.isEmpty()) {
-            newAnn = newAnn.mutateAnnotationValue(builder ->
-                    builder.stereotypes(
-                                    introducedAliasForAnnotations.stream()
-                                            .flatMap(a -> processAnnotation(context, a))
-                                            .<AnnotationValue<?>>map(ProcessedAnnotation::getAnnotationValue)
-                                            .toList()
-                            )
-            );
-        }
-        return newAnn;
-    }
-
     private ProcessedAnnotation addStereotypes(ProcessingContext context,
                                                ProcessedAnnotation processedAnnotation,
-                                               boolean stereotypesProvided) {
+                                               boolean stereotypesProvided,
+                                               List<IntroducedAlias> introducedAliases) {
         List<ProcessedAnnotation> stereotypes = Collections.emptyList();
         if (processedAnnotation.getAnnotationValue().getStereotypes() != null) {
             stereotypes = processedAnnotation.getAnnotationValue().getStereotypes().stream()
@@ -1314,6 +1306,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 extractedStereotypes.stream()
             ).toList();
         }
+        if (!introducedAliases.isEmpty()) {
+            stereotypes = applyIntroducedAliases(context, stereotypes, introducedAliases);
+        }
         List<ProcessedAnnotation> addedStereotypes = getAddedStereotypes(context, processedAnnotation.annotationType);
         if (!addedStereotypes.isEmpty()) {
             stereotypes = CollectionUtils.concat(stereotypes, addedStereotypes);
@@ -1322,6 +1317,50 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return processedAnnotation.mutateAnnotationValue(builder ->
             builder.replaceStereotypes(finalStereotypes.stream().<AnnotationValue<?>>map(ProcessedAnnotation::getAnnotationValue).toList())
         );
+    }
+
+    /**
+     * Reconciles annotations introduced by aliases with the declared stereotypes. An alias whose
+     * target annotation is declared as a stereotype overrides the declared member values — for a
+     * repeatable target the occurrence selected by {@link AliasFor#index()} (all occurrences by
+     * default). Aliases whose target is not declared contribute new stereotypes with higher
+     * priority, as before.
+     *
+     * @param context The processing context
+     * @param stereotypes The declared stereotypes
+     * @param introducedAliases The annotations introduced by aliases
+     * @return The reconciled stereotypes
+     */
+    private List<ProcessedAnnotation> applyIntroducedAliases(ProcessingContext context,
+                                                             List<ProcessedAnnotation> stereotypes,
+                                                             List<IntroducedAlias> introducedAliases) {
+        List<ProcessedAnnotation> result = new ArrayList<>(stereotypes);
+        List<ProcessedAnnotation> unmatched = new ArrayList<>(introducedAliases.size());
+        for (IntroducedAlias alias : introducedAliases) {
+            AnnotationValue<?> aliasValue = alias.getAnnotation().getAnnotationValue();
+            String targetName = aliasValue.getAnnotationName();
+            List<Integer> occurrences = new ArrayList<>(2);
+            for (int i = 0; i < result.size(); i++) {
+                if (result.get(i).getAnnotationValue().getAnnotationName().equals(targetName)) {
+                    occurrences.add(i);
+                }
+            }
+            if (occurrences.isEmpty()) {
+                unmatched.add(alias.getAnnotation());
+            } else if (alias.getIndex() < 0) {
+                for (int position : occurrences) {
+                    result.set(position, result.get(position).mutateAnnotationValue(builder -> builder.members(aliasValue.getValues())));
+                }
+            } else if (alias.getIndex() < occurrences.size()) {
+                int position = occurrences.get(alias.getIndex());
+                result.set(position, result.get(position).mutateAnnotationValue(builder -> builder.members(aliasValue.getValues())));
+            }
+            // An index outside the declared occurrences has no target and the alias is dropped
+        }
+        if (!unmatched.isEmpty()) {
+            result.addAll(0, unmatched.stream().flatMap(a -> processAnnotation(context, a)).toList());
+        }
+        return result;
     }
 
     private ProcessedAnnotation addDefaults(ProcessedAnnotation processedAnnotation) {
@@ -1437,7 +1476,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     private ProcessedAnnotation processAliases(ProcessedAnnotation processedAnnotation,
-                                               List<ProcessedAnnotation> introducedAnnotations) {
+                                               List<IntroducedAlias> introducedAnnotations) {
         T annotationType = processedAnnotation.getAnnotationType();
         if (annotationType == null) {
             return processedAnnotation;
@@ -1459,11 +1498,70 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             }
         }
 
+        // Aliases marked with `applyDefault` also apply when the member is not explicitly set,
+        // using the member's default value (e.g. jakarta.validation.OverridesAttribute semantics)
+        Map<CharSequence, Object> defaultValues = annotationValue.getDefaultValues();
+        if (defaultValues != null && !defaultValues.isEmpty()) {
+            String annotationName = annotationValue.getAnnotationName();
+            for (Map.Entry<CharSequence, Object> entry : defaultValues.entrySet()) {
+                CharSequence key = entry.getKey();
+                Object defaultValue = entry.getValue();
+                if (defaultValue == null || newValues.containsKey(key)) {
+                    continue;
+                }
+                for (AnnotationValue<AliasFor> aliasFor : getApplyDefaultAliases(annotationType, annotationName, key.toString())) {
+                    processAnnotationAlias(newValues, defaultValue, aliasFor, introducedAnnotations);
+                }
+            }
+        }
+
         // @AliasFor can modify the annotation values by aliasing to a member from the same annotation
         if (newValues.equals(annotationValue.getValues())) {
             return processedAnnotation;
         }
         return processedAnnotation.mutateAnnotationValue(builder -> builder.members(newValues));
+    }
+
+    /**
+     * Resolves the aliases of the given member that are marked with {@code applyDefault = true} and
+     * so apply even when the member is not explicitly set. The result is cached per annotation
+     * member, as it only depends on the annotation type's declaration.
+     *
+     * @param annotationType The annotation type element
+     * @param annotationName The annotation type name
+     * @param memberName The member name
+     * @return The aliases applying to the member's default value
+     */
+    private List<AnnotationValue<AliasFor>> getApplyDefaultAliases(T annotationType, String annotationName, String memberName) {
+        String key = annotationName + '#' + memberName;
+        List<AnnotationValue<AliasFor>> cached = APPLY_DEFAULT_MEMBER_ALIASES.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        List<AnnotationValue<AliasFor>> result = new ArrayList<>(2);
+        T member = getAnnotationMember(annotationType, memberName);
+        if (member != null) {
+            for (AnnotationValue<AliasFor> aliasFor : getMemberAliases(annotationType, member)) {
+                if (aliasFor.booleanValue("applyDefault").orElse(false)) {
+                    result.add(aliasFor);
+                }
+            }
+        }
+        List<AnnotationValue<AliasFor>> finalResult = result.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(result);
+        APPLY_DEFAULT_MEMBER_ALIASES.put(key, finalResult);
+        return finalResult;
+    }
+
+    private List<AnnotationValue<AliasFor>> getMemberAliases(T originatingElement, T annotationMember) {
+        Optional<AnnotationValue<Aliases>> aliases = getAnnotationValues(originatingElement, annotationMember, Aliases.class);
+        if (aliases.isPresent()) {
+            return aliases.get().getAnnotations(AnnotationMetadata.VALUE_MEMBER);
+        }
+        Optional<AnnotationValue<AliasFor>> aliasFor = getAnnotationValues(originatingElement, annotationMember, AliasFor.class);
+        if (aliasFor.isPresent()) {
+            return List.of(aliasFor.get());
+        }
+        return getTransformedAliasForValues(annotationMember);
     }
 
     private void addAnnotation(MutableAnnotationMetadata mutableAnnotationMetadata,
@@ -1770,6 +1868,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     @Internal
     public static void clearCaches() {
         ANNOTATION_DEFAULTS.clear();
+        APPLY_DEFAULT_MEMBER_ALIASES.clear();
     }
 
     /**
@@ -1981,6 +2080,28 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             return annotationValue;
         }
 
+    }
+
+    /**
+     * An annotation introduced by an alias, together with the occurrence index of the aliased
+     * repeatable annotation ({@link AliasFor#index()}).
+     */
+    private final class IntroducedAlias {
+        private final ProcessedAnnotation annotation;
+        private final int index;
+
+        private IntroducedAlias(ProcessedAnnotation annotation, int index) {
+            this.annotation = annotation;
+            this.index = index;
+        }
+
+        public ProcessedAnnotation getAnnotation() {
+            return annotation;
+        }
+
+        public int getIndex() {
+            return index;
+        }
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -86,6 +86,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private static final List<AnnotationRemapper> ALL_ANNOTATION_REMAPPERS = new ArrayList<>(5);
     private static final Map<Object, CachedAnnotationMetadata> MUTATED_ANNOTATION_METADATA = new HashMap<>(100);
     private static final Map<String, Map<CharSequence, Object>> ANNOTATION_DEFAULTS = new HashMap<>(20);
+    private static final String ALIAS_FOR_MEMBER = "member";
 
     static {
         ClassLoader classLoader = resolveServiceClassLoader();
@@ -673,7 +674,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             Object annotationValue = entry.getValue();
             if (aliasForValues.isPresent()) {
                 AnnotationValue<AliasFor> aliasFor = aliasForValues.get();
-                Optional<String> aliasMember = aliasFor.stringValue("member");
+                Optional<String> aliasMember = aliasFor.stringValue(ALIAS_FOR_MEMBER);
                 Optional<String> aliasAnnotation = aliasFor.stringValue("annotation");
                 Optional<String> aliasAnnotationName = aliasFor.stringValue("annotationName");
                 if (aliasMember.isPresent() && !(aliasAnnotation.isPresent() || aliasAnnotationName.isPresent())) {
@@ -839,7 +840,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                         List<IntroducedAlias> introducedAnnotations) {
         Optional<String> aliasAnnotation = aliasForAnnotation.stringValue("annotation");
         Optional<String> aliasAnnotationName = aliasForAnnotation.stringValue("annotationName");
-        Optional<String> aliasMember = aliasForAnnotation.stringValue("member");
+        Optional<String> aliasMember = aliasForAnnotation.stringValue(ALIAS_FOR_MEMBER);
 
         if (aliasAnnotation.isPresent() || aliasAnnotationName.isPresent()) {
             if (aliasMember.isPresent()) {
@@ -1155,9 +1156,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             }
         } else if (annotationValue.getAnnotationName().equals(AliasFor.class.getName())) {
             AnnotationValue<AliasFor> aliasFor = (AnnotationValue<AliasFor>) annotationValue;
-            if (aliasFor.stringValue("member").isEmpty()) {
+            if (aliasFor.stringValue(ALIAS_FOR_MEMBER).isEmpty()) {
                 // Default to the name of the annotated member, which the transformer cannot know
-                aliasFor = aliasFor.mutate().member("member", getAnnotationMemberName(annotationMember)).build();
+                aliasFor = aliasFor.mutate().member(ALIAS_FOR_MEMBER, getAnnotationMemberName(annotationMember)).build();
             }
             aliases.add(aliasFor);
         }
@@ -1508,12 +1509,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                     continue;
                 }
                 T member = getAnnotationMember(annotationType, key);
-                if (member == null || !hasAnnotations(member)) {
-                    continue;
-                }
-                for (AnnotationValue<AliasFor> aliasFor : getMemberAliases(annotationType, member)) {
-                    if (aliasFor.booleanValue("applyDefault").orElse(false)) {
-                        processAnnotationAlias(newValues, defaultValue, aliasFor, introducedAnnotations);
+                if (member != null && hasAnnotations(member)) {
+                    for (AnnotationValue<AliasFor> aliasFor : getMemberAliases(annotationType, member)) {
+                        if (aliasFor.booleanValue("applyDefault").orElse(false)) {
+                            processAnnotationAlias(newValues, defaultValue, aliasFor, introducedAnnotations);
+                        }
                     }
                 }
             }
@@ -2059,6 +2059,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * An annotation introduced by an alias, together with the occurrence index of the aliased
      * repeatable annotation ({@link AliasFor#index()}).
      */
+    @SuppressWarnings("java:S6206") // cannot be a record: ProcessedAnnotation is an inner class of the generic builder and unavailable in a static context
     private final class IntroducedAlias {
         private final ProcessedAnnotation annotation;
         private final int index;

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -1083,7 +1083,77 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                         aliasForValues.get(),
                         introducedAnnotations
                 );
+            } else {
+                for (AnnotationValue<AliasFor> aliasFor : getTransformedAliasForValues(annotationMember)) {
+                    processAnnotationAlias(
+                            annotationValues,
+                            annotationValue,
+                            aliasFor,
+                            introducedAnnotations
+                    );
+                }
             }
+        }
+    }
+
+    /**
+     * Allows member annotations without a compile-time dependency on Micronaut (e.g. an annotation like
+     * {@code jakarta.validation.OverridesAttribute}) to act as an {@link AliasFor} by running the
+     * registered {@link AnnotationTransformer}s over the annotations declared on the annotation member.
+     * Any {@link AliasFor} or {@link Aliases} values produced by a transformer are treated as if they
+     * were declared on the member directly. A produced {@link AliasFor} without a {@code member} value
+     * defaults to the name of the annotated member.
+     *
+     * @param annotationMember The annotation member
+     * @return The alias values produced by transformers, or an empty list
+     */
+    private List<AnnotationValue<AliasFor>> getTransformedAliasForValues(T annotationMember) {
+        List<? extends A> memberAnnotations = getAnnotationsForType(annotationMember);
+        if (memberAnnotations.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<AnnotationValue<AliasFor>> aliases = null;
+        for (A memberAnnotation : memberAnnotations) {
+            String annotationName = getAnnotationTypeName(memberAnnotation);
+            List<AnnotationTransformer<Annotation>> transformers = getAnnotationTransformers(annotationName);
+            if (CollectionUtils.isEmpty(transformers)) {
+                continue;
+            }
+            AnnotationValue<Annotation> memberAnnotationValue =
+                    (AnnotationValue<Annotation>) createAnnotationValue(annotationMember, memberAnnotation).getAnnotationValue();
+            for (AnnotationTransformer<Annotation> transformer : transformers) {
+                boolean transformed = false;
+                for (AnnotationValue<?> transformedValue : transformer.transform(memberAnnotationValue, getVisitorContext())) {
+                    if (transformedValue == memberAnnotationValue) {
+                        continue;
+                    }
+                    transformed = true;
+                    if (aliases == null) {
+                        aliases = new ArrayList<>(3);
+                    }
+                    collectAliasForValues(aliases, annotationMember, transformedValue);
+                }
+                if (transformed) {
+                    // The annotation was replaced, don't apply the remaining transformers to the original value
+                    break;
+                }
+            }
+        }
+        return aliases == null ? Collections.emptyList() : aliases;
+    }
+
+    private void collectAliasForValues(List<AnnotationValue<AliasFor>> aliases, T annotationMember, AnnotationValue<?> annotationValue) {
+        if (annotationValue.getAnnotationName().equals(Aliases.class.getName())) {
+            for (AnnotationValue<AliasFor> aliasFor : annotationValue.<AliasFor>getAnnotations(AnnotationMetadata.VALUE_MEMBER)) {
+                collectAliasForValues(aliases, annotationMember, aliasFor);
+            }
+        } else if (annotationValue.getAnnotationName().equals(AliasFor.class.getName())) {
+            AnnotationValue<AliasFor> aliasFor = (AnnotationValue<AliasFor>) annotationValue;
+            if (aliasFor.stringValue("member").isEmpty()) {
+                // Default to the name of the annotated member, which the transformer cannot know
+                aliasFor = aliasFor.mutate().member("member", getAnnotationMemberName(annotationMember)).build();
+            }
+            aliases.add(aliasFor);
         }
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -86,7 +86,6 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private static final List<AnnotationRemapper> ALL_ANNOTATION_REMAPPERS = new ArrayList<>(5);
     private static final Map<Object, CachedAnnotationMetadata> MUTATED_ANNOTATION_METADATA = new HashMap<>(100);
     private static final Map<String, Map<CharSequence, Object>> ANNOTATION_DEFAULTS = new HashMap<>(20);
-    private static final Map<String, List<AnnotationValue<AliasFor>>> APPLY_DEFAULT_MEMBER_ALIASES = new HashMap<>(20);
 
     static {
         ClassLoader classLoader = resolveServiceClassLoader();
@@ -1502,15 +1501,20 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         // using the member's default value (e.g. jakarta.validation.OverridesAttribute semantics)
         Map<CharSequence, Object> defaultValues = annotationValue.getDefaultValues();
         if (defaultValues != null && !defaultValues.isEmpty()) {
-            String annotationName = annotationValue.getAnnotationName();
             for (Map.Entry<CharSequence, Object> entry : defaultValues.entrySet()) {
                 CharSequence key = entry.getKey();
                 Object defaultValue = entry.getValue();
                 if (defaultValue == null || newValues.containsKey(key)) {
                     continue;
                 }
-                for (AnnotationValue<AliasFor> aliasFor : getApplyDefaultAliases(annotationType, annotationName, key.toString())) {
-                    processAnnotationAlias(newValues, defaultValue, aliasFor, introducedAnnotations);
+                T member = getAnnotationMember(annotationType, key);
+                if (member == null || !hasAnnotations(member)) {
+                    continue;
+                }
+                for (AnnotationValue<AliasFor> aliasFor : getMemberAliases(annotationType, member)) {
+                    if (aliasFor.booleanValue("applyDefault").orElse(false)) {
+                        processAnnotationAlias(newValues, defaultValue, aliasFor, introducedAnnotations);
+                    }
                 }
             }
         }
@@ -1520,36 +1524,6 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             return processedAnnotation;
         }
         return processedAnnotation.mutateAnnotationValue(builder -> builder.members(newValues));
-    }
-
-    /**
-     * Resolves the aliases of the given member that are marked with {@code applyDefault = true} and
-     * so apply even when the member is not explicitly set. The result is cached per annotation
-     * member, as it only depends on the annotation type's declaration.
-     *
-     * @param annotationType The annotation type element
-     * @param annotationName The annotation type name
-     * @param memberName The member name
-     * @return The aliases applying to the member's default value
-     */
-    private List<AnnotationValue<AliasFor>> getApplyDefaultAliases(T annotationType, String annotationName, String memberName) {
-        String key = annotationName + '#' + memberName;
-        List<AnnotationValue<AliasFor>> cached = APPLY_DEFAULT_MEMBER_ALIASES.get(key);
-        if (cached != null) {
-            return cached;
-        }
-        List<AnnotationValue<AliasFor>> result = new ArrayList<>(2);
-        T member = getAnnotationMember(annotationType, memberName);
-        if (member != null) {
-            for (AnnotationValue<AliasFor> aliasFor : getMemberAliases(annotationType, member)) {
-                if (aliasFor.booleanValue("applyDefault").orElse(false)) {
-                    result.add(aliasFor);
-                }
-            }
-        }
-        List<AnnotationValue<AliasFor>> finalResult = result.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(result);
-        APPLY_DEFAULT_MEMBER_ALIASES.put(key, finalResult);
-        return finalResult;
     }
 
     private List<AnnotationValue<AliasFor>> getMemberAliases(T originatingElement, T annotationMember) {
@@ -1868,7 +1842,6 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     @Internal
     public static void clearCaches() {
         ANNOTATION_DEFAULTS.clear();
-        APPLY_DEFAULT_MEMBER_ALIASES.clear();
     }
 
     /**

--- a/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/MyOverrides.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/MyOverrides.java
@@ -1,0 +1,26 @@
+package io.micronaut.annotation.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * An annotation without any Micronaut dependency, modelled after {@code jakarta.validation.OverridesAttribute},
+ * that is transformed to {@code @AliasFor} by a registered {@code AnnotationTransformer}.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+@Repeatable(MyOverridesList.class)
+public @interface MyOverrides {
+
+    Class<?> constraint();
+
+    String name() default "";
+
+    int constraintIndex() default -1;
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/MyOverridesList.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/MyOverridesList.java
@@ -1,0 +1,20 @@
+package io.micronaut.annotation.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The repeatable container of {@link MyOverrides}, modelled after
+ * {@code jakarta.validation.OverridesAttribute.List}.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+public @interface MyOverridesList {
+
+    MyOverrides[] value();
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/MyOverridesListTransformer.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/MyOverridesListTransformer.java
@@ -1,0 +1,27 @@
+package io.micronaut.annotation.mapping;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.TypedAnnotationTransformer;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.util.List;
+
+/**
+ * Transforms the {@link MyOverridesList} container to {@code @AliasFor} values.
+ */
+public class MyOverridesListTransformer implements TypedAnnotationTransformer<MyOverridesList> {
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<MyOverridesList> annotation, VisitorContext visitorContext) {
+        return annotation.<MyOverrides>getAnnotations(AnnotationMetadata.VALUE_MEMBER)
+            .stream()
+            .<AnnotationValue<?>>map(MyOverridesTransformer::toAliasFor)
+            .toList();
+    }
+
+    @Override
+    public Class<MyOverridesList> annotationType() {
+        return MyOverridesList.class;
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/MyOverridesTransformer.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/MyOverridesTransformer.java
@@ -1,0 +1,35 @@
+package io.micronaut.annotation.mapping;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.inject.annotation.TypedAnnotationTransformer;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.util.List;
+
+/**
+ * Transforms {@link MyOverrides} to {@code @AliasFor}, mirroring how
+ * {@code jakarta.validation.OverridesAttribute} would be remapped.
+ */
+public class MyOverridesTransformer implements TypedAnnotationTransformer<MyOverrides> {
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<MyOverrides> annotation, VisitorContext visitorContext) {
+        return List.of(toAliasFor(annotation));
+    }
+
+    @Override
+    public Class<MyOverrides> annotationType() {
+        return MyOverrides.class;
+    }
+
+    static AnnotationValue<AliasFor> toAliasFor(AnnotationValue<MyOverrides> annotation) {
+        AnnotationValueBuilder<AliasFor> builder = AnnotationValue.builder(AliasFor.class);
+        annotation.annotationClassValue("constraint").ifPresent(constraint -> builder.member("annotationName", constraint.getName()));
+        annotation.stringValue("name").ifPresent(name -> builder.member("member", name));
+        annotation.intValue("constraintIndex").ifPresent(index -> builder.member("index", index));
+        builder.member("applyDefault", true);
+        return builder.build();
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
@@ -1,0 +1,104 @@
+package io.micronaut.annotation.mapping
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+
+class RemapMemberAnnotationToAliasForSpec extends AbstractBeanDefinitionSpec {
+
+    void 'test member annotation transformed to AliasFor overrides the stereotype member'() {
+        given:
+            def metadata = buildTypeAnnotationMetadata('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLike {
+    int min() default 0
+    int max() default 100
+    String message() default "size"
+}
+
+@SizeLike(min = 10)
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedSize {
+
+    @MyOverrides(constraint = SizeLike.class)
+    int min() default 5
+
+    @MyOverrides(constraint = SizeLike.class, name = "message")
+    String sizeMessage() default "composed size"
+}
+
+@ComposedSize(min = 3)
+class OverridesTest {
+}
+''')
+
+        expect: 'the explicitly set member overrides the declared stereotype value'
+            metadata.hasStereotype('addann.SizeLike')
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 3
+
+        and: 'the default of an overriding member applies too'
+            metadata.stringValue('addann.SizeLike', 'message').get() == 'composed size'
+    }
+
+    void 'test repeated overrides and constraintIndex on a repeatable stereotype'() {
+        given:
+            def metadata = buildTypeAnnotationMetadata('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PatternLikeList.class)
+@interface PatternLike {
+    String regexp()
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface PatternLikeList {
+    PatternLike[] value()
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLike {
+    int min() default 0
+    int max() default 100
+}
+
+@SizeLike
+@PatternLikeList([@PatternLike(regexp = "....."), @PatternLike(regexp = "bar")])
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedZip {
+
+    @MyOverrides(constraint = SizeLike.class, name = "min")
+    @MyOverrides(constraint = SizeLike.class, name = "max")
+    int size() default 5
+
+    @MyOverrides(constraint = PatternLike.class, name = "regexp", constraintIndex = 1)
+    String regex() default "\\\\d*"
+}
+
+@ComposedZip
+class OverridesTest {
+}
+''')
+
+        when:
+            def patterns = metadata.getAnnotationValuesByName('addann.PatternLike')
+
+        then: 'both occurrences are retained and only the selected one is overridden'
+            patterns.size() == 2
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == '\\d*'
+
+        and: 'the repeated override applies the member default to both aliased members'
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 5
+            metadata.intValue('addann.SizeLike', 'max').getAsInt() == 5
+    }
+}

--- a/inject-groovy/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/inject-groovy/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -1,1 +1,3 @@
 io.micronaut.inject.beanbuilder.TestInterceptorBindingTransformer
+io.micronaut.annotation.mapping.MyOverridesTransformer
+io.micronaut.annotation.mapping.MyOverridesListTransformer

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyOverrides.java
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyOverrides.java
@@ -2,6 +2,7 @@ package io.micronaut.annotation.mapping;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -14,9 +15,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Retention(RUNTIME)
 @Target({ElementType.METHOD})
+@Repeatable(MyOverridesList.class)
 public @interface MyOverrides {
 
     Class<?> constraint();
 
     String name() default "";
+
+    int constraintIndex() default -1;
 }

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyOverrides.java
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyOverrides.java
@@ -1,0 +1,22 @@
+package io.micronaut.annotation.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * An annotation without any Micronaut dependency, modelled after {@code jakarta.validation.OverridesAttribute},
+ * that is transformed to {@code @AliasFor} by a registered {@code AnnotationTransformer}.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+public @interface MyOverrides {
+
+    Class<?> constraint();
+
+    String name() default "";
+}

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyOverridesList.java
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyOverridesList.java
@@ -1,0 +1,20 @@
+package io.micronaut.annotation.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The repeatable container of {@link MyOverrides}, modelled after
+ * {@code jakarta.validation.OverridesAttribute.List}.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+public @interface MyOverridesList {
+
+    MyOverrides[] value();
+}

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
@@ -1,0 +1,117 @@
+package io.micronaut.annotation.mapping
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.annotation.AliasFor
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.annotation.AnnotationValueBuilder
+import io.micronaut.inject.annotation.TypedAnnotationTransformer
+import io.micronaut.inject.visitor.VisitorContext
+
+class RemapMemberAnnotationToAliasForSpec extends AbstractTypeElementSpec {
+
+    void 'test member annotation transformed to AliasFor overrides the stereotype member'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLike {
+    int min() default 0;
+    int max() default 100;
+}
+
+@SizeLike(min = 10)
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedSize {
+
+    @MyOverrides(constraint = SizeLike.class)
+    int min() default 5;
+
+    @MyOverrides(constraint = SizeLike.class, name = "max")
+    int limit() default 50;
+}
+
+@Bean
+class OverridesTest {
+
+    @ComposedSize(min = 3, limit = 30)
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        expect: 'the transformed alias value wins over the value declared on the stereotype'
+            metadata.hasStereotype('addann.SizeLike')
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 3
+
+        and: 'an explicit name is used as the aliased member'
+            metadata.intValue('addann.SizeLike', 'max').getAsInt() == 30
+    }
+
+    void 'test declared stereotype values are retained when the overriding member is not set'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLike {
+    int min() default 0;
+    int max() default 100;
+}
+
+@SizeLike(min = 10)
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedSize {
+
+    @MyOverrides(constraint = SizeLike.class)
+    int min() default 5;
+}
+
+@Bean
+class OverridesTest {
+
+    @ComposedSize
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        expect: 'aliases only apply to explicitly set members'
+            metadata.hasStereotype('addann.SizeLike')
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 10
+    }
+
+    static class MyOverridesTransformer implements TypedAnnotationTransformer<MyOverrides> {
+
+        @Override
+        List<AnnotationValue<?>> transform(AnnotationValue<MyOverrides> annotation, VisitorContext visitorContext) {
+            AnnotationValueBuilder<AliasFor> builder = AnnotationValue.builder(AliasFor)
+            annotation.annotationClassValue("constraint").ifPresent { builder.member("annotationName", it.name) }
+            annotation.stringValue("name").ifPresent { builder.member("member", it) }
+            return List.of(builder.build())
+        }
+
+        @Override
+        Class<MyOverrides> annotationType() {
+            return MyOverrides.class
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
@@ -703,6 +703,115 @@ class OverridesTest {
             patterns[2].stringValue('regexp').get() == 'over'
     }
 
+    void 'test literal AliasFor applies defaults only when opted in'() {
+        given:
+            def definition = buildBeanDefinition('addann.LiteralDefaultsTest', '''
+package addann;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLike {
+    int min() default 0;
+    int max() default 100;
+}
+
+@SizeLike(min = 20, max = 30)
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedSize {
+
+    @AliasFor(annotation = SizeLike.class, member = "min", applyDefault = true)
+    int min() default 5;
+
+    @AliasFor(annotation = SizeLike.class, member = "max")
+    int max() default 6;
+}
+
+@Bean
+class LiteralDefaultsTest {
+
+    @ComposedSize
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        expect: 'a literal applyDefault alias uses the overriding member default'
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 5
+
+        and: 'a literal alias without applyDefault does not use the overriding member default'
+            metadata.intValue('addann.SizeLike', 'max').getAsInt() == 30
+    }
+
+    void 'test literal AliasFor index targets one repeatable stereotype and the default index targets all'() {
+        given:
+            def definition = buildBeanDefinition('addann.LiteralIndexTest', '''
+package addann;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PatternLikeList.class)
+@interface PatternLike {
+    String regexp();
+    String message() default "pattern";
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface PatternLikeList {
+    PatternLike[] value();
+}
+
+@PatternLike(regexp = "first")
+@PatternLike(regexp = "second")
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedPattern {
+
+    @AliasFor(annotation = PatternLike.class, member = "regexp", index = 1)
+    String regex();
+
+    @AliasFor(annotation = PatternLike.class, member = "message")
+    String patternMessage();
+}
+
+@Bean
+class LiteralIndexTest {
+
+    @ComposedPattern(regex = "selected", patternMessage = "overridden")
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then: 'the indexed literal alias changes only the selected occurrence'
+            patterns.size() == 2
+            patterns[0].stringValue('regexp').get() == 'first'
+            patterns[1].stringValue('regexp').get() == 'selected'
+
+        and: 'the default index applies the alias to every occurrence'
+            patterns[0].stringValue('message').get() == 'overridden'
+            patterns[1].stringValue('message').get() == 'overridden'
+    }
+
     static class MyOverridesTransformer implements TypedAnnotationTransformer<MyOverrides> {
 
         @Override

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
@@ -57,7 +57,7 @@ class OverridesTest {
             metadata.intValue('addann.SizeLike', 'max').getAsInt() == 30
     }
 
-    void 'test declared stereotype values are retained when the overriding member is not set'() {
+    void 'test the default value of the overriding member replaces the declared stereotype value'() {
         given:
             def definition = buildBeanDefinition('addann.OverridesTest', '''
 package addann;
@@ -94,24 +94,124 @@ class OverridesTest {
 ''')
             def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
 
-        expect: 'aliases only apply to explicitly set members'
+        expect: 'the overriding member default applies even when not explicitly set'
             metadata.hasStereotype('addann.SizeLike')
-            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 10
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 5
+
+        and: 'members without an override are not touched'
+            metadata.intValue('addann.SizeLike', 'max').orElse(100) == 100
+    }
+
+    void 'test repeated overrides and constraintIndex on a repeatable stereotype'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLike {
+    int min() default 0;
+    int max() default 100;
+    String message() default "size";
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PatternLikeList.class)
+@interface PatternLike {
+    String regexp();
+    String message() default "pattern";
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface PatternLikeList {
+    PatternLike[] value();
+}
+
+@SizeLike
+@PatternLike(regexp = ".....")
+@PatternLike(regexp = "bar")
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedZip {
+
+    @MyOverrides(constraint = SizeLike.class, name = "min")
+    @MyOverrides(constraint = SizeLike.class, name = "max")
+    int size() default 5;
+
+    @MyOverrides(constraint = SizeLike.class, name = "message")
+    String sizeMessage() default "size of 5";
+
+    @MyOverrides(constraint = PatternLike.class, name = "regexp", constraintIndex = 1)
+    String regex() default "\\\\d*";
+}
+
+@Bean
+class OverridesTest {
+
+    @ComposedZip
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then: 'both declared occurrences of the repeatable stereotype are retained'
+            patterns.size() == 2
+
+        and: 'only the occurrence selected by constraintIndex is overridden'
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == '\\d*'
+
+        and: 'a repeated override applies the same member default to several members'
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 5
+            metadata.intValue('addann.SizeLike', 'max').getAsInt() == 5
+            metadata.stringValue('addann.SizeLike', 'message').get() == 'size of 5'
     }
 
     static class MyOverridesTransformer implements TypedAnnotationTransformer<MyOverrides> {
 
         @Override
         List<AnnotationValue<?>> transform(AnnotationValue<MyOverrides> annotation, VisitorContext visitorContext) {
-            AnnotationValueBuilder<AliasFor> builder = AnnotationValue.builder(AliasFor)
-            annotation.annotationClassValue("constraint").ifPresent { builder.member("annotationName", it.name) }
-            annotation.stringValue("name").ifPresent { builder.member("member", it) }
-            return List.of(builder.build())
+            return List.of(toAliasFor(annotation))
         }
 
         @Override
         Class<MyOverrides> annotationType() {
             return MyOverrides.class
+        }
+
+        static AnnotationValue<AliasFor> toAliasFor(AnnotationValue<MyOverrides> annotation) {
+            AnnotationValueBuilder<AliasFor> builder = AnnotationValue.builder(AliasFor)
+            annotation.annotationClassValue("constraint").ifPresent { builder.member("annotationName", it.name) }
+            annotation.stringValue("name").ifPresent { builder.member("member", it) }
+            annotation.intValue("constraintIndex").ifPresent { builder.member("index", it) }
+            builder.member("applyDefault", true)
+            return builder.build()
+        }
+    }
+
+    static class MyOverridesListTransformer implements TypedAnnotationTransformer<MyOverridesList> {
+
+        @Override
+        List<AnnotationValue<?>> transform(AnnotationValue<MyOverridesList> annotation, VisitorContext visitorContext) {
+            return annotation.<MyOverrides> getAnnotations("value")
+                    .collect { MyOverridesTransformer.toAliasFor(it) as AnnotationValue<?> }
+        }
+
+        @Override
+        Class<MyOverridesList> annotationType() {
+            return MyOverridesList.class
         }
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
@@ -450,6 +450,259 @@ class OverridesTest {
             metadata.intValue('addann.SizeLike', 'min').getAsInt() == 5
     }
 
+    void 'test recursive composition mirroring the TCK FrenchZipcode shape'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(SizeLikeList.class)
+@interface SizeLike {
+    int min() default 0;
+    int max() default 100;
+    String message() default "size";
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLikeList {
+    SizeLike[] value();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PatternLikeList.class)
+@interface PatternLike {
+    String regexp();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface PatternLikeList {
+    PatternLike[] value();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface NotNullLike {
+    String message() default "notNull";
+}
+
+@NotNullLike
+@SizeLike(min = 1)
+@Retention(RetentionPolicy.RUNTIME)
+@interface NotEmptyLike {
+}
+
+@NotEmptyLike
+@SizeLike
+@PatternLike(regexp = ".....")
+@PatternLike(regexp = "bar")
+@Retention(RetentionPolicy.RUNTIME)
+@interface FrenchZip {
+
+    @MyOverrides(constraint = SizeLike.class, name = "min")
+    @MyOverrides(constraint = SizeLike.class, name = "max")
+    int size() default 5;
+
+    @MyOverrides(constraint = SizeLike.class, name = "message")
+    String sizeMessage() default "french size";
+
+    @MyOverrides(constraint = PatternLike.class, name = "regexp", constraintIndex = 1)
+    String regex() default "\\\\d*";
+}
+
+@Bean
+class OverridesTest {
+
+    @FrenchZip
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def sizeType = (Class) definition.getClass().getClassLoader().loadClass('addann.SizeLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+            def sizes = metadata.getAnnotationValuesByType(sizeType)
+
+        then: 'the composition is recursive: stereotypes of composed annotations are present'
+            metadata.hasStereotype('addann.NotEmptyLike')
+            metadata.hasStereotype('addann.NotNullLike')
+
+        and: 'the constraintIndex override only touches the selected occurrence'
+            patterns.size() == 2
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == '\\d*'
+
+        and: 'each nesting level keeps its own occurrence of the repeatable annotation'
+            sizes.size() == 2
+
+        and: 'the overrides only apply to the occurrence declared on the composing annotation'
+            def direct = sizes.find { it.intValue('min').orElse(-1) == 5 }
+            def nested = sizes.find { it.intValue('min').orElse(-1) == 1 }
+            direct != null
+            nested != null
+            direct.intValue('max').getAsInt() == 5
+            direct.stringValue('message').get() == 'french size'
+            nested.intValue('max').isEmpty()
+            nested.stringValue('message').isEmpty()
+    }
+
+    void 'test overriding a member of a composed annotation cascades through its alias chain'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLike {
+    int min() default 0;
+}
+
+@SizeLike(min = 10)
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedSize {
+
+    @MyOverrides(constraint = SizeLike.class)
+    int min() default 5;
+}
+
+@ComposedSize
+@Retention(RetentionPolicy.RUNTIME)
+@interface OuterComposed {
+
+    @MyOverrides(constraint = ComposedSize.class, name = "min")
+    int outerMin() default 7;
+}
+
+@Bean
+class OverridesTest {
+
+    @OuterComposed
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        expect: 'the override lands on the directly composed annotation'
+            metadata.intValue('addann.ComposedSize', 'min').getAsInt() == 7
+
+        and: 'the overridden member has its own alias, so the override cascades into the nested annotation'
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 7
+    }
+
+    void 'test overriding a class typed member'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface MarkerLike {
+    Class<?> type() default Object.class;
+    String message() default "marker";
+}
+
+@MarkerLike
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedMarker {
+
+    @MyOverrides(constraint = MarkerLike.class, name = "type")
+    Class<?> markerType() default String.class;
+}
+
+@Bean
+class OverridesTest {
+
+    @ComposedMarker(markerType = Integer.class)
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        expect:
+            metadata.classValue('addann.MarkerLike', 'type').get() == Integer
+    }
+
+    void 'test occurrence indexes count direct annotations and container values in declaration order'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PatternLikeList.class)
+@interface PatternLike {
+    String regexp();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface PatternLikeList {
+    PatternLike[] value();
+}
+
+@PatternLike(regexp = "direct")
+@PatternLikeList({ @PatternLike(regexp = "c0"), @PatternLike(regexp = "c1") })
+@Retention(RetentionPolicy.RUNTIME)
+@interface MixedComposed {
+
+    @MyOverrides(constraint = PatternLike.class, name = "regexp", constraintIndex = 2)
+    String regex() default "over";
+}
+
+@Bean
+class OverridesTest {
+
+    @MixedComposed
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then: 'a direct annotation and container values are indexed together in declaration order'
+            patterns.size() == 3
+            patterns[0].stringValue('regexp').get() == 'direct'
+            patterns[1].stringValue('regexp').get() == 'c0'
+            patterns[2].stringValue('regexp').get() == 'over'
+    }
+
     static class MyOverridesTransformer implements TypedAnnotationTransformer<MyOverrides> {
 
         @Override

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/RemapMemberAnnotationToAliasForSpec.groovy
@@ -179,6 +179,277 @@ class OverridesTest {
             metadata.stringValue('addann.SizeLike', 'message').get() == 'size of 5'
     }
 
+    void 'test constraintIndex override on an explicit repeatable container'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PatternLikeList.class)
+@interface PatternLike {
+    String regexp();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface PatternLikeList {
+    PatternLike[] value();
+}
+
+@PatternLikeList({ @PatternLike(regexp = "....."), @PatternLike(regexp = "bar") })
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedZip {
+
+    @MyOverrides(constraint = PatternLike.class, name = "regexp", constraintIndex = 1)
+    String regex() default "\\\\d*";
+}
+
+@Bean
+class OverridesTest {
+
+    @ComposedZip
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then: 'an explicitly declared container behaves the same as repeated annotations'
+            patterns.size() == 2
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == '\\d*'
+    }
+
+    void 'test explicitly set overriding members win over their defaults'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLike {
+    int min() default 0;
+    int max() default 100;
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PatternLikeList.class)
+@interface PatternLike {
+    String regexp();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface PatternLikeList {
+    PatternLike[] value();
+}
+
+@SizeLike
+@PatternLike(regexp = ".....")
+@PatternLike(regexp = "bar")
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedZip {
+
+    @MyOverrides(constraint = SizeLike.class, name = "min")
+    @MyOverrides(constraint = SizeLike.class, name = "max")
+    int size() default 5;
+
+    @MyOverrides(constraint = PatternLike.class, name = "regexp", constraintIndex = 1)
+    String regex() default "\\\\d*";
+}
+
+@Bean
+class OverridesTest {
+
+    @ComposedZip(size = 3, regex = "[0-9]+")
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then:
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 3
+            metadata.intValue('addann.SizeLike', 'max').getAsInt() == 3
+            patterns.size() == 2
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == '[0-9]+'
+    }
+
+    void 'test an override without an index applies to every occurrence'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PatternLikeList.class)
+@interface PatternLike {
+    String regexp();
+    String message() default "pattern";
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface PatternLikeList {
+    PatternLike[] value();
+}
+
+@PatternLike(regexp = ".....")
+@PatternLike(regexp = "bar")
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedZip {
+
+    @MyOverrides(constraint = PatternLike.class, name = "message")
+    String patternMessage() default "not a zip";
+}
+
+@Bean
+class OverridesTest {
+
+    @ComposedZip
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then: 'both occurrences receive the override, the other members are retained'
+            patterns.size() == 2
+            patterns[0].stringValue('message').get() == 'not a zip'
+            patterns[1].stringValue('message').get() == 'not a zip'
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == 'bar'
+    }
+
+    void 'test an override with an index outside the declared occurrences is dropped'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(PatternLikeList.class)
+@interface PatternLike {
+    String regexp();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface PatternLikeList {
+    PatternLike[] value();
+}
+
+@PatternLike(regexp = ".....")
+@PatternLike(regexp = "bar")
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedZip {
+
+    @MyOverrides(constraint = PatternLike.class, name = "regexp", constraintIndex = 5)
+    String regex() default "\\\\d*";
+}
+
+@Bean
+class OverridesTest {
+
+    @ComposedZip
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then: 'no occurrence is modified and no occurrence is added'
+            patterns.size() == 2
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == 'bar'
+    }
+
+    void 'test an override of an annotation that is not declared introduces a new stereotype'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann;
+
+import io.micronaut.annotation.mapping.MyOverrides;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface SizeLike {
+    int min() default 0;
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface ComposedSize {
+
+    @MyOverrides(constraint = SizeLike.class)
+    int min() default 5;
+}
+
+@Bean
+class OverridesTest {
+
+    @ComposedSize
+    @Executable
+    public String getValue() {
+        return "";
+    }
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        expect: 'the aliased annotation is contributed as a stereotype even without a declaration'
+            metadata.hasStereotype('addann.SizeLike')
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 5
+    }
+
     static class MyOverridesTransformer implements TypedAnnotationTransformer<MyOverrides> {
 
         @Override

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -5,3 +5,4 @@ io.micronaut.annotation.mapping.TransformsToRepeatableAnnotationSpec$TheAnnotati
 io.micronaut.annotation.mapping.TransformNotInheritedAnnotationSpec$TheAnnotationMapper
 io.micronaut.annotation.mapping.TransformToInheritedAnnotationSpec$TheAnnotationMapper
 io.micronaut.inject.autowired.AutowiredTransformer
+io.micronaut.annotation.mapping.RemapMemberAnnotationToAliasForSpec$MyOverridesTransformer

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -6,3 +6,4 @@ io.micronaut.annotation.mapping.TransformNotInheritedAnnotationSpec$TheAnnotatio
 io.micronaut.annotation.mapping.TransformToInheritedAnnotationSpec$TheAnnotationMapper
 io.micronaut.inject.autowired.AutowiredTransformer
 io.micronaut.annotation.mapping.RemapMemberAnnotationToAliasForSpec$MyOverridesTransformer
+io.micronaut.annotation.mapping.RemapMemberAnnotationToAliasForSpec$MyOverridesListTransformer

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/RemapMemberAnnotationToAliasForSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/RemapMemberAnnotationToAliasForSpec.groovy
@@ -1,0 +1,83 @@
+package io.micronaut.kotlin.processing.annotations
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+
+class RemapMemberAnnotationToAliasForSpec extends AbstractKotlinCompilerSpec {
+
+    // NOTE: repeatable stereotype containers on Kotlin annotation classes are not extracted into
+    // the metadata by the KSP builder (independently of aliasing), so the constraintIndex scenario
+    // covered by the Java and Groovy variants of this spec cannot be replicated here yet.
+
+    void 'test member annotation transformed to AliasFor overrides the stereotype member'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann
+
+import io.micronaut.annotation.mapping.MyOverrides
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Executable
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SizeLike(val min: Int = 0, val max: Int = 100, val message: String = "size")
+
+@SizeLike(min = 10)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ComposedSize(
+    @get:MyOverrides(constraint = SizeLike::class)
+    val min: Int = 5,
+    @get:MyOverrides(constraint = SizeLike::class, name = "message")
+    val sizeMessage: String = "composed size"
+)
+
+@Bean
+class OverridesTest {
+
+    @ComposedSize(min = 3)
+    @Executable
+    fun getValue(): String = ""
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        expect: 'the explicitly set member overrides the declared stereotype value'
+            metadata.hasStereotype('addann.SizeLike')
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 3
+
+        and: 'the default of an overriding member applies too'
+            metadata.stringValue('addann.SizeLike', 'message').get() == 'composed size'
+    }
+
+    void 'test the default value of the overriding member replaces the declared stereotype value'() {
+        given:
+            def definition = buildBeanDefinition('addann.OverridesTest', '''
+package addann
+
+import io.micronaut.annotation.mapping.MyOverrides
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Executable
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SizeLike(val min: Int = 0, val max: Int = 100)
+
+@SizeLike(min = 10)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ComposedSize(
+    @get:MyOverrides(constraint = SizeLike::class)
+    val min: Int = 5
+)
+
+@Bean
+class OverridesTest {
+
+    @ComposedSize
+    @Executable
+    fun getValue(): String = ""
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        expect:
+            metadata.hasStereotype('addann.SizeLike')
+            metadata.intValue('addann.SizeLike', 'min').getAsInt() == 5
+    }
+}

--- a/inject-kotlin/src/test/java/io/micronaut/annotation/mapping/MyOverrides.java
+++ b/inject-kotlin/src/test/java/io/micronaut/annotation/mapping/MyOverrides.java
@@ -1,0 +1,26 @@
+package io.micronaut.annotation.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * An annotation without any Micronaut dependency, modelled after {@code jakarta.validation.OverridesAttribute},
+ * that is transformed to {@code @AliasFor} by a registered {@code AnnotationTransformer}.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+@Repeatable(MyOverridesList.class)
+public @interface MyOverrides {
+
+    Class<?> constraint();
+
+    String name() default "";
+
+    int constraintIndex() default -1;
+}

--- a/inject-kotlin/src/test/java/io/micronaut/annotation/mapping/MyOverridesList.java
+++ b/inject-kotlin/src/test/java/io/micronaut/annotation/mapping/MyOverridesList.java
@@ -1,0 +1,20 @@
+package io.micronaut.annotation.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The repeatable container of {@link MyOverrides}, modelled after
+ * {@code jakarta.validation.OverridesAttribute.List}.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+public @interface MyOverridesList {
+
+    MyOverrides[] value();
+}

--- a/inject-kotlin/src/test/java/io/micronaut/annotation/mapping/MyOverridesListTransformer.java
+++ b/inject-kotlin/src/test/java/io/micronaut/annotation/mapping/MyOverridesListTransformer.java
@@ -1,0 +1,27 @@
+package io.micronaut.annotation.mapping;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.TypedAnnotationTransformer;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.util.List;
+
+/**
+ * Transforms the {@link MyOverridesList} container to {@code @AliasFor} values.
+ */
+public class MyOverridesListTransformer implements TypedAnnotationTransformer<MyOverridesList> {
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<MyOverridesList> annotation, VisitorContext visitorContext) {
+        return annotation.<MyOverrides>getAnnotations(AnnotationMetadata.VALUE_MEMBER)
+            .stream()
+            .<AnnotationValue<?>>map(MyOverridesTransformer::toAliasFor)
+            .toList();
+    }
+
+    @Override
+    public Class<MyOverridesList> annotationType() {
+        return MyOverridesList.class;
+    }
+}

--- a/inject-kotlin/src/test/java/io/micronaut/annotation/mapping/MyOverridesTransformer.java
+++ b/inject-kotlin/src/test/java/io/micronaut/annotation/mapping/MyOverridesTransformer.java
@@ -1,0 +1,35 @@
+package io.micronaut.annotation.mapping;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.inject.annotation.TypedAnnotationTransformer;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.util.List;
+
+/**
+ * Transforms {@link MyOverrides} to {@code @AliasFor}, mirroring how
+ * {@code jakarta.validation.OverridesAttribute} would be remapped.
+ */
+public class MyOverridesTransformer implements TypedAnnotationTransformer<MyOverrides> {
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<MyOverrides> annotation, VisitorContext visitorContext) {
+        return List.of(toAliasFor(annotation));
+    }
+
+    @Override
+    public Class<MyOverrides> annotationType() {
+        return MyOverrides.class;
+    }
+
+    static AnnotationValue<AliasFor> toAliasFor(AnnotationValue<MyOverrides> annotation) {
+        AnnotationValueBuilder<AliasFor> builder = AnnotationValue.builder(AliasFor.class);
+        annotation.annotationClassValue("constraint").ifPresent(constraint -> builder.member("annotationName", constraint.getName()));
+        annotation.stringValue("name").ifPresent(name -> builder.member("member", name));
+        annotation.intValue("constraintIndex").ifPresent(index -> builder.member("index", index));
+        builder.member("applyDefault", true);
+        return builder.build();
+    }
+}

--- a/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -1,2 +1,4 @@
 io.micronaut.kotlin.processing.aop.compile.TestStereotypeAnnTransformer
 io.micronaut.kotlin.processing.aop.compile.AroundConstructAnnTransformer
+io.micronaut.annotation.mapping.MyOverridesTransformer
+io.micronaut.annotation.mapping.MyOverridesListTransformer

--- a/inject/src/main/java/io/micronaut/context/annotation/AliasFor.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/AliasFor.java
@@ -49,4 +49,26 @@ public @interface AliasFor {
      * If not specified the alias is applied to the current annotation.
      */
     String annotationName() default "";
+
+    /**
+     * When the aliased {@link #annotation()} is a repeatable annotation declared multiple times as a
+     * stereotype of the annotation this member belongs to, selects which occurrence (in declaration
+     * order, starting at zero) the alias applies to. The default of {@code -1} applies the alias to
+     * every declared occurrence.
+     *
+     * @return The occurrence index of the aliased repeatable annotation
+     * @since 5.2
+     */
+    int index() default -1;
+
+    /**
+     * Whether the alias should also be applied using the member's default value when the member is
+     * not explicitly set. By default, aliases only apply to explicitly set members. This allows
+     * modelling semantics such as {@code jakarta.validation.OverridesAttribute}, where the
+     * overriding member's default value replaces the value declared on the aliased annotation.
+     *
+     * @return Whether to apply the alias for the member's default value
+     * @since 5.2
+     */
+    boolean applyDefault() default false;
 }

--- a/src/main/docs/guide/ioc/annotationMetadata.adoc
+++ b/src/main/docs/guide/ioc/annotationMetadata.adoc
@@ -98,19 +98,14 @@ Two additional members refine this behaviour:
 
 For example:
 
-.Overriding a repeatable stereotype member
-[source,java]
-----
-@Pattern(regexp = ".....")
-@Pattern(regexp = "bar")
-@interface ComposedZip {
+snippet::io.micronaut.docs.inject.aliasfor.ComposedZip[tags="imports, class", indent=0, title="Overriding a Member of a Declared Stereotype"]
 
-    @AliasFor(annotation = Pattern.class, member = "regexp", index = 1, applyDefault = true)
-    String regex() default "\\d*";
-}
-----
+<1> `@Size` is declared as a stereotype with `max` set to `5`
+<2> The `max()` member aliases `Size.max`, overriding the declared value
 
-Here any use of `@ComposedZip` produces metadata containing two `@Pattern` stereotypes with the `regexp` members `"....."` and `"\\d*"` — the second occurrence is overridden by the `regex()` default, and by an explicit value such as `@ComposedZip(regex = "[0-9]+")` when set.
+Any use of `@ComposedZip` therefore produces `@Size(min = 5, max = 10)` in the metadata — `max` comes from the `max()` default because `applyDefault` is `true` — while `@ComposedZip(max = 20)` produces `@Size(min = 5, max = 20)`.
+
+NOTE: `index()` is only computed for annotations processed from Java and Groovy sources. The Kotlin (KSP) annotation metadata builder does not extract repeatable stereotype containers, so a repeatable annotation declared multiple times on a Kotlin annotation class cannot be targeted by index.
 
 Annotations that cannot depend on Micronaut can participate in alias resolution through an api:io.micronaut.inject.annotation.AnnotationTransformer[]: when an annotation member carries no literal `@AliasFor`, the registered transformers are applied to the member's annotations, and any produced `@AliasFor` values are processed as if declared directly (a produced alias without a `member` value defaults to the annotated member's own name). This is how, for example, `jakarta.validation.OverridesAttribute` can be remapped to `@AliasFor` by a validation annotation processor.
 

--- a/src/main/docs/guide/ioc/annotationMetadata.adoc
+++ b/src/main/docs/guide/ioc/annotationMetadata.adoc
@@ -87,6 +87,33 @@ include::http-client-core/src/main/java/io/micronaut/http/client/annotation/Clie
 
 With these aliases in place, whether you define `@Client("foo")` or `@Client(id="foo")`, both the `value` and `id` members will be set, making it easier to parse and work with the annotation.
 
+==== Aliasing Members of Other Annotations
+
+An alias can also target a member of a different annotation by setting the `annotation()` (or `annotationName()`) member of ann:io.micronaut.context.annotation.AliasFor[]. When the annotated member is set, the aliased annotation receives the value as a stereotype of the annotation being processed. If the targeted annotation is already declared as a stereotype, the aliased value *overrides* the declared member value instead of contributing a second annotation.
+
+Two additional members refine this behaviour:
+
+* `applyDefault()` - by default an alias only applies when the member is explicitly set at the use site. With `applyDefault = true` the alias also applies the member's *default* value. This allows modelling semantics such as `jakarta.validation.OverridesAttribute`, where the overriding member's default replaces the value declared on the composed constraint.
+* `index()` - when the aliased annotation is repeatable and declared multiple times as a stereotype, `index` selects which occurrence (in declaration order, starting at zero) the alias overrides. The default of `-1` applies the alias to every declared occurrence, and an index outside the declared occurrences is ignored.
+
+For example:
+
+.Overriding a repeatable stereotype member
+[source,java]
+----
+@Pattern(regexp = ".....")
+@Pattern(regexp = "bar")
+@interface ComposedZip {
+
+    @AliasFor(annotation = Pattern.class, member = "regexp", index = 1, applyDefault = true)
+    String regex() default "\\d*";
+}
+----
+
+Here any use of `@ComposedZip` produces metadata containing two `@Pattern` stereotypes with the `regexp` members `"....."` and `"\\d*"` — the second occurrence is overridden by the `regex()` default, and by an explicit value such as `@ComposedZip(regex = "[0-9]+")` when set.
+
+Annotations that cannot depend on Micronaut can participate in alias resolution through an api:io.micronaut.inject.annotation.AnnotationTransformer[]: when an annotation member carries no literal `@AliasFor`, the registered transformers are applied to the member's annotations, and any produced `@AliasFor` values are processed as if declared directly (a produced alias without a `member` value defaults to the annotated member's own name). This is how, for example, `jakarta.validation.OverridesAttribute` can be remapped to `@AliasFor` by a validation annotation processor.
+
 If you do not have control over the annotation, another approach is to use an api:io.micronaut.inject.annotation.AnnotationMapper[]. To create an `AnnotationMapper`, do the following:
 
 * Implement the api:io.micronaut.inject.annotation.AnnotationMapper[] interface

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/ComposedZip.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/ComposedZip.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.docs.inject.aliasfor
+
+//tag::imports[]
+import io.micronaut.context.annotation.AliasFor
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+//end::imports[]
+
+//tag::class[]
+@Retention(RetentionPolicy.RUNTIME)
+@Size(min = 5, max = 5) // <1>
+@interface ComposedZip {
+
+    @AliasFor(annotation = Size, member = "max", applyDefault = true) // <2>
+    int max() default 10
+}
+//end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/ComposedZipSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/ComposedZipSpec.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.docs.inject.aliasfor
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ComposedZipSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run()
+
+    void "test the aliased member default overrides the declared stereotype value"() {
+        when:
+            def definition = context.getBeanDefinition(ZipCodeValidator)
+
+        then:
+            definition.intValue(Size, "min").asInt == 5
+            definition.intValue(Size, "max").asInt == 10
+    }
+
+    void "test an explicitly set member overrides the declared stereotype value"() {
+        when:
+            def definition = context.getBeanDefinition(CustomZipCodeValidator)
+
+        then:
+            definition.intValue(Size, "min").asInt == 5
+            definition.intValue(Size, "max").asInt == 20
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/CustomZipCodeValidator.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/CustomZipCodeValidator.groovy
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.aliasfor
+
+import jakarta.inject.Singleton
+
+@ComposedZip(max = 20)
+@Singleton
+class CustomZipCodeValidator {
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/Size.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/Size.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.docs.inject.aliasfor
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Size {
+    int min() default 0
+    int max() default 100
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/ZipCodeValidator.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/aliasfor/ZipCodeValidator.groovy
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.aliasfor
+
+import jakarta.inject.Singleton
+
+@ComposedZip
+@Singleton
+class ZipCodeValidator {
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/ComposedZip.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/ComposedZip.kt
@@ -1,0 +1,14 @@
+package io.micronaut.docs.inject.aliasfor
+
+//tag::imports[]
+import io.micronaut.context.annotation.AliasFor
+//end::imports[]
+
+//tag::class[]
+@Retention(AnnotationRetention.RUNTIME)
+@Size(min = 5, max = 5) // <1>
+annotation class ComposedZip(
+    @get:AliasFor(annotation = Size::class, member = "max", applyDefault = true) // <2>
+    val max: Int = 10
+)
+//end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/ComposedZipSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/ComposedZipSpec.kt
@@ -1,0 +1,26 @@
+package io.micronaut.docs.inject.aliasfor
+
+import io.micronaut.context.ApplicationContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ComposedZipSpec {
+
+    @Test
+    fun testTheAliasedMemberDefaultOverridesTheDeclaredStereotypeValue() {
+        ApplicationContext.run().use { context ->
+            val definition = context.getBeanDefinition(ZipCodeValidator::class.java)
+            assertEquals(5, definition.intValue(Size::class.java, "min").orElse(-1))
+            assertEquals(10, definition.intValue(Size::class.java, "max").orElse(-1))
+        }
+    }
+
+    @Test
+    fun testAnExplicitlySetMemberOverridesTheDeclaredStereotypeValue() {
+        ApplicationContext.run().use { context ->
+            val definition = context.getBeanDefinition(CustomZipCodeValidator::class.java)
+            assertEquals(5, definition.intValue(Size::class.java, "min").orElse(-1))
+            assertEquals(20, definition.intValue(Size::class.java, "max").orElse(-1))
+        }
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/CustomZipCodeValidator.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/CustomZipCodeValidator.kt
@@ -1,0 +1,7 @@
+package io.micronaut.docs.inject.aliasfor
+
+import jakarta.inject.Singleton
+
+@ComposedZip(max = 20)
+@Singleton
+class CustomZipCodeValidator

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/Size.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/Size.kt
@@ -1,0 +1,4 @@
+package io.micronaut.docs.inject.aliasfor
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Size(val min: Int = 0, val max: Int = 100)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/ZipCodeValidator.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/aliasfor/ZipCodeValidator.kt
@@ -1,0 +1,7 @@
+package io.micronaut.docs.inject.aliasfor
+
+import jakarta.inject.Singleton
+
+@ComposedZip
+@Singleton
+class ZipCodeValidator

--- a/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/ComposedZip.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/ComposedZip.java
@@ -1,0 +1,18 @@
+package io.micronaut.docs.inject.aliasfor;
+
+//tag::imports[]
+import io.micronaut.context.annotation.AliasFor;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+//end::imports[]
+
+//tag::class[]
+@Retention(RetentionPolicy.RUNTIME)
+@Size(min = 5, max = 5) // <1>
+public @interface ComposedZip {
+
+    @AliasFor(annotation = Size.class, member = "max", applyDefault = true) // <2>
+    int max() default 10;
+}
+//end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/ComposedZipSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/ComposedZipSpec.java
@@ -1,0 +1,28 @@
+package io.micronaut.docs.inject.aliasfor;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.BeanDefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComposedZipSpec {
+
+    @Test
+    void testTheAliasedMemberDefaultOverridesTheDeclaredStereotypeValue() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            BeanDefinition<ZipCodeValidator> definition = context.getBeanDefinition(ZipCodeValidator.class);
+            assertEquals(5, definition.intValue(Size.class, "min").orElse(-1));
+            assertEquals(10, definition.intValue(Size.class, "max").orElse(-1));
+        }
+    }
+
+    @Test
+    void testAnExplicitlySetMemberOverridesTheDeclaredStereotypeValue() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            BeanDefinition<CustomZipCodeValidator> definition = context.getBeanDefinition(CustomZipCodeValidator.class);
+            assertEquals(5, definition.intValue(Size.class, "min").orElse(-1));
+            assertEquals(20, definition.intValue(Size.class, "max").orElse(-1));
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/CustomZipCodeValidator.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/CustomZipCodeValidator.java
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.aliasfor;
+
+import jakarta.inject.Singleton;
+
+@ComposedZip(max = 20)
+@Singleton
+public class CustomZipCodeValidator {
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/Size.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/Size.java
@@ -1,0 +1,10 @@
+package io.micronaut.docs.inject.aliasfor;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Size {
+    int min() default 0;
+    int max() default 100;
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/ZipCodeValidator.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/aliasfor/ZipCodeValidator.java
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.aliasfor;
+
+import jakarta.inject.Singleton;
+
+@ComposedZip
+@Singleton
+public class ZipCodeValidator {
+}


### PR DESCRIPTION
## Summary

Extends core's annotation alias machinery so that constraint-composition semantics like `jakarta.validation.OverridesAttribute` can be expressed with `@AliasFor` and computed at build time in the annotation metadata:

- **Member-annotation remapping**: when an annotation member carries no literal `@AliasFor`/`@Aliases`, the registered `AnnotationTransformer`s are applied to the member's annotations, and any produced `@AliasFor`/`@Aliases` values are processed as if declared directly. A produced alias without a `member` value defaults to the annotated member's own name (`OverridesAttribute`'s empty-`name` semantics, which a transformer cannot know). This lets annotations with no Micronaut dependency participate in alias resolution.
- **New `@AliasFor` members**:
  - `applyDefault()` — the alias also applies when the member is not explicitly set, using the member's default value. Opt-in, so existing alias behavior is unchanged. Deliberately uncached: a `hasAnnotations(member)` short-circuit keeps the per-usage cost low for members without annotations.
  - `index()` — for a repeatable aliased annotation declared multiple times as a stereotype, selects the occurrence (declaration order) the alias applies to; `-1` (default) applies to all occurrences; an out-of-range index is dropped.
- **Stereotype reconciliation**: alias-introduced annotations are reconciled with the declared stereotypes in `addStereotypes`. When the target is declared, the aliased members override the declared values in place — for repeatable targets the occurrence selected by `index` — instead of accumulating another occurrence in the repeatable container. Targets not declared as stereotypes are still contributed as new stereotypes with higher priority, as before.

## Motivation

Enables implementing Jakarta Validation constraint composition attribute overrides without runtime reflection: a ~50-line transformer in micronaut-validation remaps `@OverridesAttribute` to `@AliasFor` and the composed constraint's usage metadata carries the overridden values. Verified end-to-end against the Jakarta Validation 3.1.1 TCK `ConstraintCompositionTest` via a composite build with micronaut-validation: all 8 OverridesAttribute-related methods pass (repeated-`@Pattern` `constraintIndex` targeting, defaults propagation, default-name resolution, explicit `List` containers), full TCK suite green.

## Notes for reviewers

- For non-repeatable declared targets the resulting metadata is identical to the previous first-writer-wins merge; the behavior change is for repeatable declared targets, where an alias-introduced annotation previously accumulated as an extra occurrence with only the aliased member set — arguably never the intended outcome.
- Overrides merge after the declared stereotype has been processed, so overriding a member of a composed-of-composed annotation does not cascade into that annotation's own stereotype tree.
- `RemapMemberAnnotationToAliasForSpec` covers eight scenarios (override precedence, explicit names, defaults, `index` on repeated and `List`-container stereotypes, index-less all-occurrence overrides, out-of-range indexes, undeclared targets). Docs added to the "Aliasing / Mapping Annotations" guide section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)