### PR TITLE
Fix client proxy tests for updated Micronaut website

### DIFF
--- a/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/ClientProxySpec.groovy
+++ b/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/ClientProxySpec.groovy
@@ -21,7 +21,7 @@ class ClientProxySpec extends Specification {
 
     static final int PROXY_PORT = 3128
     static final String URL = "https://micronaut.io/"
-    static final String HTML_FRAGMENT = 'Home - Micronaut Framework'
+    static final String HTML_FRAGMENT = '<title>Micronaut Framework</title>'
 
     @AutoCleanup
     GenericContainer proxyContainer =

--- a/test-suite/src/test/groovy/io/micronaut/docs/http/client/proxy/ClientProxySpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/docs/http/client/proxy/ClientProxySpec.groovy
@@ -22,7 +22,7 @@ class ClientProxySpec extends Specification {
 
     static final int PROXY_PORT = 3128
     static final String URL = "https://micronaut.io/"
-    static final String HTML_FRAGMENT = 'Home - Micronaut Framework'
+    static final String HTML_FRAGMENT = '<title>Micronaut Framework</title>'
 
     @AutoCleanup
     GenericContainer proxyContainer =


### PR DESCRIPTION
## Changes

- Update both client proxy specs to assert the current `<title>Micronaut Framework</title>` homepage markup.

## Verification

- `./gradlew :micronaut-http-client-jdk:check :test-suite:check`
- `./gradlew docs`
- `./gradlew :micronaut-http-client-jdk:spotlessCheck :test-suite:spotlessCheck`

The Docker-gated proxy cases were skipped because no Docker daemon is available in the test environment.