### PR TITLE
fix(validation): only advise methods that declare @RequiresValidation

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/runtime/DefaultRuntimeProxyDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/runtime/DefaultRuntimeProxyDefinition.java
@@ -135,7 +135,11 @@ public record DefaultRuntimeProxyDefinition<T>(BeanDefinition<T> proxyBeanDefini
         ));
         List<InterceptedMethod<T>> interceptedMethods = new ArrayList<>(executableMethods.size());
         for (ExecutableMethod<T, ?> executableMethod : executableMethods) {
-            Interceptor<T, ?>[] methodInterceptors = InterceptorChain.resolveIntroductionInterceptors(interceptorRegistry, executableMethod, interceptors);
+            // Only the abstract methods are implemented by the introduction advice,
+            // the concrete ones are intercepted and proceed to the actual implementation
+            Interceptor<T, ?>[] methodInterceptors = executableMethod.isAbstract()
+                ? InterceptorChain.resolveIntroductionInterceptors(interceptorRegistry, executableMethod, interceptors)
+                : InterceptorChain.resolveAroundInterceptors(interceptorRegistry, executableMethod, interceptors);
             if (methodInterceptors.length > 0) {
                 interceptedMethods.add(new InterceptedMethod<>((ExecutableMethod) executableMethod, (Interceptor[]) methodInterceptors));
             }

--- a/core-processor/src/main/java/io/micronaut/inject/processing/IntroductionInterfaceBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/IntroductionInterfaceBeanElementCreator.java
@@ -73,8 +73,16 @@ final class IntroductionInterfaceBeanElementCreator<R> extends AbstractBeanEleme
         return proxyBuilder.build();
     }
 
