### PR TITLE
Fix Python pooled request-body context conversion

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("io.micronaut.build.internal.convention-base")
+    id("io.micronaut.build.internal.python")
     id("me.champeau.jmh") version "0.7.3"
 }
 
@@ -48,6 +49,8 @@ val jmhWarmupIterations = providers.gradleProperty("jmh.warmupIterations").map(S
 val jmhProfilers = providers.gradleProperty("jmh.profilers")
     .map { it.split(",").map(String::trim).filter(String::isNotEmpty) }
     .getOrElse(emptyList())
+val jmhPoolSizes = providers.gradleProperty("jmh.poolSizes")
+    .map { it.split(",").map(String::trim).filter(String::isNotEmpty) }
 val jmhHumanOutput = providers.gradleProperty("jmh.humanOutput")
     .map(layout.projectDirectory::file)
 
@@ -57,6 +60,11 @@ jmh {
     iterations = jmhIterations
     warmupIterations = jmhWarmupIterations
     profilers = jmhProfilers
+    providers.gradleProperty("jmh.warmupTime").orNull?.let(warmup::set)
+    providers.gradleProperty("jmh.timeOnIteration").orNull?.let(timeOnIteration::set)
+    jmhPoolSizes.orNull?.let { sizes ->
+        benchmarkParameters.put("poolSize", objects.listProperty(String::class.java).value(sizes))
+    }
     humanOutputFile.set(jmhHumanOutput)
     duplicateClassesStrategy = DuplicatesStrategy.WARN
 }
@@ -69,7 +77,6 @@ tasks {
     named<Jar>("jmhJar") {
         isZip64 = true
         manifest.attributes["Multi-Release"] = "true"
-        exclude("GRAALPY-VFS/**")
     }
 }
 

--- a/benchmarks/src/jmh/java/io/micronaut/python/benchmark/PythonRequestBodyPoolBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/python/benchmark/PythonRequestBodyPoolBenchmark.java
@@ -55,7 +55,8 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>Run a smoke benchmark with
  * {@code ./gradlew :benchmarks:jmh -Pjmh.includes=io.micronaut.python.benchmark.PythonRequestBodyPoolBenchmark
- * -Pjmh.warmupIterations=1 -Pjmh.iterations=1}.</p>
+ * -Pjmh.warmupIterations=1 -Pjmh.iterations=1}. Run the full pool-size sweep by adding
+ * {@code -Pjmh.poolSizes=1,2,4,8}.</p>
  *
  * @since 5.2.0
  */
