### PR TITLE
Remove a bean from the scope map when a custom scope destroys it

### DIFF
--- a/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
@@ -179,7 +179,7 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
             }
             if (CollectionUtils.isNotEmpty(scopeMap)) {
 
-                final CreatedBean<?> createdBean = scopeMap.get(identifier);
+                final CreatedBean<?> createdBean = scopeMap.remove(identifier);
                 if (createdBean != null) {
                     try {
                         createdBean.close();

--- a/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
@@ -1,0 +1,134 @@
+package io.micronaut.context.scope
+
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanIdentifier
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import java.util.concurrent.ConcurrentHashMap
+
+class AbstractConcurrentCustomScopeSpec extends Specification {
+
+    void "remove evicts the bean so the next resolution creates a new instance"() {
+        given:
+        def scope = new TestScope()
+        def id = BeanIdentifier.of("myBean")
+        def creationContext = new TestCreationContext(id)
+
+        when:
+        def first = scope.getOrCreate(creationContext)
+
+        then:
+        scope.scopeMap.size() == 1
+
+        when:
+        def removed = scope.remove(id)
+
+        then:
+        removed.present
+        removed.get().is(first)
+        creationContext.created[0].closed
+        scope.scopeMap.isEmpty()
+
+        when:
+        def second = scope.getOrCreate(creationContext)
+
+        then:
+        !second.is(first)
+        creationContext.created.size() == 2
+        !creationContext.created[1].closed
+    }
+
+    void "remove of an unknown identifier is empty and leaves the scope untouched"() {
+        given:
+        def scope = new TestScope()
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"))
+        def bean = scope.getOrCreate(creationContext)
+
+        when:
+        def removed = scope.remove(BeanIdentifier.of("otherBean"))
+
+        then:
+        !removed.present
+        scope.scopeMap.size() == 1
+        scope.getOrCreate(creationContext).is(bean)
+    }
+
+    static class TestScope extends AbstractConcurrentCustomScope<Singleton> {
+
+        final Map<BeanIdentifier, CreatedBean<?>> scopeMap = new ConcurrentHashMap<>()
+
+        TestScope() {
+            super(Singleton)
+        }
+
+        @Override
+        boolean isRunning() {
+            return true
+        }
+
+        @Override
+        protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+            return scopeMap
+        }
+
+        @Override
+        void close() {
+            destroyScope(scopeMap)
+        }
+    }
+
+    static class TestCreationContext implements BeanCreationContext<Object> {
+
+        final BeanIdentifier id
+        final List<TestCreatedBean> created = []
+
+        TestCreationContext(BeanIdentifier id) {
+            this.id = id
+        }
+
+        @Override
+        BeanDefinition<Object> definition() {
+            return null
+        }
+
+        @Override
+        BeanIdentifier id() {
+            return id
+        }
+
+        @Override
+        CreatedBean<Object> create() {
+            def createdBean = new TestCreatedBean(id: id, bean: new Object())
+            created << createdBean
+            return createdBean
+        }
+    }
+
+    static class TestCreatedBean implements CreatedBean<Object> {
+
+        BeanIdentifier id
+        Object bean
+        boolean closed
+
+        @Override
+        BeanDefinition<Object> definition() {
+            return null
+        }
+
+        @Override
+        Object bean() {
+            return bean
+        }
+
+        @Override
+        BeanIdentifier id() {
+            return id
+        }
+
+        @Override
+        void close() {
+            closed = true
+        }
+    }
+}


### PR DESCRIPTION
`AbstractConcurrentCustomScope.remove(BeanIdentifier)` looked the bean up with `scopeMap.get(identifier)` and closed it, but never took the entry out of the scope map. The destroyed instance therefore stayed in the map and kept being served: any subsequent resolution through the scope — e.g. a client proxy dereferencing a scoped bean — returned the already destroyed instance forever, instead of triggering the creation of a fresh one.

This changes `remove` to take the entry out of the map (`scopeMap.remove(identifier)`) before closing it, matching what `destroyScope` does (close all + clear) and what `CustomScope` implementations are expected to do.

Includes a regression spec for a custom scope extending `AbstractConcurrentCustomScope`: after `remove(id)` the destroyed instance is evicted and the next resolution creates a new instance, and removing an unknown identifier leaves the scope untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)