### PR TITLE
Resolve a null proxy target through the bean resolution customizer

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/ProxyTargetNullBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/ProxyTargetNullBeanSpec.groovy
@@ -1,0 +1,104 @@
+package io.micronaut.aop.lazyproxytarget
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.BeanResolutionCustomizer
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.BeanDefinition
+
+/**
+ * A {@code @Nullable} factory method is allowed to produce {@code null}. When the produced bean is
+ * behind a lazy proxy, resolving the proxy target must route the null through
+ * {@link BeanResolutionCustomizer#resolveNullBean} the way an ordinary bean lookup does, instead of
+ * handing the proxy a null target that fails with a {@link NullPointerException} on the first
+ * intercepted call.
+ */
+class ProxyTargetNullBeanSpec extends AbstractTypeElementSpec {
+
+    void 'test a null proxy target is resolved through the customizer'() {
+        given:
+        def context = buildContext('''
+package proxynulltarget;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Singleton;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around(proxyTarget = true, lazy = true)
+@Retention(RUNTIME)
+@interface LazilyProxied {
+}
+
+@Singleton
+@InterceptorBean(LazilyProxied.class)
+class LazilyProxiedInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+class Product {
+    public String name() {
+        return "substitute";
+    }
+}
+
+@Factory
+class ProductFactory {
+
+    @LazilyProxied
+    @Prototype
+    @Nullable
+    Product product() {
+        return null;
+    }
+}
+''')
+        Class<?> productClass = context.classLoader.loadClass('proxynulltarget.Product')
+
+        when: 'the bean is looked up'
+        def proxy = context.getBean(productClass)
+
+        then: 'a lazy proxy is returned'
+        proxy.class != productClass
+
+        when: 'an intercepted call resolves the proxy target the factory produced as null'
+        def result = proxy.name()
+
+        then: 'the customizer substitute is used instead of failing with a NullPointerException'
+        result == 'substitute'
+
+        when: 'the proxy target is resolved directly'
+        def target = context.getProxyTargetBean(productClass, null)
+
+        then:
+        target != null
+        target.name() == 'substitute'
+
+        cleanup:
+        context.close()
+    }
+
+    @Override
+    protected void configureContext(ApplicationContextBuilder contextBuilder) {
+        contextBuilder.beanResolutionCustomizer(new BeanResolutionCustomizer() {
+            @Override
+            Optional<?> resolveNullBean(Argument<?> requestedBeanType, Argument<?> resolvedBeanType, BeanDefinition<?> beanDefinition) {
+                if (beanDefinition.beanType.name == 'proxynulltarget.Product') {
+                    def constructor = beanDefinition.beanType.getDeclaredConstructor()
+                    constructor.accessible = true
+                    return Optional.of(constructor.newInstance())
+                }
+                return Optional.empty()
+            }
+        })
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1477,7 +1477,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                                     Argument<T> beanType,
                                     @Nullable Qualifier<T> qualifier) {
         BeanDefinition<T> definition = getProxyTargetBeanDefinition(beanType, qualifier);
-        return Objects.requireNonNull(resolveBeanRegistration(resolutionContext, definition, beanType, qualifier)).bean;
+        return getProxyTargetBean(resolutionContext, definition, beanType, qualifier);
     }
 
     /**
@@ -1497,7 +1497,12 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                                     BeanDefinition<T> definition,
                                     Argument<T> beanType,
                                     @Nullable Qualifier<T> qualifier) {
-        return Objects.requireNonNull(resolveBeanRegistration(resolutionContext, definition, beanType, qualifier)).bean;
+        BeanRegistration<T> registration = Objects.requireNonNull(resolveBeanRegistration(resolutionContext, definition, beanType, qualifier));
+        if (registration.bean == null) {
+            // let the customizer decide what a null target becomes, as bean lookup does
+            registration = resolveNullBeanRegistration(beanType, beanType, registration);
+        }
+        return registration.bean;
     }
 
     @Override


### PR DESCRIPTION
Recreated from #12933 (identical commit) on a branch in this repository, so that SonarCloud analysis runs: the required "SonarCloud Code Analysis" check is never posted for a pull request from a fork, because the workflow gates the analysis step on `secrets.SONAR_TOKEN` and GitHub withholds repository secrets from fork pull requests.

---

`DefaultBeanContext.getProxyTargetBean` returned `registration.bean` directly. A `@Nullable` factory method is allowed to produce `null`, but when the produced bean sits behind a lazy proxy, the proxy was handed that `null` as its target and the first intercepted call failed with a `NullPointerException`.

The ordinary bean lookup path already routes a null bean through `resolveNullBeanRegistration`, where a `BeanResolutionCustomizer` can substitute a replacement value via `resolveNullBean`. The proxy target path now does the same: the `Argument`-based overload delegates to the `BeanDefinition`-based one, which consults the customizer when the resolved bean is `null`, so both the generated proxy code paths and direct `getProxyTargetBean` calls behave consistently with regular lookups.

Adds a regression spec: a lazy `proxyTarget` bean produced as `null` by a `@Nullable` factory resolves the customizer's substitute on the intercepted call instead of throwing an NPE. The spec fails with an NPE without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
