### PR TITLE
fix(processor): stop generating an imported type's introspection twice

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -49,8 +49,10 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -76,6 +78,15 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
     private static final String ANN_LOMBOK_BUILDER = "lombok.Builder";
 
     private final Set<String> processed = new HashSet<>();
+    /**
+     * The introspections written during this compilation, keyed by the generated introspection class
+     * name and holding the name of the type the introspection was generated for. An introspection
+     * generated on behalf of another element (via {@link Introspected#classNames()},
+     * {@link Introspected#classes()} or {@link io.micronaut.context.annotation.ClassImport}) is not
+     * named after the type it introspects, so this is the only reliable way to detect that the same
+     * introspection is about to be written twice.
+     */
+    private final Map<String, String> writtenIntrospections = new HashMap<>();
 
     @Override
     public int getOrder() {
@@ -100,6 +111,28 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
 
     private boolean isIntrospected(VisitorContext context, ClassElement c) {
         return processed.contains(c.getName()) || context.getClassElement(c.getPackageName() + ".$" + c.getSimpleName() + "$Introspection").isPresent();
+    }
+
+    /**
+     * Claims the introspection about to be written by the given writer.
+     *
+     * @param beanClassElement The introspected type
+     * @param writer           The writer
+     * @return {@code true} if the very same introspection was already written during this compilation
+     * and should not be written again
+     */
+    private boolean isAlreadyWritten(ClassElement beanClassElement, BeanIntrospectionWriter writer) {
+        String introspectionName = writer.getIntrospectionName();
+        String previous = writtenIntrospections.putIfAbsent(introspectionName, beanClassElement.getName());
+        if (previous == null) {
+            return false;
+        }
+        if (!previous.equals(beanClassElement.getName())) {
+            throw new ProcessingException(beanClassElement, "Introspection '" + introspectionName
+                + "' cannot be generated for '" + beanClassElement.getName()
+                + "' because it is already generated for '" + previous + "'");
+        }
+        return true;
     }
 
     private void processIntrospected(ClassElement element, VisitorContext context, AnnotationValue<Introspected> introspected) {
@@ -442,6 +475,9 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     .forEach(builderWriter::visitBeanMethod);
 
                 processed.add(classToBuild.getName());
+                if (isAlreadyWritten(builderType, builderWriter)) {
+                    return;
+                }
                 for (OutputObjectDef outputObjectDef : builderWriter.build()) {
                     write(outputObjectDef, context);
                 }
@@ -472,6 +508,10 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                                 ClassElement ce,
                                 BeanIntrospectionWriter writer,
                                 VisitorContext context) {
+        if (isAlreadyWritten(ce, writer)) {
+            processed.add(ce.getName());
+            return;
+        }
         List<PropertyElement> beanProperties = ce.getBeanProperties(propertyElementQuery).stream()
             .filter(p -> !p.isExcluded())
             .toList();

--- a/inject-java-test/src/main/java/io/micronaut/annotation/processing/test/InMemoryJavaFileManager.java
+++ b/inject-java-test/src/main/java/io/micronaut/annotation/processing/test/InMemoryJavaFileManager.java
@@ -17,6 +17,7 @@ package io.micronaut.annotation.processing.test;
 
 
 import javax.annotation.processing.Filer;
+import javax.annotation.processing.FilerException;
 import javax.lang.model.element.Element;
 import javax.tools.FileObject;
 import javax.tools.ForwardingJavaFileManager;
@@ -39,9 +40,11 @@ import java.io.Writer;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -55,6 +58,7 @@ import java.util.function.Function;
 @SuppressWarnings("all")
 final class InMemoryJavaFileManager extends ForwardingJavaFileManager<JavaFileManager> implements Filer {
     private final Map<URI, JavaFileObject> inMemoryFileObjects = new LinkedHashMap<>();
+    private final Set<URI> createdResources = new HashSet<>();
 
     InMemoryJavaFileManager(JavaFileManager fileManager) {
         super(fileManager);
@@ -164,6 +168,12 @@ final class InMemoryJavaFileManager extends ForwardingJavaFileManager<JavaFileMa
 
     @Override
     public FileObject createResource(Location location, CharSequence pkg, CharSequence relativeName, Element... originatingElements) throws IOException {
+        // The real javac Filer refuses to create the same resource twice in one compilation. Mirror that
+        // here so tests catch metadata being generated twice instead of silently overwriting it.
+        URI uri = uriForFileObject(StandardLocation.CLASS_OUTPUT, pkg.toString(), relativeName.toString());
+        if (!createdResources.add(uri)) {
+            throw new FilerException("Attempt to reopen a file for path " + uri.getPath());
+        }
         return getFileForOutput(StandardLocation.CLASS_OUTPUT, pkg.toString(), relativeName.toString(), null);
     }
 

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -6043,6 +6043,154 @@ class PrivateNoAccessors {
         e.message.contains("the field is not accessible for visibility [DEFAULT]")
     }
 
+    void "test a nested type named on classNames is introspected once"() {
+        given:
+        ApplicationContext context = buildContext('test.Holder', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.NotNull;
+
+@Introspected(classNames = {"test.Outer$Nested"})
+class Holder {}
+
+class Outer {
+    static class Nested {
+        @NotNull private String name;
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+}
+
+class Unrelated1 {}
+
+class Unrelated2 {}
+''')
+
+        when:
+        def reference = context.classLoader.loadClass('test.$test_Outer$Nested$Introspection').newInstance()
+
+        then:
+        reference instanceof BeanIntrospectionReference
+        reference.load().beanType.name == 'test.Outer$Nested'
+
+        cleanup:
+        context?.close()
+    }
+
+    void "test a nested type imported with ClassImport is introspected once"() {
+        given:
+        ApplicationContext context = buildContext('test.Holder', '''
+package test;
+
+import io.micronaut.context.annotation.ClassImport;
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.NotNull;
+
+@ClassImport(classes = {test.Outer.Nested.class}, annotate = Introspected.class)
+class Holder {}
+
+class Outer {
+    public static class Nested {
+        @NotNull private String name;
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+}
+
+class Unrelated1 {}
+
+class Unrelated2 {}
+''')
+
+        when:
+        def reference = context.classLoader.loadClass('test.$test_Outer$Nested$Introspection').newInstance()
+
+        then:
+        reference instanceof BeanIntrospectionReference
+        reference.load().beanType.name == 'test.Outer$Nested'
+
+        cleanup:
+        context?.close()
+    }
+
+    void "test a type imported by two importers is introspected once"() {
+        given:
+        ApplicationContext context = buildContext('test.Holder', '''
+package test;
+
+import io.micronaut.context.annotation.ClassImport;
+import io.micronaut.core.annotation.Introspected;
+
+@ClassImport(classes = {test.Outer.Nested.class}, annotate = Introspected.class)
+class Holder {}
+
+@ClassImport(classes = {test.Outer.Nested.class}, annotate = Introspected.class)
+class Holder2 {}
+
+class Outer {
+    public static class Nested {
+        private String name;
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+}
+''')
+
+        when:
+        def reference = context.classLoader.loadClass('test.$test_Outer$Nested$Introspection').newInstance()
+
+        then:
+        reference instanceof BeanIntrospectionReference
+        reference.load().beanType.name == 'test.Outer$Nested'
+
+        cleanup:
+        context?.close()
+    }
+
+    void "test a builder shared by two introspected types is generated once"() {
+        given:
+        ApplicationContext context = buildContext('test.Holder', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(classNames = {"test.A", "test.B"})
+class Holder {}
+
+@Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = SharedBuilder.class))
+class A {
+    private String name;
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}
+
+@Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = SharedBuilder.class))
+class B {
+    private String name;
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}
+
+class SharedBuilder {
+    private String name;
+    public SharedBuilder name(String name) { this.name = name; return this; }
+    public A buildA() { A a = new A(); a.setName(name); return a; }
+    public B buildB() { B b = new B(); b.setName(name); return b; }
+}
+''')
+
+        when:
+        def reference = context.classLoader.loadClass('test.$test_SharedBuilder$Introspection').newInstance()
+
+        then:
+        reference instanceof BeanIntrospectionReference
+        reference.load().beanType.name == 'test.SharedBuilder'
+
+        cleanup:
+        context?.close()
+    }
+
     @Override
     protected JavaParser newJavaParser() {
         return new JavaParser() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -290,11 +290,19 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                 List<JavaClassElement> javaClassElements = elements.stream()
                     .map(typeElement -> elementFactory.newSourceClassElement(typeElement, elementAnnotationMetadataFactory))
                     .collect(Collectors.toCollection(() -> new ArrayList<>(elements.size())));
-                List<ClassElement> extraClasses = new ArrayList<>();
+                // Imported elements can be discovered more than once: by several importing types, or by a
+                // type that is itself already part of this round. Visiting the same class twice would
+                // generate the same metadata twice, so only the newly discovered ones are added.
+                var visitedClassNames = javaClassElements.stream()
+                    .map(ClassElement::getName)
+                    .collect(Collectors.toCollection(HashSet::new));
                 for (JavaClassElement javaClassElement : new ArrayList<>(javaClassElements)) {
                     try {
-                        extraClasses.addAll(VisitorUtils.collectImportedElements(javaClassElement, javaVisitorContext));
-                        javaClassElements.addAll((Collection) extraClasses);
+                        for (ClassElement importedElement : VisitorUtils.collectImportedElements(javaClassElement, javaVisitorContext)) {
+                            if (importedElement instanceof JavaClassElement importedClassElement && visitedClassNames.add(importedElement.getName())) {
+                                javaClassElements.add(importedClassElement);
+                            }
+                        }
                     } catch (PostponeToNextRoundException e) {
                         javaClassElements.remove(javaClassElement);
                         postponeElement(javaClassElement, e.getNativeErrorElement(), e);

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ImportTypeElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ImportTypeElementSpec.groovy
@@ -135,6 +135,63 @@ class Importer {
             DefaultTypeElementVisitor.cleanup()
     }
 
+    void 'test an imported class is visited once when other classes are compiled alongside the importer'() {
+        when:
+            DefaultTypeElementVisitor.ENABLED = true
+            def definition = buildBeanDefinition('test.Importer', '''
+package test;
+
+import io.micronaut.context.annotation.ClassImport;
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+@ClassImport(classes = io.micronaut.visitors.MySimpleClass.class)
+class Importer {
+}
+
+class Other1 {
+}
+
+class Other2 {
+}
+
+''')
+        then:
+            definition
+            DefaultTypeElementVisitor.VISITED_CLASSES.count { it.name == 'io.micronaut.visitors.MySimpleClass' } == 1
+
+        cleanup:
+            DefaultTypeElementVisitor.cleanup()
+    }
+
+    void 'test a class imported by two importers is visited once'() {
+        when:
+            DefaultTypeElementVisitor.ENABLED = true
+            def definition = buildBeanDefinition('test.Importer', '''
+package test;
+
+import io.micronaut.context.annotation.ClassImport;
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+@ClassImport(classes = io.micronaut.visitors.MySimpleClass.class)
+class Importer {
+}
+
+@Prototype
+@ClassImport(classes = io.micronaut.visitors.MySimpleClass.class)
+class Importer2 {
+}
+
+''')
+        then:
+            definition
+            DefaultTypeElementVisitor.VISITED_CLASSES.count { it.name == 'io.micronaut.visitors.MySimpleClass' } == 1
+
+        cleanup:
+            DefaultTypeElementVisitor.cleanup()
+    }
+
     static class DefaultTypeElementVisitor implements TypeElementVisitor<Object, Object> {
 
         static boolean ENABLED = false


### PR DESCRIPTION
## What

Naming a type on `@Introspected(classNames = …)` or `@ClassImport` could generate its introspection twice and fail the build. The second `visitServiceDescriptor` call asks the `Filer` to recreate a resource it already created for this compilation:

```
error: Failed to generate class: 'test.$test_Outer$Nested$Introspection':
  Unable to generate Bean entry at path:
  META-INF/micronaut/io.micronaut.core.beans.BeanIntrospectionReference/test.$test_Outer$Nested$Introspection
```

This matters because a nested type carrying no annotation of its own is never handed to the processor by the round, so `classNames`/`@ClassImport` is the documented way to reach it — and that is exactly where the duplicate appears.

Two independent defects contributed.

### 1. Imported elements were visited once per root element

`TypeElementVisitorProcessor.process` accumulated imports into `extraClasses` and re-added the **whole accumulated list** to the visit list on every iteration:

```java
List<ClassElement> extraClasses = new ArrayList<>();
for (JavaClassElement javaClassElement : new ArrayList<>(javaClassElements)) {
    extraClasses.addAll(VisitorUtils.collectImportedElements(...));
    javaClassElements.addAll((Collection) extraClasses);
}
```

A file with three top-level types made an imported class visit **three times** — measured, not inferred. Only newly discovered imports are added now, and a class already queued for this round is not queued again. The equivalent Python processor already guarded against this; the Java one did not.

### 2. Introspections written on behalf of another element were untracked

`isIntrospected` looks for `<package>.$<Simple>$Introspection`. An introspection generated on behalf of another element is written as `$<originating class>$<Simple>$Introspection`, so the lookup never matches and the guard falls back to the in-memory `processed` set — which is keyed on the introspected type. Not every write path records its target there: `handleBuilder` writes an introspection for the **builder** type but records the type being **built**.

The introspections written during a compilation are now tracked by generated class name alongside the type they were generated for. Writing the same one twice is a no-op; a genuine name collision between two *different* types raises a readable `ProcessingException` instead of the cryptic Filer error, per the narrower of the two options in the issue.

### 3. The test harness could not see any of this

`InMemoryJavaFileManager.createResource` collapsed duplicate writes with `computeIfAbsent`, so no `AbstractTypeElementSpec` test could ever observe a double write. It now refuses to recreate a resource, the way the real javac `Filer` does. This is what turns the shared-builder case below into a genuine regression test.

## Tests

`BeanIntrospectionSpec` — nested type via `classNames`, nested type via `@ClassImport`, one type imported by two importers, and two `@Introspected` types sharing a `builderClass`. The last **fails without the visitor fix**, reproducing the reported error verbatim:

```
error: Failed to generate class: 'test.$test_SharedBuilder$Introspection': Unable to generate Bean entry at path: META-INF/micronaut/io.micronaut.core.beans.BeanIntrospectionReference/test.$test_SharedBuilder$Introspection
```

`ImportTypeElementSpec` — two visit-count cases. Both **fail without the processor fix** (`3 != 1`).

## Notes for reviewers

- **The strict Filer is the change most worth a second look.** 7018 tests across `inject-java`, `inject-java-test`, `context`, `http-validation`, `inject-groovy` and `inject-kotlin` pass with it, so nothing in the codebase was relying on the silent overwrite — but it will now surface duplicate metadata writes anywhere else they exist.
- **One correction to the issue's root-cause analysis.** The `isIntrospected` long-form blindness is real, but I could not make it produce a duplicate on its own — `processed` covers it within a compilation. The failure needs a write path that bypasses `processed` entirely, which is what the builder path does.
- **`isIntrospected` was deliberately left alone.** Broadening its classpath lookup to guess long-form names risks *skipping* introspections on incremental recompiles, where the previous compilation's output is still on the classpath. A missing introspection is a worse failure than a duplicate.
- The `@Introspected` visitor fix lives in `core-processor`, so it covers Java, Groovy and Kotlin. The processor fix is Java-only; Groovy and Kotlin have no `@ClassImport` collection path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)