### PR TITLE
Honour the argument of RuntimeBeanDefinition.Builder.singleton(boolean)

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -292,7 +292,7 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
 
         @Override
         public Builder<B> singleton(boolean isSingleton) {
-            this.singleton = true;
+            this.singleton = isSingleton;
             return this;
         }
 

--- a/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionSingletonSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionSingletonSpec.groovy
@@ -1,0 +1,62 @@
+package io.micronaut.context
+
+import spock.lang.Specification
+
+class RuntimeBeanDefinitionSingletonSpec extends Specification {
+
+    void 'test the builder honours the singleton argument'() {
+        given:
+        RuntimeBeanDefinition<Foo> definition = RuntimeBeanDefinition.builder(Foo, () -> new Foo())
+                .singleton(isSingleton)
+                .build()
+
+        expect:
+        definition.singleton == isSingleton
+
+        where:
+        isSingleton << [true, false]
+    }
+
+    void 'test a runtime bean built with singleton(false) yields a new instance per lookup'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(RuntimeBeanDefinition.builder(Foo, () -> new Foo())
+                        .singleton(false)
+                        .build())
+                .build()
+                .start()
+
+        when:
+        def first = context.getBean(Foo)
+        def second = context.getBean(Foo)
+
+        then:
+        !first.is(second)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a runtime bean built with singleton(true) yields the same instance per lookup'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(RuntimeBeanDefinition.builder(Foo, () -> new Foo())
+                        .singleton(true)
+                        .build())
+                .build()
+                .start()
+
+        when:
+        def first = context.getBean(Foo)
+        def second = context.getBean(Foo)
+
+        then:
+        first.is(second)
+
+        cleanup:
+        context.close()
+    }
+
+    static class Foo {
+    }
+}


### PR DESCRIPTION
Recreated from #12930 (identical commit) on a branch in this repository, so that SonarCloud analysis runs: the required "SonarCloud Code Analysis" check is never posted for a pull request from a fork, because the workflow gates the analysis step on `secrets.SONAR_TOKEN` and GitHub withholds repository secrets from fork pull requests.

---

`DefaultRuntimeBeanDefinition.Builder.singleton(boolean isSingleton)` assigned `this.singleton = true` unconditionally, ignoring its argument. As a result a runtime bean definition built with `singleton(false)` was still registered in the singleton scope: every `getBean` call returned the same instance, and the bean was never tracked as a dependent of the bean that resolved it (so it was not destroyed with it either).

This assigns the argument instead, and adds a regression spec verifying that `singleton(false)` yields a distinct instance per lookup while `singleton(true)` keeps returning the same one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
