### PR TITLE
Fix @InjectScope destruction for constructor parameters and prototype beans

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -3789,10 +3789,14 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     private boolean hasInjectScope() {
         if (factoryMethodDefinition != null) {
-            return hasInjectScope(factoryMethodDefinition.methodElement());
+            MethodElement methodElement = factoryMethodDefinition.methodElement();
+            return hasInjectScope((AnnotationMetadata) methodElement)
+                || hasInjectScope(methodElement.getSuspendParameters());
         }
         if (constructorDefinition != null) {
-            return hasInjectScope(constructorDefinition.constructorElement());
+            MethodElement constructorElement = constructorDefinition.constructorElement();
+            return hasInjectScope((AnnotationMetadata) constructorElement)
+                || hasInjectScope(constructorElement.getSuspendParameters());
         }
         return false;
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectscope/InjectScopeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectscope/InjectScopeSpec.groovy
@@ -75,4 +75,69 @@ class Test {
         cleanup:
         context.close()
     }
+
+    void "test inject scope on a constructor parameter of a prototype bean destroys the bean and notifies listeners"() {
+        given:
+        def context = buildContext('''
+package injectscopeprototype;
+
+import io.micronaut.context.annotation.InjectScope;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Prototype
+class Connection {
+    public boolean open = true;
+
+    @PreDestroy
+    void close() {
+        open = false;
+    }
+}
+
+@Prototype
+class Resource {
+    // no @PreDestroy of its own; destruction is only observable through the listener
+}
+
+@Singleton
+class Holder {
+    public final Connection connection;
+    public final Resource resource;
+
+    Holder(@InjectScope Connection connection, @InjectScope Resource resource) {
+        this.connection = connection;
+        this.resource = resource;
+    }
+}
+
+@Singleton
+class ResourceDestroyListener implements BeanPreDestroyEventListener<Resource> {
+    public final AtomicInteger destroyed = new AtomicInteger();
+
+    @Override
+    public Resource onPreDestroy(BeanPreDestroyEvent<Resource> event) {
+        destroyed.incrementAndGet();
+        return event.getBean();
+    }
+}
+''')
+
+        when:
+        def holder = getBean(context, 'injectscopeprototype.Holder')
+        def listener = getBean(context, 'injectscopeprototype.ResourceDestroyListener')
+
+        then: 'the prototype bean injected with @InjectScope is destroyed once the holder has been resolved'
+        !holder.connection.open
+
+        and: 'pre-destroy listeners run even for a bean with nothing else to dispose'
+        listener.destroyed.get() == 1
+
+        cleanup:
+        context.close()
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2773,7 +2773,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (scope.isPresent()) {
             Class<? extends Annotation> scopeAnnotation = scope.get();
             if (scopeAnnotation == Prototype.class) {
-                return null;
+                // a prototype bean has no lifecycle of its own, so a scope declared on the
+                // injection point (such as @InjectScope) still applies to it
+                return findInjectionPointDeclaredScope(resolutionContext);
             }
             CustomScope<?> customScope = customScopeRegistry.findScope(scopeAnnotation).orElse(null);
             if (customScope != null) {
@@ -2784,7 +2786,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             if (scopeName.isPresent()) {
                 String scopeAnnotation = scopeName.get();
                 if (Prototype.class.getName().equals(scopeAnnotation)) {
-                    return null;
+                    // a prototype bean has no lifecycle of its own, so a scope declared on the
+                    // injection point (such as @InjectScope) still applies to it
+                    return findInjectionPointDeclaredScope(resolutionContext);
                 }
                 CustomScope<?> customScope = customScopeRegistry.findScope(scopeAnnotation).orElse(null);
                 if (customScope != null) {
@@ -2793,6 +2797,19 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             }
         }
 
+        CustomScope<?> injectionPointScope = findInjectionPointDeclaredScope(resolutionContext);
+        if (injectionPointScope != null) {
+            return injectionPointScope;
+        }
+
+        if (!isScopedProxyDefinition || !isProxy) {
+            return customScopeRegistry.findDeclaredScope(definition).orElse(null);
+        }
+        return null;
+    }
+
+    @Nullable
+    private CustomScope<?> findInjectionPointDeclaredScope(@Nullable BeanResolutionContext resolutionContext) {
         if (resolutionContext != null) {
             BeanResolutionContext.Segment<?, ?> currentSegment = resolutionContext
                 .getPath()
@@ -2800,15 +2817,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 .orElse(null);
             if (currentSegment != null) {
                 Argument<?> argument = currentSegment.getArgument();
-                CustomScope<?> customScope = customScopeRegistry.findDeclaredScope(argument).orElse(null);
-                if (customScope != null) {
-                    return customScope;
-                }
+                return customScopeRegistry.findDeclaredScope(argument).orElse(null);
             }
-        }
-
-        if (!isScopedProxyDefinition || !isProxy) {
-            return customScopeRegistry.findDeclaredScope(definition).orElse(null);
         }
         return null;
     }

--- a/inject/src/main/java/io/micronaut/context/DefaultCustomScopeRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultCustomScopeRegistry.java
@@ -42,10 +42,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 1.0
  */
 public class DefaultCustomScopeRegistry implements CustomScopeRegistry {
-    /**
-     * Constant to refer to inject scope.
-     */
-    static final CustomScope<InjectScope> INJECT_SCOPE = new InjectScopeImpl();
+    // one per registry rather than shared: the scope tracks what it created, and destroys it through the
+    // context so that pre-destroy listeners run even for a bean with nothing else to dispose
     private final BeanLocator beanLocator;
     private final Map<String, Optional<CustomScope<?>>> scopes = new ConcurrentHashMap<>(2);
 
@@ -54,7 +52,7 @@ public class DefaultCustomScopeRegistry implements CustomScopeRegistry {
      */
     protected DefaultCustomScopeRegistry(BeanLocator beanLocator) {
         this.beanLocator = beanLocator;
-        this.scopes.put(InjectScope.class.getName(), Optional.of(INJECT_SCOPE));
+        this.scopes.put(InjectScope.class.getName(), Optional.of(new InjectScopeImpl(beanLocator)));
     }
 
     @Override
@@ -119,6 +117,11 @@ public class DefaultCustomScopeRegistry implements CustomScopeRegistry {
     private static final class InjectScopeImpl implements CustomScope<InjectScope>, LifeCycle<InjectScopeImpl> {
 
         private final List<CreatedBean<?>> currentCreatedBeans = new ArrayList<>(2);
+        private final BeanLocator beanLocator;
+
+        private InjectScopeImpl(BeanLocator beanLocator) {
+            this.beanLocator = beanLocator;
+        }
 
         @Override
         public Class<InjectScope> annotationType() {
@@ -145,10 +148,21 @@ public class DefaultCustomScopeRegistry implements CustomScopeRegistry {
         @Override
         public InjectScopeImpl stop() {
             for (CreatedBean<?> currentCreatedBean : currentCreatedBeans) {
-                currentCreatedBean.close();
+                if (currentCreatedBean instanceof BeanRegistration<?> registration
+                    && beanLocator instanceof BeanContext beanContext) {
+                    // close() is a no-op for a registration with nothing of its own to dispose; destroying
+                    // through the context reaches the pre-destroy listeners as well
+                    destroy(beanContext, registration);
+                } else {
+                    currentCreatedBean.close();
+                }
             }
             currentCreatedBeans.clear();
             return this;
+        }
+
+        private static <T> void destroy(BeanContext beanContext, BeanRegistration<T> registration) {
+            beanContext.destroyBean(registration);
         }
     }
 }

--- a/inject/src/test/groovy/io/micronaut/context/InjectScopePerContextSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/InjectScopePerContextSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.context
+
+import io.micronaut.context.annotation.InjectScope
+import io.micronaut.context.scope.BeanCreationContext
+import io.micronaut.context.scope.CreatedBean
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanIdentifier
+import spock.lang.Specification
+
+class InjectScopePerContextSpec extends Specification {
+
+    void "each bean context gets its own inject scope instance"() {
+        given:
+        ApplicationContext ctx1 = ApplicationContext.run()
+        ApplicationContext ctx2 = ApplicationContext.run()
+
+        when:
+        def scope1 = findInjectScope(ctx1)
+        def scope2 = findInjectScope(ctx2)
+
+        then:
+        !scope1.is(scope2)
+
+        when: 'a bean is created in the inject scope of the first context'
+        boolean closed = false
+        CreatedBean<Object> createdBean = new CreatedBean<Object>() {
+            @Override
+            BeanDefinition<Object> definition() { null }
+
+            @Override
+            Object bean() { new Object() }
+
+            @Override
+            BeanIdentifier id() { BeanIdentifier.of("test") }
+
+            @Override
+            void close() { closed = true }
+        }
+        scope1.getOrCreate(new BeanCreationContext<Object>() {
+            @Override
+            BeanDefinition<Object> definition() { null }
+
+            @Override
+            BeanIdentifier id() { BeanIdentifier.of("test") }
+
+            @Override
+            CreatedBean<Object> create() { createdBean }
+        })
+
+        and: 'the second context finishes a resolution of its own'
+        ((LifeCycle) scope2).stop()
+
+        then: 'the first context still holds its bean'
+        !closed
+
+        when:
+        ((LifeCycle) scope1).stop()
+
+        then:
+        closed
+
+        cleanup:
+        ctx1.close()
+        ctx2.close()
+    }
+
+    private static findInjectScope(ApplicationContext ctx) {
+        ((DefaultBeanContext) ctx).getCustomScopeRegistry().findScope(InjectScope.name).get()
+    }
+}


### PR DESCRIPTION
### What this fixes

Three related bugs in `@InjectScope` handling:

1. **Constructor/factory parameters were never destroyed.** `BeanDefinitionWriter.hasInjectScope()` passed the constructor/factory `MethodElement` into the `AnnotationMetadata` overload, checking the method's *own* annotations instead of its parameters, so `destroyInjectScopedBeans()` was never emitted for a bean whose only `@InjectScope` injection points are constructor or factory parameters. The field and `@PostConstruct`-method paths already iterate parameters. (The existing `InjectScopeSpec` didn't catch this because its bean also has an `@Inject` method, which triggers the emission for everything.)

2. **`@InjectScope` silently did nothing for `@Prototype` beans.** `DefaultBeanContext.findCustomScope()` returned `null` immediately for `@Prototype` definitions, so the injection-point-declared scope check further down never ran. A prototype bean has no lifecycle of its own, so it should behave like an unscoped bean here; `@Singleton` still outranks the injection point per the annotation's javadoc. The prototype branches now fall through to the extracted `findInjectionPointDeclaredScope()`.

3. **Destruction skipped `BeanPreDestroyEventListener`s, and the scope was JVM-global.** `DefaultCustomScopeRegistry.InjectScopeImpl.stop()` called `CreatedBean.close()`, which is a no-op for a registration whose definition has no pre-destroy of its own (`BeanRegistration.of` only returns a disposing registration for `DisposableBeanDefinition`/`LifeCycle`/dependents), so pre-destroy listeners never ran for `@InjectScope`-destroyed beans. `stop()` now destroys through the `BeanContext` so listeners always run. Also, `INJECT_SCOPE` was a `static final` singleton with a mutable `currentCreatedBeans` list shared by every `ApplicationContext` in the JVM; each registry now gets its own instance.

### Tests

- `InjectScopeSpec` (inject-java): a `@Prototype` bean injected via `@InjectScope` **constructor parameter only** is destroyed after the injecting bean is resolved, and a `BeanPreDestroyEventListener` fires even for a bean with no `@PreDestroy` of its own. Fails without each of the three fixes.
- `InjectScopePerContextSpec` (inject): two contexts get distinct inject-scope instances, and one context finishing a resolution no longer closes beans created in another context's inject scope.

Verified `:micronaut-inject:test` (302 tests) and the scope/lifecycle selections of `:micronaut-inject-java:test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)