### PR TITLE
Let the customizer allow a bean to instantiate to null

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanResolutionCustomizerSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanResolutionCustomizerSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContextBuilder
 import io.micronaut.context.BeanResolutionContext
 import io.micronaut.context.BeanResolutionCustomizer
+import io.micronaut.context.exceptions.BeanInstantiationException
 import io.micronaut.core.type.Argument
 import io.micronaut.inject.BeanDefinition
 
@@ -164,6 +165,68 @@ class ArrayConsumer {
         context.close()
     }
 
+    void "customizer allowing a null bean gets its resolveNullBean answer for a factory returning null"() {
+        given:
+        def context = buildContext('test.NullableProductFactory', '''
+package test;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+
+class NullableProduct {
+}
+
+@Factory
+class NullableProductFactory {
+    @Bean
+    NullableProduct nullableProduct() {
+        return null;
+    }
+}
+''')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('test.NullableProduct'))
+
+        then:
+        bean != null
+        bean.class.name == 'test.NullableProduct'
+
+        cleanup:
+        context.close()
+    }
+
+    void "factory returning null without the customizer allowing it still fails to instantiate"() {
+        given:
+        def context = buildContext('test.StrictProductFactory', '''
+package test;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+
+class StrictProduct {
+}
+
+@Factory
+class StrictProductFactory {
+    @Bean
+    StrictProduct strictProduct() {
+        return null;
+    }
+}
+''')
+
+        when:
+        context.getBean(context.classLoader.loadClass('test.StrictProduct'))
+
+        then:
+        def e = thrown(BeanInstantiationException)
+        e.message.contains('returned null')
+
+        cleanup:
+        context.close()
+    }
+
     @Override
     protected void configureContext(ApplicationContextBuilder contextBuilder) {
         contextBuilder.beanResolutionCustomizer(new BeanResolutionCustomizer() {
@@ -178,6 +241,21 @@ class ArrayConsumer {
             @Override
             boolean shouldResolveArrayAsBean(Argument<?> injectionPoint) {
                 return injectionPoint.array && injectionPoint.type.componentType.name == 'test.ArrayThing'
+            }
+
+            @Override
+            boolean shouldAllowNullBean(BeanResolutionContext resolutionContext, BeanDefinition<?> beanDefinition) {
+                return beanDefinition.beanType.name == 'test.NullableProduct'
+            }
+
+            @Override
+            Optional<?> resolveNullBean(Argument<?> requestedBeanType, Argument<?> resolvedBeanType, BeanDefinition<?> beanDefinition) {
+                if (resolvedBeanType.type.name == 'test.NullableProduct') {
+                    def constructor = resolvedBeanType.type.getDeclaredConstructor()
+                    constructor.accessible = true
+                    return Optional.of(constructor.newInstance())
+                }
+                return Optional.empty()
             }
 
             @Override

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionCustomizer.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionCustomizer.java
@@ -90,6 +90,19 @@ public interface BeanResolutionCustomizer {
     }
 
     /**
+     * Returns whether a bean definition may legitimately instantiate to {@code null} even though it is not
+     * declared {@code @Nullable}, letting {@link #resolveNullBean} decide what the {@code null} becomes.
+     *
+     * @param resolutionContext The current resolution context
+     * @param beanDefinition The bean definition that produced {@code null}
+     * @return True if a {@code null} instance is allowed
+     * @since 5.2.0
+     */
+    default boolean shouldAllowNullBean(BeanResolutionContext resolutionContext, BeanDefinition<?> beanDefinition) {
+        return false;
+    }
+
+    /**
      * Resolve a replacement value for a bean that was found but produced {@code null}.
      *
      * @param requestedBeanType The originally requested bean type

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2119,7 +2119,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             } else {
                 throw new BeanInstantiationException(resolutionContext, "Expected InstantiatableBeanDefinition [" + beanDefinition + "]");
             }
-            if (bean == null && !isNullableBeanDefinition(beanDefinition)) {
+            if (bean == null && !isNullableBeanDefinition(beanDefinition)
+                && !beanResolutionCustomizer.shouldAllowNullBean(resolutionContext, beanDefinition)) {
                 throw new BeanInstantiationException(resolutionContext, "InstantiatableBeanDefinition [" + beanDefinition + "] returned null");
             }
             if (bean instanceof Qualified qualified && declaredQualifier != null) {


### PR DESCRIPTION
Continues the `BeanResolutionCustomizer` integration-hook series (#12678) by completing the customizer's say over null instantiation.

A customizer can already substitute a value for a bean that produced `null` via `resolveNullBean`, but `DefaultBeanContext.resolveByBeanFactory` threw `InstantiatableBeanDefinition [...] returned null` before that hook was ever consulted, unless the definition itself was declared `@Nullable`. A factory/provider may legitimately produce `null`, with the integration deciding what the null becomes — a default value, a substitute, or a meaningful exception.

This adds `BeanResolutionCustomizer.shouldAllowNullBean(BeanResolutionContext, BeanDefinition)` (default `false`) and consults it in the null check of `resolveByBeanFactory`, letting the null flow through to the existing `resolveNullBeanRegistration` path.

Tests cover both directions: a customizer allowing null for a factory returning null gets its `resolveNullBean` substitute, and without the customizer's permission the existing instantiation error still throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)