### PR TITLE
Compare the members of a qualifier built from an annotation instance

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/cdiscenarios/QualifierMemberSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/cdiscenarios/QualifierMemberSpec.groovy
@@ -167,33 +167,68 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 interface Fish {
 }
 
-@Chunky(kind = Kind.COD, caught = String.class, seas = {"north", "baltic"}, weights = {1, 2})
+@Chunky(kind = Kind.COD, kinds = {Kind.COD, Kind.HADDOCK}, caught = String.class, caughts = {String.class},
+        seas = {"north", "baltic"}, weights = {1, 2}, net = @Net(mesh = 3), nets = {@Net(mesh = 4)})
 @Prototype
 class Cod implements Fish {
 }
 
-@Chunky(kind = Kind.COD, caught = String.class, seas = {"north", "baltic"}, weights = {1, 2})
-class SameChunk {
+@Prototype
+class Haddock implements Fish {
 }
 
-@Chunky(kind = Kind.HADDOCK, caught = String.class, seas = {"north", "baltic"}, weights = {1, 2})
+@Chunky(kind = Kind.COD, kinds = {Kind.COD, Kind.HADDOCK}, caught = String.class, caughts = {String.class},
+        seas = {"north", "baltic"}, weights = {1, 2}, net = @Net(mesh = 3), nets = {@Net(mesh = 4)})
+class Same {
+}
+
+@Chunky(kind = Kind.HADDOCK, kinds = {Kind.COD, Kind.HADDOCK}, caught = String.class, caughts = {String.class},
+        seas = {"north", "baltic"}, weights = {1, 2}, net = @Net(mesh = 3), nets = {@Net(mesh = 4)})
 class OtherKind {
 }
 
-@Chunky(kind = Kind.COD, caught = Integer.class, seas = {"north", "baltic"}, weights = {1, 2})
-class OtherClass {
+@Chunky(kind = Kind.COD, kinds = {Kind.HADDOCK, Kind.COD}, caught = String.class, caughts = {String.class},
+        seas = {"north", "baltic"}, weights = {1, 2}, net = @Net(mesh = 3), nets = {@Net(mesh = 4)})
+class OtherKinds {
 }
 
-@Chunky(kind = Kind.COD, caught = String.class, seas = {"north"}, weights = {1, 2})
+@Chunky(kind = Kind.COD, kinds = {Kind.COD, Kind.HADDOCK}, caught = Integer.class, caughts = {String.class},
+        seas = {"north", "baltic"}, weights = {1, 2}, net = @Net(mesh = 3), nets = {@Net(mesh = 4)})
+class OtherCaught {
+}
+
+@Chunky(kind = Kind.COD, kinds = {Kind.COD, Kind.HADDOCK}, caught = String.class, caughts = {Integer.class},
+        seas = {"north", "baltic"}, weights = {1, 2}, net = @Net(mesh = 3), nets = {@Net(mesh = 4)})
+class OtherCaughts {
+}
+
+@Chunky(kind = Kind.COD, kinds = {Kind.COD, Kind.HADDOCK}, caught = String.class, caughts = {String.class},
+        seas = {"north"}, weights = {1, 2}, net = @Net(mesh = 3), nets = {@Net(mesh = 4)})
 class OtherSeas {
 }
 
-@Chunky(kind = Kind.COD, caught = String.class, seas = {"north", "baltic"}, weights = {1, 3})
+@Chunky(kind = Kind.COD, kinds = {Kind.COD, Kind.HADDOCK}, caught = String.class, caughts = {String.class},
+        seas = {"north", "baltic"}, weights = {1, 3}, net = @Net(mesh = 3), nets = {@Net(mesh = 4)})
 class OtherWeights {
+}
+
+@Chunky(kind = Kind.COD, kinds = {Kind.COD, Kind.HADDOCK}, caught = String.class, caughts = {String.class},
+        seas = {"north", "baltic"}, weights = {1, 2}, net = @Net(mesh = 5), nets = {@Net(mesh = 4)})
+class OtherNet {
+}
+
+@Chunky(kind = Kind.COD, kinds = {Kind.COD, Kind.HADDOCK}, caught = String.class, caughts = {String.class},
+        seas = {"north", "baltic"}, weights = {1, 2}, net = @Net(mesh = 3), nets = {@Net(mesh = 6)})
+class OtherNets {
 }
 
 enum Kind {
     COD, HADDOCK
+}
+
+@Retention(RUNTIME)
+@interface Net {
+    int mesh();
 }
 
 @Qualifier
@@ -201,23 +236,30 @@ enum Kind {
 @interface Chunky {
     Kind kind();
 
+    Kind[] kinds();
+
     Class<?> caught();
+
+    Class<?>[] caughts();
 
     String[] seas();
 
     int[] weights();
+
+    Net net();
+
+    Net[] nets();
 }
 ''')
         Class<?> fish = context.classLoader.loadClass('qualifiermembershapes.Fish')
 
-        expect: 'the same members of every shape resolve the bean'
-        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.SameChunk'))).size() == 1
+        expect: 'the same members of every shape resolve the bean, and leave the unqualified one out'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.Same'))).size() == 1
 
-        and: 'and a difference in any one of them does not'
-        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.OtherKind'))).isEmpty()
-        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.OtherClass'))).isEmpty()
-        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.OtherSeas'))).isEmpty()
-        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.OtherWeights'))).isEmpty()
+        and: 'and a difference in any one of them resolves nothing'
+        ['OtherKind', 'OtherKinds', 'OtherCaught', 'OtherCaughts', 'OtherSeas', 'OtherWeights', 'OtherNet', 'OtherNets'].every {
+            context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, "qualifiermembershapes.$it"))).isEmpty()
+        }
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/cdiscenarios/QualifierMemberSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/cdiscenarios/QualifierMemberSpec.groovy
@@ -1,0 +1,273 @@
+package io.micronaut.inject.cdiscenarios
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.qualifiers.Qualifiers
+
+import java.lang.annotation.Annotation
+
+/**
+ * CDI 2.4.2: the members of a qualifier take part in resolution, so a bean qualified
+ * {@code @Chunky(realChunky = true)} does not satisfy an injection point qualified
+ * {@code @Chunky(realChunky = false)}.
+ */
+class QualifierMemberSpec extends AbstractTypeElementSpec {
+
+    void 'test byAnnotation(Annotation) compares the qualifier members'() {
+        given:
+        def context = buildContext('''
+package qualifiermember;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+interface Fish {
+}
+
+@Chunky(realChunky = true)
+@Prototype
+class Cod implements Fish {
+}
+
+@Chunky(realChunky = true)
+class ReallyChunky {
+}
+
+@Chunky(realChunky = false)
+class NotReallyChunky {
+}
+
+@Qualifier
+@Retention(RUNTIME)
+@interface Chunky {
+    boolean realChunky();
+}
+''')
+        Class<?> fish = context.classLoader.loadClass('qualifiermember.Fish')
+        Annotation chunkyTrue = annotationOn(context, 'qualifiermember.ReallyChunky')
+        Annotation chunkyFalse = annotationOn(context, 'qualifiermember.NotReallyChunky')
+
+        expect: 'the bean is resolved by a qualifier carrying the same member value'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(chunkyTrue)).size() == 1
+
+        and: 'and is not resolved by one carrying a different member value'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(chunkyFalse)).isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test byAnnotation(Annotation) matches a member left at its default'() {
+        given:
+        def context = buildContext('''
+package qualifiermemberdefault;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+interface Fish {
+}
+
+@Chunky
+@Prototype
+class Cod implements Fish {
+}
+
+@Chunky(realChunky = false)
+class NotReallyChunky {
+}
+
+@Chunky(realChunky = true)
+class ReallyChunky {
+}
+
+@Qualifier
+@Retention(RUNTIME)
+@interface Chunky {
+    boolean realChunky() default false;
+}
+''')
+        Class<?> fish = context.classLoader.loadClass('qualifiermemberdefault.Fish')
+        Annotation chunkyFalse = annotationOn(context, 'qualifiermemberdefault.NotReallyChunky')
+        Annotation chunkyTrue = annotationOn(context, 'qualifiermemberdefault.ReallyChunky')
+
+        expect: 'writing the default down is the same qualifier as leaving it out'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(chunkyFalse)).size() == 1
+
+        and: 'and the other value still does not resolve it'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(chunkyTrue)).isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test byAnnotation(Annotation) ignores @NonBinding members'() {
+        given:
+        def context = buildContext('''
+package qualifiermembernonbinding;
+
+import io.micronaut.context.annotation.NonBinding;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+interface Fish {
+}
+
+@Chunky(realChunky = true, description = "a chunky cod")
+@Prototype
+class Cod implements Fish {
+}
+
+@Chunky(realChunky = true, description = "something else entirely")
+class ReallyChunky {
+}
+
+@Chunky(realChunky = false, description = "a chunky cod")
+class NotReallyChunky {
+}
+
+@Qualifier
+@Retention(RUNTIME)
+@interface Chunky {
+    boolean realChunky();
+
+    @NonBinding
+    String description() default "";
+}
+''')
+        Class<?> fish = context.classLoader.loadClass('qualifiermembernonbinding.Fish')
+        Annotation chunkyTrue = annotationOn(context, 'qualifiermembernonbinding.ReallyChunky')
+        Annotation chunkyFalse = annotationOn(context, 'qualifiermembernonbinding.NotReallyChunky')
+
+        expect: 'the non-binding member does not stop the binding member from matching'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(chunkyTrue)).size() == 1
+
+        and: 'and does not make the binding member match'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(chunkyFalse)).isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test byAnnotation(Annotation) compares members of every shape'() {
+        given:
+        def context = buildContext('''
+package qualifiermembershapes;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+interface Fish {
+}
+
+@Chunky(kind = Kind.COD, caught = String.class, seas = {"north", "baltic"}, weights = {1, 2})
+@Prototype
+class Cod implements Fish {
+}
+
+@Chunky(kind = Kind.COD, caught = String.class, seas = {"north", "baltic"}, weights = {1, 2})
+class SameChunk {
+}
+
+@Chunky(kind = Kind.HADDOCK, caught = String.class, seas = {"north", "baltic"}, weights = {1, 2})
+class OtherKind {
+}
+
+@Chunky(kind = Kind.COD, caught = Integer.class, seas = {"north", "baltic"}, weights = {1, 2})
+class OtherClass {
+}
+
+@Chunky(kind = Kind.COD, caught = String.class, seas = {"north"}, weights = {1, 2})
+class OtherSeas {
+}
+
+@Chunky(kind = Kind.COD, caught = String.class, seas = {"north", "baltic"}, weights = {1, 3})
+class OtherWeights {
+}
+
+enum Kind {
+    COD, HADDOCK
+}
+
+@Qualifier
+@Retention(RUNTIME)
+@interface Chunky {
+    Kind kind();
+
+    Class<?> caught();
+
+    String[] seas();
+
+    int[] weights();
+}
+''')
+        Class<?> fish = context.classLoader.loadClass('qualifiermembershapes.Fish')
+
+        expect: 'the same members of every shape resolve the bean'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.SameChunk'))).size() == 1
+
+        and: 'and a difference in any one of them does not'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.OtherKind'))).isEmpty()
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.OtherClass'))).isEmpty()
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.OtherSeas'))).isEmpty()
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(annotationOn(context, 'qualifiermembershapes.OtherWeights'))).isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test byAnnotation(Annotation) still matches a qualifier with no members by type'() {
+        given:
+        def context = buildContext('''
+package qualifiermembernone;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+interface Fish {
+}
+
+@Chunky
+@Prototype
+class Cod implements Fish {
+}
+
+@Prototype
+class Haddock implements Fish {
+}
+
+@Chunky
+class Chunk {
+}
+
+@Qualifier
+@Retention(RUNTIME)
+@interface Chunky {
+}
+''')
+        Class<?> fish = context.classLoader.loadClass('qualifiermembernone.Fish')
+        Annotation chunky = annotationOn(context, 'qualifiermembernone.Chunk')
+
+        expect:
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(chunky)).size() == 1
+
+        cleanup:
+        context.close()
+    }
+
+    private static Annotation annotationOn(context, String className) {
+        Class<?> holder = context.classLoader.loadClass(className)
+        Annotation annotation = holder.annotations.find { it.annotationType().simpleName == 'Chunky' }
+        assert annotation != null
+        return annotation
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
@@ -138,8 +138,9 @@ final class AnnotationMetadataQualifier<T> extends FilteringQualifier<T> {
     }
 
     /**
-     * A member read off an annotation instance, or {@code null} when the annotation type is not open to this
-     * module and so cannot be read. A member of an annotation is never null itself, so the two do not overlap.
+     * A member read off an annotation instance, or {@code null} when it cannot be read: the annotation type is
+     * not open to this module, or the instance would not answer for the member. A member of an annotation is
+     * never null itself, so the two do not overlap.
      *
      * <p>A qualifier that cannot read one of its members cannot compare it either, and it goes on qualifying by
      * its type alone rather than by the members it did manage to read.</p>

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
@@ -15,21 +15,27 @@
  */
 package io.micronaut.inject.qualifiers;
 
+import io.micronaut.context.annotation.NonBinding;
+import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanType;
 import io.micronaut.inject.QualifiedBeanType;
+import io.micronaut.inject.annotation.AnnotationMetadataSupport;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -85,6 +91,130 @@ final class AnnotationMetadataQualifier<T> extends FilteringQualifier<T> {
         );
     }
 
+    /**
+     * The qualifier for an annotation instance, comparing the members it was written with.
+     *
+     * <p>An annotation instance answers every one of its members, so the members are read off it directly rather
+     * than out of metadata, and the ones {@link NonBinding} excludes from the comparison are left out the same way
+     * they are left out of a candidate's.</p>
+     *
+     * @param annotation The annotation
+     * @param <T>        The type
+     * @return The qualifier, or {@code null} when the annotation has no member to compare and so qualifies by its
+     *         type alone
+     */
+    @Nullable
+    static <T> AnnotationMetadataQualifier<T> fromAnnotation(Annotation annotation) {
+        Class<? extends Annotation> annotationType = annotation.annotationType();
+        Map<CharSequence, Object> bindingValues = resolveAnnotationBindingValues(annotation);
+        if (bindingValues == null || bindingValues.isEmpty()) {
+            return null;
+        }
+        return new AnnotationMetadataQualifier<>(
+            annotationType.getName(),
+            annotationType.getSimpleName(),
+            new AnnotationValue<>(annotationType.getName(), bindingValues)
+        );
+    }
+
+    /**
+     * The members of an annotation instance that take part in the comparison of two qualifiers, or {@code null}
+     * when one of them cannot be read.
+     */
+    @Nullable
+    private static Map<CharSequence, Object> resolveAnnotationBindingValues(Annotation annotation) {
+        Map<CharSequence, Object> bindingValues = new LinkedHashMap<>();
+        for (Method member : annotation.annotationType().getDeclaredMethods()) {
+            if (member.getParameterCount() != 0 || member.isSynthetic() || member.isAnnotationPresent(NonBinding.class)) {
+                continue;
+            }
+            Object value = readMember(annotation, member);
+            if (value == null) {
+                return null;
+            }
+            bindingValues.put(member.getName(), asMemberValue(value));
+        }
+        return bindingValues;
+    }
+
+    /**
+     * A member read off an annotation instance, or {@code null} when the annotation type is not open to this
+     * module and so cannot be read. A member of an annotation is never null itself, so the two do not overlap.
+     *
+     * <p>A qualifier that cannot read one of its members cannot compare it either, and it goes on qualifying by
+     * its type alone rather than by the members it did manage to read.</p>
+     */
+    @Nullable
+    private static Object readMember(Annotation annotation, Method member) {
+        try {
+            return ReflectionUtils.invokeInaccessibleMethod(annotation, member);
+        } catch (RuntimeException e) {
+            // the member of an annotation this module cannot read is a member it cannot compare
+            return null;
+        }
+    }
+
+    /**
+     * A member value read off an annotation instance, as the metadata of an annotated element records it: a class
+     * is recorded as an {@link AnnotationClassValue}, an enum by the name of its constant and a nested annotation
+     * as an {@link AnnotationValue}, so that the two sides of the comparison are the same values.
+     */
+    private static Object asMemberValue(Object value) {
+        if (value instanceof Class<?> type) {
+            return new AnnotationClassValue<>(type);
+        }
+        if (value instanceof Enum<?> constant) {
+            return constant.name();
+        }
+        if (value instanceof Annotation nested) {
+            return asAnnotationValue(nested);
+        }
+        if (value instanceof Class<?>[] types) {
+            AnnotationClassValue<?>[] classValues = new AnnotationClassValue[types.length];
+            for (int i = 0; i < types.length; i++) {
+                classValues[i] = new AnnotationClassValue<>(types[i]);
+            }
+            return classValues;
+        }
+        if (value instanceof Enum<?>[] constants) {
+            String[] names = new String[constants.length];
+            for (int i = 0; i < constants.length; i++) {
+                names[i] = constants[i].name();
+            }
+            return names;
+        }
+        if (value instanceof Annotation[] nested) {
+            AnnotationValue<?>[] annotationValues = new AnnotationValue[nested.length];
+            for (int i = 0; i < nested.length; i++) {
+                annotationValues[i] = asAnnotationValue(nested[i]);
+            }
+            return annotationValues;
+        }
+        return value;
+    }
+
+    private static AnnotationValue<Annotation> asAnnotationValue(Annotation nested) {
+        return new AnnotationValue<>(nested.annotationType().getName(), resolveAllValues(nested));
+    }
+
+    /**
+     * Every member of a nested annotation. {@link NonBinding} excludes a member from the comparison of the
+     * qualifier it is declared on, which is the annotation on the element, so a nested one is read whole.
+     */
+    private static Map<CharSequence, Object> resolveAllValues(Annotation annotation) {
+        Map<CharSequence, Object> values = new LinkedHashMap<>();
+        for (Method member : annotation.annotationType().getDeclaredMethods()) {
+            if (member.getParameterCount() != 0 || member.isSynthetic()) {
+                continue;
+            }
+            Object value = readMember(annotation, member);
+            if (value != null) {
+                values.put(member.getName(), asMemberValue(value));
+            }
+        }
+        return values;
+    }
+
     @Override
     public boolean doesQualify(Class<T> beanType, BeanType<T> candidate) {
         if (QualifierUtils.match(candidate, this)) {
@@ -108,16 +238,25 @@ final class AnnotationMetadataQualifier<T> extends FilteringQualifier<T> {
     }
 
     private <BT extends BeanType<T>> boolean matchByAnnotationMetadata(BT candidate) {
+        AnnotationMetadata candidateMetadata = candidate.getAnnotationMetadata();
         if (qualifierAnn == null) {
-            return candidate.getAnnotationMetadata().hasAnnotation(annotationName);
+            return candidateMetadata.hasAnnotation(annotationName);
         }
-        AnnotationValue<Annotation> val = resolveBindingAnnotationValue(candidate.getAnnotationMetadata());
-        return val != null && qualifierAnn.equals(val);
+        if (!candidateMetadata.hasAnnotation(annotationName)) {
+            return false;
+        }
+        // the values recorded for an element are the members it declared, so a candidate leaving a member at its
+        // default records something other than a qualifier writing that default down. The two are the same
+        // annotation, and AnnotationValue#matches compares them as such, filling in the members neither of them
+        // declared from the one set of defaults both sides are given here
+        Map<CharSequence, Object> defaults = AnnotationMetadataSupport.getDefaultValues(annotationName);
+        return withDefaults(qualifierAnn.getValues(), defaults)
+            .matches(withDefaults(resolveBindingValues(candidateMetadata, candidateMetadata.getValues(annotationName)), defaults));
     }
 
-    @Nullable
-    private <K extends Annotation> AnnotationValue<K> resolveBindingAnnotationValue(AnnotationMetadata annotationMetadata) {
-        return resolveBindingAnnotationValue(annotationMetadata, annotationName, annotationMetadata.getValues(annotationName));
+    private AnnotationValue<Annotation> withDefaults(Map<CharSequence, Object> bindingValues,
+                                                     Map<CharSequence, Object> defaults) {
+        return new AnnotationValue<>(annotationName, bindingValues, defaults);
     }
 
     @Nullable
@@ -137,7 +276,6 @@ final class AnnotationMetadataQualifier<T> extends FilteringQualifier<T> {
         return null;
     }
 
-    @Nullable
     private static Map<CharSequence, Object> resolveBindingValues(AnnotationMetadata annotationMetadata,
                                                                   Map<CharSequence, Object> values) {
         Set<String> nonBinding = resolveNonBindingMembers(annotationMetadata);

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
@@ -193,6 +193,12 @@ public class Qualifiers {
     /**
      * Build a qualifier for the given annotation.
      *
+     * <p>The members of the annotation take part in the comparison, the way they do for
+     * {@link #byAnnotation(AnnotationMetadata, AnnotationValue)}: a candidate qualified {@code @Chunky(true)} does
+     * not qualify for {@code @Chunky(false)}, and a member annotated {@link io.micronaut.context.annotation.NonBinding}
+     * is left out of the comparison from either side. An annotation with no member to compare qualifies by its type
+     * alone.</p>
+     *
      * @param annotation The annotation
      * @param <T>        The component type
      * @return The qualifier
@@ -201,6 +207,10 @@ public class Qualifiers {
         Qualifier<T> qualifier = findCustomByType(AnnotationMetadata.EMPTY_METADATA, annotation.annotationType());
         if (qualifier != null) {
             return qualifier;
+        }
+        Qualifier<T> byMembers = AnnotationMetadataQualifier.fromAnnotation(annotation);
+        if (byMembers != null) {
+            return byMembers;
         }
         return new AnnotationQualifier<>(annotation);
     }

--- a/inject/src/test/groovy/io/micronaut/inject/qualifiers/QualifierByAnnotationSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/qualifiers/QualifierByAnnotationSpec.groovy
@@ -1,0 +1,71 @@
+package io.micronaut.inject.qualifiers
+
+import spock.lang.Specification
+
+import java.lang.annotation.Annotation
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Proxy
+
+class QualifierByAnnotationSpec extends Specification {
+
+    void 'test a qualifier annotation with members is compared by them'() {
+        expect:
+        Qualifiers.byAnnotation(chunky(true)) instanceof AnnotationMetadataQualifier
+    }
+
+    void 'test a qualifier annotation with no member qualifies by its type'() {
+        expect:
+        Qualifiers.byAnnotation(plain()) instanceof AnnotationQualifier
+    }
+
+    void 'test a qualifier annotation whose member cannot be read qualifies by its type'() {
+        given: 'an annotation that will not answer for one of its members'
+        Annotation unreadable = proxy(Chunky) { Object proxy, java.lang.reflect.Method method, Object[] args ->
+            if (method.name == 'annotationType') {
+                return Chunky
+            }
+            throw new UnsupportedOperationException("the member ${method.name} cannot be read")
+        }
+
+        expect: 'the qualifier compares no members rather than the ones it did manage to read'
+        Qualifiers.byAnnotation(unreadable) instanceof AnnotationQualifier
+    }
+
+    private static Chunky chunky(boolean realChunky) {
+        proxy(Chunky) { Object proxy, java.lang.reflect.Method method, Object[] args ->
+            switch (method.name) {
+                case 'annotationType': return Chunky
+                case 'realChunky': return realChunky
+                case 'toString': return "@Chunky(realChunky=$realChunky)"
+                case 'hashCode': return realChunky.hashCode()
+                default: return false
+            }
+        }
+    }
+
+    private static Plain plain() {
+        proxy(Plain) { Object proxy, java.lang.reflect.Method method, Object[] args ->
+            switch (method.name) {
+                case 'annotationType': return Plain
+                case 'toString': return '@Plain'
+                case 'hashCode': return 0
+                default: return false
+            }
+        }
+    }
+
+    private static <A extends Annotation> A proxy(Class<A> type, Closure<?> handler) {
+        (A) Proxy.newProxyInstance(type.classLoader, [type] as Class[], handler as InvocationHandler)
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Chunky {
+        boolean realChunky()
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Plain {
+    }
+}


### PR DESCRIPTION
`Qualifiers.byAnnotation(Annotation)` matches a candidate that carries the annotation whatever its members are, so a bean qualified `@Chunky(realChunky = true)` is resolved by a lookup for `@Chunky(realChunky = false)`:

```java
if (candidate.getAnnotationMetadata().hasDeclaredAnnotation(qualifiedName)) {
    return true;
}
```

The other factory, `byAnnotation(AnnotationMetadata, AnnotationValue)`, returns an `AnnotationMetadataQualifier` and does compare the members, honouring `@NonBinding`. The two entry points disagree, and which one a caller reached for is not something the qualifier it asked for should depend on.

`byAnnotation(Annotation)` now reads the members off the annotation and returns the same qualifier the value-based factory does. An annotation with no member to compare — none declared, or every one of them `@NonBinding` — has nothing the comparison could use and goes on qualifying by its type through `AnnotationQualifier`, which is what it did before.

## What the delegation needed

**The members are read as the metadata of an annotated element records them**, which is not the shape reflection hands back: a class is recorded as an `AnnotationClassValue`, an enum by the name of its constant, a nested annotation as an `AnnotationValue`. Comparing the reflected shape against the recorded one leaves every enum- and class-valued qualifier silently not matching.

**`matchByAnnotationMetadata` compares with `AnnotationValue.matches` rather than `equals`.** An annotation instance answers every one of its members, where the values recorded for an element are the ones it declared, so a bean written `@Chunky` and a qualifier written `@Chunky(realChunky = false)` are the same annotation recorded two ways. That is the comparison https://github.com/micronaut-projects/micronaut-core/commit/3bd4817014 added for interceptor bindings, and it is the same pair of declarations here. Both sides are handed one snapshot of the annotation's defaults, taken as they are compared, so neither can complete its members from a registry the other has since seen more of.

**A member of an annotation type this module cannot reflect into cannot be compared**, and such a qualifier keeps matching by its type rather than by the members it did manage to read. The path is reachable: a qualifier annotation declared package private is not open to plain `Method.invoke`.

## Tests

`QualifierMemberSpec` covers the members being compared, a member left at its default, `@NonBinding`, every shape a member value takes, and the annotation with no member still matching by type. The first of those fails without the change, with `@Chunky(realChunky = false)` resolving the bean qualified `true`.

The `inject-java`, `inject-groovy`, `context`, `inject`, `aop`, `runtime` and `test-suite` suites pass.

## Where it was found

Building a Jakarta CDI Lite implementation on Micronaut. Section 2.4.2 of the specification has the members of a qualifier take part in resolution, and the CDI TCK tests it directly. That project works around this by never calling `byAnnotation(Annotation)` — it converts the annotation to an `AnnotationValue` itself and calls the value-based factory — and the workaround can be dropped once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
