### PR TITLE
Process a class annotated only @ClassImport

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -133,7 +133,10 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                     String packageName = NameUtils.getPackageName(name);
                     return !name.equals(AnnotationUtil.KOTLIN_METADATA) && !AnnotationUtil.STEREOTYPE_EXCLUDES.contains(packageName);
                 })
-                .filter(ann -> annotationMetadataBuilder.lookupOrBuildForType(ann).hasStereotype(ANNOTATION_STEREOTYPES)
+                .filter(ann -> ClassImport.class.getName().equals(ann.getQualifiedName().toString())
+                    // the import annotation is processed for what it names rather than for a stereotype it
+                    // carries; the stereotype check below can never see it on itself
+                    || annotationMetadataBuilder.lookupOrBuildForType(ann).hasStereotype(ANNOTATION_STEREOTYPES)
                     || isProcessedAnnotation(ann.getQualifiedName().toString()))
                 .collect(Collectors.toSet());
 

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassImportGenVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassImportGenVisitor.java
@@ -1,0 +1,30 @@
+package io.micronaut.visitors;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class ClassImportGenVisitor implements TypeElementVisitor<GenerateImporter, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        context.visitGeneratedSourceFile("test", "GeneratedImporter", element)
+            .ifPresent(sourceFile -> {
+                try {
+                    sourceFile.write(writer -> writer.write("""
+                        package test;
+
+                        @io.micronaut.context.annotation.ClassImport(
+                            classes = io.micronaut.visitors.MyImportedBean.class,
+                            annotate = jakarta.inject.Singleton.class)
+                        final class GeneratedImporter {
+                        }
+                        """));
+                } catch (Exception e) {
+                    throw new ProcessingException(element, "Failed to generate the importer: " + e.getMessage(), e);
+                }
+            });
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassImportGeneratedRoundSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassImportGeneratedRoundSpec.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+/**
+ * A generated source annotated only {@code @ClassImport} arrives in a later compilation
+ * round and must still trigger the bean definition processor.
+ */
+class ClassImportGeneratedRoundSpec extends AbstractTypeElementSpec {
+
+    void "test a generated class annotated only with @ClassImport produces bean definitions for the imported classes"() {
+        given:
+            ApplicationContext context = buildContext('test.TriggerBean', '''
+package test;
+
+import io.micronaut.visitors.GenerateImporter;
+
+@GenerateImporter
+class TriggerBean {}
+''')
+
+        when:"the imported bean is resolved"
+            def bean = getBean(context, 'io.micronaut.visitors.MyImportedBean')
+
+        then:"the generated import triggered processing in its round"
+            bean != null
+
+        cleanup:
+            context?.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassImportOnlySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassImportOnlySpec.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+/**
+ * {@code @ClassImport} is processed for the classes it names rather than for a stereotype
+ * it carries, so a class annotated with nothing else must still trigger the bean definition
+ * processor.
+ */
+class ClassImportOnlySpec extends AbstractTypeElementSpec {
+
+    void "test a class annotated only with @ClassImport produces bean definitions for the imported classes"() {
+        given:
+            ApplicationContext context = buildContext('test.Importer', '''
+package test;
+
+import io.micronaut.context.annotation.ClassImport;
+import jakarta.inject.Singleton;
+
+@ClassImport(classes = io.micronaut.visitors.MyImportedBean.class, annotate = Singleton.class)
+class Importer {}
+''')
+
+        when:"the imported bean is resolved"
+            def bean = getBean(context, 'io.micronaut.visitors.MyImportedBean')
+
+        then:"the import alone triggered processing and produced a bean definition"
+            bean != null
+            bean.greet() == 'Hello'
+
+        cleanup:
+            context?.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/GenerateImporter.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/GenerateImporter.java
@@ -1,0 +1,11 @@
+package io.micronaut.visitors;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface GenerateImporter {
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/MyImportedBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/MyImportedBean.java
@@ -1,0 +1,8 @@
+package io.micronaut.visitors;
+
+public class MyImportedBean {
+
+    public String greet() {
+        return "Hello";
+    }
+}

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -22,6 +22,7 @@ io.micronaut.annotation.AnnotateClassSpec$AnnotateClassVisitor
 io.micronaut.annotation.AnnotateTypeArgSpec$AnnotateTypeArgVisitor
 io.micronaut.aop.introduction.beans.MyRepoVisitor2
 io.micronaut.visitors.WitherVisitor
+io.micronaut.visitors.ClassImportGenVisitor
 io.micronaut.visitors.IntroductionTestGenVisitor
 io.micronaut.visitors.IntroductionTestVisitor
 io.micronaut.visitors.CollectingVisitor

--- a/inject/src/main/java/io/micronaut/context/annotation/ClassImport.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/ClassImport.java
@@ -32,6 +32,10 @@ import java.lang.annotation.Target;
  *
  * <p>Note that this annotation is likely to require more use of reflection if package protected members require injection.</p>
  *
+ * <p>Note that a source generated to carry this annotation must not be annotated
+ * {@link io.micronaut.core.annotation.Generated}: the annotation processor skips elements
+ * carrying it, so the imports would never be processed.</p>
+ *
  * @author Denis Stepanov
  * @since 4.9
  */


### PR DESCRIPTION
`BeanDefinitionInjectProcessor` keeps an annotation from the round when it has one of `ANNOTATION_STEREOTYPES` as a stereotype or `isProcessedAnnotation` matches its name. `ClassImport` is listed among the stereotypes, but an annotation type never carries itself as a stereotype, so that entry can never admit it: the import trigger survives today only because the `isProcessedAnnotation` fallback's `io.micronaut.*` pattern happens to cover it. This admits `ClassImport` by name instead, since it is processed for the classes it names rather than for a stereotype it carries.

Two specs lock the trigger: a class annotated only `@ClassImport` produces bean definitions for the imported classes, both when compiled from source (`ClassImportOnlySpec`) and when a visitor generates the importer into a later compilation round (`ClassImportGeneratedRoundSpec`).

A related trap: a generated importer must not be annotated `io.micronaut.core.annotation.Generated` — `ModelUtils.resolveTypeElements` skips elements carrying it and the imports are silently dropped (verified: the generated-round spec fails when the importer carries it). Noted in the `ClassImport` javadoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)