### PR TITLE
Leave @Primary out of composite qualifiers

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -3126,9 +3126,20 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     private ExpressionDef getQualifier(AnnotationMetadata element, Supplier<ExpressionDef> argumentExpressionSupplier) {
         final List<String> qualifierNames = element.getAnnotationNamesByStereotype(AnnotationUtil.QUALIFIER);
         if (!qualifierNames.isEmpty()) {
-            if (qualifierNames.size() == 1) {
+            // @Primary narrows nothing: it breaks the tie between candidates that already qualify, which is why
+            // it is written as no qualifier at all. Where it is written beside another qualifier it takes no part
+            // in the composite either, and leaving it in would put a null in the array the composite is built
+            // from, which the composite then dereferences
+            final List<String> narrowing = qualifierNames.stream()
+                .filter(name -> !name.equals(Primary.NAME))
+                .toList();
+            if (narrowing.isEmpty()) {
+                // nothing but @Primary was declared, which is the same as no qualifier
+                return ExpressionDef.nullValue();
+            }
+            if (narrowing.size() == 1) {
                 // simple qualifier
-                final String annotationName = qualifierNames.iterator().next();
+                final String annotationName = narrowing.iterator().next();
                 return getQualifierForAnnotation(element, annotationName, argumentExpressionSupplier.get());
             }
             // composite qualifier
@@ -3136,7 +3147,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
                 METHOD_QUALIFIER_BY_QUALIFIERS,
 
                 TYPE_QUALIFIER.array().instantiate(
-                    qualifierNames.stream().map(name -> getQualifierForAnnotation(element, name, argumentExpressionSupplier.get())).toList()
+                    narrowing.stream().map(name -> getQualifierForAnnotation(element, name, argumentExpressionSupplier.get())).toList()
                 )
             );
         }

--- a/inject-java/src/test/groovy/io/micronaut/inject/cdiscenarios/PrimaryQualifiedFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/cdiscenarios/PrimaryQualifiedFactorySpec.groovy
@@ -1,0 +1,55 @@
+package io.micronaut.inject.cdiscenarios
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class PrimaryQualifiedFactorySpec extends AbstractTypeElementSpec {
+
+    void "a factory that is primary as well as qualified can be resolved by the bean it produces"() {
+        given:
+        def context = buildContext('test.Thing', '''
+package test;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Qualifier;
+import jakarta.inject.Singleton;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@interface Marker {
+}
+
+class Thing {
+    final String name;
+    Thing(String name) {
+        this.name = name;
+    }
+}
+
+@Factory
+@Singleton
+@Primary
+@Marker
+class Things {
+    @Bean
+    @Prototype
+    Thing thing() {
+        return new Thing("made");
+    }
+}
+''')
+
+        when:
+        def thing = context.getBean(context.classLoader.loadClass('test.Thing'))
+
+        then:
+        thing.name == 'made'
+
+        cleanup:
+        context.close()
+    }
+}


### PR DESCRIPTION
Recreated from #12929 (identical commit) on a branch in this repository, so that SonarCloud analysis runs: the required "SonarCloud Code Analysis" check is never posted for a pull request from a fork, because the workflow gates the analysis step on `secrets.SONAR_TOKEN` and GitHub withholds repository secrets from fork pull requests.

---

`BeanDefinitionWriter.getQualifier` writes `@Primary` as a literal null qualifier, since primary is the same as no qualifier. That is fine while `@Primary` is the only qualifier on the element, but when it is declared beside another qualifier the null lands in the array passed to `Qualifiers.byQualifiers(...)`, and `CompositeQualifier.filterQualified` dereferences it. The result is an NPE at resolution time — for example a `@Primary` `@Factory` bean that also carries a custom qualifier throws as soon as one of its produced beans is looked up, because resolving the produced bean resolves the factory by its (composite) qualifier.

This change filters `@Primary` out of the qualifier names before the simple/composite decision: `@Primary` breaks ties between candidates that already qualify, so it narrows nothing and takes no part in a composite. If nothing but `@Primary` was declared, no qualifier is written at all, matching the existing single-qualifier behaviour.

Includes a regression spec resolving a produced bean from a factory that is both `@Primary` and qualified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
