### PR TITLE
Two startup optimisations: -5% wall, -12% CPU on cold start

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
@@ -140,60 +140,65 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
         }
 
         URL url = classLoader.getResource(prefixPath(path));
-        if (url != null) {
-            if (startsWithBase(url)) {
-                try {
-                    URI uri = url.toURI();
-                    if (uri.getScheme().equals("jar")) {
-                        synchronized (DefaultClassPathResourceLoader.class) {
-                            FileSystem fileSystem = null;
+        if (url == null) {
+            // Nothing below can turn this into a hit: the fallback re-runs the identical
+            // classLoader.getResource(prefixPath(path)), and so does the isDirectory() check inside
+            // it, so a miss used to scan the whole classpath three times. Startup probes for
+            // configuration files that are usually absent, so the miss is the common case.
+            return Optional.empty();
+        }
+        if (startsWithBase(url)) {
+            try {
+                URI uri = url.toURI();
+                if (uri.getScheme().equals("jar")) {
+                    synchronized (DefaultClassPathResourceLoader.class) {
+                        FileSystem fileSystem = null;
+                        try {
                             try {
+                                fileSystem = FileSystems.getFileSystem(uri);
+                            } catch (FileSystemNotFoundException e) {
+                                //no-op
+                            }
+                            if (fileSystem == null || !fileSystem.isOpen()) {
                                 try {
+                                    fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap(), classLoader);
+                                } catch (FileSystemAlreadyExistsException e) {
                                     fileSystem = FileSystems.getFileSystem(uri);
-                                } catch (FileSystemNotFoundException e) {
-                                    //no-op
                                 }
-                                if (fileSystem == null || !fileSystem.isOpen()) {
-                                    try {
-                                        fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap(), classLoader);
-                                    } catch (FileSystemAlreadyExistsException e) {
-                                        fileSystem = FileSystems.getFileSystem(uri);
-                                    }
+                            }
+                            Path pathObject = fileSystem.getPath(path);
+                            if (!Files.exists(pathObject) && uri.toString().contains("!/")) {
+                                // Gracefully transform a URL: "jar:file:/{JAR_PATH}!/{PREFIX}!/{RESOURCE}" to path: "{PREFIX}/{RESOURCE}"
+                                final String altPath = Arrays.stream(uri.toString().split("\\!\\/")).skip(1).collect(Collectors.joining("/"));
+                                final Path altPathObject = fileSystem.getPath(altPath);
+                                if (Files.exists(altPathObject) && !Files.isDirectory(pathObject)) {
+                                    // Use this path only if the resource exists at that location
+                                    pathObject = altPathObject;
                                 }
-                                Path pathObject = fileSystem.getPath(path);
-                                if (!Files.exists(pathObject) && uri.toString().contains("!/")) {
-                                    // Gracefully transform a URL: "jar:file:/{JAR_PATH}!/{PREFIX}!/{RESOURCE}" to path: "{PREFIX}/{RESOURCE}"
-                                    final String altPath = Arrays.stream(uri.toString().split("\\!\\/")).skip(1).collect(Collectors.joining("/"));
-                                    final Path altPathObject = fileSystem.getPath(altPath);
-                                    if (Files.exists(altPathObject) && !Files.isDirectory(pathObject)) {
-                                        // Use this path only if the resource exists at that location
-                                        pathObject = altPathObject;
-                                    }
-                                }
-                                if (Files.isDirectory(pathObject)) {
-                                    return Optional.empty();
-                                }
-                                return Optional.of(new ByteArrayInputStream(Files.readAllBytes(pathObject)));
-                            } finally {
-                                if (fileSystem != null && fileSystem.isOpen()) {
-                                    try {
-                                        fileSystem.close();
-                                    } catch (IOException e) {
-                                        log.debug("Error shutting down JAR file system [{}]: {}", fileSystem, e.getMessage(), e);
-                                    }
+                            }
+                            if (Files.isDirectory(pathObject)) {
+                                return Optional.empty();
+                            }
+                            return Optional.of(new ByteArrayInputStream(Files.readAllBytes(pathObject)));
+                        } finally {
+                            if (fileSystem != null && fileSystem.isOpen()) {
+                                try {
+                                    fileSystem.close();
+                                } catch (IOException e) {
+                                    log.debug("Error shutting down JAR file system [{}]: {}", fileSystem, e.getMessage(), e);
                                 }
                             }
                         }
-                    } else if (uri.getScheme().equals("file")) {
-                        Path pathObject = Paths.get(uri);
-                        if (Files.isDirectory(pathObject)) {
-                            return Optional.empty();
-                        }
-                        return Optional.of(Files.newInputStream(pathObject));
                     }
-                } catch (URISyntaxException | IOException | ProviderNotFoundException e) {
-                    log.debug("Error establishing whether path is a directory: {}", e.getMessage(), e);
+                } else if (uri.getScheme().equals("file")) {
+                    Path pathObject = Paths.get(uri);
+                    if (Files.isDirectory(pathObject)) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(Files.newInputStream(pathObject));
                 }
+            } catch (URISyntaxException | IOException | ProviderNotFoundException e) {
+                log.debug("Error establishing whether path is a directory: {}", e.getMessage(), e);
             }
         }
         // fallback to less sophisticated approach

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -2560,4 +2560,656 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
             this.argument = ExpressionsAwareArgument.wrapIfNecessary(argument);
         }
     }
+
+    // ------------------------------------------------------------------------------------------
+    // Concrete overrides of the AnnotationMetadataDelegate defaults.
+    //
+    // WHY: BeanDefinition's interface closure carries 344 default methods, 301 of which nothing in
+    // the class hierarchy implements. 243 of those come from one diamond - AnnotationMetadataDelegate
+    // extends AnnotationMetadata and redeclares most of it as delegating defaults - and the JVM runs
+    // DefaultMethods::generate_default_methods over that overlap every time it defines a class in the
+    // hierarchy. An application defines one per bean, so it pays for the same resolution hundreds of
+    // times. Implementing the methods here puts them in this class's vtable and the generated
+    // definitions inherit them, taking the still-inherited count from 301 to 39.
+    //
+    // Measured on 500 identically shaped classes: 174ms of CPU to define them carrying the closure,
+    // 95ms with the closure implemented by their base class. End to end that is -4% wall and -12%
+    // CPU on a 528 bean application.
+    //
+    // SAFE BECAUSE: each body is exactly what the interface default did - delegate to
+    // getAnnotationMetadata(). Of the 33 signatures where another interface in the closure also
+    // declares a default, 32 come from AnnotationMetadataProvider and AnnotationSource, both
+    // supertypes of AnnotationMetadataDelegate, so its body was already the one being inherited. The
+    // one independent case, EnvironmentConfigurable#hasPropertyExpressions, was already implemented
+    // concretely above and is not overridden here.
+    //
+    // Each body is the delegate's own: a virtual getAnnotationMetadata() call on this. That matters
+    // because the field can hold an EvaluatedAnnotationMetadata wrapper, and going through the
+    // wrapper is what the inherited default did - unwrapping here would silently drop expression
+    // evaluation.
+    //
+    // Machine generated, carrying the nullability the interfaces declare so no suppression is
+    // needed. Generating them into the class at build time, or removing the overlap at the source by
+    // reconsidering whether BeanDefinition needs to be an AnnotationMetadataDelegate at all, would
+    // both be better than keeping them checked in by hand.
+    // ------------------------------------------------------------------------------------------
+    @Override
+    public java.util.Optional<java.lang.Boolean> booleanValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().booleanValue(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Boolean> booleanValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().booleanValue(p0, p1);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Boolean> booleanValue(java.lang.String p0) {
+        return getAnnotationMetadata().booleanValue(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Boolean> booleanValue(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().booleanValue(p0, p1);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class> classValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().classValue(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class> classValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().classValue(p0, p1);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class> classValue(java.lang.String p0) {
+        return getAnnotationMetadata().classValue(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class> classValue(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().classValue(p0, p1);
+    }
+
+    @Override
+    public <V> java.lang.Class<V>[] classValues(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().classValues(p0);
+    }
+
+    @Override
+    public <V> java.lang.Class<V>[] classValues(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().classValues(p0, p1);
+    }
+
+    @Override
+    public <V> java.lang.Class<V>[] classValues(java.lang.String p0) {
+        return getAnnotationMetadata().classValues(p0);
+    }
+
+    @Override
+    public <V> java.lang.Class<V>[] classValues(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().classValues(p0, p1);
+    }
+
+    @Override
+    public io.micronaut.core.annotation.AnnotationMetadata copyAnnotationMetadata() {
+        return getAnnotationMetadata().copyAnnotationMetadata();
+    }
+
+    @Override
+    public java.util.OptionalDouble doubleValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().doubleValue(p0);
+    }
+
+    @Override
+    public java.util.OptionalDouble doubleValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().doubleValue(p0, p1);
+    }
+
+    @Override
+    public java.util.OptionalDouble doubleValue(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().doubleValue(p0, p1);
+    }
+
+    @Override
+    public <E extends java.lang.Enum<E>> java.util.Optional<E> enumValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.Class<E> p1) {
+        return getAnnotationMetadata().enumValue(p0, p1);
+    }
+
+    @Override
+    public <E extends java.lang.Enum<E>> java.util.Optional<E> enumValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1, java.lang.Class<E> p2) {
+        return getAnnotationMetadata().enumValue(p0, p1, p2);
+    }
+
+    @Override
+    public <E extends java.lang.Enum<E>> java.util.Optional<E> enumValue(java.lang.String p0, java.lang.Class<E> p1) {
+        return getAnnotationMetadata().enumValue(p0, p1);
+    }
+
+    @Override
+    public <E extends java.lang.Enum<E>> java.util.Optional<E> enumValue(java.lang.String p0, java.lang.String p1, java.lang.Class<E> p2) {
+        return getAnnotationMetadata().enumValue(p0, p1, p2);
+    }
+
+    @Override
+    public <E extends java.lang.Enum<E>> E[] enumValues(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.Class<E> p1) {
+        return getAnnotationMetadata().enumValues(p0, p1);
+    }
+
+    @Override
+    public <E extends java.lang.Enum<E>> E[] enumValues(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1, java.lang.Class<E> p2) {
+        return getAnnotationMetadata().enumValues(p0, p1, p2);
+    }
+
+    @Override
+    public <E extends java.lang.Enum<E>> E[] enumValues(java.lang.String p0, java.lang.Class<E> p1) {
+        return getAnnotationMetadata().enumValues(p0, p1);
+    }
+
+    @Override
+    public <E extends java.lang.Enum<E>> E[] enumValues(java.lang.String p0, java.lang.String p1, java.lang.Class<E> p2) {
+        return getAnnotationMetadata().enumValues(p0, p1, p2);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> java.util.Optional<io.micronaut.core.annotation.AnnotationValue<A>> findAnnotation(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().findAnnotation(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> java.util.Optional<io.micronaut.core.annotation.AnnotationValue<A>> findAnnotation(java.lang.String p0) {
+        return getAnnotationMetadata().findAnnotation(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> java.util.Optional<io.micronaut.core.annotation.AnnotationValue<A>> findDeclaredAnnotation(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().findDeclaredAnnotation(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> java.util.Optional<io.micronaut.core.annotation.AnnotationValue<A>> findDeclaredAnnotation(java.lang.String p0) {
+        return getAnnotationMetadata().findDeclaredAnnotation(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.String> findRepeatableAnnotation(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().findRepeatableAnnotation(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.String> findRepeatableAnnotation(java.lang.String p0) {
+        return getAnnotationMetadata().findRepeatableAnnotation(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> io.micronaut.core.annotation.@Nullable AnnotationValue<A> getAnnotation(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().getAnnotation(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> io.micronaut.core.annotation.@Nullable AnnotationValue<A> getAnnotation(java.lang.String p0) {
+        return getAnnotationMetadata().getAnnotation(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.String> getAnnotationNameByStereotype(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().getAnnotationNameByStereotype(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.String> getAnnotationNameByStereotype(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().getAnnotationNameByStereotype(p0);
+    }
+
+    @Override
+    public java.util.Set<java.lang.String> getAnnotationNames() {
+        return getAnnotationMetadata().getAnnotationNames();
+    }
+
+    @Override
+    public java.util.List<java.lang.String> getAnnotationNamesByStereotype(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().getAnnotationNamesByStereotype(p0);
+    }
+
+    @Override
+    public java.util.List<java.lang.String> getAnnotationNamesByStereotype(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().getAnnotationNamesByStereotype(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class<? extends java.lang.annotation.Annotation>> getAnnotationType(java.lang.String p0) {
+        return getAnnotationMetadata().getAnnotationType(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class<? extends java.lang.annotation.Annotation>> getAnnotationType(java.lang.String p0, java.lang.ClassLoader p1) {
+        return getAnnotationMetadata().getAnnotationType(p0, p1);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class<? extends java.lang.annotation.Annotation>> getAnnotationTypeByStereotype(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().getAnnotationTypeByStereotype(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class<? extends java.lang.annotation.Annotation>> getAnnotationTypeByStereotype(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().getAnnotationTypeByStereotype(p0);
+    }
+
+    @Override
+    public java.util.List<java.lang.Class<? extends java.lang.annotation.Annotation>> getAnnotationTypesByStereotype(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().getAnnotationTypesByStereotype(p0);
+    }
+
+    @Override
+    public java.util.List<java.lang.Class<? extends java.lang.annotation.Annotation>> getAnnotationTypesByStereotype(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.ClassLoader p1) {
+        return getAnnotationMetadata().getAnnotationTypesByStereotype(p0, p1);
+    }
+
+    @Override
+    public java.util.List<java.lang.Class<? extends java.lang.annotation.Annotation>> getAnnotationTypesByStereotype(java.lang.String p0) {
+        return getAnnotationMetadata().getAnnotationTypesByStereotype(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> java.util.List<io.micronaut.core.annotation.AnnotationValue<A>> getAnnotationValuesByName(java.lang.String p0) {
+        return getAnnotationMetadata().getAnnotationValuesByName(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> java.util.List<io.micronaut.core.annotation.AnnotationValue<A>> getAnnotationValuesByStereotype(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().getAnnotationValuesByStereotype(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> java.util.List<io.micronaut.core.annotation.AnnotationValue<A>> getAnnotationValuesByType(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().getAnnotationValuesByType(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> io.micronaut.core.annotation.@Nullable AnnotationValue<A> getDeclaredAnnotation(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().getDeclaredAnnotation(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> io.micronaut.core.annotation.@Nullable AnnotationValue<A> getDeclaredAnnotation(java.lang.String p0) {
+        return getAnnotationMetadata().getDeclaredAnnotation(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.String> getDeclaredAnnotationNameByStereotype(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().getDeclaredAnnotationNameByStereotype(p0);
+    }
+
+    @Override
+    public java.util.Set<java.lang.String> getDeclaredAnnotationNames() {
+        return getAnnotationMetadata().getDeclaredAnnotationNames();
+    }
+
+    @Override
+    public java.util.List<java.lang.String> getDeclaredAnnotationNamesByStereotype(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().getDeclaredAnnotationNamesByStereotype(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class<? extends java.lang.annotation.Annotation>> getDeclaredAnnotationTypeByStereotype(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().getDeclaredAnnotationTypeByStereotype(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Class<? extends java.lang.annotation.Annotation>> getDeclaredAnnotationTypeByStereotype(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().getDeclaredAnnotationTypeByStereotype(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> java.util.List<io.micronaut.core.annotation.AnnotationValue<A>> getDeclaredAnnotationValuesByName(java.lang.String p0) {
+        return getAnnotationMetadata().getDeclaredAnnotationValuesByName(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> java.util.List<io.micronaut.core.annotation.AnnotationValue<A>> getDeclaredAnnotationValuesByType(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().getDeclaredAnnotationValuesByType(p0);
+    }
+
+    @Override
+    public io.micronaut.core.annotation.AnnotationMetadata getDeclaredMetadata() {
+        return getAnnotationMetadata().getDeclaredMetadata();
+    }
+
+    @Override
+    public java.util.Set<java.lang.String> getDeclaredStereotypeAnnotationNames() {
+        return getAnnotationMetadata().getDeclaredStereotypeAnnotationNames();
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getDefaultValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1, io.micronaut.core.type.Argument<V> p2) {
+        return getAnnotationMetadata().getDefaultValue(p0, p1, p2);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getDefaultValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1, java.lang.Class<V> p2) {
+        return getAnnotationMetadata().getDefaultValue(p0, p1, p2);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getDefaultValue(java.lang.String p0, java.lang.String p1, io.micronaut.core.type.Argument<V> p2) {
+        return getAnnotationMetadata().getDefaultValue(p0, p1, p2);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getDefaultValue(java.lang.String p0, java.lang.String p1, java.lang.Class<V> p2) {
+        return getAnnotationMetadata().getDefaultValue(p0, p1, p2);
+    }
+
+    @Override
+    public java.util.Map<java.lang.CharSequence, java.lang.Object> getDefaultValues(java.lang.String p0) {
+        return getAnnotationMetadata().getDefaultValues(p0);
+    }
+
+    @Override
+    public java.util.Set<java.lang.String> getStereotypeAnnotationNames() {
+        return getAnnotationMetadata().getStereotypeAnnotationNames();
+    }
+
+    @Override
+    public io.micronaut.core.annotation.AnnotationMetadata getTargetAnnotationMetadata() {
+        return getAnnotationMetadata().getTargetAnnotationMetadata();
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Object> getValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().getValue(p0);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, io.micronaut.core.type.Argument<V> p1) {
+        return getAnnotationMetadata().getValue(p0, p1);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.Class<V> p1) {
+        return getAnnotationMetadata().getValue(p0, p1);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Object> getValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().getValue(p0, p1);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1, io.micronaut.core.type.Argument<V> p2) {
+        return getAnnotationMetadata().getValue(p0, p1, p2);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1, java.lang.Class<V> p2) {
+        return getAnnotationMetadata().getValue(p0, p1, p2);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Object> getValue(java.lang.String p0) {
+        return getAnnotationMetadata().getValue(p0);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getValue(java.lang.String p0, io.micronaut.core.type.Argument<V> p1) {
+        return getAnnotationMetadata().getValue(p0, p1);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getValue(java.lang.String p0, java.lang.Class<V> p1) {
+        return getAnnotationMetadata().getValue(p0, p1);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.Object> getValue(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().getValue(p0, p1);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getValue(java.lang.String p0, java.lang.String p1, io.micronaut.core.type.Argument<V> p2) {
+        return getAnnotationMetadata().getValue(p0, p1, p2);
+    }
+
+    @Override
+    public <V> java.util.Optional<V> getValue(java.lang.String p0, java.lang.String p1, java.lang.Class<V> p2) {
+        return getAnnotationMetadata().getValue(p0, p1, p2);
+    }
+
+    @Override
+    public <V> io.micronaut.core.value.OptionalValues<V> getValues(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.Class<V> p1) {
+        return getAnnotationMetadata().getValues(p0, p1);
+    }
+
+    @Override
+    public <V> io.micronaut.core.value.OptionalValues<V> getValues(java.lang.String p0, java.lang.Class<V> p1) {
+        return getAnnotationMetadata().getValues(p0, p1);
+    }
+
+    @Override
+    public boolean hasAnnotation(java.lang.@Nullable Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().hasAnnotation(p0);
+    }
+
+    @Override
+    public boolean hasAnnotation(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().hasAnnotation(p0);
+    }
+
+    @Override
+    public boolean hasDeclaredAnnotation(java.lang.@Nullable Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().hasDeclaredAnnotation(p0);
+    }
+
+    @Override
+    public boolean hasDeclaredAnnotation(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().hasDeclaredAnnotation(p0);
+    }
+
+    @Override
+    public boolean hasDeclaredStereotype(java.lang.Class<? extends java.lang.annotation.Annotation> @Nullable ... p0) {
+        return getAnnotationMetadata().hasDeclaredStereotype(p0);
+    }
+
+    @Override
+    public boolean hasDeclaredStereotype(java.lang.@Nullable Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().hasDeclaredStereotype(p0);
+    }
+
+    @Override
+    public boolean hasDeclaredStereotype(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().hasDeclaredStereotype(p0);
+    }
+
+    @Override
+    public boolean hasSimpleAnnotation(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().hasSimpleAnnotation(p0);
+    }
+
+    @Override
+    public boolean hasSimpleDeclaredAnnotation(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().hasSimpleDeclaredAnnotation(p0);
+    }
+
+    @Override
+    public boolean hasStereotype(java.lang.Class<? extends java.lang.annotation.Annotation> @Nullable ... p0) {
+        return getAnnotationMetadata().hasStereotype(p0);
+    }
+
+    @Override
+    public boolean hasStereotype(java.lang.String @Nullable [] p0) {
+        return getAnnotationMetadata().hasStereotype(p0);
+    }
+
+    @Override
+    public boolean hasStereotype(java.lang.@Nullable Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().hasStereotype(p0);
+    }
+
+    @Override
+    public boolean hasStereotype(java.lang.@Nullable String p0) {
+        return getAnnotationMetadata().hasStereotype(p0);
+    }
+
+    @Override
+    public java.util.OptionalInt intValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().intValue(p0);
+    }
+
+    @Override
+    public java.util.OptionalInt intValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().intValue(p0, p1);
+    }
+
+    @Override
+    public java.util.OptionalInt intValue(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().intValue(p0, p1);
+    }
+
+    @Override
+    public boolean isAnnotationPresent(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().isAnnotationPresent(p0);
+    }
+
+    @Override
+    public boolean isDeclaredAnnotationPresent(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().isDeclaredAnnotationPresent(p0);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return getAnnotationMetadata().isEmpty();
+    }
+
+    @Override
+    public boolean isFalse(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().isFalse(p0, p1);
+    }
+
+    @Override
+    public boolean isFalse(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().isFalse(p0, p1);
+    }
+
+    @Override
+    public boolean isPresent(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().isPresent(p0, p1);
+    }
+
+    @Override
+    public boolean isPresent(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().isPresent(p0, p1);
+    }
+
+    @Override
+    public boolean isRepeatableAnnotation(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().isRepeatableAnnotation(p0);
+    }
+
+    @Override
+    public boolean isRepeatableAnnotation(java.lang.String p0) {
+        return getAnnotationMetadata().isRepeatableAnnotation(p0);
+    }
+
+    @Override
+    public boolean isTrue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().isTrue(p0, p1);
+    }
+
+    @Override
+    public boolean isTrue(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().isTrue(p0, p1);
+    }
+
+    @Override
+    public java.util.OptionalLong longValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().longValue(p0, p1);
+    }
+
+    @Override
+    public java.util.OptionalLong longValue(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().longValue(p0, p1);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.String> stringValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().stringValue(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.String> stringValue(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().stringValue(p0, p1);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.String> stringValue(java.lang.String p0) {
+        return getAnnotationMetadata().stringValue(p0);
+    }
+
+    @Override
+    public java.util.Optional<java.lang.String> stringValue(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().stringValue(p0, p1);
+    }
+
+    @Override
+    public java.lang.String[] stringValues(java.lang.Class<? extends java.lang.annotation.Annotation> p0) {
+        return getAnnotationMetadata().stringValues(p0);
+    }
+
+    @Override
+    public java.lang.String[] stringValues(java.lang.Class<? extends java.lang.annotation.Annotation> p0, java.lang.String p1) {
+        return getAnnotationMetadata().stringValues(p0, p1);
+    }
+
+    @Override
+    public java.lang.String[] stringValues(java.lang.String p0) {
+        return getAnnotationMetadata().stringValues(p0);
+    }
+
+    @Override
+    public java.lang.String[] stringValues(java.lang.String p0, java.lang.String p1) {
+        return getAnnotationMetadata().stringValues(p0, p1);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> @Nullable A synthesize(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().synthesize(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> @Nullable A synthesize(java.lang.Class<A> p0, java.lang.String p1) {
+        return getAnnotationMetadata().synthesize(p0, p1);
+    }
+
+    @Override
+    public java.lang.annotation.Annotation[] synthesizeAll() {
+        return getAnnotationMetadata().synthesizeAll();
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> A[] synthesizeAnnotationsByType(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().synthesizeAnnotationsByType(p0);
+    }
+
+    @Override
+    public java.lang.annotation.Annotation[] synthesizeDeclared() {
+        return getAnnotationMetadata().synthesizeDeclared();
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> @Nullable A synthesizeDeclared(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().synthesizeDeclared(p0);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> @Nullable A synthesizeDeclared(java.lang.Class<A> p0, java.lang.String p1) {
+        return getAnnotationMetadata().synthesizeDeclared(p0, p1);
+    }
+
+    @Override
+    public <A extends java.lang.annotation.Annotation> A[] synthesizeDeclaredAnnotationsByType(java.lang.Class<A> p0) {
+        return getAnnotationMetadata().synthesizeDeclaredAnnotationsByType(p0);
+    }
 }


### PR DESCRIPTION
Two independent, drop-in changes to cold start. No new API, no build change, nothing opt-in.

Measured on a synthetic application: cold JVM, one context start per process, variants
interleaved so machine noise hits both equally. 185-jar classpath, JDK 25, 16 cores, medians
over 25 runs. CPU is process CPU time, which is far more stable than wall time on a loaded
machine.

| Shape | Wall | CPU |
|---|---|---|
| 12 modules × 40 beans (528 refs) | 221 → 209 ms (**−5.4%**) | 966 → 850 ms (**−12.0%**) |
| 1 module × 446 beans | 241 → 228 ms (−5.4%) | 916 → 777 ms (−15.2%) |
| 40 modules × 3 beans (166 refs) | 238 → 228 ms (−4.2%) | 695 → 633 ms (−8.9%) |

Bean definition counts are identical before and after in every case.

## 1. Stop scanning the classpath three times for a resource that is not there

`DefaultClassPathResourceLoader#getResourceAsStream` called `classLoader.getResource` for the
path, and on a miss fell through to a fallback that ran the identical lookup again, which in
turn called `isDirectory()` and ran it a third time. Nothing after the first miss could turn it
into a hit.

Startup probes for configuration files that are usually absent, so the miss is the common case
rather than the exceptional one. On a 185-jar classpath a single miss costs about 4 ms. The
change also removes two levels of nesting from the method.

Found while profiling native image startup, where property source loading is roughly three
quarters of the time and this is a visible part of it. It is not native-specific.

## 2. Implement the `AnnotationMetadataDelegate` defaults once, in the bean definition base

`BeanDefinition`'s interface closure carries 344 default methods, 301 of which nothing in the
class hierarchy implements. 243 of those come from a single diamond: `AnnotationMetadataDelegate`
extends `AnnotationMetadata` and redeclares most of it as delegating defaults.

The JVM runs `DefaultMethods::generate_default_methods` over that overlap every time it defines a
class in the hierarchy, and an application defines one class per bean — so it pays for the same
resolution hundreds of times. Implementing the methods once in
`AbstractInitializableBeanDefinition` puts them in its vtable and the generated definitions
inherit them, taking the still-inherited count from 301 to 39.

Isolated on 500 identically shaped classes, varying only the interface closure: **174 ms of CPU
to define them carrying the closure, 95 ms with a base class implementing it.**

### Why this is safe

Each body is exactly what the interface default did: a virtual `getAnnotationMetadata()` call on
`this`, with no unwrapping. That last part matters — the field can hold an
`EvaluatedAnnotationMetadata` wrapper, so resolving through `getTargetAnnotationMetadata()` here
would silently drop expression evaluation on annotation values.

Of the 33 signatures where another interface in the closure also declares a default, 32 come from
`AnnotationMetadataProvider` and `AnnotationSource`, both supertypes of
`AnnotationMetadataDelegate`, so its body was already the one being inherited and its declaration
is the one copied. The one independent case, `EnvironmentConfigurable#hasPropertyExpressions`, was
already implemented concretely and is not overridden.

The 124 methods are machine generated and carry the nullability the interfaces declare, so none
needs a NullAway suppression. Generating them at build time, or removing the overlap at the source
by reconsidering whether `BeanDefinition` needs to be an `AnnotationMetadataDelegate` at all,
would both be better than keeping them checked in by hand — worth a maintainer's view on which.

## Context worth having

These came out of a wider startup investigation. Two things from it that bear on how much this
matters:

- **The JDK 24+ AOT cache is worth far more.** On the same application it is −60% wall and −66%
  CPU, against −5%/−12% here, and it needs no code changes at all. The two compose: these changes
  are still worth −13% on top of the cache. If startup matters, the cache is the first move.
- **Native image is a different problem.** There, class loading is free and property source
  loading is about three quarters of a 6.4 ms start. Change 1 helps there; change 2 does not.

Tested on `micronaut-core`, `micronaut-inject`, `micronaut-context`, `micronaut-aop`,
`micronaut-runtime` and `micronaut-inject-java-test` — 8,059 tests pass, checkstyle clean.

A separate `ServiceAggregator` change (one generated aggregator per module instead of a marker
file per bean definition, opt-in, −3% wall / −12% CPU / −31% zip entries) is on
`claude/service-aggregator` and can follow as its own PR; it touches no file in common with this
one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)