### PR TITLE
Invoke @PreDestroy methods on beans with PRE_DESTROY advice

### DIFF
--- a/core-processor/src/main/java/io/micronaut/aop/writer/ProxyingBeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/ProxyingBeanDefinitionWriter.java
@@ -327,7 +327,11 @@ public abstract class ProxyingBeanDefinitionWriter implements ElementProxyBuilde
     }
 
     protected final void processAlreadyVisitedMethods(BeanDefinitionWriter parent) {
+        // the proxy definition extends the parent definition and reuses its method references,
+        // so the inherited lifecycle methods have to keep the indexes of the parent
+        proxyBeanDefinitionWriter.inheritMethodDefinitions(parent);
         parent.getPostConstructMethods().forEach(proxyBeanDefinitionWriter::addPostConstruct);
+        parent.getPreDestroyMethods().forEach(proxyBeanDefinitionWriter::addPreDestroy);
     }
 
     @Override

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -701,6 +701,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     private final List<MethodDefinition<ClassElement, MethodElement>> postConstructMethods = new ArrayList<>();
     private final List<MethodDefinition<ClassElement, MethodElement>> preDestroyMethods = new ArrayList<>();
     private final List<FieldDefinition<ClassElement, FieldElement>> allFields = new ArrayList<>();
+    private boolean inheritedMethodDefinitions;
 
     private final List<InjectCommand> injectCommands = new ArrayList<>();
 
