### PR TITLE
Allow a runtime bean definition's factory to receive the resolution context

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2401,7 +2401,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             @SuppressWarnings("unchecked")
             BeanDefinition<T> def = (BeanDefinition<T>) new DefaultRuntimeBeanDefinition<>(
                 Argument.of(beanClass),
-                () -> (T) this,
+                ctx -> (T) this,
                 null,
                 null,
                 true,

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -44,6 +44,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -57,7 +58,7 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
     private static final AtomicInteger REF_COUNT = new AtomicInteger(0);
     private static final String MSG_BEAN_TYPE_CANNOT_BE_NULL = "Bean type cannot be null";
     private final Argument<T> beanType;
-    private final Supplier<T> supplier;
+    private final Function<BeanResolutionContext, T> beanFactory;
     private final AnnotationMetadata annotationMetadata;
     private final String beanName;
     @Nullable
@@ -71,7 +72,7 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
     private final int order;
 
     DefaultRuntimeBeanDefinition(Argument<T> beanType,
-                                 Supplier<T> supplier,
+                                 Function<BeanResolutionContext, T> beanFactory,
                                  @Nullable Qualifier<T> qualifier,
                                  @Nullable AnnotationMetadata annotationMetadata,
                                  boolean isSingleton,
@@ -80,10 +81,10 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
                                  @Nullable
                                  Map<Class<?>, List<Argument<?>>> typeArguments) {
         Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
-        Objects.requireNonNull(supplier, "Bean supplier cannot be null");
+        Objects.requireNonNull(beanFactory, "Bean factory cannot be null");
 
         this.beanType = beanType;
-        this.supplier = supplier;
+        this.beanFactory = beanFactory;
         this.beanName = generateBeanName(beanType.getType());
         this.qualifier = qualifier;
         this.annotationMetadata = annotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : annotationMetadata;
@@ -228,7 +229,7 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
 
     @Override
     public T instantiate(BeanResolutionContext resolutionContext, BeanContext context) throws BeanInstantiationException {
-        return supplier.get();
+        return beanFactory.apply(resolutionContext);
     }
 
     /**
@@ -237,7 +238,7 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
      */
     static final class RuntimeBeanBuilder<B> implements RuntimeBeanDefinition.Builder<B> {
         private Argument<B> beanType;
-        private final Supplier<B> supplier;
+        private final Function<BeanResolutionContext, B> beanFactory;
         @Nullable
         private Qualifier<B> qualifier;
         private boolean singleton;
@@ -253,7 +254,14 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
 
         RuntimeBeanBuilder(Argument<B> beanType, Supplier<B> supplier) {
             this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
-            this.supplier = Objects.requireNonNull(supplier, "Bean supplier cannot be null");
+            Objects.requireNonNull(supplier, "Bean supplier cannot be null");
+            this.beanFactory = resolutionContext -> supplier.get();
+            this.annotationMetadata = AnnotationMetadata.EMPTY_METADATA;
+        }
+
+        RuntimeBeanBuilder(Argument<B> beanType, Function<BeanResolutionContext, B> beanFactory) {
+            this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
+            this.beanFactory = Objects.requireNonNull(beanFactory, "Bean factory cannot be null");
             this.annotationMetadata = AnnotationMetadata.EMPTY_METADATA;
         }
 
@@ -350,7 +358,7 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
             }
             return new DefaultRuntimeBeanDefinition<>(
                 beanType,
-                supplier,
+                beanFactory,
                 qualifier,
                 annotationMetadata,
                 singleton,

--- a/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -188,6 +189,48 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
         return new DefaultRuntimeBeanDefinition.RuntimeBeanBuilder<>(
             beanType,
             beanSupplier
+        );
+    }
+
+    /**
+     * A new builder for constructing and configuring runtime created beans where the bean factory
+     * receives the current {@link BeanResolutionContext}.
+     *
+     * <p>The resolution context allows the factory to introspect where in a resolution the bean is being
+     * created, for example via {@link BeanResolutionContext#getPath()} to discover the injection point
+     * the bean is being created for.</p>
+     *
+     * @param beanType The bean type
+     * @param beanFactory The bean factory that receives the current {@link BeanResolutionContext}
+     * @return The builder
+     * @param <B> The bean type
+     * @since 5.2.0
+     */
+    static <B> Builder<B> builder(Class<B> beanType, Function<BeanResolutionContext, B> beanFactory) {
+        return new DefaultRuntimeBeanDefinition.RuntimeBeanBuilder<>(
+            Argument.of(beanType),
+            beanFactory
+        );
+    }
+
+    /**
+     * A new builder for constructing and configuring runtime created beans where the bean factory
+     * receives the current {@link BeanResolutionContext}.
+     *
+     * <p>The resolution context allows the factory to introspect where in a resolution the bean is being
+     * created, for example via {@link BeanResolutionContext#getPath()} to discover the injection point
+     * the bean is being created for.</p>
+     *
+     * @param beanType The bean type
+     * @param beanFactory The bean factory that receives the current {@link BeanResolutionContext}
+     * @return The builder
+     * @param <B> The bean type
+     * @since 5.2.0
+     */
+    static <B> Builder<B> builder(Argument<B> beanType, Function<BeanResolutionContext, B> beanFactory) {
+        return new DefaultRuntimeBeanDefinition.RuntimeBeanBuilder<>(
+            beanType,
+            beanFactory
         );
     }
 

--- a/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionResolutionContextSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionResolutionContextSpec.groovy
@@ -1,0 +1,85 @@
+package io.micronaut.context
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.type.Argument
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import java.util.function.Function
+
+class RuntimeBeanDefinitionResolutionContextSpec extends Specification {
+
+    void "test runtime bean factory receives the resolution context of the injection point"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(["spec.name": getClass().simpleName])
+        Function<BeanResolutionContext, RuntimeBean> factory = { BeanResolutionContext resolutionContext ->
+            def segment = resolutionContext.getPath().currentSegment().orElse(null)
+            new RuntimeBean(
+                segment?.declaringType?.beanType,
+                segment?.argument?.name,
+                resolutionContext.getPath().isEmpty()
+            )
+        }
+        context.registerBeanDefinition(
+            RuntimeBeanDefinition.builder(RuntimeBean, factory).build()
+        )
+
+        when:
+        Consumer consumer = context.getBean(Consumer)
+
+        then: "the factory saw the injection point of the bean it was created for"
+        consumer.runtimeBean.declaringBeanType == Consumer
+        consumer.runtimeBean.argumentName == "runtimeBean"
+        !consumer.runtimeBean.pathWasEmpty
+
+        cleanup:
+        context.close()
+    }
+
+    void "test runtime bean factory receives the resolution context for a top level lookup"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(["spec.name": getClass().simpleName])
+        Function<BeanResolutionContext, RuntimeBean> factory = { BeanResolutionContext resolutionContext ->
+            def segment = resolutionContext.getPath().currentSegment().orElse(null)
+            new RuntimeBean(
+                segment?.declaringType?.beanType,
+                segment?.argument?.name,
+                resolutionContext.getPath().isEmpty()
+            )
+        }
+        context.registerBeanDefinition(
+            RuntimeBeanDefinition.builder(Argument.of(RuntimeBean), factory).build()
+        )
+
+        when:
+        RuntimeBean bean = context.getBean(RuntimeBean)
+
+        then: "a direct lookup has an empty path or one rooted at the bean itself"
+        bean.pathWasEmpty || bean.declaringBeanType == RuntimeBean
+
+        cleanup:
+        context.close()
+    }
+
+    static class RuntimeBean {
+        final Class<?> declaringBeanType
+        final String argumentName
+        final boolean pathWasEmpty
+
+        RuntimeBean(Class<?> declaringBeanType, String argumentName, boolean pathWasEmpty) {
+            this.declaringBeanType = declaringBeanType
+            this.argumentName = argumentName
+            this.pathWasEmpty = pathWasEmpty
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "RuntimeBeanDefinitionResolutionContextSpec")
+    static class Consumer {
+        final RuntimeBean runtimeBean
+
+        Consumer(RuntimeBean runtimeBean) {
+            this.runtimeBean = runtimeBean
+        }
+    }
+}


### PR DESCRIPTION
### What

Adds `RuntimeBeanDefinition.builder(Class<B>, Function<BeanResolutionContext, B>)` and an `Argument<B>` overload, so a bean registered at runtime can receive the current `BeanResolutionContext` when it is created.

### Why

A `RuntimeBeanDefinition` factory currently receives nothing (`Supplier<B>`). An integration registering beans at runtime sometimes needs the resolution path — e.g. to answer *what is this bean being injected into?* — but has no route to it, even though `DefaultRuntimeBeanDefinition.instantiate(BeanResolutionContext, BeanContext)` already has the resolution context in hand and drops it. Today the only workaround is a thread-local populated from outside the container, which is fragile.

With this change a factory can do:

```java
context.registerBeanDefinition(
    RuntimeBeanDefinition.builder(MyBean.class, resolutionContext -> {
        var segment = resolutionContext.getPath().currentSegment().orElse(null);
        // segment identifies the injection point this bean is being created for
        return new MyBean(segment);
    }).build()
);
```

### How

- `DefaultRuntimeBeanDefinition` now stores a `Function<BeanResolutionContext, T>`; the existing `Supplier` builders wrap as `ctx -> supplier.get()`.
- `instantiate(BeanResolutionContext, BeanContext)` passes the resolution context through to the factory.
- Existing builder methods and behavior are unchanged; only additive API. `:micronaut-inject:japiCmp` is green.

New spec `RuntimeBeanDefinitionResolutionContextSpec` verifies a factory sees the segment of the bean it is being injected into, and that a top-level `getBean` sees an empty (or self-rooted) path.

### Alternative API shape considered

Instead of a new builder overload, this could be a callback on `BeanResolutionCustomizer` exposing the current segment (e.g. `onCreateBean(BeanResolutionContext, BeanDefinition)`), letting any integration observe resolution without changing `RuntimeBeanDefinition`. That is more general but heavier: it fires for all beans rather than just the runtime-registered one that needs it, and the factory still has to correlate the callback with its own instantiation. The `Function`-based builder keeps the context exactly where it is consumed and stays a purely additive, opt-in API — but happy to switch to the customizer approach if maintainers prefer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
