### PR TITLE
Close a bean registration idempotently

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/IdempotentRegistrationCloseSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/registrationclose/IdempotentRegistrationCloseSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.registrationclose
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanRegistration
+import io.micronaut.core.type.Argument
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class IdempotentRegistrationCloseSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run()
+
+    void "closing a registration twice destroys the bean once"() {
+        given:
+        SimpleBeanPreDestroyListener preDestroy = context.getBean(SimpleBeanPreDestroyListener)
+        SimpleBeanDestroyedListener destroyed = context.getBean(SimpleBeanDestroyedListener)
+        int destroyedBefore = destroyed.destroyed.size()
+        int preDestroyBefore = preDestroy.destroyed.size()
+
+        when: "the registration is closed twice"
+        BeanRegistration<SimpleBean> registration =
+                context.getBeanRegistration(Argument.of(SimpleBean), null)
+        registration.close()
+        registration.close()
+
+        then: "each destruction listener saw the bean once"
+        preDestroy.destroyed.size() == preDestroyBefore + 1
+        destroyed.destroyed.size() == destroyedBefore + 1
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
@@ -32,6 +32,8 @@ import java.util.List;
 @Internal
 final class BeanDisposingRegistration<BT> extends BeanRegistration<BT> implements DependentBeanProvider {
     private final BeanContext beanContext;
+    private final java.util.concurrent.atomic.AtomicBoolean closed =
+        new java.util.concurrent.atomic.AtomicBoolean();
     @Nullable
     private final List<BeanRegistration<?>> dependents;
     @Nullable
@@ -62,7 +64,13 @@ final class BeanDisposingRegistration<BT> extends BeanRegistration<BT> implement
 
     @Override
     public void close() {
-        beanContext.destroyBean(this);
+        // idempotent, as AutoCloseable asks an implementation to be: destroying a bean runs its pre-destroy
+        // listeners, its @PreDestroy and its disposer, and a registration closed twice — by a
+        // try-with-resources and an explicit close, or by two owners that each believe they hold it — must
+        // not run them twice
+        if (closed.compareAndSet(false, true)) {
+            beanContext.destroyBean(this);
+        }
     }
 
     @Nullable


### PR DESCRIPTION
`BeanRegistration` is `AutoCloseable`, whose contract strongly encourages an implementation to make `close()` idempotent — precisely so that a try-with-resources together with an explicit `close()`, or two owners that each believe they hold the registration, are safe.

`BeanDisposingRegistration.close()` is `beanContext.destroyBean(this)`, and `destroyBean` has no already-destroyed check: it purges the caches, notifies `BeanPreDestroyEventListener`s, runs the bean's `@PreDestroy` and its disposer, and notifies `BeanDestroyedEventListener`s — every time it is called. So closing a registration twice destroys the bean twice.

This makes the first close destroy and the rest do nothing. `destroyBean(BeanRegistration)` itself is untouched: calling it directly twice remains the caller's business, and only `close()` carries the `AutoCloseable` expectation.

Includes a spec that closes a registration twice and asserts each destruction listener saw the bean exactly once; it fails without the change.

Found while adopting #12943 downstream: with `close()` now destroying through the context, code that hands a registration to more than one owner has to guard every hand-off itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
