### PR TITLE
Avoid sharing incomplete flows in Reactor defuse

### DIFF
--- a/http/src/main/java/io/micronaut/http/reactive/execution/ReactorExecutionFlowImpl.java
+++ b/http/src/main/java/io/micronaut/http/reactive/execution/ReactorExecutionFlowImpl.java
@@ -71,9 +71,12 @@ final class ReactorExecutionFlowImpl implements ReactiveExecutionFlow<Object> {
                 return ExecutionFlow.error(t);
             }
         } else if (publisher instanceof FlowAsMono<T> flowAsMono) {
-            // unwrap directly
-            //noinspection unchecked
-            return (ExecutionFlow<T>) flowAsMono.flow;
+            ImperativeExecutionFlow<?> completed = flowAsMono.flow.tryComplete();
+            if (completed != null) {
+                //noinspection unchecked
+                return (ExecutionFlow<T>) completed;
+            }
+            // An incomplete flow may be shared. Subscribe below to create an independent flow.
         }
 
         // special subscriber that (a) contains the propagated context and (b) can return an

--- a/http/src/test/groovy/io/micronaut/http/reactive/execution/ReactorExecutionFlowImplSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/reactive/execution/ReactorExecutionFlowImplSpec.groovy
@@ -151,6 +151,48 @@ class ReactorExecutionFlowImplSpec extends Specification {
         flow.tryCompleteValue() == "foobar"
     }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/12940")
+    def 'defuse incomplete FlowAsMono creates independent flows'() {
+        given:
+        Hooks.resetOnOperatorDebug()
+        DelayedExecutionFlow<String> source = DelayedExecutionFlow.create()
+        def mono = ReactorExecutionFlowImpl.toMono(source)
+
+        when:
+        def first = ReactorExecutionFlowImpl.defuse(mono, PropagatedContext.empty())
+        def second = ReactorExecutionFlowImpl.defuse(mono, PropagatedContext.empty())
+
+        then:
+        !first.is(source)
+        !second.is(source)
+        !first.is(second)
+        first.tryComplete() == null
+        second.tryComplete() == null
+
+        when:
+        source.complete("foo")
+
+        then:
+        first.tryCompleteValue() == "foo"
+        second.tryCompleteValue() == "foo"
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/12940")
+    def 'defuse completed FlowAsMono preserves immediate flow'() {
+        given:
+        Hooks.resetOnOperatorDebug()
+        DelayedExecutionFlow<String> source = DelayedExecutionFlow.create()
+        def mono = ReactorExecutionFlowImpl.toMono(source)
+        source.complete("foo")
+
+        when:
+        def flow = ReactorExecutionFlowImpl.defuse(mono, PropagatedContext.empty())
+
+        then:
+        flow instanceof ImperativeExecutionFlow
+        flow.tryCompleteValue() == "foo"
+    }
+
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/11744")
     def 'double cancel'() {
         given:


### PR DESCRIPTION
## Problem

`ReactorExecutionFlowImpl.defuse()` directly unwraps every `FlowAsMono`. When the wrapped `ExecutionFlow` is incomplete and is observed more than once, this exposes the same mutable delayed flow to each caller. Downstream `map`, `flatMap`, `onErrorResume`, and `onComplete` operations can then be appended to the shared chain.

The cleanup in #11546 releases delayed-flow nodes after completion, but it cannot help while a shared source remains incomplete.

## Solution

- Reuse a `FlowAsMono` source only when `tryComplete()` returns a completed imperative flow.
- Fall through to the existing subscriber path for incomplete flows so every conversion receives an independent delayed flow.
- Preserve the completed-flow fast path.

## Tests

Added regression coverage that:

1. Defuses the same incomplete `FlowAsMono` twice and verifies that the resulting flows are independent.
2. Confirms that a completed `FlowAsMono` still returns an `ImperativeExecutionFlow` with the expected value.

The first test fails on the previous implementation because both conversions return the shared underlying flow.

## Verification

Using GraalVM CE 25.1.3 (JDK 25.0.3):

- `:micronaut-http:test --tests "io.micronaut.http.reactive.execution.ReactorExecutionFlowImplSpec" --rerun-tasks --no-build-cache`: passed, 11/11 tests.
- `:micronaut-http:check --rerun-tasks --no-build-cache`: passed.

I also attempted the repository-wide `check` on Windows. It reached `micronaut-http-client` but has two unrelated environment/platform failures:

- `HttpHeadSpec`: expects `a/b`, while `java.nio.file.Path` produces `a\b` on Windows.
- `PcapLoggingSpec`: expected generated PCAP files were absent.

Fixes #12940