@@ -70,7 +71,7 @@ public class PythonRequestBodyPoolBenchmark {
         """;
 
     /** Configured Python context pool size. */
-    @Param({"1", "2", "4", "8"})
+    @Param({"4"})
     public int poolSize;
 
     private ApplicationContext applicationContext;

--- a/benchmarks/src/jmh/java/io/micronaut/python/benchmark/PythonRequestBodyPoolBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/python/benchmark/PythonRequestBodyPoolBenchmark.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.benchmark;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.python.PythonContextExecutor;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * End-to-end reproduction for pooled Python controller request-body conversion contention.
+ *
+ * <p>Each invocation sends a real HTTP request through Netty JSON decoding, body binding,
+ * generated Python wrapper conversion, and pooled controller execution. The control endpoint
+ * isolates the general cost of the same pooled controller without a data-class body.</p>
+ *
+ * <p>Run a smoke benchmark with
+ * {@code ./gradlew :benchmarks:jmh -Pjmh.includes=io.micronaut.python.benchmark.PythonRequestBodyPoolBenchmark
+ * -Pjmh.warmupIterations=1 -Pjmh.iterations=1}.</p>
+ *
+ * @since 5.2.0
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class PythonRequestBodyPoolBenchmark {
+
+    private static final String EXPECTED_BODY = "Ada:compiler:3:True:benchmark";
+    private static final String JSON = """
+        {"customer":"Ada","product":"compiler","quantity":3,"priority":true,"note":"benchmark"}
+        """;
+
+    /** Configured Python context pool size. */
+    @Param({"1", "2", "4", "8"})
+    public int poolSize;
+
+    private ApplicationContext applicationContext;
+    private HttpClient client;
+    private HttpRequest bodyRequest;
+    private HttpRequest controlRequest;
+
+    /** Starts the server and verifies both benchmark paths. */
+    @Setup(Level.Trial)
+    public void setUp() throws IOException, InterruptedException {
+        try {
+            applicationContext = ApplicationContext.builder()
+                .properties(Map.of(
+                    "micronaut.server.port", -1,
+                    "micronaut.python.pool.enabled", true,
+                    "micronaut.python.pool.size", poolSize,
+                    "micronaut.python.pool.warn-wait", "60s"
+                ))
+                .start();
+            warmPool();
+            EmbeddedServer server = applicationContext.getBean(EmbeddedServer.class).start();
+            URI root = server.getURI().resolve("/python-request-body-benchmark/");
+            client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+            bodyRequest = HttpRequest.newBuilder(root.resolve("body"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(JSON))
+                .build();
+            controlRequest = HttpRequest.newBuilder(root.resolve("control"))
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build();
+
+            verify(exchange(bodyRequest), EXPECTED_BODY);
+            verify(exchange(controlRequest), "control");
+        } catch (IOException | InterruptedException | RuntimeException e) {
+            tearDown();
+            throw e;
+        }
+    }
+
+    /** Stops the benchmark application. */
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (applicationContext != null) {
+            applicationContext.close();
+        }
+    }
+
+    /** Measures request-body conversion with one JMH worker. */
+    @Benchmark
+    @Threads(1)
+    public void bodyThreads1(Blackhole blackhole) throws IOException, InterruptedException {
+        blackhole.consume(exchange(bodyRequest));
+    }
+
+    /** Measures request-body conversion with two JMH workers. */
+    @Benchmark
+    @Threads(2)
+    public void bodyThreads2(Blackhole blackhole) throws IOException, InterruptedException {
+        blackhole.consume(exchange(bodyRequest));
+    }
+
+    /** Measures request-body conversion with four JMH workers. */
+    @Benchmark
+    @Threads(4)
+    public void bodyThreads4(Blackhole blackhole) throws IOException, InterruptedException {
+        blackhole.consume(exchange(bodyRequest));
+    }
+
+    /** Measures request-body conversion with eight JMH workers. */
+    @Benchmark
+    @Threads(8)
+    public void bodyThreads8(Blackhole blackhole) throws IOException, InterruptedException {
+        blackhole.consume(exchange(bodyRequest));
+    }
+
+    /** Measures the pooled control endpoint with one JMH worker. */
+    @Benchmark
+    @Threads(1)
+    public void controlThreads1(Blackhole blackhole) throws IOException, InterruptedException {
+        blackhole.consume(exchange(controlRequest));
+    }
+
+    /** Measures the pooled control endpoint with two JMH workers. */
+    @Benchmark
+    @Threads(2)
+    public void controlThreads2(Blackhole blackhole) throws IOException, InterruptedException {
+        blackhole.consume(exchange(controlRequest));
+    }
+
+    /** Measures the pooled control endpoint with four JMH workers. */
+    @Benchmark
+    @Threads(4)
+    public void controlThreads4(Blackhole blackhole) throws IOException, InterruptedException {
+        blackhole.consume(exchange(controlRequest));
+    }
+
+    /** Measures the pooled control endpoint with eight JMH workers. */
+    @Benchmark
+    @Threads(8)
+    public void controlThreads8(Blackhole blackhole) throws IOException, InterruptedException {
+        blackhole.consume(exchange(controlRequest));
+    }
+
+    private HttpResponse<String> exchange(HttpRequest request) throws IOException, InterruptedException {
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private void warmPool() throws InterruptedException {
+        PythonContextExecutor contextExecutor = applicationContext.getBean(PythonContextExecutor.class);
+        ExecutorService executor = Executors.newFixedThreadPool(poolSize);
+        CountDownLatch acquired = new CountDownLatch(poolSize);
+        CountDownLatch release = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>(poolSize);
+        try {
+            for (int i = 0; i < poolSize; i++) {
+                futures.add(executor.submit(() -> contextExecutor.withContext(context -> {
+                    acquired.countDown();
+                    await(release);
+                    return null;
+                })));
+            }
+            if (!acquired.await(2, TimeUnit.MINUTES)) {
+                throw new IllegalStateException("Timed out warming the Python context pool");
+            }
+            release.countDown();
+            for (Future<?> future : futures) {
+                future.get(2, TimeUnit.MINUTES);
+            }
+        } catch (java.util.concurrent.ExecutionException | java.util.concurrent.TimeoutException e) {
+            throw new IllegalStateException("Failed to warm the Python context pool", e);
+        } finally {
+            release.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        boolean interrupted = false;
+        while (true) {
+            try {
+                latch.await();
+                break;
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void verify(HttpResponse<String> response, String expected) {
+        if (response.statusCode() != 200 || !expected.equals(response.body())) {
+            throw new IllegalStateException("Unexpected benchmark response: " + response.statusCode() + " " + response.body());
+        }
+    }
+}

--- a/benchmarks/src/jmh/python/requestbodybenchmark/request_body.py
+++ b/benchmarks/src/jmh/python/requestbodybenchmark/request_body.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Annotated
+
+from micronaut.context.python.scope import ContextPooled
+from micronaut.core.annotation import Introspected
+from micronaut.http.annotation import Body, Controller, Post
+
+
+@Introspected
+@dataclass
+class BenchmarkOrder:
+    customer: str
+    product: str
+    quantity: int
+    priority: bool
+    note: str
+
+
+@ContextPooled
+@Controller("/python-request-body-benchmark")
+class PythonRequestBodyBenchmarkController:
+    @Post("/body")
+    def body(self, order: Annotated[BenchmarkOrder, Body]) -> str:
+        return f"{order.customer}:{order.product}:{order.quantity}:{order.priority}:{order.note}"
+
+    @Post("/control")
+    def control(self) -> str:
+        return "control"

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyRuntimeUtil.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyRuntimeUtil.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,6 +36,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.function.Supplier;
 
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.annotation.Internal;
@@ -72,6 +74,7 @@ public final class GraalPyRuntimeUtil {
     private static final String TO_PYTHON_STANDARD_TYPE = "__micronaut_to_python_standard_type";
     private static final String UTC_OFFSET = "__micronaut_utc_offset";
     private static final AsyncMemberAdapter ASYNC_MEMBER_ADAPTER = new AsyncMemberAdapter();
+    private static final ScopedValue<ContextConversion> CURRENT_CONTEXT_CONVERSION = ScopedValue.newInstance();
     private static final Source PUT_MEMBER_SOURCE = Source.newBuilder(PYTHON, """
         def __micronaut_put_member(target, name, value):
             setattr(target, name, value)
@@ -250,10 +253,7 @@ public final class GraalPyRuntimeUtil {
     @UsedByGeneratedCode
     public static @Nullable Object coerceValue(@Nullable Object value) {
         return switch (value) {
-            case PooledValueCoercible pooledValueCoercible when value instanceof Enum<?> ->
-                pooledValueCoercible.asPolyglotValue();
-            case ValueCoercible valueCoercible when !(value instanceof PooledValueCoercible) ->
-                valueCoercible.asPolyglotValue();
+            case ValueCoercible valueCoercible -> valueCoercible.asPolyglotValue();
             case null, default -> value;
         };
     }
@@ -266,6 +266,10 @@ public final class GraalPyRuntimeUtil {
      * @return The coerced value
      */
     public static @Nullable Object coerceToContext(@Nullable Object value, Context context) {
+        return withContextConversion(context, () -> coerceToContext0(value, context));
+    }
+
+    private static @Nullable Object coerceToContext0(@Nullable Object value, Context context) {
         Object standardType = coerceStandardTypeToContext(value, context);
         if (standardType != value) {
             return standardType;
@@ -283,7 +287,22 @@ public final class GraalPyRuntimeUtil {
                 return null;
             }
             case PooledValueCoercible pooledValueCoercible -> {
-                return pooledValueCoercible.asPolyglotValue(context);
+                return coercePooledValue(pooledValueCoercible, context);
+            }
+            case ValueCoercible valueCoercible -> {
+                Value polyglotValue = valueCoercible.asPolyglotValue();
+                if (polyglotValue == null || isValueInContext(polyglotValue, context)) {
+                    return polyglotValue;
+                }
+                throw new IllegalArgumentException(
+                    "Python wrapper " + value.getClass().getName() + " cannot be reconstructed in the target context"
+                );
+            }
+            case Value polyglotValue -> {
+                if (isValueInContext(polyglotValue, context)) {
+                    return polyglotValue;
+                }
+                throw new IllegalArgumentException("Cannot pass a polyglot Value to a different context");
             }
             case List<?> list -> {
                 List<@Nullable Object> result = new ArrayList<>(list.size());
@@ -327,6 +346,10 @@ public final class GraalPyRuntimeUtil {
      * @return The coerced value
      */
     public static @Nullable Object coerceToContext(@Nullable Object value, Context context, Class<?> declaredType) {
+        return withContextConversion(context, () -> coerceToContext0(value, context, declaredType));
+    }
+
+    private static @Nullable Object coerceToContext0(@Nullable Object value, Context context, Class<?> declaredType) {
         if (value == null) {
             return null;
         }
@@ -342,7 +365,8 @@ public final class GraalPyRuntimeUtil {
         }
         return switch (value) {
             case PooledValueCoercible pooledValueCoercible ->
-                pooledValueCoercible.asPolyglotValue(context);
+                coercePooledValue(pooledValueCoercible, context);
+            case ValueCoercible _, Value _ -> coerceToContext0(value, context);
             case List<?> _ when List.class.equals(declaredType) ->
                 coerceToContext(value, context);
             case Map<?, ?> _ when Map.class.equals(declaredType) ->
@@ -363,6 +387,61 @@ public final class GraalPyRuntimeUtil {
     @UsedByGeneratedCode
     public static boolean isValueInContext(@Nullable Value value, Context context) {
         return value != null && context.equals(value.getContext());
+    }
+
+    /**
+     * Converts a generated wrapper while preserving wrapper identity for the current conversion.
+     *
+     * @param value The generated wrapper
+     * @param context The target context
+     * @return The context-local Python value
+     */
+    @UsedByGeneratedCode
+    public static Value coercePooledValue(PooledValueCoercible value, Context context) {
+        return withContextConversion(context, () -> {
+            ContextConversion conversion = CURRENT_CONTEXT_CONVERSION.get();
+            Value existing = conversion.values.get(value);
+            if (existing != null) {
+                return existing;
+            }
+            if (conversion.inProgress.put(value, Boolean.TRUE) != null) {
+                throw new IllegalStateException(
+                    "Cyclic Python wrapper cannot be reconstructed before its target instance is allocated: "
+                        + value.getClass().getName()
+                );
+            }
+            try {
+                Value reconstructed = value.reconstructPolyglotValue(context);
+                conversion.values.put(value, reconstructed);
+                return reconstructed;
+            } finally {
+                conversion.inProgress.remove(value);
+            }
+        });
+    }
+
+    /**
+     * Registers a newly allocated Python object before generated code populates its properties.
+     *
+     * @param source The source wrapper
+     * @param context The target context
+     * @param value The newly allocated value
+     */
+    @UsedByGeneratedCode
+    public static void rememberPooledValue(PooledValueCoercible source, Context context, Value value) {
+        if (!CURRENT_CONTEXT_CONVERSION.isBound()
+            || !CURRENT_CONTEXT_CONVERSION.get().context.equals(context)
+            || !value.getContext().equals(context)) {
+            throw new IllegalStateException("No matching Python context conversion is active");
+        }
+        CURRENT_CONTEXT_CONVERSION.get().values.put(source, value);
+    }
+
+    private static <T> T withContextConversion(Context context, Supplier<T> operation) {
+        if (CURRENT_CONTEXT_CONVERSION.isBound() && CURRENT_CONTEXT_CONVERSION.get().context.equals(context)) {
+            return operation.get();
+        }
+        return ScopedValue.where(CURRENT_CONTEXT_CONVERSION, new ContextConversion(context)).call(operation::get);
     }
 
     private static @Nullable Object coerceStandardTypeToContext(@Nullable Object value, Context context) {
@@ -454,11 +533,13 @@ public final class GraalPyRuntimeUtil {
      * @return The coerced arguments
      */
     public static Object[] coerceArgumentsToContext(Context context, Object[] args) {
-        Object[] result = new Object[args.length];
-        for (int i = 0; i < args.length; i++) {
-            result[i] = coerceToContext(args[i], context);
-        }
-        return result;
+        return withContextConversion(context, () -> {
+            Object[] result = new Object[args.length];
+            for (int i = 0; i < args.length; i++) {
+                result[i] = coerceToContext0(args[i], context);
+            }
+            return result;
+        });
     }
 
     /**
@@ -519,6 +600,16 @@ public final class GraalPyRuntimeUtil {
 
     private static Value memberSetter(Context context) {
         return PythonContextRuntime.helper(context, PUT_MEMBER, PUT_MEMBER_SOURCE);
+    }
+
+    private static final class ContextConversion {
+        private final Context context;
+        private final IdentityHashMap<PooledValueCoercible, Value> values = new IdentityHashMap<>();
+        private final IdentityHashMap<PooledValueCoercible, Boolean> inProgress = new IdentityHashMap<>();
+
+        private ContextConversion(Context context) {
+            this.context = context;
+        }
     }
 
     private static Value asyncMemberFactory(Context context) {

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyRuntimeUtil.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyRuntimeUtil.java
@@ -267,6 +267,9 @@ public final class GraalPyRuntimeUtil {
      * @return The coerced value
      */
     public static @Nullable Object coerceToContext(@Nullable Object value, Context context) {
+        if (isInteropPrimitive(value)) {
+            return value;
+        }
         return withContextConversion(context, () -> coerceToContext0(value, context));
     }
 
@@ -347,6 +350,9 @@ public final class GraalPyRuntimeUtil {
      * @return The coerced value
      */
     public static @Nullable Object coerceToContext(@Nullable Object value, Context context, Class<?> declaredType) {
+        if (isInteropPrimitive(value)) {
+            return value;
+        }
         return withContextConversion(context, () -> coerceToContext0(value, context, declaredType));
     }
 
@@ -401,11 +407,11 @@ public final class GraalPyRuntimeUtil {
     public static Value coercePooledValue(PooledValueCoercible value, Context context) {
         return withContextConversion(context, () -> {
             ContextConversion conversion = CURRENT_CONTEXT_CONVERSION.get();
-            Value existing = conversion.values.get(value);
+            Value existing = conversion.get(value);
             if (existing != null) {
                 return existing;
             }
-            if (conversion.inProgress.put(value, Boolean.TRUE) != null) {
+            if (!conversion.begin(value)) {
                 throw new IllegalStateException(
                     "Cyclic Python wrapper cannot be reconstructed before its target instance is allocated: "
                         + value.getClass().getName()
@@ -413,10 +419,10 @@ public final class GraalPyRuntimeUtil {
             }
             try {
                 Value reconstructed = value.reconstructPolyglotValue(context);
-                conversion.values.put(value, reconstructed);
+                conversion.remember(value, reconstructed);
                 return reconstructed;
             } finally {
-                conversion.inProgress.remove(value);
+                conversion.end(value);
             }
         });
     }
@@ -435,7 +441,7 @@ public final class GraalPyRuntimeUtil {
             || !value.getContext().equals(context)) {
             throw new IllegalStateException("No matching Python context conversion is active");
         }
-        CURRENT_CONTEXT_CONVERSION.get().values.put(source, value);
+        CURRENT_CONTEXT_CONVERSION.get().remember(source, value);
     }
 
     private static <T> T withContextConversion(Context context, Supplier<T> operation) {
@@ -534,6 +540,16 @@ public final class GraalPyRuntimeUtil {
      * @return The coerced arguments
      */
     public static Object[] coerceArgumentsToContext(Context context, Object[] args) {
+        boolean conversionRequired = false;
+        for (Object arg : args) {
+            if (!isInteropPrimitive(arg)) {
+                conversionRequired = true;
+                break;
+            }
+        }
+        if (!conversionRequired) {
+            return args;
+        }
         return withContextConversion(context, () -> {
             Object[] result = new Object[args.length];
             for (int i = 0; i < args.length; i++) {
@@ -608,11 +624,35 @@ public final class GraalPyRuntimeUtil {
 
     private static final class ContextConversion {
         private final Context context;
-        private final IdentityHashMap<PooledValueCoercible, Value> values = new IdentityHashMap<>();
-        private final IdentityHashMap<PooledValueCoercible, Boolean> inProgress = new IdentityHashMap<>();
+        private @Nullable IdentityHashMap<PooledValueCoercible, Value> values;
+        private @Nullable IdentityHashMap<PooledValueCoercible, Boolean> inProgress;
 
         private ContextConversion(Context context) {
             this.context = context;
+        }
+
+        private @Nullable Value get(PooledValueCoercible value) {
+            return values == null ? null : values.get(value);
+        }
+
+        private void remember(PooledValueCoercible source, Value value) {
+            if (values == null) {
+                values = new IdentityHashMap<>();
+            }
+            values.put(source, value);
+        }
+
+        private boolean begin(PooledValueCoercible value) {
+            if (inProgress == null) {
+                inProgress = new IdentityHashMap<>();
+            }
+            return inProgress.put(value, Boolean.TRUE) == null;
+        }
+
+        private void end(PooledValueCoercible value) {
+            if (inProgress != null) {
+                inProgress.remove(value);
+            }
         }
     }
 

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyRuntimeUtil.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyRuntimeUtil.java
@@ -17,6 +17,7 @@ package io.micronaut.context.python;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Experimental;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -249,6 +250,8 @@ public final class GraalPyRuntimeUtil {
     @UsedByGeneratedCode
     public static @Nullable Object coerceValue(@Nullable Object value) {
         return switch (value) {
+            case PooledValueCoercible pooledValueCoercible when value instanceof Enum<?> ->
+                pooledValueCoercible.asPolyglotValue();
             case ValueCoercible valueCoercible when !(value instanceof PooledValueCoercible) ->
                 valueCoercible.asPolyglotValue();
             case null, default -> value;
@@ -266,6 +269,14 @@ public final class GraalPyRuntimeUtil {
         Object standardType = coerceStandardTypeToContext(value, context);
         if (standardType != value) {
             return standardType;
+        }
+        if (value != null && value.getClass().isArray()) {
+            int length = Array.getLength(value);
+            Object[] result = new Object[length];
+            for (int i = 0; i < length; i++) {
+                result[i] = coerceToContext(Array.get(value, i), context);
+            }
+            return result;
         }
         switch (value) {
             case null -> {
@@ -298,13 +309,6 @@ public final class GraalPyRuntimeUtil {
                 }
                 return result;
             }
-            case Object[] array -> {
-                Object[] result = new Object[array.length];
-                for (int i = 0; i < array.length; i++) {
-                    result[i] = coerceToContext(array[i], context);
-                }
-                return result;
-            }
             default -> {
             }
         }
@@ -333,6 +337,9 @@ public final class GraalPyRuntimeUtil {
         if (standardType != value) {
             return standardType;
         }
+        if (declaredType.isArray() && value.getClass().isArray()) {
+            return coerceToContext(value, context);
+        }
         return switch (value) {
             case PooledValueCoercible pooledValueCoercible ->
                 pooledValueCoercible.asPolyglotValue(context);
@@ -342,9 +349,20 @@ public final class GraalPyRuntimeUtil {
                 coerceToContext(value, context);
             case Set<?> _ when Set.class.equals(declaredType) ->
                 coerceToContext(value, context);
-            case Object[] _ when declaredType.isArray() -> coerceToContext(value, context);
             default -> value;
         };
+    }
+
+    /**
+     * Determines whether a polyglot value belongs to the supplied context.
+     *
+     * @param value The value to inspect
+     * @param context The expected context
+     * @return Whether the value belongs to the context
+     */
+    @UsedByGeneratedCode
+    public static boolean isValueInContext(@Nullable Value value, Context context) {
+        return value != null && context.equals(value.getContext());
     }
 
     private static @Nullable Object coerceStandardTypeToContext(@Nullable Object value, Context context) {

--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyRuntimeUtil.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyRuntimeUtil.java
@@ -253,7 +253,8 @@ public final class GraalPyRuntimeUtil {
     @UsedByGeneratedCode
     public static @Nullable Object coerceValue(@Nullable Object value) {
         return switch (value) {
-            case ValueCoercible valueCoercible -> valueCoercible.asPolyglotValue();
+            case ValueCoercible valueCoercible when !(value instanceof PooledValueCoercible) ->
+                valueCoercible.asPolyglotValue();
             case null, default -> value;
         };
     }
@@ -569,6 +570,9 @@ public final class GraalPyRuntimeUtil {
         Context context = target.getContext();
         if (value instanceof CompletionStage<?> completionStage) {
             return PythonAsyncioRuntime.toAwaitable(context, completionStage);
+        }
+        if (value instanceof PooledValueCoercible || value instanceof Value) {
+            return coerceToContext(value, context);
         }
         return asyncMemberFactory(context).execute(value, ASYNC_MEMBER_ADAPTER, context);
     }

--- a/context-python/src/main/java/io/micronaut/context/python/PooledValueCoercible.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PooledValueCoercible.java
@@ -34,4 +34,15 @@ public interface PooledValueCoercible extends ValueCoercible {
      * @return The value
      */
     @NonNull Value asPolyglotValue(Context context);
+
+    /**
+     * Reconstructs the Python value after context-local identity handling has been established.
+     * Generated code calls this method through {@link #asPolyglotValue(Context)}.
+     *
+     * @param context The target context
+     * @return The reconstructed value
+     */
+    default @NonNull Value reconstructPolyglotValue(Context context) {
+        return asPolyglotValue(context);
+    }
 }

--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
@@ -1159,7 +1159,7 @@ public final class PythonContextRuntime {
     }
 
     private static void populateProperties(Value instance, Map<String, Object> props) {
-        if (props != null && !props.isEmpty()) {
+        if (!props.isEmpty()) {
             Value propertySetter = propertySetter(instance.getContext());
             for (java.util.Map.Entry<String, Object> e : props.entrySet()) {
                 propertySetter.execute(

--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
@@ -870,7 +870,21 @@ public final class PythonContextRuntime {
      */
     @UsedByGeneratedCode
     public static Value newIntroduction(PythonClassReference classReference, Object... args) {
-        Value pythonClass = findClass(classReference);
+        return newIntroduction(getContext(), classReference, args);
+    }
+
+    /**
+     * Create an abstract introduction instance in a supplied context.
+     *
+     * @param context The target context
+     * @param classReference The Python class reference
+     * @param args The args
+     * @return The new instance
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static Value newIntroduction(Context context, PythonClassReference classReference, Object... args) {
+        Value pythonClass = findClass(classReference, context);
         if (!pythonClass.hasMember("__micronaut_introduction__")) {
 
             Value abstractMethods = pythonClass.getMember("__abstractmethods__");
@@ -882,7 +896,6 @@ public final class PythonContextRuntime {
                     pythonClass.putMember(methodName, stub);
                 }
             }
-            Context context = pythonClass.getContext();
             if (!context.getBindings(PYTHON).hasMember("update_abstractmethods")) {
                 context.eval(PYTHON, "from abc import update_abstractmethods");
             }
@@ -915,6 +928,24 @@ public final class PythonContextRuntime {
     }
 
     /**
+     * Create an abstract introduction instance in a supplied context, omitting trailing defaults.
+     *
+     * @param context The target context
+     * @param classReference The Python class reference
+     * @param requiredArgCount The number of non-defaulted positional constructor arguments
+     * @param args The arguments
+     * @return The new instance
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static Value newIntroductionWithDefaultedTrailingNulls(Context context,
+                                                                  PythonClassReference classReference,
+                                                                  int requiredArgCount,
+                                                                  Object... args) {
+        return newIntroduction(context, classReference, trimDefaultedTrailingNulls(requiredArgCount, args));
+    }
+
+    /**
      * Create a new instance for the given class reference and args.
      *
      * @param classReference The Python class reference
@@ -924,7 +955,21 @@ public final class PythonContextRuntime {
      */
     @UsedByGeneratedCode
     public static Value newInstance(PythonClassReference classReference, Object... args) {
-        Value pythonClass = findClass(classReference);
+        return newInstance(getContext(), classReference, args);
+    }
+
+    /**
+     * Create a new instance in a supplied context.
+     *
+     * @param context The target context
+     * @param classReference The Python class reference
+     * @param args The args
+     * @return The new instance
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static Value newInstance(Context context, PythonClassReference classReference, Object... args) {
+        Value pythonClass = findClass(classReference, context);
         return instantiate(classReference, args, pythonClass);
     }
 
@@ -938,7 +983,21 @@ public final class PythonContextRuntime {
      */
     @UsedByGeneratedCode
     public static Value enumValue(PythonClassReference classReference, String name) {
-        Value pythonClass = findClass(classReference);
+        return enumValue(getContext(), classReference, name);
+    }
+
+    /**
+     * Resolve a Python enum constant by its Java enum name in a supplied context.
+     *
+     * @param context The target context
+     * @param classReference The Python class reference
+     * @param name The enum constant name
+     * @return The Python enum constant
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static Value enumValue(Context context, PythonClassReference classReference, String name) {
+        Value pythonClass = findClass(classReference, context);
         return withContextClassLoader(() -> {
             Value enumValue = pythonClass.getMember(name);
             if (enumValue != null && !GraalPyRuntimeUtil.isNone(enumValue)) {
@@ -974,6 +1033,24 @@ public final class PythonContextRuntime {
     }
 
     /**
+     * Create a new instance in a supplied context, omitting trailing defaults.
+     *
+     * @param context The target context
+     * @param classReference The Python class reference
+     * @param requiredArgCount The number of non-defaulted positional constructor arguments
+     * @param args The arguments
+     * @return The new instance
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static Value newInstanceWithDefaultedTrailingNulls(Context context,
+                                                              PythonClassReference classReference,
+                                                              int requiredArgCount,
+                                                              Object... args) {
+        return newInstance(context, classReference, trimDefaultedTrailingNulls(requiredArgCount, args));
+    }
+
+    /**
      * Create a Python instance without invoking {@code __init__}.
      *
      * @param classReference The Python class reference
@@ -982,9 +1059,39 @@ public final class PythonContextRuntime {
      */
     @UsedByGeneratedCode
     public static Value newUninitializedInstance(PythonClassReference classReference) {
-        Context context = getContext();
+        return newUninitializedInstance(getContext(), classReference);
+    }
+
+    /**
+     * Create an instance without invoking {@code __init__} in a supplied context.
+     *
+     * @param context The target context
+     * @param classReference The Python class reference
+     * @return The new uninitialized instance
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static Value newUninitializedInstance(Context context, PythonClassReference classReference) {
         Value pythonClass = findClass(classReference, context);
         return context.eval(PYTHON, "lambda cls: object.__new__(cls)").execute(pythonClass);
+    }
+
+    /**
+     * Create an instance without invoking {@code __init__} and populate its properties in a supplied context.
+     *
+     * @param context The target context
+     * @param classReference The Python class reference
+     * @param props Map of property names to values
+     * @return The populated uninitialized instance
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static Value newUninitializedInstance(Context context,
+                                                 PythonClassReference classReference,
+                                                 Map<String, Object> props) {
+        Value instance = newUninitializedInstance(context, classReference);
+        populateProperties(instance, props);
+        return instance;
     }
 
     /**
@@ -997,19 +1104,24 @@ public final class PythonContextRuntime {
      */
     @UsedByGeneratedCode
     public static Value newInstance(PythonClassReference classReference, Map<String, Object> props) {
-        Value pythonClass = findClass(classReference);
+        return newInstance(getContext(), classReference, props);
+    }
+
+    /**
+     * Create a new instance and populate its properties in a supplied context.
+     *
+     * @param context The target context
+     * @param classReference The Python class reference
+     * @param props Map of property names to values
+     * @return The new instance with members populated
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static Value newInstance(Context context, PythonClassReference classReference, Map<String, Object> props) {
+        Value pythonClass = findClass(classReference, context);
         return withContextClassLoader(() -> {
             Value instance = instantiate(classReference, new Object[0], pythonClass);
-            if (props != null && !props.isEmpty()) {
-                Value propertySetter = propertySetter(instance.getContext());
-                for (java.util.Map.Entry<String, Object> e : props.entrySet()) {
-                    propertySetter.execute(
-                        instance,
-                        e.getKey(),
-                        GraalPyRuntimeUtil.coerceToContext(e.getValue(), instance.getContext())
-                    );
-                }
-            }
+            populateProperties(instance, props);
             return instance;
         });
     }
@@ -1024,21 +1136,39 @@ public final class PythonContextRuntime {
      */
     @UsedByGeneratedCode
     public static Value newFrozenDataclassInstance(PythonClassReference classReference, Map<String, Object> props) {
-        Value pythonClass = findClass(classReference);
+        return newFrozenDataclassInstance(getContext(), classReference, props);
+    }
+
+    /**
+     * Create a frozen dataclass instance and populate its properties in a supplied context.
+     *
+     * @param context The target context
+     * @param classReference The Python class reference
+     * @param props Map of property names to values
+     * @return The new instance with members populated
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static Value newFrozenDataclassInstance(Context context, PythonClassReference classReference, Map<String, Object> props) {
+        Value pythonClass = findClass(classReference, context);
         return withContextClassLoader(() -> {
             Value instance = uninitializedInstanceFactory(pythonClass.getContext()).execute(pythonClass);
-            if (props != null && !props.isEmpty()) {
-                Value propertySetter = propertySetter(instance.getContext());
-                for (java.util.Map.Entry<String, Object> e : props.entrySet()) {
-                    propertySetter.execute(
-                        instance,
-                        e.getKey(),
-                        GraalPyRuntimeUtil.coerceToContext(e.getValue(), instance.getContext())
-                    );
-                }
-            }
+            populateProperties(instance, props);
             return instance;
         });
+    }
+
+    private static void populateProperties(Value instance, Map<String, Object> props) {
+        if (props != null && !props.isEmpty()) {
+            Value propertySetter = propertySetter(instance.getContext());
+            for (java.util.Map.Entry<String, Object> e : props.entrySet()) {
+                propertySetter.execute(
+                    instance,
+                    e.getKey(),
+                    GraalPyRuntimeUtil.coerceToContext(e.getValue(), instance.getContext())
+                );
+            }
+        }
     }
 
     private static Value uninitializedInstanceFactory(Context context) {

--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
@@ -1088,7 +1088,7 @@ public final class PythonContextRuntime {
     @UsedByGeneratedCode
     public static Value newUninitializedInstance(Context context,
                                                  PythonClassReference classReference,
-                                                 Map<String, Object> props) {
+                                                 @Nullable Map<String, Object> props) {
         Value instance = newUninitializedInstance(context, classReference);
         populateProperties(instance, props);
         return instance;
@@ -1103,7 +1103,7 @@ public final class PythonContextRuntime {
      * @since 5.2.0
      */
     @UsedByGeneratedCode
-    public static Value newInstance(PythonClassReference classReference, Map<String, Object> props) {
+    public static Value newInstance(PythonClassReference classReference, @Nullable Map<String, Object> props) {
         return newInstance(getContext(), classReference, props);
     }
 
@@ -1117,7 +1117,7 @@ public final class PythonContextRuntime {
      * @since 5.2.0
      */
     @UsedByGeneratedCode
-    public static Value newInstance(Context context, PythonClassReference classReference, Map<String, Object> props) {
+    public static Value newInstance(Context context, PythonClassReference classReference, @Nullable Map<String, Object> props) {
         Value pythonClass = findClass(classReference, context);
         return withContextClassLoader(() -> {
             Value instance = instantiate(classReference, new Object[0], pythonClass);
@@ -1135,7 +1135,7 @@ public final class PythonContextRuntime {
      * @since 5.2.0
      */
     @UsedByGeneratedCode
-    public static Value newFrozenDataclassInstance(PythonClassReference classReference, Map<String, Object> props) {
+    public static Value newFrozenDataclassInstance(PythonClassReference classReference, @Nullable Map<String, Object> props) {
         return newFrozenDataclassInstance(getContext(), classReference, props);
     }
 
@@ -1149,7 +1149,9 @@ public final class PythonContextRuntime {
      * @since 5.2.0
      */
     @UsedByGeneratedCode
-    public static Value newFrozenDataclassInstance(Context context, PythonClassReference classReference, Map<String, Object> props) {
+    public static Value newFrozenDataclassInstance(Context context,
+                                                   PythonClassReference classReference,
+                                                   @Nullable Map<String, Object> props) {
         Value pythonClass = findClass(classReference, context);
         return withContextClassLoader(() -> {
             Value instance = uninitializedInstanceFactory(pythonClass.getContext()).execute(pythonClass);
@@ -1158,8 +1160,8 @@ public final class PythonContextRuntime {
         });
     }
 
-    private static void populateProperties(Value instance, Map<String, Object> props) {
-        if (!props.isEmpty()) {
+    private static void populateProperties(Value instance, @Nullable Map<String, Object> props) {
+        if (props != null && !props.isEmpty()) {
             Value propertySetter = propertySetter(instance.getContext());
             for (java.util.Map.Entry<String, Object> e : props.entrySet()) {
                 propertySetter.execute(
@@ -1169,6 +1171,23 @@ public final class PythonContextRuntime {
                 );
             }
         }
+    }
+
+    /**
+     * Set a property on an instance without invoking an overridden {@code __setattr__} implementation.
+     *
+     * @param instance The target instance
+     * @param name The property name
+     * @param value The property value
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    public static void setInstanceProperty(Value instance, String name, @Nullable Object value) {
+        propertySetter(instance.getContext()).execute(
+            instance,
+            name,
+            GraalPyRuntimeUtil.coerceToContext(value, instance.getContext())
+        );
     }
 
     private static Value uninitializedInstanceFactory(Context context) {

--- a/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
@@ -416,7 +416,27 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
         if (existing != null) {
             return existing;
         }
-        return eventLoopContexts.computeIfAbsent(eventLoop, _ -> borrow0(false));
+        Context created = borrow0(false);
+        Context result;
+        boolean poolClosed;
+        synchronized (this) {
+            poolClosed = closed;
+            if (poolClosed) {
+                result = created;
+            } else {
+                existing = eventLoopContexts.putIfAbsent(eventLoop, created);
+                result = existing == null ? created : existing;
+            }
+        }
+        if (poolClosed) {
+            closeContext(created);
+            throw new IllegalStateException("Pool closed");
+        }
+        if (!result.equals(created)) {
+            cache.remove(created);
+            closeContext(created);
+        }
+        return result;
     }
 
     /**
@@ -426,59 +446,57 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
     private Context borrow0(boolean pooled) {
         long start = System.nanoTime();
         long lastWarned = start;
-        boolean interrupted = false;
-        try {
-            synchronized (this) {
-                while (true) {
-                    Context polled = pooledQueue.poll();
-                    if (polled != null) {
-                        if (!pooled) {
-                            size.decrementAndGet();
-                            pooledContexts.remove(polled);
-                        }
-                        return polled;
-                    }
-                    if (creatingContext == null && (!pooled || size.get() < targetSize)) {
-                        // we can create a context.
-                        creatingContext = Thread.currentThread();
-                        break;
-                    }
-                    try {
-                        // another thread is creating a context, wait for it or wait for the queue to get a new item.
-                        if (warnThreshold == null || !warnThreshold.isPositive() || !LOG.isWarnEnabled()) {
-                            wait();
-                        } else {
-                            long now = System.nanoTime();
-                            Duration timeUntilWarn = Duration.ofNanos(lastWarned + warnThreshold.toNanos() - now);
-                            if (!timeUntilWarn.isPositive()) {
-                                LOG.warn("No available Python contexts; waiting {} so far (pool target: {}, current: {}, queue: {})", Duration.ofNanos(now - start), targetSize, size.get(), pooledQueue.size());
-                                lastWarned = now;
-                                timeUntilWarn = warnThreshold;
-                            }
-                            wait(timeUntilWarn.toMillis(), timeUntilWarn.toNanosPart() % 1_000_000);
-                        }
-                    } catch (InterruptedException e) {
-                        interrupted = true;
-                    }
-                    // we were notified, retry polling
-                }
-            }
-            assert creatingContext == Thread.currentThread();
-            try {
-                Context created = createBorrowedPooledContext(pooled);
-                if (created == null) {
+        synchronized (this) {
+            while (true) {
+                if (closed) {
                     throw new IllegalStateException("Pool closed");
                 }
-                return created;
-            } finally {
-                synchronized (this) {
-                    creatingContext = null;
-                    notifyAll();
+                Context polled = pooledQueue.poll();
+                if (polled != null) {
+                    if (!pooled) {
+                        size.decrementAndGet();
+                        pooledContexts.remove(polled);
+                    }
+                    return polled;
                 }
+                if (creatingContext == null && (!pooled || size.get() < targetSize)) {
+                    // Serialize creation to bound the transient CPU and memory cost of GraalPy startup.
+                    creatingContext = Thread.currentThread();
+                    break;
+                }
+                try {
+                    // Another thread is creating a context; wait for it or for a release.
+                    if (warnThreshold == null || !warnThreshold.isPositive() || !LOG.isWarnEnabled()) {
+                        wait();
+                    } else {
+                        long now = System.nanoTime();
+                        Duration timeUntilWarn = Duration.ofNanos(lastWarned + warnThreshold.toNanos() - now);
+                        if (!timeUntilWarn.isPositive()) {
+                            LOG.warn("No available Python contexts; waiting {} so far (pool target: {}, current: {}, queue: {})", Duration.ofNanos(now - start), targetSize, size.get(), pooledQueue.size());
+                            lastWarned = now;
+                            timeUntilWarn = warnThreshold;
+                        }
+                        // Object.wait expects whole milliseconds plus the remaining nanoseconds.
+                        wait(timeUntilWarn.toMillis(), timeUntilWarn.toNanosPart() % 1_000_000);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while waiting for a Python context", e);
+                }
+                // We were notified, retry polling after checking the closed state.
             }
+        }
+        assert creatingContext == Thread.currentThread();
+        try {
+            Context created = createBorrowedPooledContext(pooled);
+            if (created == null) {
+                throw new IllegalStateException("Pool closed");
+            }
+            return created;
         } finally {
-            if (interrupted) {
-                Thread.currentThread().interrupt();
+            synchronized (this) {
+                creatingContext = null;
+                notifyAll();
             }
         }
     }
@@ -530,6 +548,10 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
         } catch (IOException e) {
             throw new ApplicationStartupException("Failed to create Python context: " + e.getMessage(), e);
         }
+    }
+
+    private static void closeContext(Context context) {
+        GraalPyContextFactory.closeContext(context);
     }
 
     private List<Context> snapshotIncludingPrimary() {
@@ -615,15 +637,17 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
 
     private void closePool() {
         List<Context> snapshot;
+        List<Context> eventLoopSnapshot;
         synchronized (this) {
             closed = true;
             notifyAll();
             snapshot = new ArrayList<>(pooledContexts);
             pooledContexts.removeAll(snapshot);
             pooledQueue.removeAll(snapshot);
+            size.set(0);
+            eventLoopSnapshot = new ArrayList<>(eventLoopContexts.values());
+            eventLoopContexts.clear();
         }
-        List<Context> eventLoopSnapshot = new ArrayList<>(eventLoopContexts.values());
-        eventLoopContexts.clear();
         cache.clear();
         scriptInjections.clear();
         asyncScriptInjections.clear();

--- a/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
@@ -175,7 +175,7 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
                 return;
             }
             pooledQueue.add(c);
-            notify();
+            notifyAll();
         }
     }
 
@@ -473,7 +473,7 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
             } finally {
                 synchronized (this) {
                     creatingContext = null;
-                    notify();
+                    notifyAll();
                 }
             }
         } finally {

--- a/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
@@ -512,19 +512,7 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
         }
         Context c = createContext();
         if (closed) {
-            try {
-                GraalPyContextFactory.closeContext(c);
-            } catch (PolyglotException e) {
-                if (e.isCancelled()) {
-                    LOG.debug("Python pool context close cancelled during shutdown", e);
-                } else {
-                    LOG.warn("Unexpected error while closing Python pool context", e);
-                    throw e;
-                }
-            } catch (RuntimeException | Error e) {
-                LOG.warn("Unexpected error while closing Python pool context", e);
-                throw e;
-            }
+            closeContext(c);
             return null;
         }
         cache.put(c, new ConcurrentHashMap<>());
@@ -551,7 +539,19 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
     }
 
     private static void closeContext(Context context) {
-        GraalPyContextFactory.closeContext(context);
+        try {
+            GraalPyContextFactory.closeContext(context);
+        } catch (PolyglotException e) {
+            if (e.isCancelled()) {
+                LOG.debug("Python pool context was already cancelled while closing", e);
+            } else {
+                LOG.warn("Unexpected error while closing Python pool context", e);
+                throw e;
+            }
+        } catch (RuntimeException | Error e) {
+            LOG.warn("Unexpected error while closing Python pool context", e);
+            throw e;
+        }
     }
 
     private List<Context> snapshotIncludingPrimary() {

--- a/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
@@ -36,15 +36,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.BlockingDeque;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -67,13 +69,16 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
     private final HostAccess hostAccess;
     private final ApplicationContext applicationContext;
     private final GraalPyContextConfiguration contextConfiguration;
-    private final long warnThresholdMs;
+    private final @Nullable Duration warnThreshold;
 
     private final Context primaryContext;
-    private final BlockingDeque<Context> pooledQueue = new LinkedBlockingDeque<>();
-    private final List<Context> pooledContexts = new ArrayList<>();
+
+    private @Nullable Thread creatingContext = null;
+    private final Queue<Context> pooledQueue = new ArrayDeque<>();
+    private final List<Context> pooledContexts = new CopyOnWriteArrayList<>();
     private final Map<PythonEventLoop, Context> eventLoopContexts = new ConcurrentHashMap<>();
     private final Map<Context, Map<String, Value>> cache = new ConcurrentHashMap<>();
+
     private final Map<String, Map<String, Object>> scriptInjections = new ConcurrentHashMap<>();
     private final Map<String, java.util.Set<String>> asyncScriptInjections = new ConcurrentHashMap<>();
 
@@ -108,7 +113,7 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
         this.applicationContext = applicationContext;
         this.contextConfiguration = contextConfiguration;
         int configuredPoolSize = configuration.size();
-        this.warnThresholdMs = configuration.warnWaitMs();
+        this.warnThreshold = configuration.warnWait();
         this.targetSize = configuration.enabled() ? (configuredPoolSize > 0 ? configuredPoolSize : computeDefaultSize()) : 0;
     }
 
@@ -156,30 +161,7 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
      * @return A pooled context ready for exclusive use by the caller
      */
     Context borrow() {
-        long waitedMs = 0L;
-        try {
-            while (true) {
-                Context ctx = pooledQueue.pollFirst();
-                if (ctx != null) {
-                    if (waitedMs >= warnThresholdMs && LOG.isWarnEnabled()) {
-                        LOG.warn("Borrowed context after waiting {} ms (pool size: {}, queue: {})", waitedMs, size.get(), pooledQueue.size());
-                    }
-                    return ctx;
-                }
-                ctx = createBorrowedPooledContext();
-                if (ctx != null) {
-                    return ctx;
-                }
-                Thread.sleep(100);
-                waitedMs += 100;
-                if (warnThresholdMs > 0 && waitedMs % warnThresholdMs == 0 && LOG.isWarnEnabled()) {
-                    LOG.warn("No available Python contexts; waiting {} ms so far (pool target: {}, current: {}, queue: {})", waitedMs, targetSize, size.get(), pooledQueue.size());
-                }
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException(e);
-        }
+        return borrow0(true);
     }
 
     /**
@@ -188,10 +170,13 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
      * @param c The context previously obtained from {@link #borrow()}
      */
     void release(Context c) {
-        if (closed) {
-            return;
+        synchronized (this) {
+            if (closed) {
+                return;
+            }
+            pooledQueue.add(c);
+            notify();
         }
-        pooledQueue.addLast(c);
     }
 
     int pooledContextCount() {
@@ -199,7 +184,9 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
     }
 
     int availableContextCount() {
-        return pooledQueue.size();
+        synchronized (this) {
+            return pooledQueue.size();
+        }
     }
 
     @Override
@@ -289,7 +276,10 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
      * @return A context-local class value
      */
     Value getAnyClass(PythonContextRuntime.PythonClassReference classReference) {
-        Context c = pooledQueue.peekFirst();
+        Context c;
+        synchronized (this) {
+            c = pooledQueue.peek();
+        }
         if (c == null) {
             c = primaryContext;
         }
@@ -317,7 +307,10 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
      * @return A context-local script value
      */
     Value getAnyScript(String packageName, String scriptName) {
-        Context c = pooledQueue.peekFirst();
+        Context c;
+        synchronized (this) {
+            c = pooledQueue.peek();
+        }
         if (c == null) {
             c = primaryContext;
         }
@@ -423,26 +416,77 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
         if (existing != null) {
             return existing;
         }
-        synchronized (eventLoopContexts) {
-            existing = eventLoopContexts.get(eventLoop);
-            if (existing != null) {
-                return existing;
+        return eventLoopContexts.computeIfAbsent(eventLoop, _ -> borrow0(false));
+    }
+
+    /**
+     * @param pooled When {@code true}, this context should be counted towards {@link #size} and
+     *               included in {@link #pooledContexts}.
+     */
+    private Context borrow0(boolean pooled) {
+        long start = System.nanoTime();
+        long lastWarned = start;
+        boolean interrupted = false;
+        try {
+            synchronized (this) {
+                while (true) {
+                    Context polled = pooledQueue.poll();
+                    if (polled != null) {
+                        if (!pooled) {
+                            size.decrementAndGet();
+                            pooledContexts.remove(polled);
+                        }
+                        return polled;
+                    }
+                    if (creatingContext == null && (!pooled || size.get() < targetSize)) {
+                        // we can create a context.
+                        creatingContext = Thread.currentThread();
+                        break;
+                    }
+                    try {
+                        // another thread is creating a context, wait for it or wait for the queue to get a new item.
+                        if (warnThreshold == null || !warnThreshold.isPositive() || !LOG.isWarnEnabled()) {
+                            wait();
+                        } else {
+                            long now = System.nanoTime();
+                            Duration timeUntilWarn = Duration.ofNanos(lastWarned + warnThreshold.toNanos() - now);
+                            if (!timeUntilWarn.isPositive()) {
+                                LOG.warn("No available Python contexts; waiting {} so far (pool target: {}, current: {}, queue: {})", Duration.ofNanos(now - start), targetSize, size.get(), pooledQueue.size());
+                                lastWarned = now;
+                                timeUntilWarn = warnThreshold;
+                            }
+                            wait(timeUntilWarn.toMillis(), timeUntilWarn.toNanosPart() % 1_000_000);
+                        }
+                    } catch (InterruptedException e) {
+                        interrupted = true;
+                    }
+                    // we were notified, retry polling
+                }
             }
-            Context created = pooledQueue.pollFirst();
-            if (created != null) {
-                pooledContexts.remove(created);
-                size.decrementAndGet();
-            } else {
-                created = createContext();
+            assert creatingContext == Thread.currentThread();
+            try {
+                Context created = createBorrowedPooledContext(pooled);
+                if (created == null) {
+                    throw new IllegalStateException("Pool closed");
+                }
+                return created;
+            } finally {
+                synchronized (this) {
+                    creatingContext = null;
+                    notify();
+                }
             }
-            eventLoopContexts.put(eventLoop, created);
-            cache.put(created, new ConcurrentHashMap<>());
-            return created;
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 
-    private synchronized @Nullable Context createBorrowedPooledContext() {
-        if (closed || size.get() >= targetSize) {
+    private @Nullable Context createBorrowedPooledContext(boolean pooled) {
+        assert Thread.currentThread() == creatingContext;
+
+        if (closed) {
             return null;
         }
         if (LOG.isDebugEnabled()) {
@@ -465,13 +509,17 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
             }
             return null;
         }
-        pooledContexts.add(c);
         cache.put(c, new ConcurrentHashMap<>());
-        size.incrementAndGet();
+        if (pooled) {
+            pooledContexts.add(c);
+            size.incrementAndGet();
+        }
         return c;
     }
 
     private Context createContext() {
+        assert Thread.currentThread() == creatingContext;
+
         try {
             return GraalPyContextFactory.buildContext(
                 hostAccess,
@@ -482,10 +530,6 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
         } catch (IOException e) {
             throw new ApplicationStartupException("Failed to create Python context: " + e.getMessage(), e);
         }
-    }
-
-    private List<Context> snapshot() {
-        return new ArrayList<>(pooledContexts);
     }
 
     private List<Context> snapshotIncludingPrimary() {
@@ -558,17 +602,26 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
     @Override
     public CompletionStage<?> shutdownGracefully() {
         if (gracefulShutdownStarted.compareAndSet(false, true)) {
-            closed = true;
-            PythonContextRuntime.onNoActiveExecutions(snapshotIncludingPrimary(), () -> gracefulShutdown.complete(null));
+            List<Context> contexts;
+            synchronized (this) {
+                closed = true;
+                notifyAll();
+                contexts = snapshotIncludingPrimary();
+            }
+            PythonContextRuntime.onNoActiveExecutions(contexts, () -> gracefulShutdown.complete(null));
         }
         return gracefulShutdown;
     }
 
     private void closePool() {
-        closed = true;
-        List<Context> snapshot = snapshot();
-        pooledContexts.removeAll(snapshot);
-        pooledQueue.removeAll(snapshot);
+        List<Context> snapshot;
+        synchronized (this) {
+            closed = true;
+            notifyAll();
+            snapshot = new ArrayList<>(pooledContexts);
+            pooledContexts.removeAll(snapshot);
+            pooledQueue.removeAll(snapshot);
+        }
         List<Context> eventLoopSnapshot = new ArrayList<>(eventLoopContexts.values());
         eventLoopContexts.clear();
         cache.clear();

--- a/context-python/src/main/java/io/micronaut/context/python/PythonPoolConfiguration.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonPoolConfiguration.java
@@ -15,22 +15,25 @@
  */
 package io.micronaut.context.python;
 
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.bind.annotation.Bindable;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
 
 /**
  * Configuration for the PythonPool.
  *
  * @param enabled    Whether pooling is enabled.
  * @param size       The size of the pool. Defaults to the number of processors * 2.
- * @param warnWaitMs The amount of time to wait for a pooled context before a warning is printed.
+ * @param warnWait   The amount of time to wait for a pooled context before a warning is printed.
  */
 @ConfigurationProperties("micronaut.python.pool")
 @Experimental
 public record PythonPoolConfiguration(
     @Bindable(defaultValue = "true") boolean enabled,
     @Bindable(defaultValue = "0") int size,
-    @Bindable(defaultValue = "2000") long warnWaitMs
+    @Bindable(defaultValue = "2s") @Nullable Duration warnWait
 ) {
 }

--- a/context-python/src/test/java/io/micronaut/context/python/BlockingGraalPyContextCustomizer.java
+++ b/context-python/src/test/java/io/micronaut/context/python/BlockingGraalPyContextCustomizer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.python;
+
+import org.graalvm.polyglot.Context;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+final class BlockingGraalPyContextCustomizer implements GraalPyContextCustomizer {
+    private static final AtomicReference<Gate> NEXT_CONTEXT = new AtomicReference<>();
+
+    static Gate blockNextContext() {
+        Gate gate = new Gate();
+        if (!NEXT_CONTEXT.compareAndSet(null, gate)) {
+            throw new IllegalStateException("A context build is already blocked");
+        }
+        return gate;
+    }
+
+    @Override
+    public void customize(Context.Builder builder) {
+        Gate gate = NEXT_CONTEXT.getAndSet(null);
+        if (gate == null) {
+            return;
+        }
+        gate.entered.countDown();
+        boolean interrupted = false;
+        while (true) {
+            try {
+                gate.proceed.await();
+                break;
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    static final class Gate {
+        final CountDownLatch entered = new CountDownLatch(1);
+        final CountDownLatch proceed = new CountDownLatch(1);
+    }
+}

--- a/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.micronaut.http.HttpResponse;
 import org.graalvm.polyglot.Context;
@@ -32,6 +33,7 @@ import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyObject;
 import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -328,6 +330,44 @@ class GraalPyRuntimeUtilTest {
 
         assertTrue(result instanceof Map);
         assertEquals(Map.of("existing", "value"), result);
+    }
+
+    @Test
+    void coerceToContextUsesPooledConversionForTargetContext() {
+        Value targetValue = context.eval("python", "{'context': 'target'}");
+        AtomicInteger noArgumentConversions = new AtomicInteger();
+        AtomicInteger targetConversions = new AtomicInteger();
+        PooledValueCoercible body = new PooledValueCoercible() {
+            @Override
+            public Value asPolyglotValue() {
+                noArgumentConversions.incrementAndGet();
+                throw new AssertionError("The primary-context conversion must not be used");
+            }
+
+            @Override
+            public Value asPolyglotValue(Context targetContext) {
+                assertSame(context, targetContext);
+                targetConversions.incrementAndGet();
+                return targetValue;
+            }
+        };
+
+        assertSame(targetValue, GraalPyRuntimeUtil.coerceToContext(body, context));
+
+        Object nested = GraalPyRuntimeUtil.coerceToContext(
+            List.of(Map.of("bodies", new Object[] {body})),
+            context
+        );
+        List<?> nestedList = (List<?>) nested;
+        Map<?, ?> nestedMap = (Map<?, ?>) nestedList.getFirst();
+        assertArrayEquals(new Object[] {targetValue}, (Object[]) nestedMap.get("bodies"));
+        assertArrayEquals(
+            new Object[] {1, 2, 3},
+            (Object[]) GraalPyRuntimeUtil.coerceToContext(new int[] {1, 2, 3}, context, int[].class)
+        );
+
+        assertEquals(2, targetConversions.get());
+        assertEquals(0, noArgumentConversions.get());
     }
 
     @Test

--- a/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
@@ -476,9 +476,10 @@ class GraalPyRuntimeUtilTest {
             );
 
             assertTrue(exception.getMessage().contains("cannot be reconstructed in the target context"));
+            Value foreignValue = other.eval("python", "object()");
             assertThrows(
                 IllegalArgumentException.class,
-                () -> GraalPyRuntimeUtil.coerceToContext(other.eval("python", "object()"), context)
+                () -> GraalPyRuntimeUtil.coerceToContext(foreignValue, context)
             );
         }
     }

--- a/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
@@ -371,6 +371,35 @@ class GraalPyRuntimeUtilTest {
     }
 
     @Test
+    void putMemberDefersPooledWrapperConversionToTargetContext() {
+        try (Context targetContext = Context.newBuilder("python").allowAllAccess(true).build()) {
+            Value target = targetContext.eval("python", "type('Parent', (), {})()");
+            AtomicInteger noArgumentConversions = new AtomicInteger();
+            AtomicInteger targetConversions = new AtomicInteger();
+            PooledValueCoercible child = new PooledValueCoercible() {
+                @Override
+                public Value asPolyglotValue() {
+                    noArgumentConversions.incrementAndGet();
+                    return context.eval("python", "type('WrongContext', (), {})()");
+                }
+
+                @Override
+                public Value asPolyglotValue(Context context) {
+                    assertEquals(targetContext, context);
+                    targetConversions.incrementAndGet();
+                    return context.eval("python", "type('Child', (), {'name': 'target'})()");
+                }
+            };
+
+            GraalPyRuntimeUtil.putMember(target, "child", GraalPyRuntimeUtil.coerceValue(child));
+
+            assertEquals("target", target.getMember("child").getMember("name").asString());
+            assertEquals(1, targetConversions.get());
+            assertEquals(0, noArgumentConversions.get());
+        }
+    }
+
+    @Test
     void coerceArgumentsPreservesPooledWrapperIdentity() {
         Value targetValue = context.eval("python", "type('Body', (), {})()");
         AtomicInteger reconstructions = new AtomicInteger();

--- a/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
@@ -429,6 +429,15 @@ class GraalPyRuntimeUtilTest {
     }
 
     @Test
+    void interopPrimitiveArgumentsUseFastPath() {
+        Object[] arguments = {null, 1, true, "value"};
+
+        assertSame(arguments, GraalPyRuntimeUtil.coerceArgumentsToContext(context, arguments));
+        assertSame(arguments[3], GraalPyRuntimeUtil.coerceToContext(arguments[3], context));
+        assertSame(arguments[3], GraalPyRuntimeUtil.coerceToContext(arguments[3], context, String.class));
+    }
+
+    @Test
     void pooledConversionSupportsCyclesAfterTargetAllocation() {
         PooledValueCoercible node = new PooledValueCoercible() {
             @Override

--- a/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/GraalPyRuntimeUtilTest.java
@@ -371,6 +371,81 @@ class GraalPyRuntimeUtilTest {
     }
 
     @Test
+    void coerceArgumentsPreservesPooledWrapperIdentity() {
+        Value targetValue = context.eval("python", "type('Body', (), {})()");
+        AtomicInteger reconstructions = new AtomicInteger();
+        PooledValueCoercible body = new PooledValueCoercible() {
+            @Override
+            public Value asPolyglotValue() {
+                throw new AssertionError("The primary-context conversion must not be used");
+            }
+
+            @Override
+            public Value asPolyglotValue(Context targetContext) {
+                return GraalPyRuntimeUtil.coercePooledValue(this, targetContext);
+            }
+
+            @Override
+            public Value reconstructPolyglotValue(Context targetContext) {
+                assertSame(context, targetContext);
+                reconstructions.incrementAndGet();
+                return targetValue;
+            }
+        };
+
+        Object[] converted = GraalPyRuntimeUtil.coerceArgumentsToContext(context, new Object[] {body, body});
+
+        assertSame(converted[0], converted[1]);
+        assertEquals(1, reconstructions.get());
+    }
+
+    @Test
+    void pooledConversionSupportsCyclesAfterTargetAllocation() {
+        PooledValueCoercible node = new PooledValueCoercible() {
+            @Override
+            public Value asPolyglotValue() {
+                throw new AssertionError("The primary-context conversion must not be used");
+            }
+
+            @Override
+            public Value asPolyglotValue(Context targetContext) {
+                return GraalPyRuntimeUtil.coercePooledValue(this, targetContext);
+            }
+
+            @Override
+            public Value reconstructPolyglotValue(Context targetContext) {
+                Value target = targetContext.eval("python", "type('Node', (), {})()");
+                GraalPyRuntimeUtil.rememberPooledValue(this, targetContext, target);
+                GraalPyRuntimeUtil.putMember(target, "next", this);
+                return target;
+            }
+        };
+
+        Value converted = (Value) GraalPyRuntimeUtil.coerceToContext(node, context);
+        context.getBindings("python").putMember("converted_node", converted);
+
+        assertTrue(context.eval("python", "converted_node.next is converted_node").asBoolean());
+    }
+
+    @Test
+    void nonReconstructibleWrapperFromAnotherContextFailsLoudly() {
+        try (Context other = Context.newBuilder("python").allowAllAccess(true).build()) {
+            ValueCoercible wrapper = () -> other.eval("python", "object()");
+
+            IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> GraalPyRuntimeUtil.coerceToContext(wrapper, context)
+            );
+
+            assertTrue(exception.getMessage().contains("cannot be reconstructed in the target context"));
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> GraalPyRuntimeUtil.coerceToContext(other.eval("python", "object()"), context)
+            );
+        }
+    }
+
+    @Test
     void testConvertHostOptional() {
         context.getBindings("python").putMember("optional", Optional.of("value"));
 

--- a/context-python/src/test/java/io/micronaut/context/python/PythonAsyncioRuntimeTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/PythonAsyncioRuntimeTest.java
@@ -1098,6 +1098,31 @@ final class PythonAsyncioRuntimeTest {
     }
 
     @Test
+    void asyncMemberValueReconstructsPythonWrapperInTargetContext() {
+        try (Context context = Context.newBuilder(PYTHON).allowAllAccess(true).build()) {
+            Value target = context.eval(PYTHON, "type('Target', (), {})()");
+            PooledValueCoercible client = new PooledValueCoercible() {
+                @Override
+                public Value asPolyglotValue() {
+                    throw new AssertionError("Primary conversion should not be used");
+                }
+
+                @Override
+                public Value asPolyglotValue(Context targetContext) {
+                    assertEquals(context, targetContext);
+                    return targetContext.eval(PYTHON, "type('Client', (), {'name': 'python-client'})()");
+                }
+            };
+
+            Object adapted = GraalPyRuntimeUtil.asyncMemberValue(target, client);
+            GraalPyRuntimeUtil.putMember(target, "client", adapted);
+
+            assertEquals("python-client", target.getMember("client").getMember("name").asString());
+            assertEquals(context, assertInstanceOf(Value.class, adapted).getContext());
+        }
+    }
+
+    @Test
     void asyncMemberValueAdaptsPublisherMethodResultsAsScalarAwaitables() throws Exception {
         try (Context context = Context.newBuilder(PYTHON).allowAllAccess(true).build()) {
             Value target = context.eval(PYTHON, """

--- a/context-python/src/test/java/io/micronaut/context/python/PythonAsyncioRuntimeTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/PythonAsyncioRuntimeTest.java
@@ -49,6 +49,7 @@ import static io.micronaut.context.python.GraalPyRuntimeUtil.PYTHON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -285,6 +286,51 @@ final class PythonAsyncioRuntimeTest {
     }
 
     @Test
+    void disabledPoolUsesPrimaryContextWithoutCreatingPooledContexts() {
+        try (ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+            "micronaut.python.pool.enabled", false
+        ))) {
+            PythonPool pool = applicationContext.getBean(PythonPool.class);
+            Context first = pool.withContext(context -> context);
+            Context second = pool.withContext(context -> context);
+
+            assertSame(PythonContextRuntime.getContext(), first);
+            assertSame(first, second);
+            assertEquals(0, pool.pooledContextCount());
+            assertEquals(0, pool.availableContextCount());
+        }
+    }
+
+    @Test
+    void conversionFailureReleasesBorrowedContext() {
+        try (ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+            "micronaut.python.pool.enabled", true,
+            "micronaut.python.pool.size", 1
+        ))) {
+            PythonPool pool = applicationContext.getBean(PythonPool.class);
+            PooledValueCoercible failing = new PooledValueCoercible() {
+                @Override
+                public Value asPolyglotValue() {
+                    throw new AssertionError("Primary conversion should not be used");
+                }
+
+                @Override
+                public Value asPolyglotValue(Context context) {
+                    throw new IllegalArgumentException("conversion failed");
+                }
+            };
+
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                pool.withContext(context -> GraalPyRuntimeUtil.coerceToContext(failing, context))
+            );
+
+            assertEquals("conversion failed", exception.getMessage());
+            assertEquals(1, pool.pooledContextCount());
+            assertEquals(1, pool.availableContextCount());
+        }
+    }
+
+    @Test
     void concurrentBorrowsGrowToConfiguredSizeAndThenWait() throws Exception {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         try (ApplicationContext applicationContext = ApplicationContext.run(Map.of(
@@ -308,6 +354,52 @@ final class PythonAsyncioRuntimeTest {
             } finally {
                 pool.release(second);
                 pool.release(third);
+            }
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void releasedContextCanBeBorrowedWhileAnotherContextIsBeingCreated() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        try (ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+            "micronaut.python.pool.enabled", true,
+            "micronaut.python.pool.size", 2
+        ))) {
+            PythonPool pool = applicationContext.getBean(PythonPool.class);
+            Context first = pool.borrow();
+            Context expectedReuse = first;
+            Context second = null;
+            Context reused = null;
+            BlockingGraalPyContextCustomizer.Gate gate = BlockingGraalPyContextCustomizer.blockNextContext();
+            try {
+                Future<Context> creatingBorrow = executorService.submit(pool::borrow);
+                assertTrue(gate.entered.await(5, TimeUnit.SECONDS));
+
+                Future<Context> waitingBorrow = executorService.submit(pool::borrow);
+                Thread.sleep(100);
+                assertFalse(waitingBorrow.isDone());
+
+                pool.release(first);
+                first = null;
+                reused = waitingBorrow.get(1, TimeUnit.SECONDS);
+                assertSame(expectedReuse, reused);
+
+                gate.proceed.countDown();
+                second = creatingBorrow.get(5, TimeUnit.SECONDS);
+                assertEquals(2, pool.pooledContextCount());
+            } finally {
+                gate.proceed.countDown();
+                if (first != null) {
+                    pool.release(first);
+                }
+                if (second != null) {
+                    pool.release(second);
+                }
+                if (reused != null) {
+                    pool.release(reused);
+                }
             }
         } finally {
             executorService.shutdownNow();

--- a/context-python/src/test/java/io/micronaut/context/python/PythonAsyncioRuntimeTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/PythonAsyncioRuntimeTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -354,6 +355,51 @@ final class PythonAsyncioRuntimeTest {
                 pool.release(second);
                 pool.release(third);
             }
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void waitingBorrowFailsWhenPoolCloses() throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try (ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+            "micronaut.python.pool.enabled", true,
+            "micronaut.python.pool.size", 1
+        ))) {
+            PythonPool pool = applicationContext.getBean(PythonPool.class);
+            Context borrowed = pool.borrow();
+            Future<Context> waitingBorrow = executorService.submit(pool::borrow);
+            assertThrows(TimeoutException.class, () -> waitingBorrow.get(100, TimeUnit.MILLISECONDS));
+
+            pool.shutdownGracefully().toCompletableFuture().get(1, TimeUnit.SECONDS);
+
+            ExecutionException failure = assertThrows(
+                ExecutionException.class,
+                () -> waitingBorrow.get(1, TimeUnit.SECONDS)
+            );
+            assertEquals("Pool closed", assertInstanceOf(IllegalStateException.class, failure.getCause()).getMessage());
+            pool.release(borrowed);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void waitingBorrowRespondsToInterruption() throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try (ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+            "micronaut.python.pool.enabled", true,
+            "micronaut.python.pool.size", 1
+        ))) {
+            PythonPool pool = applicationContext.getBean(PythonPool.class);
+            Context borrowed = pool.borrow();
+            Future<Context> waitingBorrow = executorService.submit(pool::borrow);
+            assertThrows(TimeoutException.class, () -> waitingBorrow.get(100, TimeUnit.MILLISECONDS));
+
+            assertTrue(waitingBorrow.cancel(true));
+            assertTrue(executorService.submit(() -> true).get(1, TimeUnit.SECONDS));
+            pool.release(borrowed);
         } finally {
             executorService.shutdownNow();
         }

--- a/context-python/src/test/java/io/micronaut/context/python/PythonAsyncioRuntimeTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/PythonAsyncioRuntimeTest.java
@@ -343,8 +343,7 @@ final class PythonAsyncioRuntimeTest {
             assertEquals(2, pool.pooledContextCount());
 
             Future<Context> waitingBorrow = executorService.submit(pool::borrow);
-            Thread.sleep(200);
-            assertFalse(waitingBorrow.isDone());
+            assertThrows(TimeoutException.class, () -> waitingBorrow.get(200, TimeUnit.MILLISECONDS));
 
             pool.release(first);
             Context third = waitingBorrow.get(5, TimeUnit.SECONDS);
@@ -378,8 +377,7 @@ final class PythonAsyncioRuntimeTest {
                 assertTrue(gate.entered.await(5, TimeUnit.SECONDS));
 
                 Future<Context> waitingBorrow = executorService.submit(pool::borrow);
-                Thread.sleep(100);
-                assertFalse(waitingBorrow.isDone());
+                assertThrows(TimeoutException.class, () -> waitingBorrow.get(100, TimeUnit.MILLISECONDS));
 
                 pool.release(first);
                 first = null;

--- a/context-python/src/test/java/io/micronaut/context/python/PythonContextRuntimeTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/PythonContextRuntimeTest.java
@@ -235,4 +235,24 @@ final class PythonContextRuntimeTest {
             PythonContextRuntime.resetContext();
         }
     }
+
+    @Test
+    void uninitializedInstanceAcceptsNullProperties() {
+        try (Context context = Context.newBuilder(PYTHON).allowAllAccess(true).build()) {
+            context.eval(PYTHON, "class Empty: pass");
+            Value value = PythonContextRuntime.newUninitializedInstance(
+                context,
+                new PythonContextRuntime.PythonClassReference(
+                    null,
+                    "Empty",
+                    new String[0],
+                    "Empty",
+                    "class-instance:python.Empty"
+                ),
+                null
+            );
+
+            assertEquals("Empty", value.getMetaObject().getMetaSimpleName());
+        }
+    }
 }

--- a/context-python/src/test/resources/META-INF/services/io.micronaut.context.python.GraalPyContextCustomizer
+++ b/context-python/src/test/resources/META-INF/services/io.micronaut.context.python.GraalPyContextCustomizer
@@ -1,2 +1,3 @@
 io.micronaut.context.python.SecondGraalPyContextCustomizer
 io.micronaut.context.python.FirstGraalPyContextCustomizer
+io.micronaut.context.python.BlockingGraalPyContextCustomizer

--- a/inject-python-test/src/main/groovy/io/micronaut/python/annotation/processing/test/AbstractPythonTypeElementSpec.groovy
+++ b/inject-python-test/src/main/groovy/io/micronaut/python/annotation/processing/test/AbstractPythonTypeElementSpec.groovy
@@ -23,6 +23,7 @@ import io.micronaut.context.DefaultBeanDefinitionsProvider
 import io.micronaut.context.Qualifier
 import io.micronaut.context.event.ApplicationEventPublisherFactory
 import io.micronaut.context.python.PythonContextRuntime
+import io.micronaut.context.python.PythonContextExecutor
 import io.micronaut.core.io.IOUtils
 import io.micronaut.core.naming.NameUtils
 import io.micronaut.core.beans.BeanIntrospection
@@ -42,6 +43,8 @@ import spock.lang.Specification
 import javax.tools.JavaFileObject
 import java.util.stream.Collectors
 import java.util.stream.StreamSupport
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Base class to extend from to allow compilation of Python sources
@@ -259,6 +262,27 @@ abstract class AbstractPythonTypeElementSpec extends Specification {
      * @param contextBuilder The context builder
      */
     protected void configureContext(ApplicationContextBuilder contextBuilder) {
+    }
+
+    protected static void warmPool(ApplicationContext context, def executor, int size) {
+        def contextExecutor = context.getBean(PythonContextExecutor)
+        def acquired = new CountDownLatch(size)
+        def release = new CountDownLatch(1)
+        def futures = (1..size).collect {
+            executor.submit {
+                contextExecutor.withContext {
+                    acquired.countDown()
+                    release.await()
+                    null
+                }
+            }
+        }
+        try {
+            assert acquired.await(30, TimeUnit.SECONDS)
+        } finally {
+            release.countDown()
+        }
+        futures.each { it.get(30, TimeUnit.SECONDS) }
     }
 
     /**

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/HostAccessEndToEndSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/HostAccessEndToEndSpec.groovy
@@ -2,6 +2,8 @@ package io.micronaut.python.annotation.processing.test
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.python.PythonContextRuntime
+import io.micronaut.context.python.PooledValueCoercible
+import io.micronaut.context.python.PythonPool
 import io.micronaut.context.python.GraalPyContextFactory
 import io.micronaut.context.python.GraalPyRuntimeUtil
 import io.micronaut.context.python.ValueCoercible
@@ -563,6 +565,55 @@ class Move:
         then:
         white.name() == "WHITE"
         pythonMove.getMember('player').getMember('value').asString() == 'w'
+
+        cleanup:
+        ctx?.close()
+    }
+
+    void "introspected Python classes preserve nested identity and cycles in a pooled context"() {
+        given:
+        String py = '''
+from micronaut.core.annotation import Introspected
+
+
+@Introspected
+class Node:
+    name: str | None = None
+    next: "Node | None" = None
+
+
+@Introspected
+class Pair:
+    left: Node | None = None
+    right: Node | None = None
+
+
+'''
+        ApplicationContext ctx = buildContext(py, true, [
+            "micronaut.python.pool.enabled": true,
+            "micronaut.python.pool.size": 1
+        ])
+        Class<?> nodeClass = ctx.classLoader.loadClass('python.Node')
+        Class<?> pairClass = ctx.classLoader.loadClass('python.Pair')
+        def node = nodeClass.getDeclaredConstructor().newInstance()
+        nodeClass.getField('name').set(node, 'root')
+        nodeClass.getField('next').set(node, node)
+        def pair = pairClass.getDeclaredConstructor().newInstance()
+        pairClass.getField('left').set(pair, node)
+        pairClass.getField('right').set(pair, node)
+
+        when:
+        boolean identityPreserved = ctx.getBean(PythonPool).withContext { Context targetContext ->
+            Value targetPair = ((PooledValueCoercible) pair).asPolyglotValue(targetContext)
+            targetContext.getBindings('python').putMember('target_pair', targetPair)
+            targetContext.eval(
+                'python',
+                'target_pair.left is target_pair.right and target_pair.left.next is target_pair.left'
+            ).asBoolean()
+        }
+
+        then:
+        identityPreserved
 
         cleanup:
         ctx?.close()

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/HostAccessEndToEndSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/HostAccessEndToEndSpec.groovy
@@ -619,6 +619,43 @@ class Pair:
         ctx?.close()
     }
 
+    void "ordinary Python methods keep bare list and map elements as host bridges"() {
+        given:
+        String py = '''
+from dataclasses import dataclass
+from micronaut.core.annotation import Introspected
+
+
+@dataclass
+@Introspected
+class Item:
+    name: str
+
+
+@Introspected
+class Consumer:
+    def describe(self, item: Item, items: list[Item], items_by_name: dict[str, Item]) -> str:
+        return ":".join((
+            item.getName(),
+            items[0].getName(),
+            items_by_name.get("primary").getName(),
+        ))
+
+
+'''
+        ApplicationContext ctx = buildContext(py, true)
+        Class<?> itemClass = ctx.classLoader.loadClass('python.Item')
+        Class<?> consumerClass = ctx.classLoader.loadClass('python.Consumer')
+        def item = itemClass.getDeclaredConstructor(String).newInstance('one')
+        def consumer = consumerClass.getDeclaredConstructor().newInstance()
+
+        expect:
+        consumer.describe(item, [item], [primary: item]) == 'one:one:one'
+
+        cleanup:
+        ctx?.close()
+    }
+
     void "generated dataclass wrapper setters called from Python update Java fields"() {
         given:
         String py = '''

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PooledClassSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PooledClassSpec.groovy
@@ -1,11 +1,13 @@
 package io.micronaut.python.annotation.processing.test
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.python.PythonContextExecutor
 import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.python.annotation.processing.test.AbstractPythonTypeElementSpec
 
 import java.util.concurrent.Executors
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class PooledClassSpec extends AbstractPythonTypeElementSpec {
@@ -59,6 +61,7 @@ class PoolController:
         server.start()
         def client = context.createBean(HttpClient, server.URL)
         def executor = Executors.newFixedThreadPool(4)
+        warmPool(context, executor, 4)
 
         when:
         def getCtxId = readerClass.getMethod("get_ctx_id")
@@ -94,6 +97,27 @@ class PoolController:
         } else {
             System.setProperty("micronaut.python.context-id.enabled", previousContextIdProperty)
         }
+    }
+
+    private static void warmPool(ApplicationContext context, def executor, int size) {
+        def contextExecutor = context.getBean(PythonContextExecutor)
+        def acquired = new CountDownLatch(size)
+        def release = new CountDownLatch(1)
+        def futures = (1..size).collect {
+            executor.submit {
+                contextExecutor.withContext {
+                    acquired.countDown()
+                    release.await()
+                    null
+                }
+            }
+        }
+        try {
+            assert acquired.await(30, TimeUnit.SECONDS)
+        } finally {
+            release.countDown()
+        }
+        futures.each { it.get(30, TimeUnit.SECONDS) }
     }
 
     void "pooled class with ctor args fails compilation"() {

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PooledClassSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PooledClassSpec.groovy
@@ -1,13 +1,11 @@
 package io.micronaut.python.annotation.processing.test
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.python.PythonContextExecutor
 import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.python.annotation.processing.test.AbstractPythonTypeElementSpec
 
 import java.util.concurrent.Executors
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class PooledClassSpec extends AbstractPythonTypeElementSpec {
@@ -97,27 +95,6 @@ class PoolController:
         } else {
             System.setProperty("micronaut.python.context-id.enabled", previousContextIdProperty)
         }
-    }
-
-    private static void warmPool(ApplicationContext context, def executor, int size) {
-        def contextExecutor = context.getBean(PythonContextExecutor)
-        def acquired = new CountDownLatch(size)
-        def release = new CountDownLatch(1)
-        def futures = (1..size).collect {
-            executor.submit {
-                contextExecutor.withContext {
-                    acquired.countDown()
-                    release.await()
-                    null
-                }
-            }
-        }
-        try {
-            assert acquired.await(30, TimeUnit.SECONDS)
-        } finally {
-            release.countDown()
-        }
-        futures.each { it.get(30, TimeUnit.SECONDS) }
     }
 
     void "pooled class with ctor args fails compilation"() {

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/web/PooledControllerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/web/PooledControllerSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.python.annotation.processing.test.web
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.python.PythonContextExecutor
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
@@ -9,7 +8,6 @@ import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.python.annotation.processing.test.AbstractPythonTypeElementSpec
 
 import java.util.concurrent.Executors
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class PooledControllerSpec extends AbstractPythonTypeElementSpec {
@@ -199,24 +197,4 @@ def plain_body(item: Annotated[InventoryItem, Body]) -> str:
         }
     }
 
-    private static void warmPool(ApplicationContext context, def executor, int size) {
-        def contextExecutor = context.getBean(PythonContextExecutor)
-        def acquired = new CountDownLatch(size)
-        def release = new CountDownLatch(1)
-        def futures = (1..size).collect {
-            executor.submit {
-                contextExecutor.withContext {
-                    acquired.countDown()
-                    release.await()
-                    null
-                }
-            }
-        }
-        try {
-            assert acquired.await(30, TimeUnit.SECONDS)
-        } finally {
-            release.countDown()
-        }
-        futures.each { it.get(30, TimeUnit.SECONDS) }
-    }
 }

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/web/PooledControllerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/web/PooledControllerSpec.groovy
@@ -63,6 +63,16 @@ class Order:
     def ctx_id(self) -> str:
         return context_id()
 
+@Introspected
+class InventoryItem:
+    sku: str
+    quantity: int
+    tags: list[str]
+    metadata: dict[str, str]
+
+    def ctx_id(self) -> str:
+        return context_id()
+
 @Get("/pool/ctx")
 def ctx() -> str:
     import time
@@ -81,6 +91,10 @@ def pair() -> str:
 @Post("/pool/body")
 def body(order: Annotated[Order, Body]) -> str:
     return f"{order.customer}:{order.address.city}:{','.join(order.items)}:{order.metadata['source']}:{order.priority.value}:{order.ctx_id()}:{context_id()}"
+
+@Post("/pool/plain-body")
+def plain_body(item: Annotated[InventoryItem, Body]) -> str:
+    return f"{item.sku}:{item.quantity}:{','.join(item.tags)}:{item.metadata['source']}:{item.ctx_id()}:{context_id()}"
 '''
         def previousContextIdProperty = System.getProperty("micronaut.python.context-id.enabled")
         System.setProperty("micronaut.python.context-id.enabled", "true")
@@ -146,6 +160,33 @@ def body(order: Annotated[Order, Body]) -> str:
                 parts[5] == parts[6]
         }
         bodyResponses.collect { it.split(":")[6] }.toSet().size() >= 2
+
+        when:
+        def plainBodyResponses = (1..8).collect {
+            executor.submit {
+                def request = HttpRequest.POST("/pool/plain-body", [
+                    sku: "MN-PY",
+                    quantity: 4,
+                    tags: ["plain", "introspected"],
+                    metadata: [source: "json"]
+                ]).contentType(MediaType.APPLICATION_JSON_TYPE)
+                client.toBlocking().retrieve(request)
+            }
+        }.collect {
+            it.get(10, TimeUnit.SECONDS)
+        }
+
+        then:
+        plainBodyResponses.every {
+            def parts = it.split(":")
+            parts.length == 6 &&
+                parts[0] == "MN-PY" &&
+                parts[1] == "4" &&
+                parts[2] == "plain,introspected" &&
+                parts[3] == "json" &&
+                parts[4] == parts[5]
+        }
+        plainBodyResponses.collect { it.split(":")[5] }.toSet().size() >= 2
 
         cleanup:
         executor?.shutdownNow()

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/web/PooledControllerSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/web/PooledControllerSpec.groovy
@@ -1,11 +1,15 @@
 package io.micronaut.python.annotation.processing.test.web
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.python.PythonContextExecutor
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.python.annotation.processing.test.AbstractPythonTypeElementSpec
 
 import java.util.concurrent.Executors
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class PooledControllerSpec extends AbstractPythonTypeElementSpec {
@@ -13,7 +17,10 @@ class PooledControllerSpec extends AbstractPythonTypeElementSpec {
     void "pooled controller uses multiple contexts and injection works"() {
         given:
         def python = '''
-from micronaut.http.annotation import Get
+from dataclasses import dataclass
+from enum import Enum
+from micronaut.core.annotation import Introspected
+from micronaut.http.annotation import Body, Get, Post
 from typing import Annotated
 from jakarta.inject import Inject, Singleton
 from micronaut.context.python.scope import ContextPooled
@@ -30,13 +37,37 @@ class MessageService:
 
 message_service : Annotated[MessageService, Inject]
 
+def context_id() -> str:
+    import builtins
+    g = globals()
+    return g.get("__MN_CTX_ID__") or builtins.__dict__.get("__MN_CTX_ID__") or "unknown"
+
+@Introspected
+@dataclass(frozen=True)
+class Address:
+    city: str
+
+class Priority(Enum):
+    HIGH = "high"
+    LOW = "low"
+
+@Introspected
+@dataclass
+class Order:
+    customer: str
+    address: Address
+    items: list[str]
+    metadata: dict[str, str]
+    priority: Priority
+
+    def ctx_id(self) -> str:
+        return context_id()
+
 @Get("/pool/ctx")
 def ctx() -> str:
     import time
     time.sleep(0.1)
-    import builtins
-    g = globals()
-    return g.get("__MN_CTX_ID__") or builtins.__dict__.get("__MN_CTX_ID__") or "unknown"
+    return context_id()
 
 @Get("/pool/hello/{name}")
 def hello(name: str) -> str:
@@ -46,6 +77,10 @@ def hello(name: str) -> str:
 def pair() -> str:
     own = ctx()
     return own + ":" + message_service.ctx_id()
+
+@Post("/pool/body")
+def body(order: Annotated[Order, Body]) -> str:
+    return f"{order.customer}:{order.address.city}:{','.join(order.items)}:{order.metadata['source']}:{order.priority.value}:{order.ctx_id()}:{context_id()}"
 '''
         def previousContextIdProperty = System.getProperty("micronaut.python.context-id.enabled")
         System.setProperty("micronaut.python.context-id.enabled", "true")
@@ -55,6 +90,7 @@ def pair() -> str:
         server.start()
         def client = context.createBean(HttpClient, server.URL)
         def executor = Executors.newFixedThreadPool(4)
+        warmPool(context, executor, 4)
 
         when:
         def ids = (1..4).collect {
@@ -82,6 +118,35 @@ def pair() -> str:
         }
         pairs.toSet().size() >= 2
 
+        when:
+        def bodyResponses = (1..8).collect {
+            executor.submit {
+                def request = HttpRequest.POST("/pool/body", [
+                    customer: "Ada",
+                    address: [city: "Zürich"],
+                    items: ["compiler", "runtime"],
+                    metadata: [source: "json"],
+                    priority: "HIGH"
+                ]).contentType(MediaType.APPLICATION_JSON_TYPE)
+                client.toBlocking().retrieve(request)
+            }
+        }.collect {
+            it.get(10, TimeUnit.SECONDS)
+        }
+
+        then:
+        bodyResponses.every {
+            def parts = it.split(":")
+            parts.length == 7 &&
+                parts[0] == "Ada" &&
+                parts[1] == "Zürich" &&
+                parts[2] == "compiler,runtime" &&
+                parts[3] == "json" &&
+                parts[4] == "high" &&
+                parts[5] == parts[6]
+        }
+        bodyResponses.collect { it.split(":")[6] }.toSet().size() >= 2
+
         cleanup:
         executor?.shutdownNow()
         client?.close()
@@ -91,5 +156,26 @@ def pair() -> str:
         } else {
             System.setProperty("micronaut.python.context-id.enabled", previousContextIdProperty)
         }
+    }
+
+    private static void warmPool(ApplicationContext context, def executor, int size) {
+        def contextExecutor = context.getBean(PythonContextExecutor)
+        def acquired = new CountDownLatch(size)
+        def release = new CountDownLatch(1)
+        def futures = (1..size).collect {
+            executor.submit {
+                contextExecutor.withContext {
+                    acquired.countDown()
+                    release.await()
+                    null
+                }
+            }
+        }
+        try {
+            assert acquired.await(30, TimeUnit.SECONDS)
+        } finally {
+            release.countDown()
+        }
+        futures.each { it.get(30, TimeUnit.SECONDS) }
     }
 }

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/GenerateToStringEqualsSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/GenerateToStringEqualsSpec.groovy
@@ -57,10 +57,24 @@ class Person:
 
   @Override
   public Value asPolyglotValue(Context arg1) {
+    return GraalPyRuntimeUtil.coercePooledValue(this, arg1);
+  }
+
+  @Override
+  public Value reconstructPolyglotValue(Context arg1) {
     if (GraalPyRuntimeUtil.isValueInContext(this.graalpyInternalValue, arg1)) {
-      return this.asPolyglotValue();
+      GraalPyRuntimeUtil.rememberPooledValue(this, arg1, this.graalpyInternalValue);
+      GraalPyRuntimeUtil.putMember(this.graalpyInternalValue, "name", GraalPyRuntimeUtil.coerceToContext(this.name, arg1, java.lang.String.class));
+      GraalPyRuntimeUtil.putMember(this.graalpyInternalValue, "age", GraalPyRuntimeUtil.coerceToContext(this.age, arg1, int.class));
+      GraalPyRuntimeUtil.putMember(this.graalpyInternalValue, "address", GraalPyRuntimeUtil.coerceToContext(this.address, arg1, python.Address.class));
+      return this.graalpyInternalValue;
     } else {
-      return PythonContextRuntime.newUninitializedInstance(arg1, Person.__PYTHON_CLASS_REFERENCE, AnnotationUtil.mapOf("name", GraalPyRuntimeUtil.coerceToContext(this.name, arg1, java.lang.String.class), "age", GraalPyRuntimeUtil.coerceToContext(this.age, arg1, int.class), "address", GraalPyRuntimeUtil.coerceToContext(this.address, arg1, python.Address.class)));
+      Value targetValue = PythonContextRuntime.newUninitializedInstance(arg1, Person.__PYTHON_CLASS_REFERENCE);
+      GraalPyRuntimeUtil.rememberPooledValue(this, arg1, targetValue);
+      GraalPyRuntimeUtil.putMember(targetValue, "name", GraalPyRuntimeUtil.coerceToContext(this.name, arg1, java.lang.String.class));
+      GraalPyRuntimeUtil.putMember(targetValue, "age", GraalPyRuntimeUtil.coerceToContext(this.age, arg1, int.class));
+      GraalPyRuntimeUtil.putMember(targetValue, "address", GraalPyRuntimeUtil.coerceToContext(this.address, arg1, python.Address.class));
+      return targetValue;
     }
   }
 

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/GenerateToStringEqualsSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/GenerateToStringEqualsSpec.groovy
@@ -26,12 +26,12 @@ class Person:
         assertGeneratedSourceContains(pythonCode, """
   @JsonCreator
   public Person(@JsonProperty("name") String name, @JsonProperty("age") int age, @JsonProperty("address") Address address) {
-    this.graalpyInternalValue = PythonContextRuntime.newUninitializedInstance(Person.__PYTHON_CLASS_REFERENCE);
     this.name = name;
     this.age = age;
     this.address = address;
   }
 
+  @Override
   public Value asPolyglotValue() {
     if (this.graalpyInternalValue != null) {
       if (this.graalpyInternalValueSyncing) {
@@ -52,6 +52,15 @@ class Person:
       GraalPyRuntimeUtil.putMember(this.graalpyInternalValue, "address", GraalPyRuntimeUtil.coerceValue(this.address));
       this.graalpyInternalValueSyncing = false;
       return this.graalpyInternalValue;
+    }
+  }
+
+  @Override
+  public Value asPolyglotValue(Context arg1) {
+    if (GraalPyRuntimeUtil.isValueInContext(this.graalpyInternalValue, arg1)) {
+      return this.asPolyglotValue();
+    } else {
+      return PythonContextRuntime.newUninitializedInstance(arg1, Person.__PYTHON_CLASS_REFERENCE, AnnotationUtil.mapOf("name", GraalPyRuntimeUtil.coerceToContext(this.name, arg1, java.lang.String.class), "age", GraalPyRuntimeUtil.coerceToContext(this.age, arg1, int.class), "address", GraalPyRuntimeUtil.coerceToContext(this.address, arg1, python.Address.class)));
     }
   }
 

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonPooledStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonPooledStubGenerator.java
@@ -37,7 +37,6 @@ import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.ParameterDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
-import io.micronaut.sourcegen.model.VariableDef;
 
 import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
@@ -51,7 +50,6 @@ import static io.micronaut.python.processing.PythonStubGenerator.FROM_POLYGLOT_V
 import static io.micronaut.python.processing.PythonStubGenerator.POLYGLOT_VALUE;
 import static io.micronaut.python.processing.PythonStubGenerator.PYTHON_ASYNCIO_RUNTIME;
 import static io.micronaut.python.processing.PythonStubGenerator.addReferencedPythonClassReferenceFields;
-import static io.micronaut.python.processing.PythonStubGenerator.coerceParameterToPolyglotValue;
 import static io.micronaut.python.processing.PythonStubGenerator.erasedType;
 import static io.micronaut.python.processing.PythonStubGenerator.handleReturnType;
 import static io.micronaut.python.processing.PythonStubGenerator.isAsyncPythonMethod;
@@ -223,9 +221,7 @@ final class PythonPooledStubGenerator {
         builder.addMethod(methodBuilder.build(((aThis, methodParameters) -> {
             List<ExpressionDef> parameterExpressions = new ArrayList<>();
             for (int i = 0; i < methodElement.getParameters().length; i++) {
-                ParameterElement parameter = methodElement.getParameters()[i];
-                VariableDef.MethodParameter mp = methodParameters.get(i);
-                coerceParameterToPolyglotValue(parameter, parameterExpressions, mp);
+                parameterExpressions.add(methodParameters.get(i));
             }
             List<ExpressionDef> args = new ArrayList<>();
             args.add(pythonClassReference(element, element));
@@ -255,9 +251,7 @@ final class PythonPooledStubGenerator {
         builder.addMethod(methodBuilder.build(((aThis, methodParameters) -> {
             List<ExpressionDef> parameterExpressions = new ArrayList<>();
             for (int i = 0; i < methodElement.getParameters().length; i++) {
-                ParameterElement parameter = methodElement.getParameters()[i];
-                VariableDef.MethodParameter mp = methodParameters.get(i);
-                coerceParameterToPolyglotValue(parameter, parameterExpressions, mp);
+                parameterExpressions.add(methodParameters.get(i));
             }
             List<ExpressionDef> args = new ArrayList<>();
             args.add(ExpressionDef.constant(pkg));
@@ -326,7 +320,7 @@ final class PythonPooledStubGenerator {
             parameters.add(ExpressionDef.constant(pkg));
             parameters.add(ExpressionDef.constant(script));
             parameters.add(ExpressionDef.constant(beanProperty.getName()));
-            coerceParameterToPolyglotValue(beanProperty, parameters, methodParameters.getFirst());
+            parameters.add(methodParameters.getFirst());
             var result = PYTHON_CONTEXT_RUNTIME.invokeStatic(adaptAsyncMembers ? "injectPooledScriptAsync" : "injectPooledScript", TypeDef.VOID, parameters);
             if (returnType.equals(TypeDef.VOID)) {
                 return result;

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -285,22 +285,25 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                         && !extendsPythonClass
                         && !Object.class.getName().equals(superType.getName())
                         && !superType.isInterface();
-                    if (!extendsPythonClass) {
-                        builder.addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.ValueCoercible"));
-                    }
+                    boolean isIntrospectedBean = element.hasStereotype(Introspected.class);
 
                     // Check if this class extends another PythonClassElement
                     if (extendsPythonClass || extendsHostClass) {
                         builder.superclass(parameterizedClassTypeDef(superType));
                     }
 
-                    boolean isIntrospectedBean = element.hasStereotype(Introspected.class);
                     final boolean isIntroductionBean = element.hasStereotype(Introduction.class);
                     boolean isJunit5Test = element.getEnclosedElement(ElementQuery.ALL_METHODS.onlyInstance().annotated(ann -> ann.hasDeclaredAnnotation(JUNIT_TEST))).isPresent();
                     boolean isConfigurationBuilderType = isConfigurationBuilderType(element);
 
                     List<PropertyElement> beanProperties = element.getBeanProperties();
                     boolean hasDynamicBeanProperties = beanProperties.stream().anyMatch(PythonStubGenerator::isDynamicBeanProperty);
+                    boolean isReconstructibleBean = isIntrospectedBean && !hasDynamicBeanProperties;
+                    if (isReconstructibleBean) {
+                        builder.addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.PooledValueCoercible"));
+                    } else if (!extendsPythonClass) {
+                        builder.addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.ValueCoercible"));
+                    }
                     boolean hasConfigurationBuilderProperty = beanProperties.stream()
                         .anyMatch(PythonStubGenerator::isConfigurationBuilderProperty);
                     if (!isIntrospectedBean
@@ -483,6 +486,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                         final boolean isAbstractIntro = element.isAbstract() && isAopProxy && element.hasStereotype(Introduction.class);
                         final boolean isFrozenDataclass = isFrozenPythonDataclass(element);
                         builder.addMethod(MethodDef.builder(AS_POLYGLOT_VALUE)
+                            .addAnnotation(Override.class)
                             .addModifiers(Modifier.PUBLIC)
                             .returns(POLYGLOT_VALUE).build(((aThis, methodParameters) -> {
                                     if (hasDynamicBeanProperties && pythonValueFinal != null) {
@@ -602,6 +606,66 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                     return reconstructedValue.returning();
                                 })
                             ));
+                        if (isReconstructibleBean) {
+                            builder.addMethod(MethodDef.builder(AS_POLYGLOT_VALUE)
+                                .addAnnotation(Override.class)
+                                .addModifiers(Modifier.PUBLIC)
+                                .addParameter(POLYGLOT_CONTEXT)
+                                .returns(POLYGLOT_VALUE).build(((aThis, methodParameters) -> {
+                                ExpressionDef targetContext = methodParameters.getFirst();
+                                ExpressionDef reconstructedValue;
+                                if (isAbstractIntro) {
+                                    List<ExpressionDef> arguments = new ArrayList<>(List.of(targetContext, pythonClassReference(element, pythonClassReference)));
+                                    for (PropertyElement beanProperty : beanProperties) {
+                                        FieldDef field = propertyFields.get(beanProperty.getName());
+                                        if (field != null) {
+                                            arguments.add(coerceTypedElementToPolyglotValue(beanProperty, aThis.field(field), targetContext).cast(TypeDef.OBJECT));
+                                        }
+                                    }
+                                    reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic("newIntroduction", POLYGLOT_VALUE, arguments);
+                                } else if (isFrozenDataclass) {
+                                    List<ExpressionDef> mapEntries = new ArrayList<>();
+                                    for (PropertyElement beanProperty : beanProperties) {
+                                        FieldDef field = propertyFields.get(beanProperty.getName());
+                                        if (field != null) {
+                                            mapEntries.add(ExpressionDef.constant(beanProperty.getName()));
+                                            mapEntries.add(coerceTypedElementToPolyglotValue(beanProperty, aThis.field(field), targetContext));
+                                        }
+                                    }
+                                    ExpressionDef propsMap = ClassTypeDef.of(AnnotationUtil.class)
+                                        .invokeStatic("mapOf", TypeDef.of(Map.class), mapEntries);
+                                    reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic("newFrozenDataclassInstance", POLYGLOT_VALUE,
+                                        List.of(targetContext, pythonClassReference(element, pythonClassReference), propsMap));
+                                } else if (beanProperties.isEmpty()) {
+                                    reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic("newInstance", POLYGLOT_VALUE,
+                                        List.of(targetContext, pythonClassReference(element, pythonClassReference)));
+                                } else {
+                                    List<ExpressionDef> mapEntries = new ArrayList<>();
+                                    for (PropertyElement beanProperty : beanProperties) {
+                                        FieldDef field = propertyFields.get(beanProperty.getName());
+                                        if (field != null) {
+                                            mapEntries.add(ExpressionDef.constant(beanProperty.getName()));
+                                            mapEntries.add(coerceTypedElementToPolyglotValue(beanProperty, aThis.field(field), targetContext));
+                                        }
+                                    }
+                                    ExpressionDef propsMap = ClassTypeDef.of(AnnotationUtil.class)
+                                        .invokeStatic("mapOf", TypeDef.of(Map.class), mapEntries);
+                                    reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic(NEW_UNINITIALIZED_INSTANCE, POLYGLOT_VALUE,
+                                        List.of(targetContext, pythonClassReference(element, pythonClassReference), propsMap));
+                                }
+                                StatementDef reconstructedBody = reconstructedValue.returning();
+                                if (isFrozenDataclass && !isAbstractIntro) {
+                                    return reconstructedBody;
+                                }
+                                if (pythonValueFinal != null) {
+                                    ExpressionDef storedValue = aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field"));
+                                    return RUNTIME_UTIL.invokeStatic("isValueInContext", TypeDef.Primitive.BOOLEAN, storedValue, targetContext).isTrue()
+                                        .doIfElse(aThis.invoke(AS_POLYGLOT_VALUE, POLYGLOT_VALUE).returning(), reconstructedBody);
+                                }
+                                return reconstructedBody;
+                                })
+                            ));
+                        }
                     } else {
                         builder.addMethod(MethodDef.builder(AS_POLYGLOT_VALUE)
                             .addModifiers(Modifier.PUBLIC)
@@ -706,17 +770,6 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                     List<StatementDef> assignments = new ArrayList<>();
                                     if (extendsHostClass) {
                                         assignments.add(aThis.superRef().invokeSuperConstructor(superConstructorArguments(superType, parameters, methodParameters)));
-                                    }
-                                    if (constructorParametersBackedByFields) {
-                                        // Ordinary field-backed introspected beans must not invoke a Python
-                                        // constructor whose parameters are supplied by Micronaut.
-                                        assignments.add(aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field")).assign(
-                                            PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                                                NEW_UNINITIALIZED_INSTANCE,
-                                                POLYGLOT_VALUE,
-                                                List.of(pythonClassReference(element, pythonClassReference))
-                                            )
-                                        ));
                                     }
                                     for (int i = 0; i < parameters.length; i++) {
                                         @NonNull ParameterElement parameter = parameters[i];
@@ -2721,14 +2774,16 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         @Nullable ExpressionDef targetContext) {
         ExpressionDef parameter;
         ClassElement genericType = param.getGenericType();
-        if (genericType.isAssignable(Map.class) && genericType.getTypeArguments().get("V") instanceof PythonClassElement) {
+        boolean mapOfPython = genericType.isAssignable(Map.class) && genericType.getTypeArguments().get("V") instanceof PythonClassElement;
+        boolean listOfPython = genericType.isAssignable(List.class) && genericType.getTypeArguments().get("E") instanceof PythonClassElement;
+        if (mapOfPython) {
             parameter = RUNTIME_UTIL.invokeStatic("coerceMap", TypeDef.of(Map.class), methodParam);
-        } else if (genericType.isAssignable(List.class) && genericType.getTypeArguments().get("E") instanceof PythonClassElement) {
+        } else if (listOfPython) {
             parameter = RUNTIME_UTIL.invokeStatic("coerceList", TypeDef.of(List.class), methodParam);
         } else {
             parameter = methodParam;
         }
-        if (targetContext != null) {
+        if (targetContext != null && !(genericType instanceof PythonClassElement) && !mapOfPython && !listOfPython) {
             parameter = RUNTIME_UTIL.invokeStatic("coerceToContext", TypeDef.OBJECT, parameter, targetContext, classLiteral(param.getGenericType()));
         }
         parameters.add(parameter);
@@ -2745,6 +2800,12 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         } else {
             return expr;
         }
+    }
+
+    private static ExpressionDef coerceTypedElementToPolyglotValue(TypedElement element,
+                                                                    ExpressionDef expr,
+                                                                    ExpressionDef targetContext) {
+        return RUNTIME_UTIL.invokeStatic("coerceToContext", TypeDef.OBJECT, expr, targetContext, classLiteral(element.getGenericType()));
     }
 
     private void copyAnnotations(Element element, AbstractElementBuilder<?> builder, Set<String> annotationPackagesToCopy, VisitorContext visitorContext) {
@@ -2775,7 +2836,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(Vetoed.class)
             .addAnnotation(pythonClassAnnotation(classElement))
-            .addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.ValueCoercible"));
+            .addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.PooledValueCoercible"));
         enumBuilder.addField(pythonClassReference);
         copyAnnotations(classElement, enumBuilder, ANNOTATION_PACKAGES_TO_COPY, context);
         List<String> enumConstants = classElement instanceof EnumElement enumElement ? enumElement.values() : List.of();
@@ -2789,6 +2850,18 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             .build((aThis, parameters) -> PYTHON_CONTEXT_RUNTIME.invokeStatic(
                 "enumValue",
                 POLYGLOT_VALUE,
+                pythonClassReference(classElement, pythonClassReference),
+                aThis.invoke("name", TypeDef.STRING)
+            ).returning()));
+        enumBuilder.addMethod(MethodDef.builder(AS_POLYGLOT_VALUE)
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(POLYGLOT_CONTEXT)
+            .returns(POLYGLOT_VALUE)
+            .build((aThis, parameters) -> PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                "enumValue",
+                POLYGLOT_VALUE,
+                parameters.getFirst(),
                 pythonClassReference(classElement, pythonClassReference),
                 aThis.invoke("name", TypeDef.STRING)
             ).returning()));

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -125,6 +125,10 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
     private static final String GET_MEMBER = "getMember";
     private static final String MAP_OF = "mapOf";
     private static final String ENUM_VALUE = "enumValue";
+    private static final String TARGET_VALUE = "targetValue";
+    private static final String REMEMBER_POOLED_VALUE = "rememberPooledValue";
+    private static final String COERCE_MAP = "coerceMap";
+    private static final String COERCE_LIST = "coerceList";
     private static final String ANN_CONFIGURATION_BUILDER = "io.micronaut.context.annotation.ConfigurationBuilder";
     private static final String NEW_UNINITIALIZED_INSTANCE = "newUninitializedInstance";
     private static final String ANN_CONFIGURATION_INJECT = "io.micronaut.context.annotation.ConfigurationInject";
@@ -582,7 +586,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                                 continue;
                                             }
                                             ExpressionDef fieldRef = aThis.field(field);
-                                            syncStatements.add((StatementDef) RUNTIME_UTIL.invokeStatic(
+                                            syncStatements.add(RUNTIME_UTIL.invokeStatic(
                                                 "putMember",
                                                 TypeDef.VOID,
                                                 storedValue,
@@ -640,28 +644,28 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         }
                                     }
                                     ExpressionDef introduction = PYTHON_CONTEXT_RUNTIME.invokeStatic("newIntroduction", POLYGLOT_VALUE, arguments);
-                                    reconstructedBody = introduction.newLocal("targetValue", targetValue -> StatementDef.multi(
-                                        (StatementDef) RUNTIME_UTIL.invokeStatic(
-                                            "rememberPooledValue", TypeDef.VOID, aThis, targetContext, targetValue
+                                    reconstructedBody = introduction.newLocal(TARGET_VALUE, targetValue -> StatementDef.multi(
+                                        RUNTIME_UTIL.invokeStatic(
+                                            REMEMBER_POOLED_VALUE, TypeDef.VOID, aThis, targetContext, targetValue
                                         ),
                                         targetValue.returning()
                                     ));
                                 } else if (beanProperties.isEmpty()) {
                                     ExpressionDef instance = PYTHON_CONTEXT_RUNTIME.invokeStatic("newInstance", POLYGLOT_VALUE,
                                         List.of(targetContext, pythonClassReference(element, pythonClassReference)));
-                                    reconstructedBody = instance.newLocal("targetValue", targetValue -> StatementDef.multi(
-                                        (StatementDef) RUNTIME_UTIL.invokeStatic(
-                                            "rememberPooledValue", TypeDef.VOID, aThis, targetContext, targetValue
+                                    reconstructedBody = instance.newLocal(TARGET_VALUE, targetValue -> StatementDef.multi(
+                                        RUNTIME_UTIL.invokeStatic(
+                                            REMEMBER_POOLED_VALUE, TypeDef.VOID, aThis, targetContext, targetValue
                                         ),
                                         targetValue.returning()
                                     ));
                                 } else {
                                     ExpressionDef instance = PYTHON_CONTEXT_RUNTIME.invokeStatic(NEW_UNINITIALIZED_INSTANCE, POLYGLOT_VALUE,
                                         List.of(targetContext, pythonClassReference(element, pythonClassReference)));
-                                    reconstructedBody = instance.newLocal("targetValue", targetValue -> {
+                                    reconstructedBody = instance.newLocal(TARGET_VALUE, targetValue -> {
                                         List<StatementDef> statements = new ArrayList<>();
-                                        statements.add((StatementDef) RUNTIME_UTIL.invokeStatic(
-                                            "rememberPooledValue", TypeDef.VOID, aThis, targetContext, targetValue
+                                        statements.add(RUNTIME_UTIL.invokeStatic(
+                                            REMEMBER_POOLED_VALUE, TypeDef.VOID, aThis, targetContext, targetValue
                                         ));
                                         for (PropertyElement beanProperty : beanProperties) {
                                             FieldDef field = propertyFields.get(beanProperty.getName());
@@ -672,7 +676,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                                 beanProperty, aThis.field(field), targetContext
                                             ).cast(TypeDef.OBJECT);
                                             if (isFrozenDataclass) {
-                                                statements.add((StatementDef) PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                                                statements.add(PYTHON_CONTEXT_RUNTIME.invokeStatic(
                                                     "setInstanceProperty",
                                                     TypeDef.VOID,
                                                     targetValue,
@@ -680,7 +684,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                                     propertyValue
                                                 ));
                                             } else {
-                                                statements.add((StatementDef) RUNTIME_UTIL.invokeStatic(
+                                                statements.add(RUNTIME_UTIL.invokeStatic(
                                                     "putMember",
                                                     TypeDef.VOID,
                                                     targetValue,
@@ -696,14 +700,14 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                 if (pythonValueFinal != null) {
                                     ExpressionDef storedValue = aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field"));
                                     List<StatementDef> reuseStatements = new ArrayList<>();
-                                    reuseStatements.add((StatementDef) RUNTIME_UTIL.invokeStatic(
-                                        "rememberPooledValue", TypeDef.VOID, aThis, targetContext, storedValue
+                                    reuseStatements.add(RUNTIME_UTIL.invokeStatic(
+                                        REMEMBER_POOLED_VALUE, TypeDef.VOID, aThis, targetContext, storedValue
                                     ));
                                     if (!isFrozenDataclass) {
                                         for (PropertyElement beanProperty : beanProperties) {
                                             FieldDef field = propertyFields.get(beanProperty.getName());
                                             if (field != null) {
-                                                reuseStatements.add((StatementDef) RUNTIME_UTIL.invokeStatic(
+                                                reuseStatements.add(RUNTIME_UTIL.invokeStatic(
                                                     "putMember",
                                                     TypeDef.VOID,
                                                     storedValue,
@@ -2839,9 +2843,9 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             // borrowing the target context.
             ExpressionDef parameter;
             if (mapOfPython) {
-                parameter = RUNTIME_UTIL.invokeStatic("coerceMap", TypeDef.of(Map.class), methodParam);
+                parameter = RUNTIME_UTIL.invokeStatic(COERCE_MAP, TypeDef.of(Map.class), methodParam);
             } else if (listOfPython) {
-                parameter = RUNTIME_UTIL.invokeStatic("coerceList", TypeDef.of(List.class), methodParam);
+                parameter = RUNTIME_UTIL.invokeStatic(COERCE_LIST, TypeDef.of(List.class), methodParam);
             } else if (genericType instanceof PythonClassElement) {
                 parameter = methodParam;
             } else {
@@ -2858,9 +2862,9 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         }
         ExpressionDef parameter;
         if (mapOfPython) {
-            parameter = RUNTIME_UTIL.invokeStatic("coerceMap", TypeDef.of(Map.class), methodParam);
+            parameter = RUNTIME_UTIL.invokeStatic(COERCE_MAP, TypeDef.of(Map.class), methodParam);
         } else if (listOfPython) {
-            parameter = RUNTIME_UTIL.invokeStatic("coerceList", TypeDef.of(List.class), methodParam);
+            parameter = RUNTIME_UTIL.invokeStatic(COERCE_LIST, TypeDef.of(List.class), methodParam);
         } else {
             parameter = methodParam;
         }
@@ -2870,9 +2874,9 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
     private static ExpressionDef coerceTypedElementToPolyglotValue(TypedElement element, ExpressionDef expr) {
         ClassElement genericType = element.getGenericType();
         if (genericType.isAssignable(Map.class) && genericType.getTypeArguments().get("V") instanceof PythonClassElement) {
-            return RUNTIME_UTIL.invokeStatic("coerceMap", TypeDef.of(Map.class), expr);
+            return RUNTIME_UTIL.invokeStatic(COERCE_MAP, TypeDef.of(Map.class), expr);
         } else if (genericType.isAssignable(List.class) && genericType.getTypeArguments().get("E") instanceof PythonClassElement) {
-            return RUNTIME_UTIL.invokeStatic("coerceList", TypeDef.of(List.class), expr);
+            return RUNTIME_UTIL.invokeStatic(COERCE_LIST, TypeDef.of(List.class), expr);
         } else if (genericType instanceof PythonClassElement) {
             return RUNTIME_UTIL.invokeStatic("coerceValue", TypeDef.OBJECT, expr);
         } else {
@@ -3857,7 +3861,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                 );
             }
             return StatementDef.multi(
-                (StatementDef) RUNTIME_UTIL.invokeStatic(
+                RUNTIME_UTIL.invokeStatic(
                     "putMember",
                     TypeDef.VOID,
                     targetValue,
@@ -3869,7 +3873,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                         methodParameters.getFirst().cast(TypeDef.OBJECT)
                     )
                 ),
-                (StatementDef) PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                PYTHON_CONTEXT_RUNTIME.invokeStatic(
                     "rememberAsyncMember",
                     TypeDef.VOID,
                     targetValue,
@@ -3903,7 +3907,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                 );
             }
             return StatementDef.multi(
-                (StatementDef) RUNTIME_UTIL.invokeStatic(
+                RUNTIME_UTIL.invokeStatic(
                     "putMember",
                     TypeDef.VOID,
                     targetValue,
@@ -3915,7 +3919,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                         methodParameters.getFirst().cast(TypeDef.OBJECT)
                     )
                 ),
-                (StatementDef) PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                PYTHON_CONTEXT_RUNTIME.invokeStatic(
                     "rememberAsyncMember",
                     TypeDef.VOID,
                     targetValue,

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -110,6 +110,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
     public static final TypeDef POLYGLOT_CONTEXT = TypeDef.of(Context.class);
     public static final VariableDef.StaticField CLASS_OBJECT = ClassTypeDef.of(Object.class).getStaticField("class", TypeDef.CLASS);
     public static final String AS_POLYGLOT_VALUE = "asPolyglotValue";
+    public static final String RECONSTRUCT_POLYGLOT_VALUE = "reconstructPolyglotValue";
     public static final String FROM_POLYGLOT_VALUE = "fromPolyglotValue";
     public static final ClassTypeDef RUNTIME_UTIL = ClassTypeDef.of("io.micronaut.context.python.GraalPyRuntimeUtil");
     public static final ClassTypeDef PYTHON_ASYNCIO_RUNTIME = ClassTypeDef.of("io.micronaut.context.python.PythonAsyncioRuntime");
@@ -616,9 +617,20 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                 .addAnnotation(Override.class)
                                 .addModifiers(Modifier.PUBLIC)
                                 .addParameter(POLYGLOT_CONTEXT)
+                                .returns(POLYGLOT_VALUE)
+                                .build((aThis, methodParameters) -> RUNTIME_UTIL.invokeStatic(
+                                    "coercePooledValue",
+                                    POLYGLOT_VALUE,
+                                    aThis,
+                                    methodParameters.getFirst()
+                                ).returning()));
+                            builder.addMethod(MethodDef.builder(RECONSTRUCT_POLYGLOT_VALUE)
+                                .addAnnotation(Override.class)
+                                .addModifiers(Modifier.PUBLIC)
+                                .addParameter(POLYGLOT_CONTEXT)
                                 .returns(POLYGLOT_VALUE).build(((aThis, methodParameters) -> {
                                 ExpressionDef targetContext = methodParameters.getFirst();
-                                ExpressionDef reconstructedValue;
+                                StatementDef reconstructedBody;
                                 if (isAbstractIntro) {
                                     List<ExpressionDef> arguments = new ArrayList<>(List.of(targetContext, pythonClassReference(element, pythonClassReference)));
                                     for (PropertyElement beanProperty : beanProperties) {
@@ -627,45 +639,85 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                             arguments.add(coerceTypedElementToPolyglotValue(beanProperty, aThis.field(field), targetContext).cast(TypeDef.OBJECT));
                                         }
                                     }
-                                    reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic("newIntroduction", POLYGLOT_VALUE, arguments);
-                                } else if (isFrozenDataclass) {
-                                    List<ExpressionDef> mapEntries = new ArrayList<>();
-                                    for (PropertyElement beanProperty : beanProperties) {
-                                        FieldDef field = propertyFields.get(beanProperty.getName());
-                                        if (field != null) {
-                                            mapEntries.add(ExpressionDef.constant(beanProperty.getName()));
-                                            mapEntries.add(coerceTypedElementToPolyglotValue(beanProperty, aThis.field(field), targetContext));
-                                        }
-                                    }
-                                    ExpressionDef propsMap = ClassTypeDef.of(AnnotationUtil.class)
-                                        .invokeStatic(MAP_OF, TypeDef.of(Map.class), mapEntries);
-                                    reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic("newFrozenDataclassInstance", POLYGLOT_VALUE,
-                                        List.of(targetContext, pythonClassReference(element, pythonClassReference), propsMap));
+                                    ExpressionDef introduction = PYTHON_CONTEXT_RUNTIME.invokeStatic("newIntroduction", POLYGLOT_VALUE, arguments);
+                                    reconstructedBody = introduction.newLocal("targetValue", targetValue -> StatementDef.multi(
+                                        (StatementDef) RUNTIME_UTIL.invokeStatic(
+                                            "rememberPooledValue", TypeDef.VOID, aThis, targetContext, targetValue
+                                        ),
+                                        targetValue.returning()
+                                    ));
                                 } else if (beanProperties.isEmpty()) {
-                                    reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic("newInstance", POLYGLOT_VALUE,
+                                    ExpressionDef instance = PYTHON_CONTEXT_RUNTIME.invokeStatic("newInstance", POLYGLOT_VALUE,
                                         List.of(targetContext, pythonClassReference(element, pythonClassReference)));
+                                    reconstructedBody = instance.newLocal("targetValue", targetValue -> StatementDef.multi(
+                                        (StatementDef) RUNTIME_UTIL.invokeStatic(
+                                            "rememberPooledValue", TypeDef.VOID, aThis, targetContext, targetValue
+                                        ),
+                                        targetValue.returning()
+                                    ));
                                 } else {
-                                    List<ExpressionDef> mapEntries = new ArrayList<>();
-                                    for (PropertyElement beanProperty : beanProperties) {
-                                        FieldDef field = propertyFields.get(beanProperty.getName());
-                                        if (field != null) {
-                                            mapEntries.add(ExpressionDef.constant(beanProperty.getName()));
-                                            mapEntries.add(coerceTypedElementToPolyglotValue(beanProperty, aThis.field(field), targetContext));
+                                    ExpressionDef instance = PYTHON_CONTEXT_RUNTIME.invokeStatic(NEW_UNINITIALIZED_INSTANCE, POLYGLOT_VALUE,
+                                        List.of(targetContext, pythonClassReference(element, pythonClassReference)));
+                                    reconstructedBody = instance.newLocal("targetValue", targetValue -> {
+                                        List<StatementDef> statements = new ArrayList<>();
+                                        statements.add((StatementDef) RUNTIME_UTIL.invokeStatic(
+                                            "rememberPooledValue", TypeDef.VOID, aThis, targetContext, targetValue
+                                        ));
+                                        for (PropertyElement beanProperty : beanProperties) {
+                                            FieldDef field = propertyFields.get(beanProperty.getName());
+                                            if (field == null) {
+                                                continue;
+                                            }
+                                            ExpressionDef propertyValue = coerceTypedElementToPolyglotValue(
+                                                beanProperty, aThis.field(field), targetContext
+                                            ).cast(TypeDef.OBJECT);
+                                            if (isFrozenDataclass) {
+                                                statements.add((StatementDef) PYTHON_CONTEXT_RUNTIME.invokeStatic(
+                                                    "setInstanceProperty",
+                                                    TypeDef.VOID,
+                                                    targetValue,
+                                                    ExpressionDef.constant(beanProperty.getName()),
+                                                    propertyValue
+                                                ));
+                                            } else {
+                                                statements.add((StatementDef) RUNTIME_UTIL.invokeStatic(
+                                                    "putMember",
+                                                    TypeDef.VOID,
+                                                    targetValue,
+                                                    ExpressionDef.constant(beanProperty.getName()),
+                                                    propertyValue
+                                                ));
+                                            }
                                         }
-                                    }
-                                    ExpressionDef propsMap = ClassTypeDef.of(AnnotationUtil.class)
-                                        .invokeStatic(MAP_OF, TypeDef.of(Map.class), mapEntries);
-                                    reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic(NEW_UNINITIALIZED_INSTANCE, POLYGLOT_VALUE,
-                                        List.of(targetContext, pythonClassReference(element, pythonClassReference), propsMap));
-                                }
-                                StatementDef reconstructedBody = reconstructedValue.returning();
-                                if (isFrozenDataclass && !isAbstractIntro) {
-                                    return reconstructedBody;
+                                        statements.add(targetValue.returning());
+                                        return StatementDef.multi(statements);
+                                    });
                                 }
                                 if (pythonValueFinal != null) {
                                     ExpressionDef storedValue = aThis.field(requireField(pythonValueFinal, "Expected graalpyInternalValue field"));
+                                    List<StatementDef> reuseStatements = new ArrayList<>();
+                                    reuseStatements.add((StatementDef) RUNTIME_UTIL.invokeStatic(
+                                        "rememberPooledValue", TypeDef.VOID, aThis, targetContext, storedValue
+                                    ));
+                                    if (!isFrozenDataclass) {
+                                        for (PropertyElement beanProperty : beanProperties) {
+                                            FieldDef field = propertyFields.get(beanProperty.getName());
+                                            if (field != null) {
+                                                reuseStatements.add((StatementDef) RUNTIME_UTIL.invokeStatic(
+                                                    "putMember",
+                                                    TypeDef.VOID,
+                                                    storedValue,
+                                                    ExpressionDef.constant(beanProperty.getName()),
+                                                    coerceTypedElementToPolyglotValue(
+                                                        beanProperty, aThis.field(field), targetContext
+                                                    ).cast(TypeDef.OBJECT)
+                                                ));
+                                            }
+                                        }
+                                    }
+                                    reuseStatements.add(storedValue.returning());
                                     return RUNTIME_UTIL.invokeStatic("isValueInContext", TypeDef.Primitive.BOOLEAN, storedValue, targetContext).isTrue()
-                                        .doIfElse(aThis.invoke(AS_POLYGLOT_VALUE, POLYGLOT_VALUE).returning(), reconstructedBody);
+                                        .doIfElse(StatementDef.multi(reuseStatements), reconstructedBody);
                                 }
                                 return reconstructedBody;
                                 })
@@ -2777,6 +2829,21 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         List<ExpressionDef> parameters,
         VariableDef.MethodParameter methodParam,
         @Nullable ExpressionDef targetContext) {
+        if (targetContext != null) {
+            // Generated Python-class arguments stay as host bridges for ordinary methods because
+            // Python code can call their generated Java methods. Pooled bridges instead pass raw
+            // arguments to invokePooled, which converts them after borrowing the target context.
+            parameters.add(param.getGenericType() instanceof PythonClassElement
+                ? methodParam
+                : RUNTIME_UTIL.invokeStatic(
+                    "coerceToContext",
+                    TypeDef.OBJECT,
+                    methodParam,
+                    targetContext,
+                    classLiteral(param.getGenericType())
+                ));
+            return;
+        }
         ExpressionDef parameter;
         ClassElement genericType = param.getGenericType();
         boolean mapOfPython = genericType.isAssignable(Map.class) && genericType.getTypeArguments().get("V") instanceof PythonClassElement;
@@ -2787,9 +2854,6 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             parameter = RUNTIME_UTIL.invokeStatic("coerceList", TypeDef.of(List.class), methodParam);
         } else {
             parameter = methodParam;
-        }
-        if (targetContext != null && !(genericType instanceof PythonClassElement) && !mapOfPython && !listOfPython) {
-            parameter = RUNTIME_UTIL.invokeStatic("coerceToContext", TypeDef.OBJECT, parameter, targetContext, classLiteral(param.getGenericType()));
         }
         parameters.add(parameter);
     }
@@ -2859,6 +2923,17 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                 aThis.invoke("name", TypeDef.STRING)
             ).returning()));
         enumBuilder.addMethod(MethodDef.builder(AS_POLYGLOT_VALUE)
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(POLYGLOT_CONTEXT)
+            .returns(POLYGLOT_VALUE)
+            .build((aThis, parameters) -> RUNTIME_UTIL.invokeStatic(
+                "coercePooledValue",
+                POLYGLOT_VALUE,
+                aThis,
+                parameters.getFirst()
+            ).returning()));
+        enumBuilder.addMethod(MethodDef.builder(RECONSTRUCT_POLYGLOT_VALUE)
             .addAnnotation(Override.class)
             .addModifiers(Modifier.PUBLIC)
             .addParameter(POLYGLOT_CONTEXT)

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -2829,25 +2829,34 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         List<ExpressionDef> parameters,
         VariableDef.MethodParameter methodParam,
         @Nullable ExpressionDef targetContext) {
+        ClassElement genericType = param.getGenericType();
+        boolean mapOfPython = genericType.isAssignable(Map.class) && genericType.getTypeArguments().get("V") instanceof PythonClassElement;
+        boolean listOfPython = genericType.isAssignable(List.class) && genericType.getTypeArguments().get("E") instanceof PythonClassElement;
         if (targetContext != null) {
-            // Generated Python-class arguments stay as host bridges for ordinary methods because
-            // Python code can call their generated Java methods. Pooled bridges instead pass raw
-            // arguments to invokePooled, which converts them after borrowing the target context.
-            parameters.add(param.getGenericType() instanceof PythonClassElement
-                ? methodParam
-                : RUNTIME_UTIL.invokeStatic(
+            // Generated Python-class arguments stay as host bridges for ordinary methods, including
+            // inside lists and maps, so Python consistently uses their generated Java accessors.
+            // Pooled bridges instead pass raw arguments to invokePooled, which converts them after
+            // borrowing the target context.
+            ExpressionDef parameter;
+            if (mapOfPython) {
+                parameter = RUNTIME_UTIL.invokeStatic("coerceMap", TypeDef.of(Map.class), methodParam);
+            } else if (listOfPython) {
+                parameter = RUNTIME_UTIL.invokeStatic("coerceList", TypeDef.of(List.class), methodParam);
+            } else if (genericType instanceof PythonClassElement) {
+                parameter = methodParam;
+            } else {
+                parameter = RUNTIME_UTIL.invokeStatic(
                     "coerceToContext",
                     TypeDef.OBJECT,
                     methodParam,
                     targetContext,
                     classLiteral(param.getGenericType())
-                ));
+                );
+            }
+            parameters.add(parameter);
             return;
         }
         ExpressionDef parameter;
-        ClassElement genericType = param.getGenericType();
-        boolean mapOfPython = genericType.isAssignable(Map.class) && genericType.getTypeArguments().get("V") instanceof PythonClassElement;
-        boolean listOfPython = genericType.isAssignable(List.class) && genericType.getTypeArguments().get("E") instanceof PythonClassElement;
         if (mapOfPython) {
             parameter = RUNTIME_UTIL.invokeStatic("coerceMap", TypeDef.of(Map.class), methodParam);
         } else if (listOfPython) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -122,6 +122,8 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
     private static final String HTTP_RESPONSE = "io.micronaut.http.HttpResponse";
     private static final String PUBLISHER = "org.reactivestreams.Publisher";
     private static final String GET_MEMBER = "getMember";
+    private static final String MAP_OF = "mapOf";
+    private static final String ENUM_VALUE = "enumValue";
     private static final String ANN_CONFIGURATION_BUILDER = "io.micronaut.context.annotation.ConfigurationBuilder";
     private static final String NEW_UNINITIALIZED_INSTANCE = "newUninitializedInstance";
     private static final String ANN_CONFIGURATION_INJECT = "io.micronaut.context.annotation.ConfigurationInject";
@@ -298,6 +300,9 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
 
                     List<PropertyElement> beanProperties = element.getBeanProperties();
                     boolean hasDynamicBeanProperties = beanProperties.stream().anyMatch(PythonStubGenerator::isDynamicBeanProperty);
+                    // Declared attributes are fully represented by generated Java fields. Custom
+                    // Python properties may depend on hidden state that cannot be reconstructed in
+                    // another context from the BeanIntrospection alone.
                     boolean isReconstructibleBean = isIntrospectedBean && !hasDynamicBeanProperties;
                     if (isReconstructibleBean) {
                         builder.addSuperinterface(ClassTypeDef.of("io.micronaut.context.python.PooledValueCoercible"));
@@ -542,7 +547,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                             mapEntries.add(coerceTypedElementToPolyglotValue(beanProperty, fieldRef));
                                         }
                                         ExpressionDef propsMap = ClassTypeDef.of(AnnotationUtil.class)
-                                            .invokeStatic("mapOf", TypeDef.of(Map.class), mapEntries);
+                                            .invokeStatic(MAP_OF, TypeDef.of(Map.class), mapEntries);
                                         reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic(
                                             "newFrozenDataclassInstance",
                                             POLYGLOT_VALUE,
@@ -633,7 +638,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         }
                                     }
                                     ExpressionDef propsMap = ClassTypeDef.of(AnnotationUtil.class)
-                                        .invokeStatic("mapOf", TypeDef.of(Map.class), mapEntries);
+                                        .invokeStatic(MAP_OF, TypeDef.of(Map.class), mapEntries);
                                     reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic("newFrozenDataclassInstance", POLYGLOT_VALUE,
                                         List.of(targetContext, pythonClassReference(element, pythonClassReference), propsMap));
                                 } else if (beanProperties.isEmpty()) {
@@ -649,7 +654,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         }
                                     }
                                     ExpressionDef propsMap = ClassTypeDef.of(AnnotationUtil.class)
-                                        .invokeStatic("mapOf", TypeDef.of(Map.class), mapEntries);
+                                        .invokeStatic(MAP_OF, TypeDef.of(Map.class), mapEntries);
                                     reconstructedValue = PYTHON_CONTEXT_RUNTIME.invokeStatic(NEW_UNINITIALIZED_INSTANCE, POLYGLOT_VALUE,
                                         List.of(targetContext, pythonClassReference(element, pythonClassReference), propsMap));
                                 }
@@ -2848,7 +2853,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             .addModifiers(Modifier.PUBLIC)
             .returns(POLYGLOT_VALUE)
             .build((aThis, parameters) -> PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                "enumValue",
+                ENUM_VALUE,
                 POLYGLOT_VALUE,
                 pythonClassReference(classElement, pythonClassReference),
                 aThis.invoke("name", TypeDef.STRING)
@@ -2859,7 +2864,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             .addParameter(POLYGLOT_CONTEXT)
             .returns(POLYGLOT_VALUE)
             .build((aThis, parameters) -> PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                "enumValue",
+                ENUM_VALUE,
                 POLYGLOT_VALUE,
                 parameters.getFirst(),
                 pythonClassReference(classElement, pythonClassReference),
@@ -2937,7 +2942,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                 "enumStringValue",
                 TypeDef.STRING,
                 PYTHON_CONTEXT_RUNTIME.invokeStatic(
-                    "enumValue",
+                    ENUM_VALUE,
                     POLYGLOT_VALUE,
                     pythonClassReference(classElement, classElement),
                     enumName

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -142,6 +142,11 @@ final class PyronautCompilerTest {
         assertTrue(frozen.contains("PooledValueCoercible"));
         assertTrue(frozen.contains("newFrozenDataclassInstance(arg1,"));
 
+        String regularClass = Files.readString(findGeneratedSource(outputDirectory, "TeamBuilder.java"));
+        assertTrue(regularClass.contains("PooledValueCoercible"));
+        assertTrue(regularClass.contains("asPolyglotValue(Context "));
+        assertTrue(regularClass.contains("newUninitializedInstance(arg1,"));
+
     }
 
     @Test

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -135,12 +135,14 @@ final class PyronautCompilerTest {
         assertTrue(generated.contains("PythonContextRuntime.newInstance"));
         assertTrue(generated.contains("PooledValueCoercible"));
         assertTrue(generated.contains("asPolyglotValue(Context "));
+        assertTrue(generated.contains("reconstructPolyglotValue(Context "));
         assertTrue(generated.contains("newUninitializedInstance(arg1,"));
         assertTrue(generated.contains("GraalPyRuntimeUtil.coerceToContext"));
 
         String frozen = Files.readString(findGeneratedSource(outputDirectory, "TeamId.java"));
         assertTrue(frozen.contains("PooledValueCoercible"));
-        assertTrue(frozen.contains("newFrozenDataclassInstance(arg1,"));
+        assertTrue(frozen.contains("reconstructPolyglotValue(Context "));
+        assertTrue(frozen.contains("PythonContextRuntime.setInstanceProperty"));
 
         String regularClass = Files.readString(findGeneratedSource(outputDirectory, "TeamBuilder.java"));
         assertTrue(regularClass.contains("PooledValueCoercible"));

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -96,6 +96,11 @@ final class PyronautCompilerTest {
                     self.value = value
                     return self
 
+            @Introspected
+            @dataclass(frozen=True)
+            class TeamId:
+                value: str
+
             @ConfigurationProperties("team")
             @Introspected
             @dataclass(init=False)
@@ -126,15 +131,17 @@ final class PyronautCompilerTest {
             .targetDir(outputDirectory.toFile())
             .build()
             .compile();
-        Path generatedSource;
-        try (var paths = Files.walk(outputDirectory)) {
-            generatedSource = paths
-                .filter(path -> path.getFileName().toString().equals("TeamConfiguration.java"))
-                .findFirst()
-                .orElseThrow();
-        }
-        String generated = Files.readString(generatedSource);
+        String generated = Files.readString(findGeneratedSource(outputDirectory, "TeamConfiguration.java"));
         assertTrue(generated.contains("PythonContextRuntime.newInstance"));
+        assertTrue(generated.contains("PooledValueCoercible"));
+        assertTrue(generated.contains("asPolyglotValue(Context "));
+        assertTrue(generated.contains("newUninitializedInstance(arg1,"));
+        assertTrue(generated.contains("GraalPyRuntimeUtil.coerceToContext"));
+
+        String frozen = Files.readString(findGeneratedSource(outputDirectory, "TeamId.java"));
+        assertTrue(frozen.contains("PooledValueCoercible"));
+        assertTrue(frozen.contains("newFrozenDataclassInstance(arg1,"));
+
     }
 
     @Test
@@ -169,5 +176,14 @@ final class PyronautCompilerTest {
         }
         assertTrue(filesList.contains("__main__.py"));
         assertFalse(filesList.contains(".pyc"));
+    }
+
+    private static Path findGeneratedSource(Path outputDirectory, String fileName) throws Exception {
+        try (var paths = Files.walk(outputDirectory)) {
+            return paths
+                .filter(path -> path.getFileName().toString().equals(fileName))
+                .findFirst()
+                .orElseThrow();
+        }
     }
 }

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -1330,7 +1330,7 @@ class ProductMappers:
                 );
                 assertEquals(List.of("__PYTHON_CLASS_REFERENCE"), enumDef.getFields().stream().map(FieldDef::getName).toList());
                 assertEquals(1, enumDef.getSuperinterfaces().size());
-                assertEquals(List.of("asPolyglotValue", "asPolyglotValue", "fromPolyglotValue", "jsonValue", "toString"), enumDef.getMethods().stream().map(MethodDef::getName).toList());
+                assertEquals(List.of("asPolyglotValue", "asPolyglotValue", "reconstructPolyglotValue", "fromPolyglotValue", "jsonValue", "toString"), enumDef.getMethods().stream().map(MethodDef::getName).toList());
             }
         }
     }

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAstParserTest.java
@@ -1330,7 +1330,7 @@ class ProductMappers:
                 );
                 assertEquals(List.of("__PYTHON_CLASS_REFERENCE"), enumDef.getFields().stream().map(FieldDef::getName).toList());
                 assertEquals(1, enumDef.getSuperinterfaces().size());
-                assertEquals(List.of("asPolyglotValue", "fromPolyglotValue", "jsonValue", "toString"), enumDef.getMethods().stream().map(MethodDef::getName).toList());
+                assertEquals(List.of("asPolyglotValue", "asPolyglotValue", "fromPolyglotValue", "jsonValue", "toString"), enumDef.getMethods().stream().map(MethodDef::getName).toList());
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add a permanent end-to-end JMH benchmark for pooled Python JSON request bodies and a no-body control endpoint.
- Convert reconstructible `@Introspected` Python wrappers in the controller’s borrowed GraalPy context, including recursive nested, collection, map, array, enum, mutable, and frozen properties.
- Integrate the PythonPool concurrency lifecycle changes from #12908, with deterministic pool and context-release regressions.
- Preserve ordinary host-bridge and non-pooled compatibility; request-wide context leasing remains out of scope.

## Evidence

The pre-fix and fixed revisions were benchmarked consecutively on the same host with the same benchmark source and JMH settings: 8 workers, pool size 8, 5 × 2 s warmup, and 5 × 2 s measurement.

| Endpoint | Pre-fix | Fixed | Change |
| --- | ---: | ---: | ---: |
| JSON request body | 1,124 ops/s | 33,987 ops/s | ~30.2× |
| No-body control | 38,214 ops/s | 37,842 ops/s | −1.0% |

The pre-fix body path stabilized around 1.1k ops/s while the fixed path stabilized around 34k ops/s. The unchanged control result confirms that the context-aware conversion removes primary-context serialization without imposing a request-wide pooled-controller tax. The matching reports are `python-request-body-baseline-review3.txt` and `python-request-body-fixed-review3-clean.txt` under `benchmarks/build/reports/jmh/`; async-profiler outputs remain under the same report directory.

The complete 1/2/4/8 worker × 1/2/4/8 pool-size sweep also compiles and completes successfully. Its shorter per-trial results are retained as regression data, while the table above uses the longer like-for-like run requested during review.

## Verification

- Full affected checks pass for `micronaut-context-python`, `micronaut-inject-python`, `micronaut-inject-python-test`, and `test-suite-python` with `-Ppython-ci` (122 + 104 + 583 + 196 tests).
- Checkstyle and Spotless pass as part of those module checks.
- The end-to-end JMH benchmark compiles and both the full scaling sweep and longer matched comparison complete successfully.
