### PR TITLE
fix(ksp): detect @JvmRepeatable when resolving repeatable containers

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
@@ -107,7 +107,9 @@ internal class KotlinVisitorContext(
     private fun computeRepeatableContainerNameForType(annotationType: KSAnnotated): String? {
         val name = Repeatable::class.java.name
         val repeatable = annotationType.annotations.find {
-            it.annotationType.resolve().declaration.qualifiedName?.asString() == name
+            // Resolve through getAnnotationTypeName so that Kotlin's @JvmRepeatable,
+            // a typealias for java.lang.annotation.Repeatable, is detected as well
+            getAnnotationTypeName(it) == name
         }
         if (repeatable != null) {
             val value = repeatable.arguments.find { it.name?.asString() == "value" }?.value

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/RepeatableStereotypeSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/RepeatableStereotypeSpec.groovy
@@ -1,0 +1,124 @@
+package io.micronaut.kotlin.processing.annotations
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+
+class RepeatableStereotypeSpec extends AbstractKotlinCompilerSpec {
+
+    void 'test repeated annotation declared with JvmRepeatable applied directly to a method'() {
+        given:
+            def definition = buildBeanDefinition('addann.DirectTest', '''
+package addann
+
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Executable
+
+@Retention(AnnotationRetention.RUNTIME)
+@JvmRepeatable(PatternLikeList::class)
+annotation class PatternLike(val regexp: String)
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PatternLikeList(val value: Array<PatternLike>)
+
+@Bean
+class DirectTest {
+
+    @PatternLike(regexp = ".....")
+    @PatternLike(regexp = "bar")
+    @Executable
+    fun getValue(): String = ""
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then: 'both occurrences are retained inside the repeatable container'
+            metadata.hasAnnotation('addann.PatternLikeList')
+            patterns.size() == 2
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == 'bar'
+    }
+
+    void 'test repeated annotation stereotype declared with JvmRepeatable'() {
+        given:
+            def definition = buildBeanDefinition('addann.RepeatedTest', '''
+package addann
+
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Executable
+
+@Retention(AnnotationRetention.RUNTIME)
+@JvmRepeatable(PatternLikeList::class)
+annotation class PatternLike(val regexp: String)
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PatternLikeList(val value: Array<PatternLike>)
+
+@PatternLike(regexp = ".....")
+@PatternLike(regexp = "bar")
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ComposedZip
+
+@Bean
+class RepeatedTest {
+
+    @ComposedZip
+    @Executable
+    fun getValue(): String = ""
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then: 'both declared occurrences of the repeatable stereotype are retained'
+            metadata.hasStereotype('addann.PatternLikeList')
+            patterns.size() == 2
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == 'bar'
+    }
+
+    void 'test explicit container annotation stereotype'() {
+        given:
+            def definition = buildBeanDefinition('addann.ContainerTest', '''
+package addann
+
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Executable
+
+@Retention(AnnotationRetention.RUNTIME)
+@JvmRepeatable(PatternLikeList::class)
+annotation class PatternLike(val regexp: String)
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PatternLikeList(val value: Array<PatternLike>)
+
+@PatternLikeList(value = [PatternLike(regexp = "....."), PatternLike(regexp = "bar")])
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ComposedZip
+
+@Bean
+class ContainerTest {
+
+    @ComposedZip
+    @Executable
+    fun getValue(): String = ""
+}
+''')
+            def metadata = definition.getRequiredMethod("getValue").getAnnotationMetadata()
+
+        when:
+            def patternType = (Class) definition.getClass().getClassLoader().loadClass('addann.PatternLike')
+            def patterns = metadata.getAnnotationValuesByType(patternType)
+
+        then: 'an explicitly declared container behaves the same as repeated annotations'
+            metadata.hasStereotype('addann.PatternLikeList')
+            patterns.size() == 2
+            patterns[0].stringValue('regexp').get() == '.....'
+            patterns[1].stringValue('regexp').get() == 'bar'
+    }
+}


### PR DESCRIPTION
## What changed

The repeatable-container lookup in `KotlinVisitorContext.computeRepeatableContainerNameForType` compared the resolved annotation declaration's qualified name against `java.lang.annotation.Repeatable`. For annotations declared in Kotlin source with `@JvmRepeatable`, the KSP model resolves the annotation type to the `kotlin.jvm.JvmRepeatable` typealias declaration, so the comparison never matched and the container was not detected.

The lookup now resolves through `getAnnotationTypeName` (already memoized), which expands the typealias to the binary name before comparing, so `@JvmRepeatable` is recognized the same way as the Java annotation.

## Why

Without container detection, repeated Kotlin annotations were added to the metadata without a repeatable container, so successive occurrences overwrote one another instead of accumulating. All but one value were lost for:

- repeated annotations applied directly to an element,
- repeated annotations used as stereotypes on an annotation class,
- explicitly applied container annotations (which the KSP builder expands into their nested values before processing).

The Java (APT) and Groovy builders already handle the equivalent shapes correctly; this brings KSP in line with them.

## Notes for reviewers

- New `RepeatableStereotypeSpec` in `inject-kotlin` covers the three scenarios above, asserting two retained `PatternLike` values via `getAnnotationValuesByType`, mirroring the existing Java specs.
- The tests assert `hasStereotype` on the container name rather than the repeated annotation name because `hasStereotype(String)` intentionally does not resolve repeatable containers (same behavior on the Java processor).
- While diagnosing this, I found that `AnnotationMetadataHierarchy` never overrides `getStereotypeAnnotationNames()`/`getDeclaredStereotypeAnnotationNames()`, so those always return an empty set on hierarchy metadata regardless of language. That is a separate pre-existing issue and is not addressed here.
- Verified with the new spec, the full `inject-kotlin` suite (793 tests), and `test-suite-kotlin` (one unrelated flaky HTTP test passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)