### PR TITLE
Reuse one interceptor instance across a bean's lifecycle

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/Intercepted.java
+++ b/aop/src/main/java/io/micronaut/aop/Intercepted.java
@@ -60,7 +60,8 @@ public interface Intercepted extends InterceptedBean {
      */
     @Internal
     @UsedByGeneratedCode
-    @SuppressWarnings("checkstyle:MethodName")
+    // The $ prefix marks this as generated-code infrastructure and keeps it clear of any method on the proxied type.
+    @SuppressWarnings({"checkstyle:MethodName", "java:S100"})
     default List<BeanRegistration<Interceptor<?, ?>>> $interceptorRegistrations() {
         return List.of();
     }

--- a/aop/src/main/java/io/micronaut/aop/Intercepted.java
+++ b/aop/src/main/java/io/micronaut/aop/Intercepted.java
@@ -15,7 +15,12 @@
  */
 package io.micronaut.aop;
 
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.inject.proxy.InterceptedBean;
+
+import java.util.List;
 
 /**
  * An interface implemented by generated proxy classes.
@@ -24,4 +29,39 @@ import io.micronaut.inject.proxy.InterceptedBean;
  * @since 1.0
  */
 public interface Intercepted extends InterceptedBean {
+
+    /**
+     * The interceptor registrations that were resolved for this proxy.
+     *
+     * <p>The scenario this exists for is an advised bean that also declares lifecycle advice:</p>
+     *
+     * <pre>{@code
+     * @Retention(RUNTIME)
+     * @Around
+     * @InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+     * @InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+     * @interface Tracked {}
+     *
+     * @Singleton @Tracked
+     * class MyBean { @PostConstruct void init() {} @PreDestroy void close() {} }
+     * }</pre>
+     *
+     * <p>The proxy constructor is given the registrations that match the target's bindings and keeps them, so
+     * post-construct and pre-destroy interception select from the same set the proxy already uses for its methods,
+     * and a {@code @Prototype} interceptor is one instance for the whole life of one target. Destruction in
+     * particular has no other route to them: it runs with a fresh resolution context, and the proxy instance is the
+     * only thing that survives from creation to destruction.</p>
+     *
+     * <p>Proxies whose target declares no lifecycle binding, and proxies generated before this existed, keep the
+     * empty default; the runtime then resolves interceptors by binding as it always did.</p>
+     *
+     * @return The retained interceptor registrations, never {@code null}
+     * @since 5.2.0
+     */
+    @Internal
+    @UsedByGeneratedCode
+    @SuppressWarnings("checkstyle:MethodName")
+    default List<BeanRegistration<Interceptor<?, ?>>> $interceptorRegistrations() {
+        return List.of();
+    }
 }

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableIntercepted.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableIntercepted.java
@@ -15,12 +15,16 @@
  */
 package io.micronaut.aop.beandefinition;
 
+import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.chain.MethodInterceptorChain;
+import io.micronaut.aop.chain.SharedInterceptorRegistrations;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.context.BeanRegistration;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.InitializingBeanDefinition;
 
+import java.util.Collection;
 import java.util.Objects;
 
 /**
@@ -35,12 +39,14 @@ public interface InitializableIntercepted<T> extends InitializingBeanDefinition<
 
     @Override
     default T initialize(BeanResolutionContext resolutionContext, BeanContext context, T bean) {
+        Collection<BeanRegistration<Interceptor<?, ?>>> shared = SharedInterceptorRegistrations.peek(resolutionContext, this);
         return Objects.requireNonNull(MethodInterceptorChain.initialize(
             resolutionContext,
             context,
             this,
             new InitializableInterceptedMethod<>(this, resolutionContext, context, bean),
-            bean
+            bean,
+            shared
         ));
     }
 

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableIntercepted.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableIntercepted.java
@@ -17,7 +17,6 @@ package io.micronaut.aop.beandefinition;
 
 import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.chain.MethodInterceptorChain;
-import io.micronaut.aop.chain.SharedInterceptorRegistrations;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.BeanRegistration;

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
@@ -22,9 +22,15 @@ import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.inject.InstantiatableBeanDefinition;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -46,6 +52,36 @@ public interface InterceptedBeanDefinition<T> extends InstantiatableBeanDefiniti
      */
     @Nullable Object[] resolveInstantiationValues(BeanResolutionContext resolutionContext, BeanContext context);
 
+    /**
+     * Resolves the interceptors that construction, post-construct and pre-destroy interception of this bean all
+     * select from.
+     *
+     * <p>The qualifier is built from the bean's own annotation metadata, so it covers every {@code @InterceptorBinding}
+     * the bean declares whatever kind each was declared for. That makes the result a superset of what any one phase
+     * needs; each interception point filters it again by its own binding and kind. Resolving once is what lets a
+     * non-singleton interceptor be shared by every phase of one bean.</p>
+     *
+     * <p>Override to supply the set another way. Returning {@code null} leaves each interception point to resolve its
+     * own, which is the behaviour of a bean that declares no interceptor binding at all.</p>
+     *
+     * @param resolutionContext The resolution context
+     * @param constructor       The constructor, whose metadata may carry bindings the type does not
+     * @return The interceptors, or {@code null} when the bean binds none
+     * @since 5.2.0
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    default @Nullable List<BeanRegistration<Interceptor<T, T>>> resolveInterceptors(BeanResolutionContext resolutionContext,
+                                                                                   AnnotationMetadataProvider constructor) {
+        AnnotationMetadata metadata = new AnnotationMetadataHierarchy(getAnnotationMetadata(), constructor.getAnnotationMetadata());
+        if (metadata.getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING).isEmpty()) {
+            return null;
+        }
+        return new ArrayList(resolutionContext.getBeanRegistrations(
+            Interceptor.ARGUMENT,
+            Qualifiers.byInterceptorBinding(metadata)
+        ));
+    }
+
     @Override
     default T instantiate(BeanResolutionContext resolutionContext, BeanContext context) {
         InterceptedConstructor<T> constructor = new InterceptedConstructor<>(this, resolutionContext, context);
@@ -54,8 +90,7 @@ public interface InterceptedBeanDefinition<T> extends InstantiatableBeanDefiniti
         Object[] values = resolveInstantiationValues(resolutionContext, context);
         // One resolution for construction, post-construct and pre-destroy rather than one per interception point, so a
         // non-singleton interceptor is shared by every phase of this bean.
-        List<BeanRegistration<Interceptor<T, T>>> interceptors =
-            SharedInterceptorRegistrations.resolve(resolutionContext, this, constructor);
+        List<BeanRegistration<Interceptor<T, T>>> interceptors = resolveInterceptors(resolutionContext, constructor);
         SharedInterceptorRegistrations.push(resolutionContext, this, interceptors);
         try {
             return ConstructorInterceptorChain.instantiate(

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
@@ -26,7 +26,6 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.inject.InstantiatableBeanDefinition;
-import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import org.jspecify.annotations.Nullable;
 
@@ -65,14 +64,16 @@ public interface InterceptedBeanDefinition<T> extends InstantiatableBeanDefiniti
      * own, which is the behaviour of a bean that declares no interceptor binding at all.</p>
      *
      * @param resolutionContext The resolution context
-     * @param constructor       The constructor, whose metadata may carry bindings the type does not
+     * @param constructor       The constructor, whose metadata is this bean's combined with the constructor's
      * @return The interceptors, or {@code null} when the bean binds none
      * @since 5.2.0
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     default @Nullable List<BeanRegistration<Interceptor<T, T>>> resolveInterceptors(BeanResolutionContext resolutionContext,
                                                                                    AnnotationMetadataProvider constructor) {
-        AnnotationMetadata metadata = new AnnotationMetadataHierarchy(getAnnotationMetadata(), constructor.getAnnotationMetadata());
+        // The constructor already exposes this bean's metadata combined with the constructor's, so use it rather
+        // than building a second hierarchy around it on every bean creation.
+        AnnotationMetadata metadata = constructor.getAnnotationMetadata();
         if (metadata.getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING).isEmpty()) {
             return null;
         }

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
@@ -15,12 +15,17 @@
  */
 package io.micronaut.aop.beandefinition;
 
+import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.chain.ConstructorInterceptorChain;
+import io.micronaut.aop.chain.SharedInterceptorRegistrations;
+import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.InstantiatableBeanDefinition;
 import org.jspecify.annotations.Nullable;
+
+import java.util.List;
 
 /**
  * Intercepted {@link InstantiatableBeanDefinition}.
@@ -43,14 +48,27 @@ public interface InterceptedBeanDefinition<T> extends InstantiatableBeanDefiniti
 
     @Override
     default T instantiate(BeanResolutionContext resolutionContext, BeanContext context) {
-        return ConstructorInterceptorChain.instantiate(
-            resolutionContext,
-            context,
-            null,
-            this,
-            new InterceptedConstructor<>(this, resolutionContext, context),
-            resolveInstantiationValues(resolutionContext, context)
-        );
+        InterceptedConstructor<T> constructor = new InterceptedConstructor<>(this, resolutionContext, context);
+        // Resolve the constructor values first, as before, so that resolving interceptors cannot change the order in
+        // which this bean's own dependencies are created.
+        Object[] values = resolveInstantiationValues(resolutionContext, context);
+        // One resolution for construction, post-construct and pre-destroy rather than one per interception point, so a
+        // non-singleton interceptor is shared by every phase of this bean.
+        List<BeanRegistration<Interceptor<T, T>>> interceptors =
+            SharedInterceptorRegistrations.resolve(resolutionContext, this, constructor);
+        SharedInterceptorRegistrations.push(resolutionContext, this, interceptors);
+        try {
+            return ConstructorInterceptorChain.instantiate(
+                resolutionContext,
+                context,
+                interceptors,
+                this,
+                constructor,
+                values
+            );
+        } finally {
+            SharedInterceptorRegistrations.pop(resolutionContext, this, interceptors);
+        }
     }
 
     /**

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
@@ -17,7 +17,6 @@ package io.micronaut.aop.beandefinition;
 
 import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.chain.ConstructorInterceptorChain;
-import io.micronaut.aop.chain.SharedInterceptorRegistrations;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
@@ -17,6 +17,7 @@ package io.micronaut.aop.beandefinition;
 
 import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.chain.ConstructorInterceptorChain;
+import io.micronaut.aop.chain.SharedInterceptorRegistrations;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
@@ -63,14 +64,28 @@ public interface ParameterizedInterceptedBeanDefinition<T>
     @Override
     default T doInstantiate(BeanResolutionContext resolutionContext, BeanContext context, Map<String, Object> requiredArgumentValues) {
         @Nullable Object[] values = resolveInstantiationValues(resolutionContext, context, requiredArgumentValues);
-        return ConstructorInterceptorChain.instantiate(
-            resolutionContext,
-            context,
-            resolveInterceptors(resolutionContext, context, values),
-            this,
-            new InterceptedParametrizedConstructor<>(this, resolutionContext, context),
-            values
-        );
+        InterceptedParametrizedConstructor<T> constructor = new InterceptedParametrizedConstructor<>(this, resolutionContext, context);
+        List<BeanRegistration<Interceptor<T, T>>> declared = resolveInterceptors(resolutionContext, context, values);
+        if (declared != null) {
+            // An explicitly supplied set is bound for construction only, so it is used here but not shared with the
+            // post-construct interception of this bean, which may bind interceptors this set does not contain.
+            return ConstructorInterceptorChain.instantiate(resolutionContext, context, declared, this, constructor, values);
+        }
+        List<BeanRegistration<Interceptor<T, T>>> interceptors =
+            SharedInterceptorRegistrations.resolve(resolutionContext, this, constructor);
+        SharedInterceptorRegistrations.push(resolutionContext, this, interceptors);
+        try {
+            return ConstructorInterceptorChain.instantiate(
+                resolutionContext,
+                context,
+                interceptors,
+                this,
+                constructor,
+                values
+            );
+        } finally {
+            SharedInterceptorRegistrations.pop(resolutionContext, this, interceptors);
+        }
     }
 
     /**

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
@@ -22,9 +22,15 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.inject.ParametrizedInstantiatableBeanDefinition;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -61,6 +67,30 @@ public interface ParameterizedInterceptedBeanDefinition<T>
      */
     @Nullable Object[] resolveInstantiationValues(BeanResolutionContext resolutionContext, BeanContext context, Map<String, Object> requiredArgumentValues);
 
+    /**
+     * Resolves the interceptors that construction, post-construct and pre-destroy interception of this bean all
+     * select from. See
+     * {@link InterceptedBeanDefinition#resolveInterceptors(BeanResolutionContext, AnnotationMetadataProvider)}, which
+     * this mirrors for parametrized definitions.
+     *
+     * @param resolutionContext The resolution context
+     * @param constructor       The constructor, whose metadata may carry bindings the type does not
+     * @return The interceptors, or {@code null} when the bean binds none
+     * @since 5.2.0
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    default @Nullable List<BeanRegistration<Interceptor<T, T>>> resolveLifecycleInterceptors(BeanResolutionContext resolutionContext,
+                                                                                            AnnotationMetadataProvider constructor) {
+        AnnotationMetadata metadata = new AnnotationMetadataHierarchy(getAnnotationMetadata(), constructor.getAnnotationMetadata());
+        if (metadata.getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING).isEmpty()) {
+            return null;
+        }
+        return new ArrayList(resolutionContext.getBeanRegistrations(
+            Interceptor.ARGUMENT,
+            Qualifiers.byInterceptorBinding(metadata)
+        ));
+    }
+
     @Override
     default T doInstantiate(BeanResolutionContext resolutionContext, BeanContext context, Map<String, Object> requiredArgumentValues) {
         @Nullable Object[] values = resolveInstantiationValues(resolutionContext, context, requiredArgumentValues);
@@ -71,8 +101,7 @@ public interface ParameterizedInterceptedBeanDefinition<T>
             // post-construct interception of this bean, which may bind interceptors this set does not contain.
             return ConstructorInterceptorChain.instantiate(resolutionContext, context, declared, this, constructor, values);
         }
-        List<BeanRegistration<Interceptor<T, T>>> interceptors =
-            SharedInterceptorRegistrations.resolve(resolutionContext, this, constructor);
+        List<BeanRegistration<Interceptor<T, T>>> interceptors = resolveLifecycleInterceptors(resolutionContext, constructor);
         SharedInterceptorRegistrations.push(resolutionContext, this, interceptors);
         try {
             return ConstructorInterceptorChain.instantiate(

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
@@ -26,7 +26,6 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.inject.ParametrizedInstantiatableBeanDefinition;
-import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import org.jspecify.annotations.Nullable;
 
@@ -74,14 +73,16 @@ public interface ParameterizedInterceptedBeanDefinition<T>
      * this mirrors for parametrized definitions.
      *
      * @param resolutionContext The resolution context
-     * @param constructor       The constructor, whose metadata may carry bindings the type does not
+     * @param constructor       The constructor, whose metadata is this bean's combined with the constructor's
      * @return The interceptors, or {@code null} when the bean binds none
      * @since 5.2.0
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     default @Nullable List<BeanRegistration<Interceptor<T, T>>> resolveLifecycleInterceptors(BeanResolutionContext resolutionContext,
                                                                                             AnnotationMetadataProvider constructor) {
-        AnnotationMetadata metadata = new AnnotationMetadataHierarchy(getAnnotationMetadata(), constructor.getAnnotationMetadata());
+        // The constructor already exposes this bean's metadata combined with the constructor's, so use it rather
+        // than building a second hierarchy around it on every bean creation.
+        AnnotationMetadata metadata = constructor.getAnnotationMetadata();
         if (metadata.getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING).isEmpty()) {
             return null;
         }

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
@@ -17,7 +17,6 @@ package io.micronaut.aop.beandefinition;
 
 import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.chain.ConstructorInterceptorChain;
-import io.micronaut.aop.chain.SharedInterceptorRegistrations;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/SharedInterceptorRegistrations.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/SharedInterceptorRegistrations.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop.chain;
+package io.micronaut.aop.beandefinition;
 
 import io.micronaut.aop.Interceptor;
 import io.micronaut.core.annotation.Internal;
@@ -58,6 +58,9 @@ import java.util.List;
  * <p>Destruction happens later with a fresh resolution context, so nothing is shared with it here; see
  * {@code MethodInterceptorChain} for how pre-destroy reaches the interceptors a bean owns.</p>
  *
+ * <p>Everything here is package-private except {@link #store}, which the runtime proxy path in
+ * {@code io.micronaut.aop.runtime} calls from another package.</p>
+ *
  * @author Denis Stepanov
  * @since 5.2.0
  */
@@ -85,7 +88,7 @@ public final class SharedInterceptorRegistrations {
      * @since 5.2.0
      */
     @SuppressWarnings("unchecked")
-    public static void push(BeanResolutionContext resolutionContext,
+    static void push(BeanResolutionContext resolutionContext,
                             BeanDefinition<?> definition,
                             @Nullable List<?> registrations) {
         if (registrations == null || registrations.isEmpty()) {
@@ -112,7 +115,7 @@ public final class SharedInterceptorRegistrations {
      * @since 5.2.0
      */
     @SuppressWarnings("unchecked")
-    public static void pop(BeanResolutionContext resolutionContext,
+    static void pop(BeanResolutionContext resolutionContext,
                            BeanDefinition<?> definition,
                            @Nullable List<?> registrations) {
         if (registrations == null || registrations.isEmpty()) {
@@ -158,7 +161,7 @@ public final class SharedInterceptorRegistrations {
      * @since 5.2.0
      */
     @SuppressWarnings("unchecked")
-    public static @Nullable Collection<BeanRegistration<Interceptor<?, ?>>> peek(BeanResolutionContext resolutionContext,
+    static @Nullable Collection<BeanRegistration<Interceptor<?, ?>>> peek(BeanResolutionContext resolutionContext,
                                                                                 BeanDefinition<?> definition) {
         Deque<Entry> stack = stack(resolutionContext);
         if (stack != null && !stack.isEmpty()) {

--- a/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
@@ -33,7 +33,6 @@ import org.jspecify.annotations.Nullable;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.ArrayUtils;
-import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.qualifiers.Qualifiers;
@@ -440,6 +439,7 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
                 interceptors.add((BeanRegistration<Interceptor<?, ?>>) dependent);
             }
         }
-        return CollectionUtils.isEmpty(interceptors) ? Collections.emptyList() : interceptors;
+        // Only ever assigned immediately before an add, so a non-null list is never empty.
+        return interceptors == null ? Collections.emptyList() : interceptors;
     }
 }

--- a/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.aop.chain;
 
+import io.micronaut.aop.Intercepted;
 import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.InterceptorKind;
 import io.micronaut.aop.InterceptorRegistry;
@@ -32,12 +33,16 @@ import org.jspecify.annotations.Nullable;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import static io.micronaut.core.util.ArrayUtils.EMPTY_OBJECT_ARRAY;
@@ -85,7 +90,6 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
         super(interceptors, target, executionHandle, EMPTY_OBJECT_ARRAY);
         this.kind = kind;
     }
-
 
     /**
      * Constructor.
@@ -184,6 +188,13 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
     /**
      * Internal method that handles the logic for executing {@link InterceptorKind#POST_CONSTRUCT} interception.
      *
+     * <p>Superseded by
+     * {@link #initialize(BeanResolutionContext, BeanContext, BeanDefinition, ExecutableMethod, Object, Collection)},
+     * which is what the framework calls now so that post-construct interception can reuse the interceptors already
+     * resolved while the bean was constructed. This form resolves interceptors by binding, and nothing in the
+     * framework or in currently generated code calls it. It is kept because it is part of the generated-code surface:
+     * bean definitions compiled by earlier versions call it directly.</p>
+     *
      * @param resolutionContext The resolution context
      * @param beanContext The bean context
      * @param definition The definition
@@ -202,18 +213,55 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
         BeanDefinition<T1> definition,
         ExecutableMethod<T1, T1> postConstructMethod,
         T1 bean) {
+        return initialize(resolutionContext, beanContext, definition, postConstructMethod, bean, null);
+    }
+
+    /**
+     * Variant of {@link #initialize(BeanResolutionContext, BeanContext, BeanDefinition, ExecutableMethod, Object)}
+     * that reuses registrations already resolved for this bean.
+     *
+     * <p>Called for a bean whose interceptors were resolved once while it was constructed, so that a
+     * {@code @Prototype} interceptor which ran the constructor also runs {@code @PostConstruct}. Passing
+     * {@code null} resolves interceptors by binding, which is what the five-argument form does and what generated
+     * code from earlier versions continues to do.</p>
+     *
+     * @param resolutionContext  The resolution context
+     * @param beanContext        The bean context
+     * @param definition         The definition
+     * @param postConstructMethod The post construct method
+     * @param bean               The bean
+     * @param interceptors       Registrations resolved for this bean, or {@code null} to resolve them
+     * @param <T1>               The bean type
+     * @return the bean instance
+     * @since 5.2.0
+     */
+    @Internal
+    @UsedByGeneratedCode
+    @Nullable
+    public static <T1> T1 initialize(
+        BeanResolutionContext resolutionContext,
+        BeanContext beanContext,
+        BeanDefinition<T1> definition,
+        ExecutableMethod<T1, T1> postConstructMethod,
+        T1 bean,
+        @Nullable Collection<BeanRegistration<Interceptor<?, ?>>> interceptors) {
         return doIntercept(
             resolutionContext,
             beanContext,
             definition,
             postConstructMethod,
             bean,
-            InterceptorKind.POST_CONSTRUCT
+            InterceptorKind.POST_CONSTRUCT,
+            interceptors
         );
     }
 
     /**
      * Internal method that handles the logic for executing {@link InterceptorKind#PRE_DESTROY} interception.
+     *
+     * <p>Resolves interceptors by binding. Unlike post-construct, destruction has nothing resolved in advance to hand
+     * over, because it runs with a fresh resolution context, so this remains the form the framework calls; the
+     * overload taking registrations exists for a caller that does hold them.</p>
      *
      * @param resolutionContext The resolution context
      * @param beanContext The bean context
@@ -233,13 +281,45 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
         BeanDefinition<T1> definition,
         ExecutableMethod<T1, T1> preDestroyMethod,
         T1 bean) {
+        return dispose(resolutionContext, beanContext, definition, preDestroyMethod, bean, null);
+    }
+
+    /**
+     * Variant of {@link #dispose(BeanResolutionContext, BeanContext, BeanDefinition, ExecutableMethod, Object)} that
+     * reuses registrations already resolved for this bean.
+     *
+     * <p>Nothing supplies registrations here today: destruction runs with a fresh resolution context, so a bean
+     * reaches its interceptors either through the field on its proxy or through the registrations the container
+     * passes to the dispose call. The parameter exists so a caller that does hold them can hand them over.</p>
+     *
+     * @param resolutionContext The resolution context
+     * @param beanContext       The bean context
+     * @param definition        The definition
+     * @param preDestroyMethod  The pre destroy method
+     * @param bean              The bean
+     * @param interceptors      Registrations resolved for this bean, or {@code null} to resolve them
+     * @param <T1>              The bean type
+     * @return the bean instance
+     * @since 5.2.0
+     */
+    @Internal
+    @UsedByGeneratedCode
+    @Nullable
+    public static <T1> T1 dispose(
+        BeanResolutionContext resolutionContext,
+        BeanContext beanContext,
+        BeanDefinition<T1> definition,
+        ExecutableMethod<T1, T1> preDestroyMethod,
+        T1 bean,
+        @Nullable Collection<BeanRegistration<Interceptor<?, ?>>> interceptors) {
         return doIntercept(
             resolutionContext,
             beanContext,
             definition,
             preDestroyMethod,
             bean,
-            InterceptorKind.PRE_DESTROY
+            InterceptorKind.PRE_DESTROY,
+            interceptors
         );
     }
 
@@ -251,14 +331,25 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
         BeanDefinition<T1> definition,
         ExecutableMethod<T1, T1> interceptedMethod,
         T1 bean,
-        InterceptorKind kind) {
+        InterceptorKind kind,
+        @Nullable Collection<BeanRegistration<Interceptor<?, ?>>> shared) {
         final AnnotationMetadata annotationMetadata = interceptedMethod.getAnnotationMetadata();
         final Collection<AnnotationValue<?>> binding = resolveInterceptorValues(annotationMetadata, kind);
 
-        final Collection<BeanRegistration<Interceptor<?, ?>>> resolved = resolutionContext.getBeanRegistrations(
-            Interceptor.ARGUMENT,
-            Qualifiers.byInterceptorBindingValues(binding)
-        );
+        final Collection<BeanRegistration<Interceptor<?, ?>>> resolved;
+        if (shared != null && !shared.isEmpty()) {
+            // Resolved once while the bean was created and handed to this interception point.
+            resolved = shared;
+        } else if (bean instanceof Intercepted intercepted && !intercepted.$interceptorRegistrations().isEmpty()) {
+            // Retained by the generated proxy.
+            resolved = intercepted.$interceptorRegistrations();
+        } else if (kind == InterceptorKind.PRE_DESTROY) {
+            // Destruction runs with a fresh resolution context, so a bean with lifecycle advice but no proxy has
+            // nothing handed to it. Reuse the interceptor instances the bean still owns.
+            resolved = resolveLifecycleInterceptors(resolutionContext, binding);
+        } else {
+            resolved = resolutionContext.getBeanRegistrations(Interceptor.ARGUMENT, Qualifiers.byInterceptorBindingValues(binding));
+        }
         final InterceptorRegistry interceptorRegistry = beanContext.getBean(InterceptorRegistry.ARGUMENT);
         final Interceptor[] resolvedInterceptors = interceptorRegistry
             .resolveInterceptors(
@@ -281,5 +372,72 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
         } else {
             return interceptedMethod.invoke(bean);
         }
+    }
+
+    /**
+     * Resolves the interceptor candidates for pre-destroy interception.
+     *
+     * <p>Destruction runs with a fresh resolution context, so a bean with lifecycle advice but no retaining proxy has
+     * nothing handed to it. The interceptor instances it owns are still reachable through the registrations the
+     * container passes to the dispose call, and every interceptor bound to the bean's lifecycle was created while the
+     * bean was, so those registrations are the candidate set. When the bean owns none, candidates are resolved by
+     * binding as before.</p>
+     *
+     * @param resolutionContext The resolution context
+     * @param binding           The binding of the interception point
+     * @return The interceptor registrations to select from
+     */
+    private static Collection<BeanRegistration<Interceptor<?, ?>>> resolveLifecycleInterceptors(
+        BeanResolutionContext resolutionContext,
+        Collection<AnnotationValue<?>> binding) {
+
+        final List<BeanRegistration<Interceptor<?, ?>>> existing = findExistingInterceptors(resolutionContext);
+        if (existing.isEmpty()) {
+            return resolutionContext.getBeanRegistrations(
+                Interceptor.ARGUMENT,
+                Qualifiers.byInterceptorBindingValues(binding)
+            );
+        }
+        return existing;
+    }
+
+    /**
+     * Finds the interceptor instances that the bean being destroyed already owns.
+     *
+     * <p>The scenario is pre-destroy interception of a bean with lifecycle advice but no around proxy. Every
+     * interceptor bound to such a bean's lifecycle was created while the bean was, and became one of its dependent
+     * registrations, so those registrations are the candidate set and nothing further needs resolving.</p>
+     *
+     * <p>Because the resolution context at destruction is a fresh one with no dependents of its own, the
+     * registrations owned by the bean arrive through {@link BeanResolutionContext#EXISTING_DEPENDENT_BEANS}.</p>
+     *
+     * <p>Returns empty for a bean that owns no interceptors, which includes a prototype created through
+     * {@code createBean} and destroyed through {@code destroyBean(Object)}: no registration is tracked for it, so
+     * nothing can be handed over and its interceptors are resolved by binding instead.</p>
+     *
+     * <p>Singleton interceptors are ignored because resolving them again yields the same instance.</p>
+     *
+     * @param resolutionContext The resolution context
+     * @return The reusable interceptor registrations, never {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    private static List<BeanRegistration<Interceptor<?, ?>>> findExistingInterceptors(BeanResolutionContext resolutionContext) {
+        List<BeanRegistration<?>> dependents = resolutionContext.getDependentBeans();
+        if (dependents.isEmpty() && resolutionContext.getAttribute(BeanResolutionContext.EXISTING_DEPENDENT_BEANS) instanceof List<?> attribute) {
+            dependents = (List<BeanRegistration<?>>) attribute;
+        }
+        if (dependents.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<BeanRegistration<Interceptor<?, ?>>> interceptors = null;
+        for (BeanRegistration<?> dependent : dependents) {
+            if (dependent.getBean() instanceof Interceptor) {
+                if (interceptors == null) {
+                    interceptors = new ArrayList<>(dependents.size());
+                }
+                interceptors.add((BeanRegistration<Interceptor<?, ?>>) dependent);
+            }
+        }
+        return CollectionUtils.isEmpty(interceptors) ? Collections.emptyList() : interceptors;
     }
 }

--- a/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
@@ -386,6 +386,7 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
      * @param resolutionContext The resolution context
      * @param binding           The binding of the interception point
      * @return The interceptor registrations to select from
+     * @since 5.2.0
      */
     private static Collection<BeanRegistration<Interceptor<?, ?>>> resolveLifecycleInterceptors(
         BeanResolutionContext resolutionContext,
@@ -419,6 +420,7 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
      *
      * @param resolutionContext The resolution context
      * @return The reusable interceptor registrations, never {@code null}
+     * @since 5.2.0
      */
     @SuppressWarnings("unchecked")
     private static List<BeanRegistration<Interceptor<?, ?>>> findExistingInterceptors(BeanResolutionContext resolutionContext) {

--- a/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
@@ -387,39 +387,31 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
      * @return The interceptor registrations to select from
      * @since 5.2.0
      */
+    @SuppressWarnings("unchecked")
     private static Collection<BeanRegistration<Interceptor<?, ?>>> resolveLifecycleInterceptors(
         BeanResolutionContext resolutionContext,
         Collection<AnnotationValue<?>> binding) {
 
-        final List<BeanRegistration<Interceptor<?, ?>>> existing = findExistingInterceptors(resolutionContext);
-        if (existing.isEmpty()) {
-            return resolutionContext.getBeanRegistrations(
+        Object attribute = resolutionContext.getAttribute(BeanResolutionContext.EXISTING_INTERCEPTOR_REGISTRATIONS);
+        if (attribute instanceof List<?> existing) {
+            return (List<BeanRegistration<Interceptor<?, ?>>>) existing;
+        }
+        List<BeanRegistration<Interceptor<?, ?>>> existing = findExistingInterceptors(resolutionContext);
+        return existing.isEmpty()
+            ? resolutionContext.getBeanRegistrations(
                 Interceptor.ARGUMENT,
                 Qualifiers.byInterceptorBindingValues(binding)
-            );
-        }
-        return existing;
+            )
+            : existing;
     }
 
     /**
-     * Finds the interceptor instances that the bean being destroyed already owns.
-     *
-     * <p>The scenario is pre-destroy interception of a bean with lifecycle advice but no around proxy. Every
-     * interceptor bound to such a bean's lifecycle was created while the bean was, and became one of its dependent
-     * registrations, so those registrations are the candidate set and nothing further needs resolving.</p>
-     *
-     * <p>Because the resolution context at destruction is a fresh one with no dependents of its own, the
-     * registrations owned by the bean arrive through {@link BeanResolutionContext#EXISTING_DEPENDENT_BEANS}.</p>
-     *
-     * <p>Returns empty for a bean that owns no interceptors, which includes a prototype created through
-     * {@code createBean} and destroyed through {@code destroyBean(Object)}: no registration is tracked for it, so
-     * nothing can be handed over and its interceptors are resolved by binding instead.</p>
-     *
-     * <p>Singleton interceptors are ignored because resolving them again yields the same instance.</p>
+     * Finds interceptor registrations already associated with a legacy disposal path. New bean registrations carry
+     * the exact selected set through {@link BeanResolutionContext#EXISTING_INTERCEPTOR_REGISTRATIONS}; this fallback
+     * remains for generated factory definitions that cannot transfer that set during construction.
      *
      * @param resolutionContext The resolution context
-     * @return The reusable interceptor registrations, never {@code null}
-     * @since 5.2.0
+     * @return Existing interceptor registrations
      */
     @SuppressWarnings("unchecked")
     private static List<BeanRegistration<Interceptor<?, ?>>> findExistingInterceptors(BeanResolutionContext resolutionContext) {
@@ -439,7 +431,6 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
                 interceptors.add((BeanRegistration<Interceptor<?, ?>>) dependent);
             }
         }
-        // Only ever assigned immediately before an add, so a non-null list is never empty.
         return interceptors == null ? Collections.emptyList() : interceptors;
     }
 }

--- a/aop/src/main/java/io/micronaut/aop/chain/SharedInterceptorRegistrations.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/SharedInterceptorRegistrations.java
@@ -16,26 +16,19 @@
 package io.micronaut.aop.chain;
 
 import io.micronaut.aop.Interceptor;
-import io.micronaut.aop.InterceptorKind;
-import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
-import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.inject.BeanDefinition;
-import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
-import io.micronaut.inject.qualifiers.Qualifiers;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 
 /**
- * Shares one interceptor resolution between the construction and the post-construct interception of a bean.
+ * Carries the interceptors resolved for a bean from its construction to its post-construct interception.
  *
  * <p>The scenario this exists for is a bean whose advice is declared with {@code @AroundConstruct} and lifecycle
  * interceptor bindings but no {@code @Around}, so no proxy is generated and there is no instance field in which to
@@ -73,53 +66,6 @@ public final class SharedInterceptorRegistrations {
     private static final String ATTRIBUTE = "io.micronaut.aop.sharedInterceptorRegistrations";
 
     private SharedInterceptorRegistrations() {
-    }
-
-    /**
-     * Resolves the interceptor registrations that a bean's construction, post-construct and pre-destroy interception
-     * can all select from.
-     *
-     * <p>The binding is the union of the {@code AROUND_CONSTRUCT}, {@code POST_CONSTRUCT} and {@code PRE_DESTROY}
-     * bindings declared by the bean, so the result is a superset of what any one phase needs. Widening cannot
-     * over-apply an interceptor: every interception point filters this set again by its own binding and kind before
-     * building a chain. It does mean an interceptor bound only to {@code @PreDestroy} is created while the bean is
-     * created rather than when it is destroyed, which is what allows the same instance to serve both.</p>
-     *
-     * <p>Returns {@code null} for a bean that declares none of those bindings, for example a bean with only
-     * {@code @Around} advice, so that such beans resolve exactly as they did before.</p>
-     *
-     * <p>A bean that gets a proxy never reaches this: its proxy is handed the same union as a constructor argument,
-     * qualified at compile time by {@code AopProxyWriter}, and
-     * {@code ProxyInterceptedBeanDefinition#instantiate} takes the registrations from there. The two encode one rule
-     * on either side of compilation, so a change to the kinds merged here belongs in that writer as well.</p>
-     *
-     * @param resolutionContext The resolution context
-     * @param definition        The bean definition
-     * @param constructor       The constructor metadata, or {@code null}
-     * @param <T>               The bean type
-     * @return The resolved registrations, or {@code null} when the bean declares no lifecycle-related binding
-     * @since 5.2.0
-     */
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <T> @Nullable List<BeanRegistration<Interceptor<T, T>>> resolve(BeanResolutionContext resolutionContext,
-                                                                                 BeanDefinition<?> definition,
-                                                                                 @Nullable AnnotationMetadataProvider constructor) {
-        AnnotationMetadata definitionMetadata = definition.getAnnotationMetadata();
-        AnnotationMetadata constructorMetadata = constructor == null
-            ? definitionMetadata
-            : new AnnotationMetadataHierarchy(definitionMetadata, constructor.getAnnotationMetadata());
-
-        Collection<AnnotationValue<?>> binding = new ArrayList<>();
-        binding.addAll(AbstractInterceptorChain.resolveInterceptorValues(constructorMetadata, InterceptorKind.AROUND_CONSTRUCT));
-        binding.addAll(AbstractInterceptorChain.resolveInterceptorValues(definitionMetadata, InterceptorKind.POST_CONSTRUCT));
-        binding.addAll(AbstractInterceptorChain.resolveInterceptorValues(definitionMetadata, InterceptorKind.PRE_DESTROY));
-        if (binding.isEmpty()) {
-            return null;
-        }
-        return new ArrayList(resolutionContext.getBeanRegistrations(
-            Interceptor.ARGUMENT,
-            Qualifiers.byInterceptorBindingValues(binding)
-        ));
     }
 
     /**

--- a/aop/src/main/java/io/micronaut/aop/chain/SharedInterceptorRegistrations.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/SharedInterceptorRegistrations.java
@@ -88,11 +88,17 @@ public final class SharedInterceptorRegistrations {
      * <p>Returns {@code null} for a bean that declares none of those bindings, for example a bean with only
      * {@code @Around} advice, so that such beans resolve exactly as they did before.</p>
      *
+     * <p>A bean that gets a proxy never reaches this: its proxy is handed the same union as a constructor argument,
+     * qualified at compile time by {@code AopProxyWriter}, and
+     * {@code ProxyInterceptedBeanDefinition#instantiate} takes the registrations from there. The two encode one rule
+     * on either side of compilation, so a change to the kinds merged here belongs in that writer as well.</p>
+     *
      * @param resolutionContext The resolution context
      * @param definition        The bean definition
      * @param constructor       The constructor metadata, or {@code null}
      * @param <T>               The bean type
      * @return The resolved registrations, or {@code null} when the bean declares no lifecycle-related binding
+     * @since 5.2.0
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T> @Nullable List<BeanRegistration<Interceptor<T, T>>> resolve(BeanResolutionContext resolutionContext,
@@ -129,6 +135,7 @@ public final class SharedInterceptorRegistrations {
      * @param resolutionContext The resolution context
      * @param definition        The definition being instantiated
      * @param registrations     The registrations
+     * @since 5.2.0
      */
     @SuppressWarnings("unchecked")
     public static void push(BeanResolutionContext resolutionContext,
@@ -155,6 +162,7 @@ public final class SharedInterceptorRegistrations {
      * @param resolutionContext The resolution context
      * @param definition        The definition being instantiated
      * @param registrations     The registrations that were pushed
+     * @since 5.2.0
      */
     public static void pop(BeanResolutionContext resolutionContext,
                            BeanDefinition<?> definition,
@@ -174,6 +182,7 @@ public final class SharedInterceptorRegistrations {
      * @param resolutionContext The resolution context
      * @param definition        The definition being initialized
      * @return The registrations, or {@code null} when this initialization is not nested in that construction
+     * @since 5.2.0
      */
     @SuppressWarnings("unchecked")
     public static @Nullable Collection<BeanRegistration<Interceptor<?, ?>>> peek(BeanResolutionContext resolutionContext,

--- a/aop/src/main/java/io/micronaut/aop/chain/SharedInterceptorRegistrations.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/SharedInterceptorRegistrations.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.chain;
+
+import io.micronaut.aop.Interceptor;
+import io.micronaut.aop.InterceptorKind;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Shares one interceptor resolution between the construction and the post-construct interception of a bean.
+ *
+ * <p>The scenario this exists for is a bean whose advice is declared with {@code @AroundConstruct} and lifecycle
+ * interceptor bindings but no {@code @Around}, so no proxy is generated and there is no instance field in which to
+ * retain anything:</p>
+ *
+ * <pre>{@code
+ * @Retention(RUNTIME)
+ * @AroundConstruct
+ * @InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+ * @interface Managed {}
+ *
+ * @Singleton @Managed
+ * class Product { @PostConstruct void init() {} }
+ * }</pre>
+ *
+ * <p>Without sharing, construction and post-construct each resolve their own interceptor, so a {@code @Prototype}
+ * interceptor cannot carry state from one phase to the next.</p>
+ *
+ * <p>A bean definition is a stateless singleton shared by every instance, so the resolved registrations cannot be kept
+ * on it. They are kept on the {@link BeanResolutionContext} instead, which is one instance for the whole of a bean's
+ * creation. The window is narrower than it looks: for a bean with constructor advice the generated
+ * {@code doInstantiate} runs post-construct interception from <em>inside</em> the constructor interceptor chain, so
+ * the registrations are pushed before construction and popped after it, and entries are keyed by definition so that a
+ * bean created while another is being constructed reads its own.</p>
+ *
+ * <p>Destruction happens later with a fresh resolution context, so nothing is shared with it here; see
+ * {@code MethodInterceptorChain} for how pre-destroy reaches the interceptors a bean owns.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.2.0
+ */
+@Internal
+public final class SharedInterceptorRegistrations {
+
+    private static final String ATTRIBUTE = "io.micronaut.aop.sharedInterceptorRegistrations";
+
+    private SharedInterceptorRegistrations() {
+    }
+
+    /**
+     * Resolves the interceptor registrations that a bean's construction, post-construct and pre-destroy interception
+     * can all select from.
+     *
+     * <p>The binding is the union of the {@code AROUND_CONSTRUCT}, {@code POST_CONSTRUCT} and {@code PRE_DESTROY}
+     * bindings declared by the bean, so the result is a superset of what any one phase needs. Widening cannot
+     * over-apply an interceptor: every interception point filters this set again by its own binding and kind before
+     * building a chain. It does mean an interceptor bound only to {@code @PreDestroy} is created while the bean is
+     * created rather than when it is destroyed, which is what allows the same instance to serve both.</p>
+     *
+     * <p>Returns {@code null} for a bean that declares none of those bindings, for example a bean with only
+     * {@code @Around} advice, so that such beans resolve exactly as they did before.</p>
+     *
+     * @param resolutionContext The resolution context
+     * @param definition        The bean definition
+     * @param constructor       The constructor metadata, or {@code null}
+     * @param <T>               The bean type
+     * @return The resolved registrations, or {@code null} when the bean declares no lifecycle-related binding
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> @Nullable List<BeanRegistration<Interceptor<T, T>>> resolve(BeanResolutionContext resolutionContext,
+                                                                                 BeanDefinition<?> definition,
+                                                                                 @Nullable AnnotationMetadataProvider constructor) {
+        AnnotationMetadata definitionMetadata = definition.getAnnotationMetadata();
+        AnnotationMetadata constructorMetadata = constructor == null
+            ? definitionMetadata
+            : new AnnotationMetadataHierarchy(definitionMetadata, constructor.getAnnotationMetadata());
+
+        Collection<AnnotationValue<?>> binding = new ArrayList<>();
+        binding.addAll(AbstractInterceptorChain.resolveInterceptorValues(constructorMetadata, InterceptorKind.AROUND_CONSTRUCT));
+        binding.addAll(AbstractInterceptorChain.resolveInterceptorValues(definitionMetadata, InterceptorKind.POST_CONSTRUCT));
+        binding.addAll(AbstractInterceptorChain.resolveInterceptorValues(definitionMetadata, InterceptorKind.PRE_DESTROY));
+        if (binding.isEmpty()) {
+            return null;
+        }
+        return new ArrayList(resolutionContext.getBeanRegistrations(
+            Interceptor.ARGUMENT,
+            Qualifiers.byInterceptorBindingValues(binding)
+        ));
+    }
+
+    /**
+     * Makes the registrations resolved for a bean visible to the post-construct interception of that same bean.
+     *
+     * <p>Called immediately before the constructor interceptor chain runs, and matched by {@link #pop} in a
+     * {@code finally}. Because post-construct interception happens inside that chain, this is the only window in
+     * which {@link #peek} can see the entry.</p>
+     *
+     * <p>Nesting is handled by the stack: if the constructor of one bean, or one of its {@code @AroundConstruct}
+     * interceptors, causes another bean to be created, that bean pushes and pops its own entry above this one.</p>
+     *
+     * @param resolutionContext The resolution context
+     * @param definition        The definition being instantiated
+     * @param registrations     The registrations
+     */
+    @SuppressWarnings("unchecked")
+    public static void push(BeanResolutionContext resolutionContext,
+                            BeanDefinition<?> definition,
+                            @Nullable List<?> registrations) {
+        if (registrations == null || registrations.isEmpty()) {
+            return;
+        }
+        Deque<Entry> stack = (Deque<Entry>) resolutionContext.getAttribute(ATTRIBUTE);
+        if (stack == null) {
+            stack = new ArrayDeque<>(3);
+            resolutionContext.setAttribute(ATTRIBUTE, stack);
+        }
+        stack.push(new Entry(definition, registrations));
+    }
+
+    /**
+     * Removes the entry added by {@link #push}, once the bean has been constructed and its post-construct
+     * interception has run.
+     *
+     * <p>Removes nothing unless the top of the stack belongs to this definition, so an unbalanced push elsewhere
+     * cannot discard an entry that is still in use.</p>
+     *
+     * @param resolutionContext The resolution context
+     * @param definition        The definition being instantiated
+     * @param registrations     The registrations that were pushed
+     */
+    public static void pop(BeanResolutionContext resolutionContext,
+                           BeanDefinition<?> definition,
+                           @Nullable List<?> registrations) {
+        if (registrations == null || registrations.isEmpty()) {
+            return;
+        }
+        Deque<Entry> stack = stack(resolutionContext);
+        if (stack != null && !stack.isEmpty() && stack.peek().definition == definition) {
+            stack.pop();
+        }
+    }
+
+    /**
+     * Returns the registrations resolved while the given definition is being instantiated.
+     *
+     * @param resolutionContext The resolution context
+     * @param definition        The definition being initialized
+     * @return The registrations, or {@code null} when this initialization is not nested in that construction
+     */
+    @SuppressWarnings("unchecked")
+    public static @Nullable Collection<BeanRegistration<Interceptor<?, ?>>> peek(BeanResolutionContext resolutionContext,
+                                                                                BeanDefinition<?> definition) {
+        Deque<Entry> stack = stack(resolutionContext);
+        if (stack == null || stack.isEmpty()) {
+            return null;
+        }
+        Entry entry = stack.peek();
+        return entry.definition == definition
+            ? (Collection<BeanRegistration<Interceptor<?, ?>>>) entry.registrations
+            : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static @Nullable Deque<Entry> stack(BeanResolutionContext resolutionContext) {
+        return (Deque<Entry>) resolutionContext.getAttribute(ATTRIBUTE);
+    }
+
+    private record Entry(BeanDefinition<?> definition, List<?> registrations) {
+    }
+}

--- a/aop/src/main/java/io/micronaut/aop/chain/SharedInterceptorRegistrations.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/SharedInterceptorRegistrations.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.IdentityHashMap;
 import java.util.List;
 
 /**
@@ -110,6 +111,7 @@ public final class SharedInterceptorRegistrations {
      * @param registrations     The registrations that were pushed
      * @since 5.2.0
      */
+    @SuppressWarnings("unchecked")
     public static void pop(BeanResolutionContext resolutionContext,
                            BeanDefinition<?> definition,
                            @Nullable List<?> registrations) {
@@ -118,8 +120,33 @@ public final class SharedInterceptorRegistrations {
         }
         Deque<Entry> stack = stack(resolutionContext);
         if (stack != null && !stack.isEmpty() && stack.peek().definition == definition) {
-            stack.pop();
+            Entry entry = stack.pop();
+            store(resolutionContext, entry.definition, entry.registrations);
         }
+    }
+
+    /**
+     * Stores registrations resolved outside the constructor-sharing stack, such as runtime proxy definitions.
+     *
+     * @param resolutionContext The resolution context
+     * @param definition        The definition being instantiated
+     * @param registrations     The registrations
+     * @since 5.2.0
+     */
+    @SuppressWarnings("unchecked")
+    public static void store(BeanResolutionContext resolutionContext,
+                             BeanDefinition<?> definition,
+                             @Nullable List<?> registrations) {
+        if (registrations == null || registrations.isEmpty()) {
+            return;
+        }
+        IdentityHashMap<BeanDefinition<?>, List<?>> completed = (IdentityHashMap<BeanDefinition<?>, List<?>>)
+            resolutionContext.getAttribute(BeanResolutionContext.INTERCEPTOR_REGISTRATIONS);
+        if (completed == null) {
+            completed = new IdentityHashMap<>(3);
+            resolutionContext.setAttribute(BeanResolutionContext.INTERCEPTOR_REGISTRATIONS, completed);
+        }
+        completed.put(definition, registrations);
     }
 
     /**
@@ -134,13 +161,19 @@ public final class SharedInterceptorRegistrations {
     public static @Nullable Collection<BeanRegistration<Interceptor<?, ?>>> peek(BeanResolutionContext resolutionContext,
                                                                                 BeanDefinition<?> definition) {
         Deque<Entry> stack = stack(resolutionContext);
-        if (stack == null || stack.isEmpty()) {
+        if (stack != null && !stack.isEmpty()) {
+            Entry entry = stack.peek();
+            if (entry.definition == definition) {
+                return (Collection<BeanRegistration<Interceptor<?, ?>>>) entry.registrations;
+            }
             return null;
         }
-        Entry entry = stack.peek();
-        return entry.definition == definition
-            ? (Collection<BeanRegistration<Interceptor<?, ?>>>) entry.registrations
-            : null;
+        IdentityHashMap<BeanDefinition<?>, List<?>> completed = (IdentityHashMap<BeanDefinition<?>, List<?>>)
+            resolutionContext.getAttribute(BeanResolutionContext.INTERCEPTOR_REGISTRATIONS);
+        if (completed == null) {
+            return null;
+        }
+        return (Collection<BeanRegistration<Interceptor<?, ?>>>) completed.get(definition);
     }
 
     @SuppressWarnings("unchecked")

--- a/aop/src/main/java/io/micronaut/aop/runtime/DefaultRuntimeProxyDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/runtime/DefaultRuntimeProxyDefinition.java
@@ -18,7 +18,7 @@ package io.micronaut.aop.runtime;
 import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.InterceptorRegistry;
 import io.micronaut.aop.chain.InterceptorChain;
-import io.micronaut.aop.chain.SharedInterceptorRegistrations;
+import io.micronaut.aop.beandefinition.SharedInterceptorRegistrations;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;

--- a/aop/src/main/java/io/micronaut/aop/runtime/DefaultRuntimeProxyDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/runtime/DefaultRuntimeProxyDefinition.java
@@ -18,6 +18,7 @@ package io.micronaut.aop.runtime;
 import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.InterceptorRegistry;
 import io.micronaut.aop.chain.InterceptorChain;
+import io.micronaut.aop.chain.SharedInterceptorRegistrations;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
@@ -89,6 +90,7 @@ public record DefaultRuntimeProxyDefinition<T>(BeanDefinition<T> proxyBeanDefini
             (Argument) Argument.of(Interceptor.class),
             binding
         ));
+        SharedInterceptorRegistrations.store(resolutionContext, proxyBeanDefinition, interceptors);
         List<InterceptedMethod<T>> interceptedMethods = new ArrayList<>(executableMethods.size());
         for (ExecutableMethod<T, ?> executableMethod : executableMethods) {
             Interceptor<T, ?>[] methodInterceptors = InterceptorChain.resolveAroundInterceptors(interceptorRegistry, executableMethod, interceptors);
@@ -133,6 +135,7 @@ public record DefaultRuntimeProxyDefinition<T>(BeanDefinition<T> proxyBeanDefini
             (Argument) Argument.of(Interceptor.class),
             binding
         ));
+        SharedInterceptorRegistrations.store(resolutionContext, proxyBeanDefinition, interceptors);
         List<InterceptedMethod<T>> interceptedMethods = new ArrayList<>(executableMethods.size());
         for (ExecutableMethod<T, ?> executableMethod : executableMethods) {
             Interceptor<T, ?>[] methodInterceptors = InterceptorChain.resolveIntroductionInterceptors(interceptorRegistry, executableMethod, interceptors);

--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -184,7 +184,6 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
 
     private static final Method RESOLVE_AROUND_INTERCEPTORS_METHOD = ReflectionUtils.getRequiredInternalMethod(InterceptorChain.class, "resolveAroundInterceptors", InterceptorRegistry.class, ExecutableMethod.class, List.class);
 
-    private static final Method GET_INTERCEPTOR_REGISTRATIONS_METHOD = ReflectionUtils.getRequiredInternalMethod(Intercepted.class, "$interceptorRegistrations");
 
     private static final Constructor<?> CONSTRUCTOR_METHOD_INTERCEPTOR_CHAIN = ReflectionUtils.findConstructor(MethodInterceptorChain.class, Interceptor[].class, Object.class, ExecutableMethod.class, Object[].class).orElseThrow(() ->
         new IllegalStateException("new MethodInterceptorChain(..) constructor not found. Incompatible version of Micronaut?")
@@ -209,6 +208,10 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
 
     private static final String FIELD_INTERCEPTORS = "$interceptors";
     private static final String FIELD_INTERCEPTOR_REGISTRATIONS = "$interceptorRegistrations";
+
+    // The proxy accessor is named after the field it returns.
+    private static final Method GET_INTERCEPTOR_REGISTRATIONS_METHOD =
+        ReflectionUtils.getRequiredInternalMethod(Intercepted.class, FIELD_INTERCEPTOR_REGISTRATIONS);
     private static final String FIELD_BEAN_LOCATOR = "$beanLocator";
     private static final String FIELD_BEAN_QUALIFIER = "$beanQualifier";
     private static final String FIELD_PROXY_METHODS = "$proxyMethods";

--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -184,6 +184,8 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
 
     private static final Method RESOLVE_AROUND_INTERCEPTORS_METHOD = ReflectionUtils.getRequiredInternalMethod(InterceptorChain.class, "resolveAroundInterceptors", InterceptorRegistry.class, ExecutableMethod.class, List.class);
 
+    private static final Method GET_INTERCEPTOR_REGISTRATIONS_METHOD = ReflectionUtils.getRequiredInternalMethod(Intercepted.class, "$interceptorRegistrations");
+
     private static final Constructor<?> CONSTRUCTOR_METHOD_INTERCEPTOR_CHAIN = ReflectionUtils.findConstructor(MethodInterceptorChain.class, Interceptor[].class, Object.class, ExecutableMethod.class, Object[].class).orElseThrow(() ->
         new IllegalStateException("new MethodInterceptorChain(..) constructor not found. Incompatible version of Micronaut?")
     );
@@ -206,6 +208,7 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
     );
 
     private static final String FIELD_INTERCEPTORS = "$interceptors";
+    private static final String FIELD_INTERCEPTOR_REGISTRATIONS = "$interceptorRegistrations";
     private static final String FIELD_BEAN_LOCATOR = "$beanLocator";
     private static final String FIELD_BEAN_QUALIFIER = "$beanQualifier";
     private static final String FIELD_PROXY_METHODS = "$proxyMethods";
@@ -501,6 +504,25 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
 
         proxyBuilder.addField(interceptorsField);
 
+        FieldDef interceptorRegistrationsField;
+        if (proxyBeanDefinitionWriter.hasInterceptedLifecycle()) {
+            interceptorRegistrationsField = FieldDef.builder(FIELD_INTERCEPTOR_REGISTRATIONS, List.class)
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .build();
+            proxyBuilder.addField(interceptorRegistrationsField);
+            proxyBuilder.addMethod(MethodDef.override(GET_INTERCEPTOR_REGISTRATIONS_METHOD)
+                .build((aThis, methodParameters) -> aThis.field(interceptorRegistrationsField).returning()));
+
+            // The constructor argument is qualified by the accumulated around/introduction bindings only. Widen it
+            // with the lifecycle bindings so the retained list is a superset of what lifecycle interception needs,
+            // otherwise a lifecycle interceptor bound by a different annotation would be dropped.
+            AnnotationMetadata targetAnnotationMetadata = targetType.getAnnotationMetadata();
+            visitInterceptorBinding(InterceptedMethodUtil.resolveInterceptorBinding(targetAnnotationMetadata, InterceptorKind.POST_CONSTRUCT));
+            visitInterceptorBinding(InterceptedMethodUtil.resolveInterceptorBinding(targetAnnotationMetadata, InterceptorKind.PRE_DESTROY));
+        } else {
+            interceptorRegistrationsField = null;
+        }
+
         FieldDef proxyMethodsField = FieldDef.builder(FIELD_PROXY_METHODS, ExecutableMethod[].class)
             .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
             .build();
@@ -575,7 +597,7 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
 
         proxyBuilder.addSuperinterface(TypeDef.of(isIntroduction ? Introduced.class : Intercepted.class));
 
-        addConstructor(proxyBuilder, classTargetType, targetField, interceptorsField, proxyMethodsField, interceptedMethods);
+        addConstructor(proxyBuilder, classTargetType, targetField, interceptorsField, interceptorRegistrationsField, proxyMethodsField, interceptedMethods);
 
         List<OutputObjectDef> classes = new ArrayList<>();
         classes.add(new OutputObjectDef(proxyBuilder.build(), null, originatingElements));
@@ -599,10 +621,16 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                                 ClassTypeDef targetType,
                                 @Nullable FieldDef targetField,
                                 FieldDef interceptorsField,
+                                @Nullable FieldDef interceptorRegistrationsField,
                                 FieldDef proxyMethodsField,
                                 List<MethodElement> interceptedMethods) {
 
         List<MethodDef.MethodBodyBuilder> bodyBuilders = new ArrayList<>();
+        if (interceptorRegistrationsField != null) {
+            bodyBuilders.add((aThis, methodParameters) -> aThis.field(interceptorRegistrationsField).assign(
+                methodParameters.get(constructor.findParameterIndex(INTERCEPTORS_PARAMETER))
+            ));
+        }
 
         if (isProxyTarget) {
 

--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -516,6 +516,9 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
             // The constructor argument is qualified by the accumulated around/introduction bindings only. Widen it
             // with the lifecycle bindings so the retained list is a superset of what lifecycle interception needs,
             // otherwise a lifecycle interceptor bound by a different annotation would be dropped.
+            // This is the compile-time half of the same rule SharedInterceptorRegistrations#resolve applies at
+            // runtime for beans that get no proxy: whatever a bean binds for construction, post-construct and
+            // pre-destroy is resolved as one set. Keep the two in step.
             AnnotationMetadata targetAnnotationMetadata = targetType.getAnnotationMetadata();
             visitInterceptorBinding(InterceptedMethodUtil.resolveInterceptorBinding(targetAnnotationMetadata, InterceptorKind.POST_CONSTRUCT));
             visitInterceptorBinding(InterceptedMethodUtil.resolveInterceptorBinding(targetAnnotationMetadata, InterceptorKind.PRE_DESTROY));

--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -519,7 +519,7 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
             // The constructor argument is qualified by the accumulated around/introduction bindings only. Widen it
             // with the lifecycle bindings so the retained list is a superset of what lifecycle interception needs,
             // otherwise a lifecycle interceptor bound by a different annotation would be dropped.
-            // This is the compile-time half of the same rule SharedInterceptorRegistrations#resolve applies at
+            // This is the compile-time half of the same rule InterceptedBeanDefinition#resolveInterceptors applies at
             // runtime for beans that get no proxy: whatever a bean binds for construction, post-construct and
             // pre-destroy is resolved as one set. Keep the two in step.
             AnnotationMetadata targetAnnotationMetadata = targetType.getAnnotationMetadata();

--- a/core-processor/src/main/java/io/micronaut/inject/processing/BeanDefinitionCreatorFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/BeanDefinitionCreatorFactory.java
@@ -48,7 +48,11 @@ public abstract class BeanDefinitionCreatorFactory {
 
     private static <R> List<R> produceInternal(ClassElement classElement, ElementBeanDefinitionBuilderFactory<R> beanDefinitionBuilder, VisitorContext visitorContext) {
         boolean isAbstract = classElement.isAbstract();
-        boolean isIntroduction = isIntroduction(classElement);
+        // An interceptor declares @InterceptorBinding(kind = INTRODUCTION) to state which advice it implements,
+        // not to request advice for itself. Without the same guard that isAopProxyType applies, the interceptor is
+        // compiled into its own introduction proxy that carries the target's lifecycle bindings, and resolving
+        // interceptors for that proxy finds the proxy again and recurses until the stack is exhausted.
+        boolean isIntroduction = !classElement.isAssignable(Interceptor.class) && isIntroduction(classElement);
         if (ConfigurationReaderBeanElementCreator.isConfigurationProperties(classElement)) {
             if (classElement.isInterface()) {
                 return new IntroductionInterfaceBeanElementCreator<>(classElement, visitorContext, beanDefinitionBuilder).build();

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -2824,6 +2824,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
      * interceptor for the same target.</p>
      *
      * @return {@code true} if this definition intercepts either lifecycle phase
+     * @since 5.2.0
      */
     public boolean hasInterceptedLifecycle() {
         return isPostConstructIntercepted() || isPreDestroyIntercepted();

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -2813,6 +2813,22 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
         return isInterceptedLifeCycleByType(this.annotationMetadata, "POST_CONSTRUCT");
     }
 
+    /**
+     * Whether this bean definition generates intercepted post-construct or pre-destroy handling.
+     *
+     * <p>Proxy generation uses this to decide whether to give the proxy a field holding its interceptor
+     * registrations. The decision belongs here rather than in the proxy writer because it must agree exactly with
+     * the decision to generate the lifecycle methods: the same proxy-target, factory-method and interceptor-bean
+     * rules apply. A proxy that retained registrations without intercepting its lifecycle would carry a field
+     * nothing reads, and one that intercepted its lifecycle without retaining them would resolve a second
+     * interceptor for the same target.</p>
+     *
+     * @return {@code true} if this definition intercepts either lifecycle phase
+     */
+    public boolean hasInterceptedLifecycle() {
+        return isPostConstructIntercepted() || isPreDestroyIntercepted();
+    }
+
     private static MethodDefinition<ClassElement, MethodElement> createMethodDefinition(ClassElement beanType,
                                                                                         MethodElement methodElement,
                                                                                         AnnotationMetadata annotationMetadata,

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/LifecycleInterceptorCompileSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/LifecycleInterceptorCompileSpec.groovy
@@ -1,0 +1,330 @@
+package io.micronaut.aop.compile
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+class LifecycleInterceptorCompileSpec extends AbstractTypeElementSpec {
+
+    void 'test lifecycle infrastructure preserves the user interface as the primary proxy interface'() {
+        given:
+        ApplicationContext context = buildContext('''
+package lifecycleinterface;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Context;
+import java.lang.annotation.*;
+
+@Context
+@TrackedIntroduction
+interface MyApi {
+    String name();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Introduction
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface TrackedIntroduction {
+}
+
+@Context
+@InterceptorBinding(value = TrackedIntroduction.class, kind = InterceptorKind.INTRODUCTION)
+@InterceptorBinding(value = TrackedIntroduction.class, kind = InterceptorKind.POST_CONSTRUCT)
+class IntroductionInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static int postConstructCalls;
+    static int introductionCalls;
+
+    IntroductionInterceptor() {
+        instances++;
+    }
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        InterceptorKind kind = ((MethodInvocationContext<?, ?>) context).getKind();
+        if (kind == InterceptorKind.POST_CONSTRUCT) {
+            postConstructCalls++;
+            return context.proceed();
+        }
+        introductionCalls++;
+        return "target";
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('lifecycleinterface.IntroductionInterceptor')
+        Class<?> targetType = context.classLoader.loadClass('lifecycleinterface.MyApi')
+
+        when:
+        def bean = context.getBean(targetType)
+
+        then:
+        bean.class.interfaces.first() == targetType
+        bean.name() == 'target'
+        interceptorType.instances == 1
+        interceptorType.postConstructCalls == 1
+        interceptorType.introductionCalls == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test prototype interceptor is created once per target and reused for its lifecycle'() {
+        given:
+        ApplicationContext context = buildContext('''
+package lifecycleretention;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+
+    private final int id = ++instances;
+
+    TrackingInterceptor() {
+        events.add(id + ":CREATE");
+    }
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        InterceptorKind kind = context instanceof ConstructorInvocationContext
+            ? InterceptorKind.AROUND_CONSTRUCT
+            : ((MethodInvocationContext<?, ?>) context).getKind();
+        events.add(id + ":" + kind);
+        return context.proceed();
+    }
+
+    @PreDestroy
+    void destroy() {
+        events.add(id + ":INTERCEPTOR_DESTROY");
+    }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    MyBean() {
+        TrackingInterceptor.events.add("TARGET_CONSTRUCTOR");
+    }
+
+    @PostConstruct
+    void init() {
+        TrackingInterceptor.events.add("TARGET_POST_CONSTRUCT");
+    }
+
+    String work() {
+        TrackingInterceptor.events.add("TARGET_METHOD");
+        return "done";
+    }
+
+    @PreDestroy
+    void close() {
+        TrackingInterceptor.events.add("TARGET_PRE_DESTROY");
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('lifecycleretention.TrackingInterceptor')
+        Class<?> targetType = context.classLoader.loadClass('lifecycleretention.MyBean')
+
+        when:
+        def bean = context.getBean(targetType)
+
+        then: 'the interceptor is created before construction and reused for post construct'
+        interceptorType.instances == 1
+        interceptorType.events == [
+            '1:CREATE',
+            '1:AROUND_CONSTRUCT',
+            'TARGET_CONSTRUCTOR',
+            '1:POST_CONSTRUCT',
+            'TARGET_POST_CONSTRUCT'
+        ]
+
+        when:
+        assert bean.work() == 'done'
+
+        then: 'the same interceptor handles business methods'
+        interceptorType.instances == 1
+        interceptorType.events[-2..-1] == ['1:AROUND', 'TARGET_METHOD']
+
+        when:
+        context.stop()
+
+        then: 'the same interceptor handles pre destroy and is destroyed as a target dependency'
+        interceptorType.instances == 1
+        interceptorType.events[-3..-1] == [
+            '1:PRE_DESTROY',
+            'TARGET_PRE_DESTROY',
+            '1:INTERCEPTOR_DESTROY'
+        ]
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test lifecycle-only prototype interceptor is retained when around advice uses a different binding'() {
+        given:
+        ApplicationContext context = buildContext('''
+package lifecyclebindings;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Around
+@AroundConstruct
+@interface WorkAdvice {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface LifecycleAdvice {
+}
+
+@Prototype
+@InterceptorBinding(value = LifecycleAdvice.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = LifecycleAdvice.class, kind = InterceptorKind.PRE_DESTROY)
+class LifecycleInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+    private final int id = ++instances;
+
+    LifecycleInterceptor() {
+        events.add(id + ":CREATE");
+    }
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        InterceptorKind kind = ((MethodInvocationContext<?, ?>) context).getKind();
+        events.add(id + ":" + kind);
+        return context.proceed();
+    }
+
+    @PreDestroy
+    void destroy() {
+        events.add(id + ":DESTROY");
+    }
+}
+
+@Singleton
+@WorkAdvice
+@LifecycleAdvice
+class MyBean {
+    @PostConstruct
+    void init() {
+        LifecycleInterceptor.events.add("TARGET_POST_CONSTRUCT");
+    }
+
+    @PreDestroy
+    void close() {
+        LifecycleInterceptor.events.add("TARGET_PRE_DESTROY");
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('lifecyclebindings.LifecycleInterceptor')
+        Class<?> targetType = context.classLoader.loadClass('lifecyclebindings.MyBean')
+
+        when:
+        context.getBean(targetType)
+
+        then:
+        interceptorType.instances == 1
+        interceptorType.events == ['1:CREATE', '1:POST_CONSTRUCT', 'TARGET_POST_CONSTRUCT']
+
+        when:
+        context.stop()
+
+        then:
+        interceptorType.events[-3..-1] == ['1:PRE_DESTROY', 'TARGET_PRE_DESTROY', '1:DESTROY']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test each prototype target receives a different prototype interceptor'() {
+        given:
+        ApplicationContext context = buildContext('''
+package lifecycleprototypes;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Around
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Tracked {
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        Object result = context.proceed();
+        if (((MethodInvocationContext<?, ?>) context).getKind() == InterceptorKind.POST_CONSTRUCT) {
+            ((MyBean) context.getTarget()).interceptorId = id;
+        }
+        return result;
+    }
+}
+
+@Prototype
+@Tracked
+class MyBean {
+    int interceptorId;
+
+    int interceptorId() {
+        return interceptorId;
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('lifecycleprototypes.TrackingInterceptor')
+        Class<?> targetType = context.classLoader.loadClass('lifecycleprototypes.MyBean')
+
+        when:
+        def first = context.getBean(targetType)
+        def second = context.getBean(targetType)
+
+        then:
+        !first.is(second)
+        first.interceptorId() == 1
+        second.interceptorId() == 2
+        interceptorType.instances == 2
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorOrderingSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorOrderingSpec.groovy
@@ -1,0 +1,589 @@
+package io.micronaut.aop.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+/**
+ * Interceptor selection and ordering for beans that combine around advice with lifecycle advice.
+ *
+ * Reusing the interceptor instances a bean already owns changes where the candidate set comes from, so these
+ * cover the properties that set has to keep: the order interceptors run in, the kinds they are selected for,
+ * and the fact that they never leak between beans.
+ */
+class LifecycleInterceptorOrderingSpec extends AbstractTypeElementSpec {
+
+    void 'test interceptor order is honoured in every phase of a proxied bean'() {
+        given:
+        ApplicationContext context = buildContext('''
+package ordering.proxied;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+class Events {
+    static final List<String> LOG = new ArrayList<>();
+}
+
+abstract class Base implements Interceptor<Object, Object>, io.micronaut.core.order.Ordered {
+    abstract String id();
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        Events.LOG.add(kind + ":" + id());
+        return context.proceed();
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class First extends Base {
+    String id() { return "first"; }
+    public int getOrder() { return 10; }
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class Second extends Base {
+    String id() { return "second"; }
+    public int getOrder() { return 20; }
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class Third extends Base {
+    String id() { return "third"; }
+    public int getOrder() { return 30; }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> events = context.classLoader.loadClass('ordering.proxied.Events')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('ordering.proxied.MyBean'))
+        bean.work()
+        context.stop()
+        def log = events.LOG
+
+        then: 'every phase runs all three in declared order'
+        log.findAll { it.startsWith('AROUND_CONSTRUCT') } == ['AROUND_CONSTRUCT:first', 'AROUND_CONSTRUCT:second', 'AROUND_CONSTRUCT:third']
+        log.findAll { it.startsWith('POST_CONSTRUCT') } == ['POST_CONSTRUCT:first', 'POST_CONSTRUCT:second', 'POST_CONSTRUCT:third']
+        log.findAll { it.startsWith('AROUND:') } == ['AROUND:first', 'AROUND:second', 'AROUND:third']
+        log.findAll { it.startsWith('PRE_DESTROY') } == ['PRE_DESTROY:first', 'PRE_DESTROY:second', 'PRE_DESTROY:third']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test interceptor order is honoured in every phase without an around proxy'() {
+        given:
+        ApplicationContext context = buildContext('''
+package ordering.noproxy;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Managed {
+}
+
+class Events {
+    static final List<String> LOG = new ArrayList<>();
+}
+
+abstract class Base implements Interceptor<Object, Object>, io.micronaut.core.order.Ordered {
+    abstract String id();
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        Events.LOG.add(kind + ":" + id());
+        return context.proceed();
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class Alpha extends Base {
+    String id() { return "alpha"; }
+    public int getOrder() { return 1; }
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class Beta extends Base {
+    String id() { return "beta"; }
+    public int getOrder() { return 2; }
+}
+
+@Singleton
+@Managed
+class MyBean {
+    @PostConstruct void init() {}
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> events = context.classLoader.loadClass('ordering.noproxy.Events')
+
+        when:
+        context.getBean(context.classLoader.loadClass('ordering.noproxy.MyBean'))
+        context.stop()
+        def log = events.LOG
+
+        then:
+        log.findAll { it.startsWith('AROUND_CONSTRUCT') } == ['AROUND_CONSTRUCT:alpha', 'AROUND_CONSTRUCT:beta']
+        log.findAll { it.startsWith('POST_CONSTRUCT') } == ['POST_CONSTRUCT:alpha', 'POST_CONSTRUCT:beta']
+        log.findAll { it.startsWith('PRE_DESTROY') } == ['PRE_DESTROY:alpha', 'PRE_DESTROY:beta']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test an interceptor bound to one kind only runs for that kind'() {
+        given:
+        ApplicationContext context = buildContext('''
+package ordering.kinds;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+class Events {
+    static final List<String> LOG = new ArrayList<>();
+}
+
+abstract class Base implements Interceptor<Object, Object>, io.micronaut.core.order.Ordered {
+    abstract String id();
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        Events.LOG.add(id() + "@" + kind);
+        return context.proceed();
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+class AroundOnly extends Base {
+    String id() { return "around"; }
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+class PostOnly extends Base {
+    String id() { return "post"; }
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class PreOnly extends Base {
+    String id() { return "pre"; }
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+class ConstructOnly extends Base {
+    String id() { return "construct"; }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> events = context.classLoader.loadClass('ordering.kinds.Events')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('ordering.kinds.MyBean'))
+        bean.work()
+        context.stop()
+        def log = events.LOG
+
+        then: 'each interceptor is selected for its own kind and no other'
+        log.findAll { it.endsWith('@AROUND_CONSTRUCT') } == ['construct@AROUND_CONSTRUCT']
+        log.findAll { it.endsWith('@POST_CONSTRUCT') } == ['post@POST_CONSTRUCT']
+        log.findAll { it.endsWith('@AROUND') } == ['around@AROUND']
+        log.findAll { it.endsWith('@PRE_DESTROY') } == ['pre@PRE_DESTROY']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test interceptors do not leak between beans with different bindings'() {
+        given:
+        ApplicationContext context = buildContext('''
+package ordering.isolation;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Around
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Red {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Around
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Blue {
+}
+
+class Events {
+    static final List<String> LOG = new ArrayList<>();
+}
+
+@Prototype
+@InterceptorBinding(value = Red.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Red.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Red.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Red.class, kind = InterceptorKind.PRE_DESTROY)
+class RedInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        Events.LOG.add("red:" + (context instanceof ConstructorInvocationContext
+            ? ((ConstructorInvocationContext<?>) context).getDeclaringType().getSimpleName()
+            : context.getTarget().getClass().getSimpleName()));
+        return context.proceed();
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Blue.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Blue.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Blue.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Blue.class, kind = InterceptorKind.PRE_DESTROY)
+class BlueInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        Events.LOG.add("blue:" + (context instanceof ConstructorInvocationContext
+            ? ((ConstructorInvocationContext<?>) context).getDeclaringType().getSimpleName()
+            : context.getTarget().getClass().getSimpleName()));
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Red
+class RedBean {
+    @PostConstruct void init() {}
+    @PreDestroy void close() {}
+}
+
+@Singleton
+@Blue
+class BlueBean {
+    @PostConstruct void init() {}
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> events = context.classLoader.loadClass('ordering.isolation.Events')
+
+        when:
+        context.getBean(context.classLoader.loadClass('ordering.isolation.RedBean'))
+        context.getBean(context.classLoader.loadClass('ordering.isolation.BlueBean'))
+        context.stop()
+        def log = events.LOG
+
+        then: 'neither interceptor ever sees the other binding of bean'
+        !log.isEmpty()
+        log.findAll { it.startsWith('red:') }.every { it.contains('RedBean') }
+        log.findAll { it.startsWith('blue:') }.every { it.contains('BlueBean') }
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a constructor interceptor is not selected for lifecycle phases'() {
+        given:
+        ApplicationContext context = buildContext('''
+package ordering.ctor;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Managed {
+}
+
+class Events {
+    static final List<String> LOG = new ArrayList<>();
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class CtorInterceptor implements ConstructorInterceptor<Object> {
+    @Override
+    public Object intercept(ConstructorInvocationContext<Object> context) {
+        Events.LOG.add("ctor");
+        return context.proceed();
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class LifecycleInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        Events.LOG.add("method:" + context.getKind().name());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Managed
+class MyBean {
+    @PostConstruct void init() {}
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> events = context.classLoader.loadClass('ordering.ctor.Events')
+
+        when:
+        context.getBean(context.classLoader.loadClass('ordering.ctor.MyBean'))
+        context.stop()
+        def log = events.LOG
+
+        then: 'the constructor interceptor runs once, the method interceptor only for the lifecycle kinds'
+        log.count { it == 'ctor' } == 1
+        log.findAll { it.startsWith('method:') } == ['method:POST_CONSTRUCT', 'method:PRE_DESTROY']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test lifecycle advice on a proxyTarget bean'() {
+        given:
+        ApplicationContext context = buildContext('''
+package ordering.proxytarget;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Around(proxyTarget = true)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+class Events {
+    static final List<String> LOG = new ArrayList<>();
+    static int instances;
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    private final int id = ++Events.instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        Events.LOG.add(id + ":" + kind);
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> events = context.classLoader.loadClass('ordering.proxytarget.Events')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('ordering.proxytarget.MyBean'))
+        bean.work()
+        context.stop()
+        def log = events.LOG
+
+        then: 'each phase is intercepted exactly once and in order'
+        log.collect { it.substring(it.indexOf(':') + 1) } == ['AROUND_CONSTRUCT', 'POST_CONSTRUCT', 'AROUND', 'PRE_DESTROY']
+
+        and: 'construction, post construct and pre destroy of the target share one interceptor'
+        log.findAll { !it.endsWith(':AROUND') }.collect { it.substring(0, it.indexOf(':')) }.toSet().size() == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test lifecycle advice on a factory produced bean'() {
+        given:
+        ApplicationContext context = buildContext('''
+package ordering.factory;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+class Events {
+    static final List<String> LOG = new ArrayList<>();
+    static int instances;
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    private final int id = ++Events.instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        Events.LOG.add(id + ":" + ((MethodInvocationContext<?, ?>) context).getKind().name());
+        return context.proceed();
+    }
+}
+
+class MyBean {
+    @PostConstruct void init() {}
+    public String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+
+@Factory
+class MyFactory {
+    @Singleton
+    @Tracked
+    MyBean myBean() {
+        return new MyBean();
+    }
+}
+''')
+        Class<?> events = context.classLoader.loadClass('ordering.factory.Events')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('ordering.factory.MyBean'))
+        bean.work()
+        context.stop()
+        def log = events.LOG
+
+        then: 'every phase of a factory produced bean is intercepted, in order'
+        log.collect { it.substring(it.indexOf(':') + 1) } == ['POST_CONSTRUCT', 'AROUND', 'PRE_DESTROY']
+
+        and: 'the lifecycle phases share one interceptor'
+        log.findAll { !it.endsWith(':AROUND') }.collect { it.substring(0, it.indexOf(':')) }.toSet().size() == 1
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorReuseSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorReuseSpec.groovy
@@ -673,6 +673,79 @@ class MyBean {
         context.close()
     }
 
+    void 'test a proxy with constructor advice reuses the list it was constructed with for every phase'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.ctorproxy;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+class Seen {
+    static final Map<String, Object> BY_KIND = new LinkedHashMap<>();
+    static int instances;
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    TrackingInterceptor() { Seen.instances++; }
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        Seen.BY_KIND.put(kind, this);
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> seen = context.classLoader.loadClass('reuse.ctorproxy.Seen')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('reuse.ctorproxy.MyBean'))
+        bean.work()
+        def registrations = io.micronaut.aop.Intercepted.getMethod('$interceptorRegistrations').invoke(bean)
+        context.stop()
+
+        then: 'one interceptor is resolved for the bean and used by every phase'
+        seen.instances == 1
+        seen.BY_KIND.keySet() as List == ['AROUND_CONSTRUCT', 'POST_CONSTRUCT', 'AROUND', 'PRE_DESTROY']
+
+        and: 'constructor interception used the very instance the proxy retains, so nothing was resolved twice'
+        registrations.size() == 1
+        seen.BY_KIND.values().every { it.is(registrations[0].bean) }
+
+        cleanup:
+        context.close()
+    }
+
     void 'test singleton interceptors are unaffected'() {
         given:
         ApplicationContext context = buildContext('''

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorReuseSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorReuseSpec.groovy
@@ -1,0 +1,745 @@
+package io.micronaut.aop.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+class LifecycleInterceptorReuseSpec extends AbstractTypeElementSpec {
+
+    void 'test a prototype interceptor is reused for every interception point of one bean'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.proxy;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        events.add(id + ":" + kind);
+        return context.proceed();
+    }
+
+    @PreDestroy
+    void destroy() {
+        events.add(id + ":DESTROYED");
+    }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.proxy.TrackingInterceptor')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('reuse.proxy.MyBean'))
+        bean.work()
+        bean.work()
+
+        then: 'one instance serves construction, post construct and every method call'
+        interceptorType.instances == 1
+        interceptorType.events == [
+                '1:AROUND_CONSTRUCT',
+                '1:POST_CONSTRUCT',
+                '1:AROUND',
+                '1:AROUND'
+        ]
+
+        when:
+        context.stop()
+
+        then: 'the same instance serves pre destroy and is then destroyed as a dependent'
+        interceptorType.instances == 1
+        interceptorType.events[-2..-1] == ['1:PRE_DESTROY', '1:DESTROYED']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test each intercepted bean gets its own interceptor instance'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.pertarget;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Tracked {
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final Map<Integer, Set<String>> seen = new LinkedHashMap<>();
+
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        seen.computeIfAbsent(id, k -> new LinkedHashSet<>())
+            .add(((MethodInvocationContext<?, ?>) context).getExecutableMethod().getDeclaringType().getSimpleName());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class BeanA {
+    @PostConstruct void init() {}
+    String work() { return "a"; }
+}
+
+@Singleton
+@Tracked
+class BeanB {
+    @PostConstruct void init() {}
+    String work() { return "b"; }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.pertarget.TrackingInterceptor')
+
+        when:
+        context.getBean(context.classLoader.loadClass('reuse.pertarget.BeanA')).work()
+        context.getBean(context.classLoader.loadClass('reuse.pertarget.BeanB')).work()
+
+        then: 'two instances, and neither is shared between the two targets'
+        interceptorType.instances == 2
+        interceptorType.seen.keySet() as List == [1, 2]
+        interceptorType.seen[1].every { it.contains('BeanA') }
+        interceptorType.seen[2].every { it.contains('BeanB') }
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test lifecycle advice bound by a different annotation than the around advice still applies'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.mixed;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@interface Aro {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Life {
+}
+
+@Prototype
+@InterceptorBinding(value = Aro.class, kind = InterceptorKind.AROUND)
+class AroundInterceptor implements Interceptor<Object, Object> {
+    static int calls;
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        calls++;
+        return context.proceed();
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Life.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Life.class, kind = InterceptorKind.PRE_DESTROY)
+class LifecycleInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static int postConstructCalls;
+    static int preDestroyCalls;
+    static int reusedForPreDestroy;
+
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        InterceptorKind kind = ((MethodInvocationContext<?, ?>) context).getKind();
+        if (kind == InterceptorKind.POST_CONSTRUCT) {
+            postConstructCalls++;
+        } else {
+            preDestroyCalls++;
+            if (id == 1) {
+                reusedForPreDestroy++;
+            }
+        }
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Aro
+@Life
+class MyBean {
+    static int inits;
+    @PostConstruct void init() { inits++; }
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> myBean = context.classLoader.loadClass('reuse.mixed.MyBean')
+        Class<?> around = context.classLoader.loadClass('reuse.mixed.AroundInterceptor')
+        Class<?> lifecycle = context.classLoader.loadClass('reuse.mixed.LifecycleInterceptor')
+
+        when:
+        context.getBean(myBean).work()
+
+        then: 'the lifecycle interceptor is not shadowed by the around binding'
+        myBean.inits == 1
+        around.calls == 1
+        lifecycle.postConstructCalls == 1
+        lifecycle.instances == 1
+
+        when:
+        context.stop()
+
+        then: 'and the very same instance is reused for pre destroy'
+        lifecycle.preDestroyCalls == 1
+        lifecycle.instances == 1
+        lifecycle.reusedForPreDestroy == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test reuse for lifecycle advice without an around proxy'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.noproxy;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Managed {
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class ManagedInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        events.add(id + ":" + kind);
+        return context.proceed();
+    }
+}
+
+@io.micronaut.context.annotation.Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class PrototypeInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Managed
+class MyBean {
+    @PostConstruct void init() {}
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.noproxy.ManagedInterceptor')
+
+        when:
+        context.getBean(context.classLoader.loadClass('reuse.noproxy.MyBean'))
+        context.stop()
+
+        then: 'a single instance covers construction, post construct and pre destroy'
+        interceptorType.instances == 1
+        interceptorType.events == ['1:AROUND_CONSTRUCT', '1:POST_CONSTRUCT', '1:PRE_DESTROY']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test reuse for a dependent prototype with lifecycle advice and no around proxy'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.dependent;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Managed {
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class ManagedInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        events.add(id + ":" + kind);
+        return context.proceed();
+    }
+}
+
+@Prototype
+@Managed
+class Item {
+    @PostConstruct void init() {}
+    @PreDestroy void close() {}
+}
+
+@Singleton
+class Holder {
+    final Item item;
+    Holder(Item item) { this.item = item; }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.dependent.ManagedInterceptor')
+
+        when:
+        context.getBean(context.classLoader.loadClass('reuse.dependent.Holder'))
+        context.stop()
+
+        then: 'the prototype is destroyed as a dependent, so one instance covers all three phases'
+        interceptorType.instances == 1
+        interceptorType.events == ['1:AROUND_CONSTRUCT', '1:POST_CONSTRUCT', '1:PRE_DESTROY']
+
+        cleanup:
+        context.close()
+    }
+
+    // destroyBean(Object) cannot find a registration for a bean created with createBean, so the registrations
+    // owned by that bean are not available to the dispose call and pre destroy still resolves a new interceptor.
+    void 'test a prototype created through createBean reuses the interceptor up to post construct'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.createbean;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PreDestroy;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@Prototype
+@interface ProductBean {
+}
+
+@Prototype
+@InterceptorBinding(value = ProductBean.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = ProductBean.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = ProductBean.class, kind = InterceptorKind.PRE_DESTROY)
+class ProductInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        events.add(id + ":" + kind);
+        return context.proceed();
+    }
+}
+
+@ProductBean
+class Product {
+    private final String productName;
+    Product(@Parameter String productName) { this.productName = productName; }
+    String getProductName() { return productName; }
+    @PreDestroy void disable() {}
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.createbean.ProductInterceptor')
+
+        when:
+        def product = context.createBean(context.classLoader.loadClass('reuse.createbean.Product'), 'test')
+        context.destroyBean(product)
+
+        then: 'construction and post construct share one instance, pre destroy does not'
+        interceptorType.instances == 2
+        interceptorType.events == ['1:AROUND_CONSTRUCT', '1:POST_CONSTRUCT', '2:PRE_DESTROY']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test an intercepted bean resolved as a nested dependency is not confused with its consumer'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.nested;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Tracked {
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final Map<Integer, List<String>> postConstructs = new LinkedHashMap<>();
+
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        MethodInvocationContext<?, ?> mic = (MethodInvocationContext<?, ?>) context;
+        if (mic.getKind() == InterceptorKind.POST_CONSTRUCT) {
+            postConstructs.computeIfAbsent(id, k -> new ArrayList<>())
+                .add(mic.getTarget().getClass().getName());
+        }
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class Inner {
+    @PostConstruct void init() {}
+    String work() { return "inner"; }
+}
+
+@Singleton
+@Tracked
+class Outer {
+    final Inner inner;
+    Outer(Inner inner) { this.inner = inner; }
+    @PostConstruct void init() {}
+    String work() { return "outer"; }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.nested.TrackingInterceptor')
+
+        when:
+        context.getBean(context.classLoader.loadClass('reuse.nested.Outer'))
+
+        then: 'each bean got its own interceptor, and each interceptor saw exactly one post construct'
+        interceptorType.instances == 2
+        interceptorType.postConstructs.size() == 2
+        interceptorType.postConstructs.values().every { it.size() == 1 }
+        interceptorType.postConstructs.values().collect { it[0] }.toSet().size() == 2
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a singleton lifecycle interceptor still applies alongside a prototype one with no around proxy'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.noproxysingleton;
+
+import io.micronaut.aop.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Managed {
+}
+
+@Singleton
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class SharedInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> kinds = new ArrayList<>();
+
+    SharedInterceptor() { instances++; }
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        kinds.add(context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Managed
+class MyBean {
+    @PostConstruct void init() {}
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.noproxysingleton.SharedInterceptor')
+
+        when:
+        context.getBean(context.classLoader.loadClass('reuse.noproxysingleton.MyBean'))
+        context.stop()
+
+        then: 'a singleton interceptor is not a dependent of the bean, so pre destroy must still find it alongside the prototype one'
+        interceptorType.kinds == ['AROUND_CONSTRUCT', 'POST_CONSTRUCT', 'PRE_DESTROY']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the registrations a proxy exposes are exactly the ones injected into it'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.identity;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+class Seen {
+    static final Map<String, Object> BY_KIND = new LinkedHashMap<>();
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class PrototypeInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        Seen.BY_KIND.put("prototype@" + ((MethodInvocationContext<?, ?>) context).getKind().name(), this);
+        return context.proceed();
+    }
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+class SingletonInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        Seen.BY_KIND.put("singleton@" + ((MethodInvocationContext<?, ?>) context).getKind().name(), this);
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> seen = context.classLoader.loadClass('reuse.identity.Seen')
+        Class<?> prototypeType = context.classLoader.loadClass('reuse.identity.PrototypeInterceptor')
+        Class<?> singletonType = context.classLoader.loadClass('reuse.identity.SingletonInterceptor')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('reuse.identity.MyBean'))
+        bean.work()
+        def accessor = io.micronaut.aop.Intercepted.getMethod('$interceptorRegistrations')
+        def registrations = accessor.invoke(bean)
+
+        then: 'the proxy exposes the registrations it was constructed with, not a copy'
+        bean instanceof io.micronaut.aop.Intercepted
+        accessor.invoke(bean).is(registrations)
+        registrations.every { it instanceof io.micronaut.context.BeanRegistration }
+
+        and: 'every interceptor bound to the target is present exactly once'
+        registrations.collect { it.beanDefinition.beanType }.toSet() == [prototypeType, singletonType].toSet()
+        registrations.size() == 2
+
+        and: 'the instances exposed are the very instances that performed the interception'
+        def exposed = registrations.collectEntries { [it.beanDefinition.beanType, it.bean] }
+        seen.BY_KIND['prototype@AROUND'].is(exposed[prototypeType])
+        seen.BY_KIND['prototype@POST_CONSTRUCT'].is(exposed[prototypeType])
+        seen.BY_KIND['singleton@POST_CONSTRUCT'].is(exposed[singletonType])
+
+        when: 'the bean is destroyed'
+        context.stop()
+
+        then: 'pre destroy used that same instance too'
+        seen.BY_KIND['prototype@PRE_DESTROY'].is(exposed[prototypeType])
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test singleton interceptors are unaffected'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.singleton;
+
+import io.micronaut.aop.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> kinds = new ArrayList<>();
+
+    TrackingInterceptor() { instances++; }
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        kinds.add(((MethodInvocationContext<?, ?>) context).getKind().name());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class BeanA {
+    @PostConstruct void init() {}
+    String work() { return "a"; }
+    @PreDestroy void close() {}
+}
+
+@Singleton
+@Tracked
+class BeanB {
+    @PostConstruct void init() {}
+    String work() { return "b"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.singleton.TrackingInterceptor')
+
+        when:
+        context.getBean(context.classLoader.loadClass('reuse.singleton.BeanA')).work()
+        context.getBean(context.classLoader.loadClass('reuse.singleton.BeanB')).work()
+        context.stop()
+
+        then: 'one shared instance still sees every interception point of both beans'
+        interceptorType.instances == 1
+        interceptorType.kinds.count { it == 'POST_CONSTRUCT' } == 2
+        interceptorType.kinds.count { it == 'AROUND' } == 2
+        interceptorType.kinds.count { it == 'PRE_DESTROY' } == 2
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorReuseSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorReuseSpec.groovy
@@ -532,6 +532,7 @@ package reuse.noproxysingleton;
 import io.micronaut.aop.*;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import io.micronaut.context.annotation.Prototype;
 import jakarta.inject.Singleton;
 import java.lang.annotation.*;
 import java.util.*;
@@ -563,6 +564,25 @@ class SharedInterceptor implements Interceptor<Object, Object> {
     }
 }
 
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class PerBeanInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> kinds = new ArrayList<>();
+
+    PerBeanInterceptor() { instances++; }
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        kinds.add(context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name());
+        return context.proceed();
+    }
+}
+
 @Singleton
 @Managed
 class MyBean {
@@ -578,6 +598,146 @@ class MyBean {
 
         then: 'a singleton interceptor is not a dependent of the bean, so pre destroy must still find it alongside the prototype one'
         interceptorType.kinds == ['AROUND_CONSTRUCT', 'POST_CONSTRUCT', 'PRE_DESTROY']
+        context.classLoader.loadClass('reuse.noproxysingleton.PerBeanInterceptor').instances == 1
+        context.classLoader.loadClass('reuse.noproxysingleton.PerBeanInterceptor').kinds == ['AROUND_CONSTRUCT', 'POST_CONSTRUCT', 'PRE_DESTROY']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test an injected interceptor is not reused as a lifecycle interceptor'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.noproxyinjected;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Managed {
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class LifecycleInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static int postConstructCalls;
+    static int preDestroyCalls;
+
+    LifecycleInterceptor() { instances++; }
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        if (kind.equals("POST_CONSTRUCT")) {
+            postConstructCalls++;
+        } else if (kind.equals("PRE_DESTROY")) {
+            preDestroyCalls++;
+        }
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Managed
+class MyBean {
+    MyBean(LifecycleInterceptor injected) {}
+    @PostConstruct void init() {}
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.noproxyinjected.LifecycleInterceptor')
+
+        when:
+        context.getBean(context.classLoader.loadClass('reuse.noproxyinjected.MyBean'))
+        context.stop()
+
+        then: 'the ordinary dependency and lifecycle candidate are distinct, but only the latter receives lifecycle advice'
+        interceptorType.instances == 2
+        interceptorType.postConstructCalls == 1
+        interceptorType.preDestroyCalls == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a runtime proxy reuses lifecycle interceptor registrations'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.runtime;
+
+import io.micronaut.aop.*;
+import io.micronaut.aop.runtime.RuntimeProxy;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Managed {
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.PRE_DESTROY)
+class LifecycleInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        events.add(id + ":" + kind);
+        return context.proceed();
+    }
+}
+
+@Singleton
+@RuntimeProxy(io.micronaut.aop.ByteBuddyRuntimeProxy.class)
+@Managed
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        context.registerSingleton(new io.micronaut.aop.ByteBuddyRuntimeProxy())
+        Class<?> interceptorType = context.classLoader.loadClass('reuse.runtime.LifecycleInterceptor')
+
+        when:
+        context.getBean(context.classLoader.loadClass('reuse.runtime.MyBean')).work()
+        context.stop()
+
+        then:
+        interceptorType.instances == 1
+        interceptorType.events == [
+            '1:POST_CONSTRUCT',
+            '1:AROUND',
+            '1:PRE_DESTROY'
+        ]
 
         cleanup:
         context.close()

--- a/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
@@ -34,24 +34,30 @@ final class BeanDisposingRegistration<BT> extends BeanRegistration<BT> implement
     private final BeanContext beanContext;
     @Nullable
     private final List<BeanRegistration<?>> dependents;
+    @Nullable
+    private final List<?> interceptorRegistrations;
 
     BeanDisposingRegistration(BeanContext beanContext,
                               BeanIdentifier identifier,
                               BeanDefinition<BT> beanDefinition,
                               BT createdBean,
-                              List<BeanRegistration<?>> dependents) {
+                              List<BeanRegistration<?>> dependents,
+                              @Nullable List<?> interceptorRegistrations) {
         super(identifier, beanDefinition, createdBean);
         this.beanContext = beanContext;
         this.dependents = dependents;
+        this.interceptorRegistrations = interceptorRegistrations;
     }
 
     BeanDisposingRegistration(BeanContext beanContext,
                               BeanIdentifier identifier,
                               BeanDefinition<BT> beanDefinition,
-                              BT createdBean) {
+                              BT createdBean,
+                              @Nullable List<?> interceptorRegistrations) {
         super(identifier, beanDefinition, createdBean);
         this.beanContext = beanContext;
         this.dependents = null;
+        this.interceptorRegistrations = interceptorRegistrations;
     }
 
     @Override
@@ -67,5 +73,13 @@ final class BeanDisposingRegistration<BT> extends BeanRegistration<BT> implement
     @Override
     public List<BeanRegistration<?>> dependentBeans() {
         return dependents == null ? List.of() : List.copyOf(dependents);
+    }
+
+    /**
+     * @return The interceptor registrations selected while this bean was created, or {@code null}
+     */
+    @Nullable
+    List<?> getInterceptorRegistrations() {
+        return interceptorRegistrations;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/BeanRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanRegistration.java
@@ -105,9 +105,23 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
                                              K bean,
                                              @Nullable
                                              List<BeanRegistration<?>> dependents) {
+        return of(beanContext, identifier, beanDefinition, bean, dependents, null);
+    }
+
+    /**
+     * Creates a bean registration with optional dependent and lifecycle interceptor registrations.
+     *
+     * <p>This overload is package-private because the interceptor registrations are an internal bean-creation detail.</p>
+     */
+    static <K> BeanRegistration<K> of(BeanContext beanContext,
+                                      BeanIdentifier identifier,
+                                      BeanDefinition<K> beanDefinition,
+                                      K bean,
+                                      @Nullable List<BeanRegistration<?>> dependents,
+                                      @Nullable List<?> interceptorRegistrations) {
         return CollectionUtils.isNotEmpty(dependents) ?
-            new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean, Objects.requireNonNull(dependents)) :
-            new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean);
+            new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean, Objects.requireNonNull(dependents), interceptorRegistrations) :
+            new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean, interceptorRegistrations);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -46,6 +46,22 @@ import java.util.Optional;
 @UsedByGeneratedCode
 public interface BeanResolutionContext extends ValueResolver<CharSequence>, AutoCloseable, BeanLocator, ConversionServiceProvider {
 
+    /**
+     * Attribute that exposes the dependent bean registrations already created for the bean this context
+     * is operating on.
+     *
+     * <p>During bean creation those registrations are available from {@link #getDependentBeans()}, but a bean is
+     * destroyed with a fresh resolution context that has no dependents of its own. This attribute carries the
+     * registrations owned by the bean being destroyed, so that {@code @PreDestroy} advice can reuse the interceptor
+     * instances created for that same bean rather than resolving new ones.</p>
+     *
+     * <p>Set only while a bean is being disposed of, and only when that bean owns dependent registrations. The value
+     * is a {@code List<BeanRegistration<?>>} and must be treated as read-only.</p>
+     *
+     * @since 5.2.0
+     */
+    String EXISTING_DEPENDENT_BEANS = "io.micronaut.context.existingDependentBeans";
+
     @Override
     default void close() {
         // no-op

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -47,20 +47,37 @@ import java.util.Optional;
 public interface BeanResolutionContext extends ValueResolver<CharSequence>, AutoCloseable, BeanLocator, ConversionServiceProvider {
 
     /**
-     * Attribute that exposes the dependent bean registrations already created for the bean this context
-     * is operating on.
+     * Attribute that exposes the dependent bean registrations already created for the bean this context is operating
+     * on.
      *
      * <p>During bean creation those registrations are available from {@link #getDependentBeans()}, but a bean is
-     * destroyed with a fresh resolution context that has no dependents of its own. This attribute carries the
-     * registrations owned by the bean being destroyed, so that {@code @PreDestroy} advice can reuse the interceptor
-     * instances created for that same bean rather than resolving new ones.</p>
-     *
-     * <p>Set only while a bean is being disposed of, and only when that bean owns dependent registrations. The value
-     * is a {@code List<BeanRegistration<?>>} and must be treated as read-only.</p>
+     * destroyed with a fresh resolution context that has no dependents of its own. This attribute is retained for
+     * compatibility with generated factory definitions that still use that fallback.</p>
      *
      * @since 5.2.0
      */
     String EXISTING_DEPENDENT_BEANS = "io.micronaut.context.existingDependentBeans";
+
+    /**
+     * Attribute used while a bean is being created to transfer the interceptor registrations selected for that bean
+     * to its {@link BeanRegistration}.
+     *
+     * <p>The value is an identity map keyed by {@link BeanDefinition}. It is consumed by the bean context after
+     * creation and must be treated as an implementation detail.</p>
+     *
+     * @since 5.2.0
+     */
+    String INTERCEPTOR_REGISTRATIONS = "io.micronaut.aop.interceptorRegistrations";
+
+    /**
+     * Attribute that exposes the interceptor registrations selected while creating the bean being disposed.
+     *
+     * <p>The value is a read-only {@code List<BeanRegistration<?>>}. It is set only while a bean is being disposed and
+     * is intended for lifecycle interception.</p>
+     *
+     * @since 5.2.0
+     */
+    String EXISTING_INTERCEPTOR_REGISTRATIONS = "io.micronaut.aop.existingInterceptorRegistrations";
 
     @Override
     default void close() {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1177,7 +1177,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
         if (definition instanceof DisposableBeanDefinition) {
             try {
-                ((DisposableBeanDefinition<T>) definition).dispose(this, beanToDestroy);
+                disposeBean((DisposableBeanDefinition<T>) definition, registration, beanToDestroy);
             } catch (Exception e) {
                 if (LOG.isWarnEnabled()) {
                     LOG.warn("Error disposing bean [{}]... Continuing...", beanToDestroy, e);
@@ -1204,6 +1204,40 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
 
         triggerBeanDestroyedListeners(definition, beanToDestroy);
+    }
+
+    /**
+     * Disposes of the bean, exposing the registrations it owns so that {@code @PreDestroy} advice can reuse
+     * interceptor instances that were already created for the same bean.
+     *
+     * <p>The scenario is a bean with lifecycle advice but no around proxy, so it has no instance field in which
+     * interceptor registrations could have been retained. A bean is destroyed long after it was created and with a
+     * fresh resolution context, so without this the pre-destroy advice would resolve a new interceptor and a
+     * {@code @Prototype} interceptor could not release the state it set up in {@code @PostConstruct}.</p>
+     *
+     * <p>The registrations are already in hand here: they are the dependents this method's caller destroys once the
+     * bean has been disposed of. Beans that own no dependents, which includes every prototype created through
+     * {@code createBean} and destroyed through {@code destroyBean(Object)}, take the plain path.</p>
+     *
+     * @param definition    The disposable definition
+     * @param registration  The registration of the bean being destroyed
+     * @param beanToDestroy The bean
+     * @param <T>           The bean type
+     */
+    private <T> void disposeBean(DisposableBeanDefinition<T> definition,
+                                 BeanRegistration<T> registration,
+                                 T beanToDestroy) {
+        List<BeanRegistration<?>> dependents = registration instanceof DependentBeanProvider provider
+            ? provider.dependentBeans()
+            : Collections.emptyList();
+        if (dependents.isEmpty()) {
+            definition.dispose(this, beanToDestroy);
+            return;
+        }
+        try (DefaultBeanResolutionContext resolutionContext = new DefaultBeanResolutionContext(this, definition)) {
+            resolutionContext.setAttribute(BeanResolutionContext.EXISTING_DEPENDENT_BEANS, dependents);
+            definition.dispose(resolutionContext, this, beanToDestroy);
+        }
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1223,6 +1223,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
      * @param registration  The registration of the bean being destroyed
      * @param beanToDestroy The bean
      * @param <T>           The bean type
+     * @since 5.2.0
      */
     private <T> void disposeBean(DisposableBeanDefinition<T> definition,
                                  BeanRegistration<T> registration,

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1215,9 +1215,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
      * fresh resolution context, so without this the pre-destroy advice would resolve a new interceptor and a
      * {@code @Prototype} interceptor could not release the state it set up in {@code @PostConstruct}.</p>
      *
-     * <p>The registrations are already in hand here: they are the dependents this method's caller destroys once the
-     * bean has been disposed of. Beans that own no dependents, which includes every prototype created through
-     * {@code createBean} and destroyed through {@code destroyBean(Object)}, take the plain path.</p>
+     * <p>The registrations are retained by the bean registration created alongside the bean. Beans created through
+     * {@code createBean} and destroyed through {@code destroyBean(Object)} have no bean registration and therefore
+     * retain the existing fresh-resolution behaviour.</p>
      *
      * @param definition    The disposable definition
      * @param registration  The registration of the bean being destroyed
@@ -1231,12 +1231,23 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         List<BeanRegistration<?>> dependents = registration instanceof DependentBeanProvider provider
             ? provider.dependentBeans()
             : Collections.emptyList();
-        if (dependents.isEmpty()) {
+        List<?> interceptorRegistrations = registration instanceof BeanDisposingRegistration<?> disposingRegistration
+            ? disposingRegistration.getInterceptorRegistrations()
+            : null;
+        if (dependents.isEmpty() && (interceptorRegistrations == null || interceptorRegistrations.isEmpty())) {
             definition.dispose(this, beanToDestroy);
             return;
         }
         try (DefaultBeanResolutionContext resolutionContext = new DefaultBeanResolutionContext(this, definition)) {
-            resolutionContext.setAttribute(BeanResolutionContext.EXISTING_DEPENDENT_BEANS, dependents);
+            if (!dependents.isEmpty()) {
+                resolutionContext.setAttribute(BeanResolutionContext.EXISTING_DEPENDENT_BEANS, dependents);
+            }
+            if (interceptorRegistrations != null && !interceptorRegistrations.isEmpty()) {
+                resolutionContext.setAttribute(
+                    BeanResolutionContext.EXISTING_INTERCEPTOR_REGISTRATIONS,
+                    interceptorRegistrations
+                );
+            }
             definition.dispose(resolutionContext, this, beanToDestroy);
         }
     }
@@ -2916,6 +2927,13 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 } else {
                     throw new BeanInstantiationException("BeanDefinition doesn't support creating a new instance of the bean");
                 }
+                List<?> interceptorRegistrations = null;
+                if (context.getAttribute(BeanResolutionContext.INTERCEPTOR_REGISTRATIONS) instanceof Map<?, ?> registrations) {
+                    Object value = registrations.remove(definition);
+                    if (value instanceof List<?> list) {
+                        interceptorRegistrations = list;
+                    }
+                }
                 bean = postBeanCreated(context, definition, beanType, qualifier, bean);
 
                 BeanRegistration<?> dependentFactoryBean = context.getAndResetDependentFactoryBean();
@@ -2928,7 +2946,14 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 }
                 BeanKey<T> beanKey = new BeanKey<>(beanType, registrationQualifier);
                 List<BeanRegistration<?>> dependentBeans = context.getAndResetDependentBeans();
-                BeanRegistration<T> beanRegistration = BeanRegistration.of(this, beanKey, definition, bean, dependentBeans);
+                BeanRegistration<T> beanRegistration = BeanRegistration.of(
+                    this,
+                    beanKey,
+                    definition,
+                    bean,
+                    dependentBeans,
+                    interceptorRegistrations
+                );
                 context.pushDependentBeans(parentDependentBeans);
                 if (dependent) {
                     context.addDependentBean(beanRegistration);

--- a/src/main/docs/guide/aop/interceptorLifecycle.adoc
+++ b/src/main/docs/guide/aop/interceptorLifecycle.adoc
@@ -1,0 +1,158 @@
+An api:aop.Interceptor[] is an ordinary bean, so its scope decides how many instances exist and how long each one
+lives. That choice matters as soon as an interceptor keeps state, because the framework decides from it whether one
+instance is shared by every intercepted bean or whether each intercepted bean gets its own.
+
+== Interception Kinds
+
+A single interceptor can be bound to more than one kind. The kind also decides which interceptor interface is
+selected: only api:aop.ConstructorInterceptor[] beans are invoked for `AROUND_CONSTRUCT`, and only
+api:aop.MethodInterceptor[] beans for the others. An interceptor that implements neither, that is a plain
+api:aop.Interceptor[], is eligible for every kind it is bound to.
+
+|===
+|Kind |Applies to |Requires
+
+|`AROUND`
+|Every intercepted method of the bean
+|ann:aop.Around[] on the target
+
+|`INTRODUCTION`
+|Every abstract method of the bean
+|ann:aop.Introduction[] on the target
+
+|`AROUND_CONSTRUCT`
+|The bean's constructor
+|ann:aop.AroundConstruct[] on the target
+
+|`POST_CONSTRUCT`
+|The bean's `@PostConstruct` methods
+|`@InterceptorBinding(kind = POST_CONSTRUCT)` on the target
+
+|`PRE_DESTROY`
+|The bean's `@PreDestroy` methods
+|`@InterceptorBinding(kind = PRE_DESTROY)` on the target
+|===
+
+== Interceptor Scope
+
+ann:aop.InterceptorBean[] is meta-annotated with `@Singleton`, so unless you say otherwise an interceptor is a
+singleton:
+
+* *Singleton* – one instance for the whole application context, shared by every intercepted bean and every kind it is
+bound to. It must not hold state that belongs to one intercepted bean, because it will see many. State that belongs to
+one _type_ can be cached against the `ExecutableMethod` or declaring type from the api:aop.InvocationContext[].
+* *Non-singleton* – declare ann:context.annotation.Prototype[], or another non-singleton scope, and the framework
+creates *one instance per intercepted bean*. That instance is then reused for every kind bound to that bean, so state
+set up while the bean is constructed is still there when the bean is destroyed.
+
+.A per-target interceptor
+[source,java]
+----
+@Prototype // <1>
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+public class TrackingInterceptor implements Interceptor<Object, Object> {
+
+    private Registration registration; // <2>
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        MethodInvocationContext<?, ?> method = (MethodInvocationContext<?, ?>) context;
+        if (method.getKind() == InterceptorKind.POST_CONSTRUCT) {
+            registration = Tracker.register(method.getTarget());
+        } else if (method.getKind() == InterceptorKind.PRE_DESTROY) {
+            registration.close(); // <3>
+        }
+        return context.proceed();
+    }
+}
+----
+
+<1> The interceptor overrides the default singleton scope, so one is created per intercepted bean
+<2> State that belongs to a single intercepted bean, which a singleton interceptor could not hold safely
+<3> The same instance handles `@PreDestroy`, so it can release what it acquired in `@PostConstruct`
+
+== Life Cycle of a Non-Singleton Interceptor
+
+For one intercepted bean, in order:
+
+. The interceptors bound to that bean are resolved once, while the bean is being created.
+. `AROUND_CONSTRUCT` interception runs, then the bean's constructor.
+. `POST_CONSTRUCT` interception runs, then the bean's `@PostConstruct` methods.
+. `AROUND` or `INTRODUCTION` interception runs on each method call, for as long as the bean lives.
+. `PRE_DESTROY` interception runs, then the bean's `@PreDestroy` methods.
+. The interceptor is destroyed as a dependent of the intercepted bean, so its own `@PreDestroy` runs *after* the
+target's.
+
+The same instance serves every step. A singleton interceptor follows the same sequence but the instance is shared with
+every other intercepted bean, and it is destroyed with the context rather than with any one target.
+
+Where the interceptors are held depends on the shape of the intercepted bean, which is an implementation detail but
+explains the one case that behaves differently:
+
+|===
+|Target |Held by |Phases sharing one instance
+
+|ann:aop.Around[] advice
+|The generated proxy
+|construct, methods, post-construct, pre-destroy
+
+|`@Around(proxyTarget = true)`
+|The generated proxy
+|construct, methods, post-construct, pre-destroy
+
+|ann:aop.Introduction[] advice
+|The generated proxy
+|methods, post-construct, pre-destroy
+
+|Bean produced by a ann:context.annotation.Factory[] method
+|The generated proxy
+|methods, post-construct, pre-destroy
+
+|ann:aop.AroundConstruct[] advice with no ann:aop.Around[]
+|The bean's registration in the context
+|construct, post-construct, pre-destroy
+
+|A ann:context.annotation.Prototype[] created with `createBean` and destroyed with `destroyBean(Object)`
+|Nothing; the context tracks no registration for it
+|construct and post-construct only
+|===
+
+NOTE: In the last row the context has no registration for the instance, so nothing links its destruction back to what
+it was created with, and `PRE_DESTROY` resolves a new interceptor. Prototypes injected into other beans, and prototypes
+destroyed through their `BeanRegistration`, are unaffected.
+
+== Ordering
+
+When several interceptors apply to the same interception point they run in ascending order, and the order is the same
+in every kind. An interceptor controls its position by implementing `io.micronaut.core.order.Ordered`:
+
+[source,java]
+----
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+public class FirstInterceptor implements Interceptor<Object, Object>, Ordered {
+
+    @Override
+    public int getOrder() {
+        return 10; // runs before an interceptor returning 20
+    }
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+----
+
+== Selection
+
+An interceptor is selected for an interception point when its binding annotation matches the target's, *and* it is
+bound to that kind. Binding to one kind does not imply the others, so an interceptor bound only to `POST_CONSTRUCT`
+never runs for `AROUND`, and an interceptor bound only to `AROUND` never runs for a lifecycle phase. Interceptors bound
+by a different annotation are never applied to the bean.
+
+TIP: Reuse of one interceptor instance across the phases of a proxied bean is part of the generated proxy. After
+upgrading, recompile intercepted classes so that beans compiled by an earlier version pick it up; until then they
+behave as they did before, resolving an interceptor per interception point.

--- a/src/main/docs/guide/aop/lifecycleAdvice.adoc
+++ b/src/main/docs/guide/aop/lifecycleAdvice.adoc
@@ -42,3 +42,7 @@ snippet::io.micronaut.docs.aop.lifecycle.ProductInterceptors[tags="method-interc
 <1> A new ann:aop.InterceptorBean[] is defined that is a api:aop.MethodInterceptor[]
 <2> `@PostConstruct` interception is handled
 <3> `@PreDestroy` interception is handled
+
+An interceptor bound to these lifecycle kinds is a singleton by default, and one instance is then shared by every bean
+it is applied to. To give each intercepted bean its own interceptor, so that state set up in `@PostConstruct` is still
+available in `@PreDestroy`, see <<interceptorLifecycle, Interceptor Life Cycle>>.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -100,6 +100,7 @@ aop:
   introductionAdvice: Introduction Advice
   adapterAdvice: Method Adapter Advice
   lifecycleAdvice: Bean Life Cycle Advice
+  interceptorLifecycle: Interceptor Life Cycle
   validation:
     title: Validation Advice
   caching:


### PR DESCRIPTION
## Summary

A non-singleton interceptor is already one instance per intercepted bean for constructor and method interception, but `@PostConstruct` and `@PreDestroy` each resolved a fresh one. An interceptor could therefore not release in `@PreDestroy` what it acquired in `@PostConstruct`.

For one advised singleton and one prototype interceptor bound to all kinds, `5.2.x` creates three instances:

```
1:AROUND_CONSTRUCT   1:AROUND   2:POST_CONSTRUCT   3:PRE_DESTROY
```

This makes it one, reused by every phase, and destroyed as a dependent of the target after the target's own `@PreDestroy`.

## What changed

- `InterceptedBeanDefinition` and `ParameterizedInterceptedBeanDefinition` resolve one registration set covering `AROUND_CONSTRUCT`, `POST_CONSTRUCT` and `PRE_DESTROY`, pass it to the constructor chain, and make it visible to post-construct interception of the same bean. A bean with constructor advice runs post-construct interception from *inside* the constructor chain, so the set is pushed before construction and popped after it, keyed by definition so a bean created while another is being constructed reads its own.
- A proxy whose target has lifecycle bindings retains its registrations and exposes them through `Intercepted`. That is the only route surviving from creation to destruction, since `dispose` runs with a fresh resolution context.
- `DefaultBeanContext` hands the registrations a bean owns to the dispose call, so a bean with lifecycle advice and **no** proxy can reuse them for `@PreDestroy`.

Each interception point still filters by its own binding and kind, so the wider binding cannot over-apply an interceptor.

## Also fixed

An interceptor bound to an `@Introduction` annotation was compiled into its own introduction proxy carrying the target's `POST_CONSTRUCT` binding. Creating it ran post-construct interception, which resolved interceptors by binding, found the proxy again and recursed until the stack was exhausted — such a bean could not be created at all on `5.2.x`. `isAopProxyType` already excluded `Interceptor` beans from around advice for this reason; the same guard now applies on the introduction path. This is independent of the rest and could be split out.

## Compatibility

- `initialize`/`dispose` keep their existing signatures and delegate to new overloads that take the registrations.
- `Intercepted.$interceptorRegistrations()` has an empty default, so proxies generated by earlier versions and non-proxy beans fall through to the previous resolve-by-binding path.
- The sharing lives in default methods of the definition interfaces, so definitions compiled by earlier versions pick it up **without recompiling**. Only the proxy-retained path needs a recompile.
- `japiCmp` green on `micronaut-aop`, `micronaut-inject` and `micronaut-core-processor`.

## Known limitation

A prototype created with `createBean` and destroyed with `destroyBean(Object)` has no tracked registration — `findBeanRegistration(Object)` searches only the singleton and custom scopes — so nothing links its destruction back to its creation and `@PreDestroy` resolves a new interceptor. It shares one instance for construction and post-construct. A test pins this. Prototypes injected into other beans are unaffected.

## Verification

| Module | Tests | Failures |
|---|---|---|
| micronaut-inject-java | 4903 | 0 |
| micronaut-inject-groovy | 1053 | 0 |
| micronaut-inject-kotlin | 790 | 0 |
| micronaut-inject | 296 | 0 |
| test-suite | 483 | 0 |

Plus `:micronaut-aop:check`, `:micronaut-core-processor:check` and `validateAssembleDocs`.

21 new specs cover reuse across every phase; ordering and kind selection with several interceptors; the target shapes that reach lifecycle interception by different routes (around, `proxyTarget = true`, introduction, factory-produced, `@AroundConstruct` with no proxy); binding isolation between beans; and that the registrations a proxy exposes are the same list instance it was constructed with, holding the very instances that performed the interception.

## Docs

New **Interceptor Life Cycle** page: the five kinds and which interceptor interface each selects, singleton versus per-target scope, the sequence one bean's interceptor sees, ordering, selection rules, and a table of behaviour per target shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)