### PR TITLE
Fire destruction listeners when closing a context-created bean registration

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/DependentBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/DependentBean.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.lifecycle.registrationclose;
+
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+public class DependentBean {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/DependentBeanDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/DependentBeanDestroyedListener.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.lifecycle.registrationclose;
+
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class DependentBeanDestroyedListener implements BeanDestroyedEventListener<DependentBean> {
+
+    final List<DependentBean> destroyed = new ArrayList<>();
+
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<DependentBean> event) {
+        destroyed.add(event.getBean());
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/DependentBeanPreDestroyListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/DependentBeanPreDestroyListener.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.lifecycle.registrationclose;
+
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class DependentBeanPreDestroyListener implements BeanPreDestroyEventListener<DependentBean> {
+
+    final List<DependentBean> destroyed = new ArrayList<>();
+
+    @Override
+    public DependentBean onPreDestroy(BeanPreDestroyEvent<DependentBean> event) {
+        destroyed.add(event.getBean());
+        return event.getBean();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/OwnerBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/OwnerBean.java
@@ -1,0 +1,13 @@
+package io.micronaut.inject.lifecycle.registrationclose;
+
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+public class OwnerBean {
+
+    final DependentBean dependent;
+
+    OwnerBean(DependentBean dependent) {
+        this.dependent = dependent;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/OwnerBeanDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/OwnerBeanDestroyedListener.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.lifecycle.registrationclose;
+
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class OwnerBeanDestroyedListener implements BeanDestroyedEventListener<OwnerBean> {
+
+    final List<OwnerBean> destroyed = new ArrayList<>();
+
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<OwnerBean> event) {
+        destroyed.add(event.getBean());
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/OwnerBeanPreDestroyListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/OwnerBeanPreDestroyListener.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.lifecycle.registrationclose;
+
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class OwnerBeanPreDestroyListener implements BeanPreDestroyEventListener<OwnerBean> {
+
+    final List<OwnerBean> destroyed = new ArrayList<>();
+
+    @Override
+    public OwnerBean onPreDestroy(BeanPreDestroyEvent<OwnerBean> event) {
+        destroyed.add(event.getBean());
+        return event.getBean();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/RegistrationCloseListenersSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/RegistrationCloseListenersSpec.groovy
@@ -1,0 +1,93 @@
+package io.micronaut.inject.lifecycle.registrationclose
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanRegistration
+import io.micronaut.inject.BeanIdentifier
+import spock.lang.Specification
+
+class RegistrationCloseListenersSpec extends Specification {
+
+    void "closing a registration of a bean without destroy logic triggers destruction listeners"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        SimpleBeanPreDestroyListener preListener = context.getBean(SimpleBeanPreDestroyListener)
+        SimpleBeanDestroyedListener postListener = context.getBean(SimpleBeanDestroyedListener)
+        SimpleBean bean = context.getBean(SimpleBean)
+
+        when:
+        BeanRegistration<SimpleBean> registration = BeanRegistration.of(
+                context,
+                BeanIdentifier.of(SimpleBean.name),
+                context.getBeanDefinition(SimpleBean),
+                bean
+        )
+
+        then:
+        preListener.destroyed.empty
+        postListener.destroyed.empty
+
+        when:
+        registration.close()
+
+        then:
+        preListener.destroyed == [bean]
+        postListener.destroyed == [bean]
+
+        cleanup:
+        context.close()
+    }
+
+    void "closing a registration destroys dependent beans and triggers their listeners"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        OwnerBeanPreDestroyListener ownerPre = context.getBean(OwnerBeanPreDestroyListener)
+        OwnerBeanDestroyedListener ownerPost = context.getBean(OwnerBeanDestroyedListener)
+        DependentBeanPreDestroyListener dependentPre = context.getBean(DependentBeanPreDestroyListener)
+        DependentBeanDestroyedListener dependentPost = context.getBean(DependentBeanDestroyedListener)
+
+        when:
+        BeanRegistration<OwnerBean> registration = context.getBeanRegistrations(OwnerBean).first()
+        OwnerBean owner = registration.bean()
+
+        then:
+        ownerPre.destroyed.empty
+        dependentPre.destroyed.empty
+
+        when:
+        registration.close()
+
+        then:
+        ownerPre.destroyed == [owner]
+        ownerPost.destroyed == [owner]
+        dependentPre.destroyed == [owner.dependent]
+        dependentPost.destroyed == [owner.dependent]
+
+        cleanup:
+        context.close()
+    }
+
+    void "a pre destroy listener can replace the bean instance"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        SimpleBeanPreDestroyListener preListener = context.getBean(SimpleBeanPreDestroyListener)
+        SimpleBeanDestroyedListener postListener = context.getBean(SimpleBeanDestroyedListener)
+        SimpleBean bean = context.getBean(SimpleBean)
+        SimpleBean replacement = new SimpleBean()
+        preListener.replacement = replacement
+
+        when:
+        BeanRegistration.of(
+                context,
+                BeanIdentifier.of(SimpleBean.name),
+                context.getBeanDefinition(SimpleBean),
+                bean
+        ).close()
+
+        then:
+        preListener.destroyed == [bean]
+        postListener.destroyed == [replacement]
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/SimpleBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/SimpleBean.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.lifecycle.registrationclose;
+
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+public class SimpleBean {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/SimpleBeanDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/SimpleBeanDestroyedListener.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.lifecycle.registrationclose;
+
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class SimpleBeanDestroyedListener implements BeanDestroyedEventListener<SimpleBean> {
+
+    final List<SimpleBean> destroyed = new ArrayList<>();
+
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<SimpleBean> event) {
+        destroyed.add(event.getBean());
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/SimpleBeanPreDestroyListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/SimpleBeanPreDestroyListener.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.lifecycle.registrationclose;
+
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class SimpleBeanPreDestroyListener implements BeanPreDestroyEventListener<SimpleBean> {
+
+    final List<SimpleBean> destroyed = new ArrayList<>();
+    SimpleBean replacement;
+
+    @Override
+    public SimpleBean onPreDestroy(BeanPreDestroyEvent<SimpleBean> event) {
+        destroyed.add(event.getBean());
+        return replacement == null ? event.getBean() : replacement;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/BeanRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanRegistration.java
@@ -24,7 +24,6 @@ import io.micronaut.core.util.ObjectUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
 import io.micronaut.inject.BeanType;
-import io.micronaut.inject.DisposableBeanDefinition;
 
 import java.util.List;
 import java.util.Objects;
@@ -85,7 +84,11 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
     }
 
     /**
-     * Creates new bean registration. Possibly disposing registration can be returned.
+     * Creates new bean registration. When a bean context is provided the returned registration's
+     * {@link #close()} destroys the bean through {@link BeanContext#destroyBean(BeanRegistration)},
+     * triggering {@link io.micronaut.context.event.BeanPreDestroyEventListener} and
+     * {@link io.micronaut.context.event.BeanDestroyedEventListener} instances even if the bean has
+     * no destruction logic of its own.
      *
      * @param beanContext    The bean context
      * @param identifier     The bean identifier
@@ -102,13 +105,12 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
                                              K bean,
                                              @Nullable
                                              List<BeanRegistration<?>> dependents) {
-        boolean hasDependents = CollectionUtils.isNotEmpty(dependents);
-        if (beanDefinition instanceof DisposableBeanDefinition || bean instanceof LifeCycle || hasDependents) {
-            return hasDependents ?
-                new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean, Objects.requireNonNull(dependents)) :
-                new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean);
+        if (beanContext == null) {
+            return new BeanRegistration<>(identifier, beanDefinition, bean);
         }
-        return new BeanRegistration<>(identifier, beanDefinition, bean);
+        return CollectionUtils.isNotEmpty(dependents) ?
+            new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean, dependents) :
+            new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean);
     }
 
     @Override


### PR DESCRIPTION
## Problem

`BeanRegistration.of(BeanContext, BeanIdentifier, BeanDefinition, bean, dependents)` only returns a `BeanDisposingRegistration` — whose `close()` destroys the bean through `BeanContext.destroyBean(registration)` — when the definition is a `DisposableBeanDefinition`, the bean is a `LifeCycle`, or there are dependents. For any other bean it returns a plain `BeanRegistration` whose `close()` is a no-op.

Closing such a registration therefore silently skips `BeanPreDestroyEventListener` / `BeanDestroyedEventListener` (and the cache purging `destroyBean` performs). The main real-world path is custom scopes, which destroy their beans via `CreatedBean.close()` (`AbstractConcurrentCustomScope.destroyScope()`, `DefaultCustomScopeRegistry`, `RefreshScope`): a scoped bean with no `@PreDestroy` of its own never reaches the destruction listeners when the scope is destroyed.

A bean with no destruction logic of its own can still matter to a `BeanPreDestroyEventListener`/`BeanDestroyedEventListener` — the listener contract should not depend on whether the bean happens to implement its own dispose logic.

## Change

When a bean context is provided, `BeanRegistration.of(...)` now always returns the disposing registration, so `close()` always destroys through the context and the destruction listeners fire consistently.

## Call-site audit / behavior notes

- `DefaultBeanContext.destroyBean(registration)` handles `BeanDisposingRegistration` via an `instanceof` branch and never calls `close()` on it, so there is no recursion; the context shutdown path (`stop()`) also goes through `destroyBean` directly and is unchanged.
- Destroying a bean through `destroyBean(...)` and then also closing its registration (e.g. a scope tearing down later) runs `destroyBean` twice and fires the listeners twice. This is not new: registrations of beans with dispose logic (and any registration with dependents) already behaved this way — there was never an idempotency guard on `close()`.
- `BeanRegistration.equals()` compares `getClass()`: a manually constructed `new BeanRegistration(...)` no longer equals an `of()`-created registration for a bean without dispose logic (it previously could). Equality between `of()`-created registrations is unchanged. No code in the repository relies on the old mixed-class equality.
- Registrations for such beans now carry two extra reference fields (context + dependents); footprint impact is negligible.
- Binary compatibility is unaffected: no signatures changed and `BeanDisposingRegistration` is package-private/`@Internal`.

## Tests

- Closing a registration of a bean with no `@PreDestroy`/`LifeCycle` fires `BeanPreDestroyEventListener` and `BeanDestroyedEventListener`.
- Closing a registration destroys dependent beans and fires their listeners too.
- A `BeanPreDestroyEventListener` can replace the bean instance per its contract; the `BeanDestroyedEvent` sees the replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