@@ -893,7 +894,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     @Override
     public BeanDefinitionWriter addPostConstruct(MethodDefinition<ClassElement, MethodElement> methodDefinition) {
-        allMethods.add(methodDefinition);
+        addInjectionMethod(methodDefinition);
         postConstructMethods.add(methodDefinition);
         postProcessMethod(methodDefinition);
         return this;
@@ -901,17 +902,42 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     @Override
     public BeanDefinitionWriter addPreDestroy(MethodDefinition<ClassElement, MethodElement> methodDefinition) {
-        allMethods.add(methodDefinition);
+        addInjectionMethod(methodDefinition);
         preDestroyMethods.add(methodDefinition);
         postProcessMethod(methodDefinition);
         return this;
+    }
+
+    /**
+     * Inherits the injection method definitions of the super bean definition.
+     *
+     * <p>A definition that extends another one reuses the method references of its super definition
+     * at runtime, so the local definitions have to mirror the super ones for the generated indexes
+     * to resolve the correct arguments.</p>
+     *
+     * @param parent The super bean definition writer
+     */
+    public void inheritMethodDefinitions(BeanDefinitionWriter parent) {
+        if (!allMethods.isEmpty()) {
+            throw new IllegalStateException("Cannot inherit the method definitions of " + parent + " after methods have been added to " + this);
+        }
+        allMethods.addAll(parent.allMethods);
+        inheritedMethodDefinitions = true;
+    }
+
+    private void addInjectionMethod(MethodDefinition<ClassElement, MethodElement> methodDefinition) {
+        if (inheritedMethodDefinitions) {
+            // the definitions are already present at the index of the super definition
+            return;
+        }
+        allMethods.add(methodDefinition);
     }
 
     @Override
     public BeanDefinitionWriter addMethodInjection(MethodDefinition<ClassElement, MethodElement> methodDefinition) {
         injectCommands.add(new InjectMethod(methodDefinition));
         if (shouldKeepInjectionPoint(methodDefinition.annotationMetadata())) {
-            allMethods.add(methodDefinition);
+            addInjectionMethod(methodDefinition);
         }
         postProcessMethod(methodDefinition);
         return this;
@@ -1119,6 +1145,13 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
      */
     public List<MethodDefinition<ClassElement, MethodElement>> getPostConstructMethods() {
         return postConstructMethods;
+    }
+
+    /**
+     * @return The pre destroy method definitions scheduled for invocation
+     */
+    public List<MethodDefinition<ClassElement, MethodElement>> getPreDestroyMethods() {
+        return preDestroyMethods;
     }
 
     /**

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/PreDestroyInterceptorCompileSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/PreDestroyInterceptorCompileSpec.groovy
@@ -1,0 +1,84 @@
+package io.micronaut.aop.compile
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.Intercepted
+import io.micronaut.context.ApplicationContext
+
+class PreDestroyInterceptorCompileSpec extends AbstractTypeElementSpec {
+
+    void "test the bean's own @PreDestroy method is invoked when PRE_DESTROY is intercepted"() {
+        given:
+        ApplicationContext context = buildContext('''
+package predestroybinding;
+
+import java.lang.annotation.*;
+import io.micronaut.aop.*;
+import jakarta.inject.*;
+import java.util.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import javax.annotation.*;
+
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@InterceptorBinding(kind=InterceptorKind.AROUND)
+@InterceptorBinding(kind=InterceptorKind.PRE_DESTROY)
+@interface TestAnn {
+}
+
+@Singleton
+@TestAnn
+class TestInterceptor implements MethodInterceptor {
+    List<String> calls = new ArrayList<>();
+    @Override
+    public Object intercept(MethodInvocationContext context) {
+        calls.add("interceptor " + context.getKind());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@TestAnn
+class MyBean {
+    List<String> calls = new ArrayList<>();
+
+    public String work() {
+        return "work";
+    }
+
+    @PostConstruct
+    void start() {
+        calls.add("bean postConstruct");
+    }
+
+    @PreDestroy
+    void stop() {
+        calls.add("bean preDestroy");
+    }
+}
+''')
+        def interceptor = getBean(context, 'predestroybinding.TestInterceptor')
+
+        when: "the intercepted bean is created and a method invoked"
+        def instance = getBean(context, 'predestroybinding.MyBean')
+
+        then: "the bean's @PostConstruct method still runs"
+        instance instanceof Intercepted
+        instance.calls == ["bean postConstruct"]
+
+        when:
+        instance.work()
+
+        then:
+        interceptor.calls == ["interceptor AROUND"]
+
+        when: "the context is stopped"
+        context.stop()
+
+        then: "both the PRE_DESTROY interceptor and the bean's @PreDestroy method are invoked"
+        interceptor.calls == ["interceptor AROUND", "interceptor PRE_DESTROY"]
+        instance.calls == ["bean postConstruct", "bean preDestroy"]
+
+        cleanup:
+        context.close()
+    }
+}


### PR DESCRIPTION
## Problem

When a bean has `PRE_DESTROY` interception advice, its own `@PreDestroy` methods are never invoked — only the interceptors run.

```java
@Retention(RUNTIME) @Target(TYPE)
@InterceptorBinding(kind = InterceptorKind.AROUND)
@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
@interface MnAdvice {}

@Singleton @MnAdvice
class MnBean {
    static final List<String> CALLS = new ArrayList<>();
    public String work() { return "work"; }
    @PreDestroy void stop() { CALLS.add("bean preDestroy"); }
}
```

Calling `work()` and then closing the context records `[interceptor AROUND, interceptor PRE_DESTROY]` — `bean preDestroy` is missing.

It is visible in the generated `$MnBean$Definition$Intercepted$Definition`: `doInitialize(...)` calls `postConstruct(...)` **and** `start()`, but `doDispose(...)` calls only `preDestroy(...)` and returns.

## Root cause

`buildLifeCycleMethod` is already symmetric between `doInitialize` and `doDispose`. The asymmetry was upstream, in `ProxyingBeanDefinitionWriter#processAlreadyVisitedMethods`, which inherited the target's `@PostConstruct` methods into the proxy definition but never its `@PreDestroy` ones — leaving `preDestroyMethods` empty, so `doDispose` had nothing to emit.

## Second defect

Copying the pre destroy definitions across on its own broke `ProxyBeanWithPreDestroySpec` with an `ArrayIndexOutOfBoundsException`.

The proxy definition **extends** the target definition (`visitSuperBeanDefinition`), so at runtime it reuses the parent's `$INJECTION_METHODS` array — but it builds its own `allMethods` list, and `doInjectMethod` indexes into that array with `allMethods.indexOf(...)`. For a `@PreDestroy` method with injected arguments (`@PreDestroy void another(C c)`), the proxy emitted index 3 where the parent's reference sat at index 4, resolving into a zero-arg method reference.

This was latent before this change — it only ever worked because the sole inherited member (`@PostConstruct`) happened to land at index 0. `inheritMethodDefinitions(parent)` now seeds the child's `allMethods` from the parent so the indexes line up, and `addInjectionMethod` stops appending once definitions are inherited.

## Verification

`PreDestroyInterceptorCompileSpec` mirrors the reproduction and asserts both `interceptor.calls == ["interceptor AROUND", "interceptor PRE_DESTROY"]` and `instance.calls == ["bean postConstruct", "bean preDestroy"]`. It fails on the current code and passes with this change. `javap` confirms the regenerated `$B$Definition$Intercepted$Definition.dispose` now uses index 4, matching the parent.

Green locally: `micronaut-inject-java` (4882), `core-processor` (790), `micronaut-context` (483), `inject-groovy` (1053), `inject-kotlin` (48), the three `inject-*-test` modules, and `test-suite`/`-groovy`/`-kotlin`. Checkstyle clean.

## Out of scope

With `@Around(proxyTarget = true)` the PRE_DESTROY interceptor never fires on the target bean at all (the bean's own `@PreDestroy` does run). This behaves identically before and after this change and is left alone here. Note that the existing assertions covering it in `PostConstructInterceptorCompileSpec` — `destroyInterceptor.invoked == proxyTarget ? 3 : 2` — parse as `(invoked == proxyTarget) ? 3 : 2`, so they assert nothing and would not have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)