+    /**
+     * Checks if the method is an interface default method.
+     * Only invoked for a non-abstract method of an interface, where a static and a private method
+     * are the only alternatives to a default method; an interface method can never be final.
+     *
+     * @param method The non-abstract method of the interface
+     * @return true if the method is a default method
+     */
     private static boolean isDefaultMethod(MethodElement method) {
-        return !method.isAbstract() && !method.isStatic() && !method.isPrivate() && !method.isFinal();
+        return !method.isStatic() && !method.isPrivate();
     }
 
     private void handlePropertyMethod(ElementProxyBuilder<R> proxyBuilder, List<MethodElement> methods, @Nullable MethodElement method) {

--- a/core-processor/src/main/java/io/micronaut/inject/processing/IntroductionInterfaceBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/IntroductionInterfaceBeanElementCreator.java
@@ -55,8 +55,12 @@ final class IntroductionInterfaceBeanElementCreator<R> extends AbstractBeanEleme
         List<MethodElement> nonAbstractMethods = methods.stream().filter(m -> !m.isAbstract()).toList();
         // Remove abstract methods overridden by non-abstract ones
         methods.removeIf(method -> method.isAbstract() && nonAbstractMethods.stream().anyMatch(nonAbstractMethod -> nonAbstractMethod.overrides(method)));
-        // Remove non-abstract methods without explicit around advice
-        methods.removeIf(method -> !method.isAbstract() && !InterceptedMethodUtil.hasDeclaredAroundAdvice(method.getAnnotationMetadata()));
+        // Remove non-abstract methods without around advice.
+        // The around advice can be declared by the method itself or, for the default methods, by the type
+        boolean typeDeclaresAroundAdvice = InterceptedMethodUtil.hasDeclaredAroundAdvice(classElement.getAnnotationMetadata());
+        methods.removeIf(method -> !method.isAbstract()
+            && !InterceptedMethodUtil.hasDeclaredAroundAdvice(method.getAnnotationMetadata())
+            && !(typeDeclaresAroundAdvice && isDefaultMethod(method)));
         Collections.reverse(methods); // reverse to process hierarchy starting from declared methods
         for (MethodElement methodElement : methods) {
             visitIntrospectedMethod(proxyBuilder, methodElement);
@@ -67,6 +71,10 @@ final class IntroductionInterfaceBeanElementCreator<R> extends AbstractBeanEleme
             handlePropertyMethod(proxyBuilder, methods, beanProperty.getWriteMethod().orElse(null));
         }
         return proxyBuilder.build();
+    }
+
+    private static boolean isDefaultMethod(MethodElement method) {
+        return !method.isAbstract() && !method.isStatic() && !method.isPrivate() && !method.isFinal();
     }
 
     private void handlePropertyMethod(ElementProxyBuilder<R> proxyBuilder, List<MethodElement> methods, @Nullable MethodElement method) {

--- a/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
@@ -291,7 +291,9 @@ public class DefaultElementBeanDefinitionBuilderFactory implements ElementBeanDe
                 // Configuration beans are validated at the startup and don't require validation advice
                 beanDefinitionWriter.setRequiresPostConstructBeanValidation(true);
             } else {
-                for (MethodElement methodElement : target.getEnclosedElements(ElementQuery.ALL_METHODS.annotated(am -> am.hasAnnotation(ANN_REQUIRES_VALIDATION)))) {
+                // NOTE: the method's annotation metadata combines the class and the method annotations,
+                // only the methods that declare `@RequiresValidation` themselves should get the validation advice
+                for (MethodElement methodElement : target.getEnclosedElements(ElementQuery.ALL_METHODS.annotated(am -> am.hasDeclaredAnnotation(ANN_REQUIRES_VALIDATION)))) {
                     methodElement.annotate(ANN_VALIDATED);
                 }
             }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/validation/ValidationAdviceSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/validation/ValidationAdviceSpec.groovy
@@ -1,0 +1,85 @@
+package io.micronaut.inject.validation
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.writer.BeanDefinitionVisitor
+
+class ValidationAdviceSpec extends AbstractBeanDefinitionSpec {
+
+    private static final String ANN_VALIDATED = 'io.micronaut.validation.Validated'
+
+    void "test only the constrained method of an introduction interface is validated"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('validationadvice.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package validationadvice
+
+import io.micronaut.aop.introduction.*
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+@Stub
+@Singleton
+interface MyBean {
+
+    String constrained(@NotBlank String name)
+
+    String notConstrained(String name)
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+
+    void "test only the constrained method of an introduction abstract class is validated"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('validationadvice.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package validationadvice
+
+import io.micronaut.aop.introduction.*
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+@Stub
+@Singleton
+abstract class MyBean {
+
+    abstract String constrained(@NotBlank String name)
+
+    abstract String notConstrained(String name)
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+
+    void "test a constrained method inherited from a super interface is validated"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('validationadvice.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package validationadvice
+
+import io.micronaut.aop.introduction.*
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+interface Parent {
+
+    String constrained(@NotBlank String name)
+
+    String notConstrained(String name)
+}
+
+@Stub
+@Singleton
+interface MyBean extends Parent {
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/IntroductionInterfaceMethodsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/IntroductionInterfaceMethodsSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.writer.BeanDefinitionVisitor
+
+class IntroductionInterfaceMethodsSpec extends AbstractTypeElementSpec {
+
+    void "test only abstract methods are proxied when the type declares no around advice"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.aop.introduction.*;
+
+@Stub
+@jakarta.inject.Singleton
+interface MyBean {
+
+    String abstractMethod();
+
+    default String defaultMethod() {
+        return "default";
+    }
+}
+''')
+
+        then:
+        beanDefinition.getExecutableMethods()*.name.toSorted() == ["abstractMethod"]
+    }
+
+    void "test a default method declaring around advice is proxied"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.aop.introduction.*;
+
+@Stub
+@jakarta.inject.Singleton
+interface MyBean {
+
+    String abstractMethod();
+
+    @Tx
+    default String advisedDefaultMethod() {
+        return "default";
+    }
+
+    default String defaultMethod() {
+        return "default";
+    }
+}
+''')
+
+        then:
+        beanDefinition.getExecutableMethods()*.name.toSorted() == ["abstractMethod", "advisedDefaultMethod"]
+    }
+
+    void "test static and private methods are not proxied when the type declares around advice"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.aop.introduction.*;
+
+@Stub
+@Tx
+@jakarta.inject.Singleton
+interface MyBean {
+
+    String abstractMethod();
+
+    default String defaultMethod() {
+        return privateMethod() + staticMethod();
+    }
+
+    private String privateMethod() {
+        return "private";
+    }
+
+    static String staticMethod() {
+        return "static";
+    }
+}
+''')
+
+        then:
+        beanDefinition.getExecutableMethods()*.name.toSorted() == ["abstractMethod", "defaultMethod"]
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/validation/ValidationAdviceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/validation/ValidationAdviceSpec.groovy
@@ -1,0 +1,140 @@
+package io.micronaut.inject.validation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
+
+class ValidationAdviceSpec extends AbstractTypeElementSpec {
+
+    private static final String ANN_VALIDATED = 'io.micronaut.validation.Validated'
+
+    void "test only the constrained method of a bean is validated"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
+package test;
+
+import jakarta.validation.constraints.NotBlank;
+
+@jakarta.inject.Singleton
+class MyBean {
+
+    public String constrained(@NotBlank String name) {
+        return name;
+    }
+
+    public String notConstrained(String name) {
+        return name;
+    }
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        beanDefinition.findMethod("notConstrained", String).isEmpty()
+    }
+
+    void "test only the constrained method of an introduction interface is validated"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.aop.introduction.*;
+import jakarta.validation.constraints.NotBlank;
+
+@Stub
+@jakarta.inject.Singleton
+interface MyBean {
+
+    String constrained(@NotBlank String name);
+
+    String notConstrained(String name);
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+
+    void "test only the constrained method of an introduction abstract class is validated"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.aop.introduction.*;
+import jakarta.validation.constraints.NotBlank;
+
+@Stub
+@jakarta.inject.Singleton
+abstract class MyBean {
+
+    public abstract String constrained(@NotBlank String name);
+
+    public abstract String notConstrained(String name);
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+
+    void "test a constrained method inherited from a super interface is validated"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.aop.introduction.*;
+import jakarta.validation.constraints.NotBlank;
+
+interface Parent {
+
+    String constrained(@NotBlank String name);
+
+    String notConstrained(String name);
+}
+
+@Stub
+@jakarta.inject.Singleton
+interface MyBean extends Parent {
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+
+    void "test a method overriding a constrained method is validated"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+package test;
+
+import io.micronaut.aop.introduction.*;
+import jakarta.validation.constraints.NotBlank;
+
+interface Parent {
+
+    String constrained(@NotBlank String name);
+
+    String notConstrained(String name);
+}
+
+@Stub
+@jakarta.inject.Singleton
+interface MyBean extends Parent {
+
+    @Override
+    String constrained(String name);
+
+    @Override
+    String notConstrained(String name);
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+}

--- a/inject-java/src/test/java/io/micronaut/aop/bytebuddy/introduction/RuntimeProxyRepositoryTest.java
+++ b/inject-java/src/test/java/io/micronaut/aop/bytebuddy/introduction/RuntimeProxyRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +44,10 @@ class RuntimeProxyRepositoryTest {
     void testMethodsCount() {
         try (ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "RuntimeProxyTest"))) {
             Collection<ExecutableMethod<CustomCrudRepo, ?>> executableMethods = context.getBeanDefinition(CustomCrudRepo.class).getExecutableMethods();
-            assertEquals(1, executableMethods.size());
+            // `findById` is implemented by the introduction advice, `findByIdWithDefault` is intercepted by the type level around advice
+            assertEquals(2, executableMethods.size());
+            assertEquals(List.of("findById", "findByIdWithDefault"),
+                executableMethods.stream().map(ExecutableMethod::getName).sorted().toList());
         }
     }
 }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/validation/ValidationAdviceSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/validation/ValidationAdviceSpec.groovy
@@ -1,0 +1,137 @@
+package io.micronaut.kotlin.processing.inject.validation
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.annotation.processing.test.KotlinCompiler
+import io.micronaut.inject.BeanDefinition
+
+class ValidationAdviceSpec extends AbstractKotlinCompilerSpec {
+
+    private static final String ANN_VALIDATED = 'io.micronaut.validation.Validated'
+
+    void "test only the constrained method of a bean is validated"() {
+        when:
+        BeanDefinition beanDefinition = KotlinCompiler.buildInterceptedBeanDefinition('test.MyBean', '''
+package test
+
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+@Singleton
+open class MyBean {
+
+    open fun constrained(@NotBlank name: String): String = name
+
+    open fun notConstrained(name: String): String = name
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        beanDefinition.findMethod("notConstrained", String).isEmpty()
+    }
+
+    void "test only the constrained method of an introduction interface is validated"() {
+        when:
+        BeanDefinition beanDefinition = KotlinCompiler.buildIntroducedBeanDefinition('test.MyBean', '''
+package test
+
+import io.micronaut.kotlin.processing.aop.introduction.Stub
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+@Stub
+@Singleton
+interface MyBean {
+
+    fun constrained(@NotBlank name: String): String
+
+    fun notConstrained(name: String): String
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+
+    void "test only the constrained method of an introduction abstract class is validated"() {
+        when:
+        BeanDefinition beanDefinition = KotlinCompiler.buildIntroducedBeanDefinition('test.MyBean', '''
+package test
+
+import io.micronaut.kotlin.processing.aop.introduction.Stub
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+@Stub
+@Singleton
+abstract class MyBean {
+
+    abstract fun constrained(@NotBlank name: String): String
+
+    abstract fun notConstrained(name: String): String
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+
+    void "test a constrained method inherited from a super interface is validated"() {
+        when:
+        BeanDefinition beanDefinition = KotlinCompiler.buildIntroducedBeanDefinition('test.MyBean', '''
+package test
+
+import io.micronaut.kotlin.processing.aop.introduction.Stub
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+interface Parent {
+
+    fun constrained(@NotBlank name: String): String
+
+    fun notConstrained(name: String): String
+}
+
+@Stub
+@Singleton
+interface MyBean : Parent
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+
+    void "test a method overriding a constrained method is validated"() {
+        when:
+        BeanDefinition beanDefinition = KotlinCompiler.buildIntroducedBeanDefinition('test.MyBean', '''
+package test
+
+import io.micronaut.kotlin.processing.aop.introduction.Stub
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+interface Parent {
+
+    fun constrained(@NotBlank name: String): String
+
+    fun notConstrained(name: String): String
+}
+
+@Stub
+@Singleton
+interface MyBean : Parent {
+
+    override fun constrained(name: String): String
+
+    override fun notConstrained(name: String): String
+}
+''')
+
+        then:
+        beanDefinition.getRequiredMethod("constrained", String).hasAnnotation(ANN_VALIDATED)
+        !beanDefinition.getRequiredMethod("notConstrained", String).hasAnnotation(ANN_VALIDATED)
+    }
+}

--- a/inject-python-test/build.gradle.kts
+++ b/inject-python-test/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
     testImplementation(projects.micronautInjectJavaHelper)
     testImplementation(projects.micronautRetry)
     testImplementation(libs.micronaut.validation)
+    testImplementation(libs.micronaut.validation.processor) {
+        exclude(group = "io.micronaut")
+    }
     testImplementation("io.micronaut.data:micronaut-data-processor") {
         exclude(group = "io.micronaut")
     }

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/ValidationAdviceSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/ValidationAdviceSpec.groovy
@@ -1,0 +1,80 @@
+package io.micronaut.python.annotation.processing.test
+
+import io.micronaut.aop.writer.RuntimeProxyBeanDefinitionWriter
+import io.micronaut.inject.BeanDefinition
+
+class ValidationAdviceSpec extends AbstractPythonTypeElementSpec {
+
+    private static final String ANN_VALIDATED = 'io.micronaut.validation.Validated'
+
+    private static final String STUB = '''
+from typing import Annotated
+from abc import ABC, abstractmethod
+from micronaut.aop import InterceptorBean, Introduction, MethodInvocationContext
+from micronaut.context.annotation import Executable
+from jakarta.inject import Singleton
+from jakarta.validation.constraints import NotBlank
+import java
+
+MethodInterceptor = java.type("io.micronaut.aop.MethodInterceptor")
+
+@Introduction
+def Stub(cls):
+    return cls
+
+@InterceptorBean(Stub)
+@Singleton
+class StubIntroduction(MethodInterceptor):
+    def intercept(self, context: MethodInvocationContext):
+        return None
+'''
+
+    void "test only the constrained method of an introduction class is validated"() {
+        when:
+        BeanDefinition definition = buildBeanDefinition("python", "MyBean" + RuntimeProxyBeanDefinitionWriter.RUNTIME_PROXY_SUFFIX, STUB + '''
+@Stub
+class MyBean(ABC):
+    @abstractmethod
+    @Executable
+    def constrained(self, name: Annotated[str, NotBlank]) -> None:
+        pass
+
+    @abstractmethod
+    @Executable
+    def not_constrained(self, name: str) -> None:
+        pass
+''')
+        def constrained = definition.executableMethods.find { it.methodName == "constrained" }
+        def notConstrained = definition.executableMethods.find { it.methodName == "not_constrained" }
+
+        then:
+        constrained.hasAnnotation(ANN_VALIDATED)
+        !notConstrained.hasAnnotation(ANN_VALIDATED)
+    }
+
+    void "test a constrained method inherited from a super class is validated"() {
+        when:
+        BeanDefinition definition = buildBeanDefinition("python", "MyBean" + RuntimeProxyBeanDefinitionWriter.RUNTIME_PROXY_SUFFIX, STUB + '''
+class Parent(ABC):
+    @abstractmethod
+    @Executable
+    def constrained(self, name: Annotated[str, NotBlank]) -> None:
+        pass
+
+    @abstractmethod
+    @Executable
+    def not_constrained(self, name: str) -> None:
+        pass
+
+@Stub
+class MyBean(Parent):
+    pass
+''')
+        def constrained = definition.executableMethods.find { it.methodName == "constrained" }
+        def notConstrained = definition.executableMethods.find { it.methodName == "not_constrained" }
+
+        then:
+        constrained.hasAnnotation(ANN_VALIDATED)
+        !notConstrained.hasAnnotation(ANN_VALIDATED)
+    }
+}


### PR DESCRIPTION
## What

When an introduction proxy is created, the methods to advise with the validation interceptor are selected in `DefaultElementBeanDefinitionBuilderFactory`:

```java
for (MethodElement methodElement : target.getEnclosedElements(
        ElementQuery.ALL_METHODS.annotated(am -> am.hasAnnotation(ANN_REQUIRES_VALIDATION)))) {
    methodElement.annotate(ANN_VALIDATED);
}
```

The predicate receives the method's `AnnotationMetadata`, which for a `MethodElement` **combines the class and the method** annotations. `ValidationVisitor` puts `@RequiresValidation` on the class as soon as *any* member of it needs validation, so `am.hasAnnotation(...)` was true for every method of the type and every method was annotated `@Validated`.

The fix narrows the predicate to `hasDeclaredAnnotation`, which is what `DeclaredBeanElementCreator#makeInterceptedForValidationIfNeeded` already uses for ordinary beans.

## Why

An introduction bean with one constrained method routed *all* of its methods through `ValidatingInterceptor`. Nothing was validated incorrectly — the interceptor finds nothing and returns — but every call paid for an interception it did not need. It also makes `@ValidateOnExecution(ExecutableType.NONE)` inexpressible: a method has to be *described* by `BeanDescriptor.getConstraintsForMethod` while its execution is not intercepted, which needs `@Executable` without `@RequiresValidation`. With the class-level annotation leaking through the query, the method was re-advised regardless.

Ordinary `@Singleton` beans were never affected — that path already used `hasDeclaredAnnotation`. The leak was confined to introduction proxies.

## Two gaps this uncovered

Removing the stray `@Validated` broke `MyRepoIntroductionSpec."test tx default repo methods"` and `MyAbstractRepoSpec."test default interceptor method"`. Both assert that a **type-level** `@Around` advice intercepts an interface **default** method — the behaviour added in 47455d9741 for micronaut-projects/micronaut-data#2943. They were passing only because the leaked `@Validated` gave those default methods a declared around advice. Two real gaps:

1. **`IntroductionInterfaceBeanElementCreator`** pre-filtered out every non-abstract method lacking *declared* around advice, stricter than `visitIntrospectedMethod`, which already honours around advice declared by the type. Default methods now survive the filter when the type declares around advice, matching how abstract classes behave.

2. **`DefaultRuntimeProxyDefinition#introduction`** resolved *introduction* interceptors for every executable method. `resolveIntroductionInterceptors` returns around + introduction with the introduction interceptor terminating the chain, so a concrete method's real implementation was never invoked (`findByIdWithDefault` returned `null`). Abstract methods now resolve introduction interceptors and concrete ones around interceptors, matching what the compile-time `AopProxyWriter` does.

`RuntimeProxyRepositoryTest#testMethodsCount` expected 1 executable method; with `@ByteBuddyStacktraceVerified` (type-level `@Around`) on `CustomCrudRepo`, the default method is now legitimately intercepted, so it is updated to 2 with the names asserted.

## Compatibility

No API break — `japiCmp` is green for `:micronaut-aop` and `:micronaut-core-processor`, and no signature changed.

Behaviour, against released 5.1.x:

- **Abstract methods of introduction proxies**: no functional change. They are proxied regardless and `ValidatingInterceptor` was a no-op for them. Visible only as metadata (`hasAnnotation("io.micronaut.validation.Validated")` is now false) and a shorter interceptor chain.
- **Default/concrete methods of such a type**: previously proxied only because of the stray annotation, now proxied only when the type or the method declares around advice. `getExecutableMethods()` can list fewer methods. Return values are unchanged — the old chain was `[ValidatingInterceptor] → proceed → real impl`.
- **Interface default methods with a type-level `@Around`** are now intercepted where before that happened only if the type incidentally had a constrained member. This *adds* interception and is the item most worth a release note.
- **Concrete methods on runtime introduction proxies** now run their real implementation instead of being terminated by the introduction interceptor. Every around interceptor is kept, in the same order.
- Constructor, field and injection-point validation are untouched — those go through `BeanDefinitionWriter#applyConfigurationInjectionIfNecessary`, keyed on the constructor's own declared `@RequiresValidation`.

## Tests

New `ValidationAdviceSpec` in `inject-java` (5 cases: concrete bean, introduction interface, introduction abstract class, method inherited from a super interface, overriding method) and in `inject-groovy` (3 cases). All fail on the unfixed compiler and pass with it.

Green locally: `:micronaut-inject-java:test`, `:micronaut-inject-groovy:test`, `:micronaut-inject-kotlin:test`, `:micronaut-aop:test`, `:micronaut-context:test`, `:micronaut-inject:test`, `:micronaut-core-processor:test`, `:test-suite:test`, `:test-suite-groovy:test`, `:test-suite-kotlin:test`, plus checkstyle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
