### PR TITLE
Support static methods meta-annotated as @Executable

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -379,8 +379,9 @@ sealed class DeclaredBeanElementCreator<R> extends AbstractBeanElementCreator<R>
     }
 
     private boolean visitAopAndExecutableMethod(ElementBeanDefinitionBuilder<R> beanDefinitionBuilder, MethodElement methodElement) {
-        if (methodElement.isStatic() && !isExplicitlyAnnotatedAsExecutable(methodElement)) {
-            // Only allow static executable methods when it's explicitly annotated with Executable.class
+        if (methodElement.isStatic() && !isStaticExecutableMethod(methodElement)) {
+            // Only allow static executable methods when the method itself is annotated with @Executable
+            // (directly or via an annotation meta-annotated with @Executable)
             return false;
         }
         if (methodElement.hasStereotype(Adapter.class)) {
@@ -459,6 +460,26 @@ sealed class DeclaredBeanElementCreator<R> extends AbstractBeanElementCreator<R>
 
     private static boolean isExplicitlyAnnotatedAsExecutable(MethodElement methodElement) {
         return methodElement.getMethodAnnotationMetadata().hasDeclaredAnnotation(Executable.class);
+    }
+
+    /**
+     * Should a static method be turned into an executable method? That is the case when the method itself
+     * is annotated with {@link Executable}, either directly or via an annotation meta-annotated with
+     * {@link Executable}. Executable advice inherited from the declaring class doesn't count, since that
+     * would silently turn every static utility method of the class into an executable method.
+     *
+     * @param methodElement The method element
+     * @return true if it should
+     */
+    private static boolean isStaticExecutableMethod(MethodElement methodElement) {
+        AnnotationMetadata methodAnnotationMetadata = methodElement.getMethodAnnotationMetadata();
+        if (methodAnnotationMetadata.hasDeclaredAnnotation(Executable.class)) {
+            return true;
+        }
+        // Adapter advice, for example @EventListener, adapts a method of a bean instance and cannot be
+        // applied to a static method, so those methods keep being ignored
+        return methodAnnotationMetadata.hasDeclaredStereotype(Executable.class)
+            && !methodAnnotationMetadata.hasDeclaredStereotype(Adapter.class);
     }
 
     /**

--- a/inject-java/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
@@ -537,4 +537,109 @@ class ExecutableConstructorBean {
         definition.findMethod('<init>').isEmpty()
         definition.findMethod('describe').isPresent()
     }
+
+    void "test executable method is created for a static method"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.StaticExecutableBean','''\
+package test;
+
+import io.micronaut.context.annotation.Executable;
+import jakarta.inject.Singleton;
+
+@Singleton
+class StaticExecutableBean {
+
+    @Executable
+    public static String staticMethod(String name) {
+        return "static " + name;
+    }
+
+    @Executable
+    public String instanceMethod(String name) {
+        return "instance " + name;
+    }
+}
+''')
+        expect:
+        definition != null
+        definition.findMethod('staticMethod', String).isPresent()
+        definition.findMethod('staticMethod', String).get().declaringType == definition.beanType
+        definition.findMethod('staticMethod', String).get().returnType.type == String
+
+        and: 'the static method can be invoked without an instance'
+        definition.findMethod('staticMethod', String).get().invoke(null, 'foo') == 'static foo'
+        definition.findMethod('instanceMethod', String).isPresent()
+    }
+
+    void "test executable method is created for a static method meta-annotated as executable"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.StaticMetaExecutableBean','''\
+package test;
+
+import io.micronaut.inject.executable.RepeatableExecutable;
+import jakarta.inject.Singleton;
+
+@Singleton
+class StaticMetaExecutableBean {
+
+    @RepeatableExecutable("a")
+    public static String staticMethod(String name) {
+        return "static " + name;
+    }
+}
+''')
+        expect:
+        definition != null
+        definition.findMethod('staticMethod', String).isPresent()
+        definition.findMethod('staticMethod', String).get().invoke(null, 'foo') == 'static foo'
+    }
+
+    void "test @Executable on the class does not make static methods executable"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.ClassExecutableBean','''\
+package test;
+
+import io.micronaut.context.annotation.Executable;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Executable
+class ClassExecutableBean {
+
+    public static String staticMethod(String name) {
+        return "static " + name;
+    }
+
+    public String instanceMethod(String name) {
+        return "instance " + name;
+    }
+}
+''')
+        expect:
+        definition != null
+        definition.findMethod('instanceMethod', String).isPresent()
+        definition.findMethod('staticMethod', String).isEmpty()
+    }
+
+    void "test a static method with adapter advice is still ignored"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.StaticEventListenerBean','''\
+package test;
+
+import io.micronaut.context.event.StartupEvent;
+import io.micronaut.runtime.event.annotation.EventListener;
+import jakarta.inject.Singleton;
+
+@Singleton
+class StaticEventListenerBean {
+
+    @EventListener
+    public static void onStartup(StartupEvent event) {
+    }
+}
+''')
+        expect: 'adapter advice needs a bean instance to adapt, so the static method is not executable'
+        definition != null
+        definition.findMethod('onStartup', io.micronaut.context.event.StartupEvent).isEmpty()
+    }
 }


### PR DESCRIPTION
## The gap

A `static` method only becomes an `ExecutableMethod` when it carries `@Executable` as a *direct* annotation. A static method annotated with an annotation that is itself meta-annotated with `@Executable` — which is how nearly every executable annotation in the ecosystem is defined (`@Get`, `@Scheduled`, `@RepeatableExecutable`, …) — is silently dropped: no error, no warning, it simply isn't in `BeanDefinition.getExecutableMethods()`.

```java
@Singleton
class MyBean {
    @Executable                 // works today
    static String a(String s) { return s; }

    @RepeatableExecutable("a")  // @Executable meta-annotated -> silently missing
    static String b(String s) { return s; }
}
```

Frameworks that dispatch through executable methods therefore cannot dispatch to such methods and must fall back to reflection, which also costs them GraalVM native image friendliness.

## The change

`DeclaredBeanElementCreator#visitAopAndExecutableMethod` now gates statics on the `@Executable` *stereotype* of the method's own annotation metadata rather than on the declared annotation, so a static method reaches the executable writer the same way an instance method does.

Nothing was needed in `BeanDefinitionWriter`/`DispatchWriter`: `ExecutableMethod.invoke(Object, Object...)` already ignores the passed instance for a static target and `DispatchWriter.MethodDispatchTarget` already emits `invokestatic`, so the generated code stays reflection free, never touches the instance, and `getDeclaringType()` remains the declaring class.

Two boundaries are deliberately kept as they are, and are now covered by tests:

- `@Executable` **on the class** still does not make its static methods executable — otherwise every static helper of an `@Executable` class would silently be exposed.
- A static method carrying **adapter advice** (`@EventListener` and friends) is still ignored, since adapter advice adapts a method of a bean instance. Making it an error would break builds that today compile silently.

Interception is unchanged: a static method is still excluded from AOP, and around advice on a static method keeps failing with the existing `Method defines AOP advice but is declared static` error.

## Tests

Four new cases in `ExecutableBeanSpec`: static `@Executable` (declaring type, return type and reflection-free `invoke`), static meta-annotated executable (the actual fix — fails on `5.2.x`), class-level `@Executable` not exposing statics, and static adapter advice still ignored.

Regression pass, each task run in isolation, all green:
`inject-java` (4959), `inject-groovy` (227), `inject-java-test` (1063), `inject-kotlin` (56), `inject-kotlin-test` (64), `core-processor` (312), `inject` (111), `context` (48), `router` (807), `runtime`, `test-suite` (487), `test-suite-groovy` (230), `test-suite-kotlin` (327), `http-server-netty` (1128).

🤖 Generated with [Claude Code](https://claude.com/claude-code)