### PR TITLE
Throw IllegalStateException when resolving beans from a context that is not running

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2431,7 +2431,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             return beanRegistration;
         }
 
-        assertContextState();
+        if (!configured.get()) {
+            // the bean definitions are unavailable before configuration and are reset on stop;
+            // fail with the lifecycle error rather than an NPE from the definition lookup
+            assertContextState();
+        }
 
         Optional<BeanDefinition<T>> concreteCandidate = findBeanDefinition(resolutionContext, beanType, qualifier);
 

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2431,6 +2431,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             return beanRegistration;
         }
 
+        assertContextState();
+
         Optional<BeanDefinition<T>> concreteCandidate = findBeanDefinition(resolutionContext, beanType, qualifier);
 
         BeanRegistration<T> registration;
@@ -2486,7 +2488,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     private void assertContextState() {
         if (!this.running.get() && !this.initializing.get()) {
-            throw new BeanContextException("Cannot resolve beans until the context is running");
+            // resolving against a context in the wrong lifecycle state, including a stale
+            // reference held across shutdown, is what IllegalStateException means in the JDK
+            throw new IllegalStateException("Cannot resolve beans until the context is running");
         }
     }
 

--- a/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.context
 
 import io.micronaut.context.env.PropertySource
-import io.micronaut.context.exceptions.BeanContextException
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.context.scope.CustomScopeRegistry
 import io.micronaut.runtime.ApplicationConfiguration
@@ -43,7 +42,7 @@ class ApplicationContextBuilderSpec extends Specification {
         context.getBean(ApplicationConfiguration)
 
         then:
-        thrown(BeanContextException)
+        thrown(IllegalStateException)
 
         when:"The context is started"
         context.start()

--- a/inject/src/test/groovy/io/micronaut/context/DefaultBeanContextSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/DefaultBeanContextSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.context
 
 
 import io.micronaut.core.type.Argument
+import io.micronaut.runtime.ApplicationConfiguration
 import spock.lang.Specification
 
 class DefaultBeanContextSpec extends Specification {
@@ -85,6 +86,22 @@ class DefaultBeanContextSpec extends Specification {
 
         cleanup:
         beanContext.close()
+    }
+
+    def "resolving a bean from a closed context throws IllegalStateException"() {
+        given:
+            ApplicationContext context = ApplicationContext.run()
+
+        expect:
+            context.getBean(ApplicationConfiguration) != null
+
+        when:
+            context.close()
+            context.getBean(ApplicationConfiguration)
+
+        then:
+            IllegalStateException e = thrown()
+            e.message == "Cannot resolve beans until the context is running"
     }
 
     static class MyBean {


### PR DESCRIPTION
Recreated from #12932 (identical commits) on a branch in this repository, so that SonarCloud analysis runs: the required "SonarCloud Code Analysis" check is never posted for a pull request from a fork, because the workflow gates the analysis step on `secrets.SONAR_TOKEN` and GitHub withholds repository secrets from fork pull requests.

---

Resolving a bean against a context that is not running currently reports as `BeanContextException`, which extends plain `RuntimeException`. Using an object in the wrong lifecycle state is exactly what `IllegalStateException` means in the JDK's vocabulary, and a stale context reference held across shutdown should report the same way.

There is also a second, worse symptom: resolving from a *closed* context often doesn't reach `assertContextState` at all. The state check sits after the bean definition lookup, and `stop()` resets the bean definition provider, so the lookup dies first with a `NullPointerException`:

```
java.lang.NullPointerException
    at java.util.Objects.requireNonNull(Objects.java:220)
    at io.micronaut.context.beans.DefaultBeanDefinitionService.resolveProducersForBeanType(DefaultBeanDefinitionService.java:325)
    at io.micronaut.context.beans.DefaultBeanDefinitionService.getBeanDefinitions(DefaultBeanDefinitionService.java:197)
    at io.micronaut.context.DefaultBeanContext.findBeanCandidates(DefaultBeanContext.java:1978)
    ...
    at io.micronaut.context.DefaultBeanContext.getBean(DefaultBeanContext.java:813)
```

### Changes

- `DefaultBeanContext.assertContextState` now throws `IllegalStateException` instead of `BeanContextException`.
- When the context is not configured (never configured, or `stop()` has reset the bean definition provider), the state is asserted in `resolveBeanRegistration` before the bean definition lookup, so a closed context consistently reports the lifecycle error instead of the `NullPointerException` above. A configured-but-not-started context still resolves candidates as before (e.g. `NonUniqueBeanException` is still reported ahead of the lifecycle error), and cached singleton lookups keep working.
- Adjusted `ApplicationContextBuilderSpec` and added a regression test: `getBean` after `context.close()` throws `IllegalStateException`.

### On the breaking-change surface

Changing the thrown type is mildly breaking for code that catches `BeanContextException` around resolution against a stopped context. Two options were considered:

1. **Throw `IllegalStateException` directly** (implemented). The message is unchanged, and code relying on catching `BeanContextException` for a context in the wrong lifecycle state is arguably already depending on a bug — the JDK-idiomatic type for this condition is `IllegalStateException`, and the closed-context path frequently threw `NullPointerException` rather than `BeanContextException` anyway, so the old contract was not reliable.
2. **Softer variant**: introduce a dedicated exception for this site (e.g. `BeanContextNotRunningException`) extending `IllegalStateException`. That preserves a Micronaut-specific type to catch while gaining the correct JDK semantics, at the cost of a new public exception type — happy to switch to this if preferred. (It cannot extend both `IllegalStateException` and `BeanContextException`, so existing `catch (BeanContextException)` code is broken either way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

