### PR TITLE
Fix an interceptor not matching a bean that leaves a binding member at its default

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/chain/AbstractInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/AbstractInterceptorChain.java
@@ -188,7 +188,7 @@ abstract class AbstractInterceptorChain<B, R> implements InvocationContext<B, R>
      * @return The binding
      * @since 3.3.0
      */
-    protected static Collection<AnnotationValue<?>> resolveInterceptorValues(AnnotationMetadata annotationMetadata, InterceptorKind kind) {
+    static Collection<AnnotationValue<?>> resolveInterceptorValues(AnnotationMetadata annotationMetadata, InterceptorKind kind) {
         annotationMetadata = annotationMetadata.getTargetAnnotationMetadata();
         if (annotationMetadata instanceof AnnotationMetadataHierarchy annotationMetadataHierarchy) {
             final List<AnnotationValue<InterceptorBinding>> declaredValues =

--- a/aop/src/main/java/io/micronaut/aop/chain/DefaultInterceptorRegistry.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/DefaultInterceptorRegistry.java
@@ -205,7 +205,7 @@ public final class DefaultInterceptorRegistry implements InterceptorRegistry {
             }
             AnnotationValue<Annotation> otherMembers =
                 applicableValue.getAnnotation(InterceptorBindingQualifier.META_BINDING_VALUES).orElse(null);
-            if (otherMembers != null && !memberBinding.equals(otherMembers)) {
+            if (otherMembers != null && !InterceptorBindingQualifier.bindingValuesMatch(memberBinding, otherMembers)) {
                 continue;
             }
             return true;

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -1430,17 +1430,17 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         if (other == null || !annotationName.equals(other.getAnnotationName())) {
             return false;
         }
-        Map<CharSequence, Object> values = completedValues(this);
-        Map<CharSequence, Object> otherValues = completedValues(other);
-        if (values.size() != otherValues.size()) {
+        Map<CharSequence, Object> members = completedValues(this);
+        Map<CharSequence, Object> otherMembers = completedValues(other);
+        if (members.size() != otherMembers.size()) {
             return false;
         }
-        for (Map.Entry<CharSequence, Object> member : values.entrySet()) {
-            if (!otherValues.containsKey(member.getKey())) {
+        for (Map.Entry<CharSequence, Object> member : members.entrySet()) {
+            if (!otherMembers.containsKey(member.getKey())) {
                 return false;
             }
             Object value = member.getValue();
-            Object otherValue = otherValues.get(member.getKey());
+            Object otherValue = otherMembers.get(member.getKey());
             if (value == null || otherValue == null) {
                 if (value != null || otherValue != null) {
                     return false;

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -1407,6 +1407,62 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         return object.toString();
     }
 
+    /**
+     * Whether this and another annotation value are the same annotation.
+     *
+     * <p>Two values are the same annotation when they name the same annotation and bind the same members to the
+     * same values, with the members neither of them declared filled in from the defaults of the annotation. An
+     * element which leaves a member at its default therefore matches one which writes that default down, which
+     * {@link #equals(Object)} does not do: it compares the members that were declared.</p>
+     *
+     * <p>This is a comparison of every member, where {@link #equals(Object)} passes over a member the other value
+     * does not have. A member can only be left out when it has a default, so filling the defaults in is what makes
+     * every member comparable.</p>
+     *
+     * @param other The other annotation value
+     * @return Whether the two are the same annotation
+     * @since 5.2.0
+     */
+    public boolean matches(@Nullable AnnotationValue<?> other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || !annotationName.equals(other.getAnnotationName())) {
+            return false;
+        }
+        Map<CharSequence, Object> values = completedValues(this);
+        Map<CharSequence, Object> otherValues = completedValues(other);
+        if (values.size() != otherValues.size()) {
+            return false;
+        }
+        for (Map.Entry<CharSequence, Object> member : values.entrySet()) {
+            if (!otherValues.containsKey(member.getKey())) {
+                return false;
+            }
+            Object value = member.getValue();
+            Object otherValue = otherValues.get(member.getKey());
+            if (value == null || otherValue == null) {
+                if (value != null || otherValue != null) {
+                    return false;
+                }
+            } else if (!AnnotationUtil.areEqual(value, otherValue)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Map<CharSequence, Object> completedValues(AnnotationValue<?> value) {
+        Map<CharSequence, Object> defaults = value.getDefaultValues();
+        Map<CharSequence, Object> declared = value.getValues();
+        if (defaults == null || defaults.isEmpty()) {
+            return declared;
+        }
+        Map<CharSequence, Object> completed = new LinkedHashMap<>(defaults);
+        completed.putAll(declared);
+        return completed;
+    }
+
     @Override
     public int hashCode() {
         return 31 * annotationName.hashCode() + AnnotationUtil.calculateHashCode(getValues());

--- a/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueSpec.groovy
@@ -216,6 +216,76 @@ class AnnotationValueSpec extends Specification {
         av.getAnnotation("bar", Bar.class).get() == innerAv
         av.getAnnotation("bars", Bar.class).get() == innerAv
     }
+    void "test matches() fills the members neither value declared in from the defaults"() {
+        given:
+        def defaults = [level: "INFO"] as Map<CharSequence, Object>
+        def declared = new AnnotationValue("test.Audited", [level: "INFO"] as Map<CharSequence, Object>, defaults)
+        def omitted = new AnnotationValue("test.Audited", [:] as Map<CharSequence, Object>, defaults)
+        def other = new AnnotationValue("test.Audited", [level: "DEBUG"] as Map<CharSequence, Object>, defaults)
+
+        expect: "the declared default and the omitted one are the same annotation"
+        declared.matches(omitted)
+        omitted.matches(declared)
+
+        and: "a member declared as something else is not"
+        !declared.matches(other)
+        !omitted.matches(other)
+
+        and: "equals() still compares the members that were declared"
+        declared != omitted
+    }
+
+    void "test matches() compares the annotation name"() {
+        given:
+        def av = new AnnotationValue("test.Foo", [value: 1] as Map<CharSequence, Object>)
+
+        expect: "a value matches itself"
+        av.matches(av)
+
+        and:
+        !av.matches(null)
+        !av.matches(new AnnotationValue("test.Bar", [value: 1] as Map<CharSequence, Object>))
+    }
+
+    void "test matches() compares every member"() {
+        given:
+        def av = new AnnotationValue("test.Foo", [one: 1] as Map<CharSequence, Object>)
+
+        expect: "a value with a member the other does not have is not the same annotation"
+        !av.matches(new AnnotationValue("test.Foo", [one: 1, two: 2] as Map<CharSequence, Object>))
+        !new AnnotationValue("test.Foo", [one: 1, two: 2] as Map<CharSequence, Object>).matches(av)
+
+        and: "nor is one binding the same number of members under other names"
+        !av.matches(new AnnotationValue("test.Foo", [two: 1] as Map<CharSequence, Object>))
+
+        and: "nor one binding the same member to something else"
+        !av.matches(new AnnotationValue("test.Foo", [one: 2] as Map<CharSequence, Object>))
+
+        and:
+        av.matches(new AnnotationValue("test.Foo", [one: 1] as Map<CharSequence, Object>))
+    }
+
+    void "test matches() compares a member bound to null"() {
+        given:
+        def nullValue = new AnnotationValue("test.Foo", [one: null] as Map<CharSequence, Object>)
+        def value = new AnnotationValue("test.Foo", [one: 1] as Map<CharSequence, Object>)
+
+        expect:
+        nullValue.matches(new AnnotationValue("test.Foo", [one: null] as Map<CharSequence, Object>))
+        !nullValue.matches(value)
+        !value.matches(nullValue)
+    }
+
+    void "test matches() with no defaults to fill in"() {
+        given: "one value carrying no defaults and one carrying an empty map of them"
+        def noDefaults = new AnnotationValue("test.Foo", [one: 1] as Map<CharSequence, Object>, (Map<CharSequence, Object>) null)
+        def emptyDefaults = new AnnotationValue("test.Foo", [one: 1] as Map<CharSequence, Object>, [:] as Map<CharSequence, Object>)
+
+        expect: "the declared members are compared as they are"
+        noDefaults.matches(emptyDefaults)
+        emptyDefaults.matches(noDefaults)
+        !noDefaults.matches(new AnnotationValue("test.Foo", [:] as Map<CharSequence, Object>, (Map<CharSequence, Object>) null))
+    }
 }
 
 @interface Bar {}

--- a/inject-java/src/test/groovy/io/micronaut/aop/binding/BindingMemberDefaultsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/binding/BindingMemberDefaultsSpec.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.binding
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.core.annotation.AnnotationValue
+
+/**
+ * An interceptor binding whose members take part in the binding is compared by the members the annotation has,
+ * the defaulted ones included.
+ */
+class BindingMemberDefaultsSpec extends AbstractTypeElementSpec {
+
+    private static final String SOURCE = '''
+package bindingdefaults;
+
+import io.micronaut.aop.*;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.ArrayList;
+import java.util.List;
+
+// no @Around: an annotation carrying both @Around and @InterceptorBinding(bindMembers = true) records two
+// interceptor bindings, and the one @Around produces carries no members and so matches anything
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@InterceptorBinding(kind = InterceptorKind.AROUND, bindMembers = true)
+@interface Zone {
+    String value() default "north";
+}
+
+@Singleton
+@Zone("north")
+class NorthInterceptor implements MethodInterceptor<Object, Object> {
+
+    static final List<String> INTERCEPTED = new ArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        INTERCEPTED.add(context.getTarget().getClass().getSimpleName());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Zone
+class DefaultedTarget {
+    String work() {
+        return "done";
+    }
+}
+
+@Singleton
+@Zone("north")
+class DeclaredTarget {
+    String work() {
+        return "done";
+    }
+}
+
+@Singleton
+@Zone("south")
+class OtherTarget {
+    String work() {
+        return "done";
+    }
+}
+'''
+
+    void 'a defaulted member and the default written down are one binding'() {
+        given:
+        def context = buildContext(SOURCE)
+        def intercepted = context.classLoader.loadClass('bindingdefaults.NorthInterceptor').INTERCEPTED
+        intercepted.clear()
+
+        when: 'a target declaring the default, one writing it down, and one declaring something else are called'
+        ['DefaultedTarget', 'DeclaredTarget', 'OtherTarget'].each {
+            def bean = context.getBean(context.classLoader.loadClass("bindingdefaults.$it"))
+            bean.work()
+        }
+
+        then: 'the interceptor bound to @Zone("north") ran on the first two and not on the third'
+        intercepted.findAll { it.contains('DefaultedTarget') }.size() == 1
+        intercepted.findAll { it.contains('DeclaredTarget') }.size() == 1
+        intercepted.findAll { it.contains('OtherTarget') }.isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'the values recorded for an element are the ones it declared'() {
+        given:
+        def context = buildContext(SOURCE)
+
+        expect: 'nothing about what is generated changed, so metadata of an earlier version compares alike'
+        bindingValues(context, 'bindingdefaults.DefaultedTarget').first().getValues().isEmpty()
+        bindingValues(context, 'bindingdefaults.DeclaredTarget').first().stringValue().get() == 'north'
+
+        cleanup:
+        context.close()
+    }
+
+    private static List<AnnotationValue<?>> bindingValues(context, String type) {
+        def definition = context.getBeanDefinition(context.classLoader.loadClass(type))
+        definition.getAnnotationMetadata()
+                .getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING)
+                .findAll { it.stringValue().isPresent() }
+                .collect { it.getAnnotation('$bindingValues').orElse(null) }
+                .findAll { it != null }
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/InterceptorBindingQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/InterceptorBindingQualifier.java
@@ -126,7 +126,8 @@ public final class InterceptorBindingQualifier<T> extends FilteringQualifier<T> 
                     interceptorBinding.getAnnotation(META_BINDING_VALUES).orElse(null);
                 boolean matched = true;
                 for (AnnotationValue<?> binding : bindingList) {
-                    matched = matched && (!binding.isPresent(META_BINDING_VALUES) || otherBinding != null && binding.equals(otherBinding));
+                    matched = matched && (!binding.isPresent(META_BINDING_VALUES)
+                        || otherBinding != null && bindingValuesMatch(otherBinding, binding));
                 }
                 return matched;
             }
@@ -144,7 +145,8 @@ public final class InterceptorBindingQualifier<T> extends FilteringQualifier<T> 
                     final AnnotationValue<Annotation> otherBinding =
                         annotation.getAnnotation(META_BINDING_VALUES).orElse(null);
                     for (AnnotationValue<?> binding : bindingList) {
-                        matched = (!binding.isPresent(META_BINDING_VALUES) || otherBinding != null && binding.equals(otherBinding));
+                        matched = (!binding.isPresent(META_BINDING_VALUES)
+                            || otherBinding != null && bindingValuesMatch(otherBinding, binding));
                         if (matched) {
                             break;
                         }
@@ -159,6 +161,26 @@ public final class InterceptorBindingQualifier<T> extends FilteringQualifier<T> 
             }
             return matched;
         }
+    }
+
+    /**
+     * Whether the members an interceptor binds by are the members the intercept point binds by.
+     *
+     * <p>The values recorded for an element are the members it declared, so an element leaving a defaulted member
+     * out records something other than one writing the default down. The two are the same annotation, and
+     * {@link AnnotationValue#matches(AnnotationValue)} compares them as such.</p>
+     *
+     * @param interceptorValues    The members the interceptor binds by, or {@code null} when it binds by none
+     * @param interceptPointValues The members the intercept point binds by, or {@code null} when it has none
+     * @return Whether the two are the same binding
+     */
+    @Internal
+    public static boolean bindingValuesMatch(@Nullable AnnotationValue<?> interceptorValues,
+                                             @Nullable AnnotationValue<?> interceptPointValues) {
+        if (interceptorValues == null) {
+            return true;
+        }
+        return interceptorValues.matches(interceptPointValues);
     }
 
     @Override

--- a/inject/src/test/groovy/io/micronaut/inject/qualifiers/InterceptorBindingValuesMatchSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/qualifiers/InterceptorBindingValuesMatchSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.inject.qualifiers
+
+import io.micronaut.core.annotation.AnnotationValue
+import spock.lang.Specification
+
+class InterceptorBindingValuesMatchSpec extends Specification {
+
+    void "test an interceptor binding by no members matches any intercept point"() {
+        expect:
+        InterceptorBindingQualifier.bindingValuesMatch(null, null)
+        InterceptorBindingQualifier.bindingValuesMatch(null, bindingValues(level: "INFO"))
+    }
+
+    void "test an interceptor binding by members matches the members meaning the same"() {
+        given:
+        def defaults = [level: "INFO"] as Map<CharSequence, Object>
+        def interceptor = new AnnotationValue("test.Binding", [level: "INFO"] as Map<CharSequence, Object>, defaults)
+        def omitted = new AnnotationValue("test.Binding", [:] as Map<CharSequence, Object>, defaults)
+        def different = new AnnotationValue("test.Binding", [level: "DEBUG"] as Map<CharSequence, Object>, defaults)
+
+        expect: "an intercept point leaving the member at its default is the same binding"
+        InterceptorBindingQualifier.bindingValuesMatch(interceptor, omitted)
+
+        and: "one binding the member to something else is not"
+        !InterceptorBindingQualifier.bindingValuesMatch(interceptor, different)
+
+        and: "nor is an intercept point binding by no members at all"
+        !InterceptorBindingQualifier.bindingValuesMatch(interceptor, null)
+    }
+
+    private static AnnotationValue<?> bindingValues(Map<CharSequence, Object> values) {
+        new AnnotationValue("test.Binding", values)
+    }
+}


### PR DESCRIPTION
## The bug

An interceptor bound to an annotation member does not intercept a bean that leaves that member at its default, although the two declarations mean the same thing.

Take an auditing interceptor, bound by the level it audits at:

```java
@Retention(RUNTIME)
@Target({ElementType.TYPE, ElementType.METHOD})
@InterceptorBinding(kind = InterceptorKind.AROUND, bindMembers = true)
public @interface Audited {
    Level level() default Level.INFO;
}

@Singleton
@Audited(level = Level.INFO)
public class InfoAuditInterceptor implements MethodInterceptor<Object, Object> {

    @Override
    public Object intercept(MethodInvocationContext<Object, Object> context) {
        LOG.info("{}", context.getTargetMethod());
        return context.proceed();
    }
}
```

A service that wants the default level writes:

```java
@Singleton
@Audited
public class PaymentService {

    public Receipt pay(Order order) { ... }
}
```

`pay` is not audited. Writing `@Audited(level = Level.INFO)` on the service instead makes it work. Nothing is logged or thrown to say why the first form did not, so it reads as the interceptor being broken.

The cause is that `InterceptorBindingMembers` builds `$bindingValues` from `annotationValue.getValues()`, which holds the members the element declared. The interceptor records `@Audited(level = INFO)` and the service records `@Audited()`, and the two are compared as different bindings.

## The fix

`AnnotationValue.matches` compares two values as the same annotation: the members neither of them declared are filled in from the defaults of the annotation, and every member is then compared. The recorded values carry their own defaults, so it needs nothing but the values themselves.

```java
public boolean matches(@Nullable AnnotationValue<?> other)
```

`InterceptorBindingQualifier` and `DefaultInterceptorRegistry` compare a binding with it, so `@Audited` and `@Audited(level = Level.INFO)` are one binding, while a service annotated `@Audited(level = Level.DEBUG)` is still not intercepted by the INFO interceptor.

`equals` and `hashCode` are deliberately untouched. `equals` compares the members that were declared, which is what everything comparing annotation metadata expects and what `hashCode` is consistent with — `AbstractInterceptorChain.resolveInterceptorValues` collects these values into a `HashSet`, so the two have to stay in step. `matches` is the comparison to reach for when two declarations of one annotation should be judged by what they mean.

`AbstractInterceptorChain.resolveInterceptorValues` is package private rather than `protected`. The class is `@Internal`, and every caller and both subclasses are in its own package, so `protected` granted access nobody had a use for.

## Compatibility

Comparing rather than recording is what keeps this compatible.

- **What the processor writes is unchanged.** A class compiled by an earlier version of Micronaut carries the metadata it always did and is compared exactly as a class compiled by this one. Filling the defaults in when the values are recorded would instead have made an interceptor from an older jar stop matching a newly compiled element.
- **`equals` and `hashCode` keep their current contract**, so nothing outside interceptor binding comparison changes.
- **One pair of bindings stops matching, and it was matching on members neither side declared.** `equals` compares sizes and then skips any member the other value does not have, so `@Audited(level = INFO)` and a hypothetical `@Audited(logger = "x")` compare equal. `matches` compares every member instead. A member can only be left out when it has a default, so where an annotation has no defaults the two comparisons agree, and the case cannot arise there because a member without a default cannot be omitted.
- No API is removed, and the visibility change narrows rather than widens.

## Tests

`BindingMemberDefaultsSpec` asserts the behaviour, and that what is recorded is unchanged. Without the change the first of the two fails, with the bean that relies on the default going unintercepted. The `inject-java` and `inject-groovy` suites pass.

## A related bug, not fixed here

Had `@Audited` above been written the other way round, with `@Around` alongside the binding, the symptom would have been the opposite and worse: **every** `@Audited` bean intercepted, whatever level it asked for.

`InterceptorBindingMembers` emits one `@InterceptorBinding` per stereotype, and the `@Around` branch carries no members. An annotation declaring both therefore records two bindings, and `DefaultInterceptorRegistry.matches` returns `true` on reaching the memberless one, so member binding is silently defeated.

That bug hides this one wherever `@Around` is used, which is why the annotation above declares `@InterceptorBinding(kind = AROUND)` instead — it triggers the proxy on its own. Existing tests do not catch it because they never combine the two with members: `AroundCompileSpec`'s `@TestAnn` has members but no `@Around`, and `AroundConstructCompileSpec`'s `FooClassBinding` has `@Around(proxyTarget = true)` but no members. Happy to fix it here as well if you would rather have the two together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
