### PR TITLE
Read a live annotation as an AnnotationValue

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -68,6 +68,26 @@ import static io.micronaut.core.reflect.ReflectionUtils.EMPTY_CLASS_ARRAY;
  */
 public class AnnotationValue<A extends Annotation> implements AnnotationValueResolver {
 
+    private static final String ANNOTATION_PARAMETER = "annotation";
+
+    /**
+     * The members of each annotation type, by name, in declaration order: the zero-argument methods it declares,
+     * looked up once per type rather than on every read of an instance.
+     */
+    private static final ClassValue<Map<String, Method>> ANNOTATION_MEMBERS = new ClassValue<>() {
+        @Override
+        protected Map<String, Method> computeValue(Class<?> annotationType) {
+            Method[] declared = annotationType.getDeclaredMethods();
+            Map<String, Method> members = CollectionUtils.newLinkedHashMap(declared.length);
+            for (Method member : declared) {
+                if (member.getParameterCount() == 0 && !member.isSynthetic()) {
+                    members.put(member.getName(), member);
+                }
+            }
+            return Collections.unmodifiableMap(members);
+        }
+    };
+
     private final String annotationName;
     private final ConvertibleValues<Object> convertibleValues;
     private final Map<CharSequence, Object> values;
@@ -1549,7 +1569,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @since 4.0.0
      */
     public static <T extends Annotation> AnnotationValueBuilder<T> builder(AnnotationValue<T> annotation) {
-        ArgumentUtils.requireNonNull("annotation", annotation);
+        ArgumentUtils.requireNonNull(ANNOTATION_PARAMETER, annotation);
         return new AnnotationValueBuilder<>(annotation, annotation.getRetentionPolicy());
     }
 
@@ -1562,7 +1582,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @return The builder
      */
     public static <T extends Annotation> AnnotationValueBuilder<T> builder(AnnotationValue<T> annotation, @Nullable RetentionPolicy retentionPolicy) {
-        ArgumentUtils.requireNonNull("annotation", annotation);
+        ArgumentUtils.requireNonNull(ANNOTATION_PARAMETER, annotation);
         return new AnnotationValueBuilder<>(annotation, retentionPolicy);
     }
 
@@ -1593,7 +1613,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @since 5.2.0
      */
     public static <T extends Annotation> AnnotationValue<T> of(T annotation) {
-        ArgumentUtils.requireNonNull("annotation", annotation);
+        ArgumentUtils.requireNonNull(ANNOTATION_PARAMETER, annotation);
         Class<? extends Annotation> annotationType = annotation.annotationType();
         Map<String, Method> members = ANNOTATION_MEMBERS.get(annotationType);
         Map<CharSequence, Object> values = CollectionUtils.newLinkedHashMap(members.size());
@@ -1602,24 +1622,6 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         }
         return new AnnotationValue<>(annotationType.getName(), values, RetentionPolicy.RUNTIME);
     }
-
-    /**
-     * The members of each annotation type, by name, in declaration order: the zero-argument methods it declares,
-     * looked up once per type rather than on every read of an instance.
-     */
-    private static final ClassValue<Map<String, Method>> ANNOTATION_MEMBERS = new ClassValue<>() {
-        @Override
-        protected Map<String, Method> computeValue(Class<?> annotationType) {
-            Method[] declared = annotationType.getDeclaredMethods();
-            Map<String, Method> members = CollectionUtils.newLinkedHashMap(declared.length);
-            for (Method member : declared) {
-                if (member.getParameterCount() == 0 && !member.isSynthetic()) {
-                    members.put(member.getName(), member);
-                }
-            }
-            return Collections.unmodifiableMap(members);
-        }
-    };
 
     /**
      * A member read off an annotation instance.

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -1595,8 +1595,9 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
     public static <T extends Annotation> AnnotationValue<T> of(T annotation) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         Class<? extends Annotation> annotationType = annotation.annotationType();
-        Map<CharSequence, Object> values = new LinkedHashMap<>();
-        for (Method member : annotationType.getDeclaredMethods()) {
+        Method[] members = annotationType.getDeclaredMethods();
+        Map<CharSequence, Object> values = CollectionUtils.newLinkedHashMap(members.length);
+        for (Method member : members) {
             if (member.getParameterCount() != 0 || member.isSynthetic()) {
                 continue;
             }

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -1595,16 +1595,31 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
     public static <T extends Annotation> AnnotationValue<T> of(T annotation) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         Class<? extends Annotation> annotationType = annotation.annotationType();
-        Method[] members = annotationType.getDeclaredMethods();
-        Map<CharSequence, Object> values = CollectionUtils.newLinkedHashMap(members.length);
-        for (Method member : members) {
-            if (member.getParameterCount() != 0 || member.isSynthetic()) {
-                continue;
-            }
-            values.put(member.getName(), toMemberValue(readMember(annotation, member)));
+        Map<String, Method> members = ANNOTATION_MEMBERS.get(annotationType);
+        Map<CharSequence, Object> values = CollectionUtils.newLinkedHashMap(members.size());
+        for (Map.Entry<String, Method> member : members.entrySet()) {
+            values.put(member.getKey(), toMemberValue(readMember(annotation, member.getValue())));
         }
         return new AnnotationValue<>(annotationType.getName(), values, RetentionPolicy.RUNTIME);
     }
+
+    /**
+     * The members of each annotation type, by name, in declaration order: the zero-argument methods it declares,
+     * looked up once per type rather than on every read of an instance.
+     */
+    private static final ClassValue<Map<String, Method>> ANNOTATION_MEMBERS = new ClassValue<>() {
+        @Override
+        protected Map<String, Method> computeValue(Class<?> annotationType) {
+            Method[] declared = annotationType.getDeclaredMethods();
+            Map<String, Method> members = CollectionUtils.newLinkedHashMap(declared.length);
+            for (Method member : declared) {
+                if (member.getParameterCount() == 0 && !member.isSynthetic()) {
+                    members.put(member.getName(), member);
+                }
+            }
+            return Collections.unmodifiableMap(members);
+        }
+    };
 
     /**
      * A member read off an annotation instance.
@@ -1641,37 +1656,34 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @return The value as metadata records it
      */
     private static Object toMemberValue(Object value) {
-        if (value instanceof Class<?> type) {
-            return new AnnotationClassValue<>(type);
-        }
-        if (value instanceof Enum<?> constant) {
-            return constant.name();
-        }
-        if (value instanceof Annotation nested) {
-            return of(nested);
-        }
-        if (value instanceof Class<?>[] types) {
-            AnnotationClassValue<?>[] classValues = new AnnotationClassValue[types.length];
-            for (int i = 0; i < types.length; i++) {
-                classValues[i] = new AnnotationClassValue<>(types[i]);
+        return switch (value) {
+            case Class<?> type -> new AnnotationClassValue<>(type);
+            case Enum<?> constant -> constant.name();
+            case Annotation nested -> of(nested);
+            case Annotation[] nested -> {
+                AnnotationValue<?>[] annotationValues = new AnnotationValue[nested.length];
+                for (int i = 0; i < nested.length; i++) {
+                    annotationValues[i] = of(nested[i]);
+                }
+                yield annotationValues;
             }
-            return classValues;
-        }
-        if (value instanceof Enum<?>[] constants) {
-            String[] names = new String[constants.length];
-            for (int i = 0; i < constants.length; i++) {
-                names[i] = constants[i].name();
+            // a generic array type is not a pattern the parser accepts, so the two are matched by a guard
+            case Object[] array when array instanceof Class<?>[] types -> {
+                AnnotationClassValue<?>[] classValues = new AnnotationClassValue[types.length];
+                for (int i = 0; i < types.length; i++) {
+                    classValues[i] = new AnnotationClassValue<>(types[i]);
+                }
+                yield classValues;
             }
-            return names;
-        }
-        if (value instanceof Annotation[] nested) {
-            AnnotationValue<?>[] annotationValues = new AnnotationValue[nested.length];
-            for (int i = 0; i < nested.length; i++) {
-                annotationValues[i] = of(nested[i]);
+            case Object[] array when array instanceof Enum<?>[] constants -> {
+                String[] names = new String[constants.length];
+                for (int i = 0; i < constants.length; i++) {
+                    names[i] = constants[i].name();
+                }
+                yield names;
             }
-            return annotationValues;
-        }
-        return value;
+            default -> value;
+        };
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -21,6 +21,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.expressions.EvaluatedExpression;
 import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
@@ -31,6 +32,7 @@ import org.jspecify.annotations.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Array;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1562,6 +1564,113 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
     public static <T extends Annotation> AnnotationValueBuilder<T> builder(AnnotationValue<T> annotation, @Nullable RetentionPolicy retentionPolicy) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         return new AnnotationValueBuilder<>(annotation, retentionPolicy);
+    }
+
+    /**
+     * Reads a live annotation instance as an annotation value.
+     *
+     * <p>Code handed annotation instances at runtime, such as a qualifier passed to a bean lookup, needs them in
+     * the form compiled metadata records them so that the two compare equal. Every zero-argument member of the
+     * annotation is read, the ones left at their default included since an instance answers every one of its
+     * members, and converted the way an annotation processor records it:</p>
+     *
+     * <ul>
+     *     <li>a {@link Class} becomes an {@link AnnotationClassValue}</li>
+     *     <li>an {@link Enum} becomes the name of its constant</li>
+     *     <li>a nested {@link Annotation} becomes an {@link AnnotationValue} of every one of its members, recursively</li>
+     *     <li>an array of any of the above becomes an array of the converted form</li>
+     *     <li>any other value, such as a primitive, a {@link String} or an array of either, is kept as it is</li>
+     * </ul>
+     *
+     * <p>No member is left out. Whether a member takes part in the comparison of two qualifiers is a concern of the
+     * qualifier rather than of the conversion, so {@code @NonBinding} is not applied here.</p>
+     *
+     * @param annotation The annotation instance
+     * @param <T>        The annotation type
+     * @return The annotation value, with {@link RetentionPolicy#RUNTIME} retention
+     * @throws IllegalStateException When a member cannot be read, because the annotation type is not open to this
+     *                               module or because the instance does not answer for it
+     * @since 5.2.0
+     */
+    public static <T extends Annotation> AnnotationValue<T> of(T annotation) {
+        ArgumentUtils.requireNonNull("annotation", annotation);
+        Class<? extends Annotation> annotationType = annotation.annotationType();
+        Map<CharSequence, Object> values = new LinkedHashMap<>();
+        for (Method member : annotationType.getDeclaredMethods()) {
+            if (member.getParameterCount() != 0 || member.isSynthetic()) {
+                continue;
+            }
+            values.put(member.getName(), toMemberValue(readMember(annotation, member)));
+        }
+        return new AnnotationValue<>(annotationType.getName(), values, RetentionPolicy.RUNTIME);
+    }
+
+    /**
+     * A member read off an annotation instance.
+     *
+     * @param annotation The annotation instance
+     * @param member     The member
+     * @return The value, never null
+     * @throws IllegalStateException When the member cannot be read
+     */
+    private static Object readMember(Annotation annotation, Method member) {
+        Object value;
+        try {
+            value = ReflectionUtils.invokeInaccessibleMethod(annotation, member);
+        } catch (RuntimeException e) {
+            // the reflective wrappers say nothing an invocation target's own exception does not say better
+            Throwable cause = e;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            throw new IllegalStateException("Cannot read member [" + member.getName() + "] of annotation ["
+                + annotation.annotationType().getName() + "]: " + cause, e);
+        }
+        if (value == null) {
+            throw new IllegalStateException("Cannot read member [" + member.getName() + "] of annotation ["
+                + annotation.annotationType().getName() + "]: the instance answered null");
+        }
+        return value;
+    }
+
+    /**
+     * A member value read off an annotation instance, in the form compiled metadata records it.
+     *
+     * @param value The value as reflection returns it
+     * @return The value as metadata records it
+     */
+    private static Object toMemberValue(Object value) {
+        if (value instanceof Class<?> type) {
+            return new AnnotationClassValue<>(type);
+        }
+        if (value instanceof Enum<?> constant) {
+            return constant.name();
+        }
+        if (value instanceof Annotation nested) {
+            return of(nested);
+        }
+        if (value instanceof Class<?>[] types) {
+            AnnotationClassValue<?>[] classValues = new AnnotationClassValue[types.length];
+            for (int i = 0; i < types.length; i++) {
+                classValues[i] = new AnnotationClassValue<>(types[i]);
+            }
+            return classValues;
+        }
+        if (value instanceof Enum<?>[] constants) {
+            String[] names = new String[constants.length];
+            for (int i = 0; i < constants.length; i++) {
+                names[i] = constants[i].name();
+            }
+            return names;
+        }
+        if (value instanceof Annotation[] nested) {
+            AnnotationValue<?>[] annotationValues = new AnnotationValue[nested.length];
+            for (int i = 0; i < nested.length; i++) {
+                annotationValues[i] = of(nested[i]);
+            }
+            return annotationValues;
+        }
+        return value;
     }
 
     /**

--- a/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueOfAnnotationSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueOfAnnotationSpec.groovy
@@ -1,0 +1,184 @@
+package io.micronaut.core.annotation
+
+import spock.lang.Specification
+
+import java.lang.annotation.Annotation
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+/**
+ * {@link AnnotationValue#of(Annotation)} reads a live annotation the way compiled metadata records it.
+ */
+class AnnotationValueOfAnnotationSpec extends Specification {
+
+    void 'test the annotation name and retention'() {
+        when:
+        AnnotationValue<Chunky> value = AnnotationValue.of(chunkyOn(Cod))
+
+        then:
+        value.annotationName == Chunky.name
+        value.retentionPolicy == RetentionPolicy.RUNTIME
+    }
+
+    void 'test primitive and string members are kept as they are'() {
+        when:
+        AnnotationValue<Chunky> value = AnnotationValue.of(chunkyOn(Cod))
+
+        then:
+        value.values.realChunky == true
+        value.values.weight == 12
+        value.values.sea == 'north'
+        value.values.seas == ['north', 'baltic'] as String[]
+        value.values.weights == [1, 2] as int[]
+    }
+
+    void 'test an enum member is recorded by the name of its constant'() {
+        when:
+        AnnotationValue<Chunky> value = AnnotationValue.of(chunkyOn(Cod))
+
+        then:
+        value.values.kind == 'COD'
+        value.values.kind instanceof String
+        value.values.kinds == ['COD', 'HADDOCK'] as String[]
+        value.values.kinds instanceof String[]
+    }
+
+    void 'test a class member is recorded as an annotation class value'() {
+        when:
+        AnnotationValue<Chunky> value = AnnotationValue.of(chunkyOn(Cod))
+
+        then:
+        value.values.caught == new AnnotationClassValue<>(String)
+        value.values.caughts == [new AnnotationClassValue<>(String), new AnnotationClassValue<>(Integer)] as AnnotationClassValue[]
+        value.values.caughts instanceof AnnotationClassValue[]
+    }
+
+    void 'test a nested annotation is recorded as an annotation value of every one of its members'() {
+        when:
+        AnnotationValue<Chunky> value = AnnotationValue.of(chunkyOn(Cod))
+        AnnotationValue<Net> net = value.values.net as AnnotationValue<Net>
+        AnnotationValue<Net>[] nets = value.values.nets as AnnotationValue<Net>[]
+
+        then: 'the nested annotation converts its own members too'
+        net.annotationName == Net.name
+        net.values == [mesh: 3, material: 'NYLON', knot: new AnnotationClassValue<>(Object)]
+        net.values.material instanceof String
+
+        and: 'an array of nested annotations converts every element'
+        nets.length == 2
+        nets[0].annotationName == Net.name
+        nets[0].values == [mesh: 4, material: 'HEMP', knot: new AnnotationClassValue<>(Object)]
+        nets[1].values == [mesh: 5, material: 'NYLON', knot: new AnnotationClassValue<>(String)]
+    }
+
+    void 'test a member left at its default is present'() {
+        when: 'Haddock writes nothing down'
+        AnnotationValue<Chunky> value = AnnotationValue.of(chunkyOn(Haddock))
+
+        then: 'the live instance still answers every member'
+        value.values.keySet() == ['realChunky', 'weight', 'sea', 'seas', 'weights', 'kind', 'kinds', 'caught', 'caughts', 'net', 'nets'] as Set
+        value.values.realChunky == false
+        value.values.weight == 0
+        value.values.sea == ''
+        value.values.kind == 'HADDOCK'
+        value.values.caught == new AnnotationClassValue<>(Object)
+        (value.values.net as AnnotationValue).values == [mesh: 1, material: 'NYLON', knot: new AnnotationClassValue<>(Object)]
+        (value.values.nets as AnnotationValue[]).length == 0
+    }
+
+    void 'test two instances written the same way read equal'() {
+        expect:
+        AnnotationValue.of(chunkyOn(Cod)) == AnnotationValue.of(chunkyOn(Cod))
+        AnnotationValue.of(chunkyOn(Cod)).hashCode() == AnnotationValue.of(chunkyOn(Cod)).hashCode()
+        AnnotationValue.of(chunkyOn(Cod)) != AnnotationValue.of(chunkyOn(Haddock))
+    }
+
+    void 'test a member that cannot be read is reported rather than skipped'() {
+        given: 'an annotation that will not answer for one of its members'
+        Chunky unreadable = (Chunky) Proxy.newProxyInstance(Chunky.classLoader, [Chunky] as Class[], { Object proxy, Method method, Object[] args ->
+            if (method.name == 'annotationType') {
+                return Chunky
+            }
+            throw new UnsupportedOperationException("the member ${method.name} cannot be read")
+        } as InvocationHandler)
+
+        when:
+        AnnotationValue.of(unreadable)
+
+        then:
+        IllegalStateException e = thrown()
+        e.message.startsWith('Cannot read member [')
+        e.message.contains("] of annotation [${Chunky.name}]")
+        e.message.contains('UnsupportedOperationException: the member realChunky cannot be read')
+        e.cause != null
+    }
+
+    void 'test a null annotation is rejected'() {
+        when:
+        AnnotationValue.of(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    enum Kind {
+        COD, HADDOCK
+    }
+
+    enum Material {
+        NYLON, HEMP
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Net {
+        int mesh() default 1
+
+        Material material() default Material.NYLON
+
+        Class<?> knot() default Object
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Chunky {
+        boolean realChunky() default false
+
+        int weight() default 0
+
+        String sea() default ''
+
+        String[] seas() default []
+
+        int[] weights() default []
+
+        Kind kind() default Kind.HADDOCK
+
+        Kind[] kinds() default []
+
+        Class<?> caught() default Object
+
+        Class<?>[] caughts() default []
+
+        Net net() default @Net
+
+        Net[] nets() default []
+    }
+
+    private static Chunky chunkyOn(Class<?> holder) {
+        Chunky chunky = holder.getAnnotation(Chunky)
+        assert chunky != null
+        return chunky
+    }
+
+    @Chunky(realChunky = true, weight = 12, sea = 'north', seas = ['north', 'baltic'], weights = [1, 2],
+            kind = Kind.COD, kinds = [Kind.COD, Kind.HADDOCK], caught = String, caughts = [String, Integer],
+            net = @Net(mesh = 3), nets = [@Net(mesh = 4, material = Material.HEMP), @Net(mesh = 5, knot = String)])
+    static class Cod {
+    }
+
+    @Chunky
+    static class Haddock {
+    }
+}

--- a/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueOfAnnotationSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueOfAnnotationSpec.groovy
@@ -97,12 +97,17 @@ class AnnotationValueOfAnnotationSpec extends Specification {
     }
 
     void 'test a member that cannot be read is reported rather than skipped'() {
-        given: 'an annotation that will not answer for one of its members'
+        given: 'an annotation that will not answer for one of its members, and answers the rest with their defaults'
+        // only one member fails: the order in which the members are read is not specified, and the message
+        // must name the member that failed, whichever came first
         Chunky unreadable = (Chunky) Proxy.newProxyInstance(Chunky.classLoader, [Chunky] as Class[], { Object proxy, Method method, Object[] args ->
             if (method.name == 'annotationType') {
                 return Chunky
             }
-            throw new UnsupportedOperationException("the member ${method.name} cannot be read")
+            if (method.name == 'realChunky') {
+                throw new UnsupportedOperationException("the member ${method.name} cannot be read")
+            }
+            return method.defaultValue
         } as InvocationHandler)
 
         when:

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationValueOfAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationValueOfAnnotationSpec.groovy
@@ -1,0 +1,187 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+
+import java.lang.annotation.Annotation
+
+/**
+ * {@link AnnotationValue#of(Annotation)} reads a live annotation in the form the compiled metadata of an
+ * annotated element records it, so that the two compare equal.
+ */
+class AnnotationValueOfAnnotationSpec extends AbstractTypeElementSpec {
+
+    void 'test an annotation read off a live instance equals the one compiled into a definition'() {
+        given:
+        ApplicationContext context = buildContext('''
+package avof;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+interface Fish {
+}
+
+@Located(region = @Region(value = "east", zones = {Zone.NORTH, Zone.SOUTH}), kind = Kind.COD, caught = String.class,
+         kinds = {Kind.COD, Kind.HADDOCK}, caughts = {String.class, Integer.class}, seas = {"north", "baltic"}, weights = {1, 2},
+         regions = {@Region(value = "west", zones = {Zone.SOUTH})}, name = "cod")
+@Prototype
+class Cod implements Fish {
+}
+
+@Located(region = @Region(value = "east", zones = {Zone.NORTH, Zone.SOUTH}), kind = Kind.COD, caught = String.class,
+         kinds = {Kind.COD, Kind.HADDOCK}, caughts = {String.class, Integer.class}, seas = {"north", "baltic"}, weights = {1, 2},
+         regions = {@Region(value = "west", zones = {Zone.SOUTH})}, name = "cod")
+class Same {
+}
+
+@Located(region = @Region(value = "west", zones = {Zone.NORTH, Zone.SOUTH}), kind = Kind.COD, caught = String.class,
+         kinds = {Kind.COD, Kind.HADDOCK}, caughts = {String.class, Integer.class}, seas = {"north", "baltic"}, weights = {1, 2},
+         regions = {@Region(value = "west", zones = {Zone.SOUTH})}, name = "cod")
+class OtherRegion {
+}
+
+enum Kind {
+    COD, HADDOCK
+}
+
+enum Zone {
+    NORTH, SOUTH
+}
+
+@Retention(RUNTIME)
+@interface Region {
+    String value();
+
+    Zone[] zones();
+}
+
+@Qualifier
+@Retention(RUNTIME)
+@interface Located {
+    Region region();
+
+    Region[] regions();
+
+    Kind kind();
+
+    Kind[] kinds();
+
+    Class<?> caught();
+
+    Class<?>[] caughts();
+
+    String[] seas();
+
+    int[] weights();
+
+    String name();
+}
+''')
+        Class<?> fish = context.classLoader.loadClass('avof.Fish')
+        Class<?> cod = context.classLoader.loadClass('avof.Cod')
+        BeanDefinition<?> definition = context.getBeanDefinition(cod)
+        AnnotationValue<Annotation> compiled = definition.getAnnotation('avof.Located')
+        Annotation same = locatedOn(context, 'avof.Same')
+        Annotation otherRegion = locatedOn(context, 'avof.OtherRegion')
+
+        expect: 'the compiled metadata holds the annotation'
+        compiled != null
+        compiled.values.keySet() == ['region', 'regions', 'kind', 'kinds', 'caught', 'caughts', 'seas', 'weights', 'name'] as Set
+
+        and: 'and the one read off the live instance is equal to it, member by member and as a whole'
+        AnnotationValue<Annotation> live = AnnotationValue.of(same)
+        live.values.keySet() == compiled.values.keySet()
+        compiled.values.keySet().every { member ->
+            assert io.micronaut.core.annotation.AnnotationUtil.areEqual(live.values[member], compiled.values[member]), "member $member differs: live=${live.values[member]} compiled=${compiled.values[member]}"
+            true
+        }
+        live == compiled
+        compiled == live
+        live.hashCode() == compiled.hashCode()
+
+        and: 'a nested annotation that differs is not equal'
+        AnnotationValue.of(otherRegion) != compiled
+
+        and: 'which is what resolving a bean by the live instance turns on'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(same)).size() == 1
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(otherRegion)).isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test @NonBinding on a member of a nested annotation is not honoured'() {
+        given:
+        ApplicationContext context = buildContext('''
+package avofnested;
+
+import io.micronaut.context.annotation.NonBinding;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+interface Fish {
+}
+
+@Located(region = @Region(value = "east", note = "the cod"), note = "a cod")
+@Prototype
+class Cod implements Fish {
+}
+
+@Located(region = @Region(value = "east", note = "the cod"), note = "something else")
+class SameRegion {
+}
+
+@Located(region = @Region(value = "east", note = "something else"), note = "a cod")
+class OtherRegionNote {
+}
+
+@Retention(RUNTIME)
+@interface Region {
+    String value();
+
+    @NonBinding
+    String note();
+}
+
+@Qualifier
+@Retention(RUNTIME)
+@interface Located {
+    Region region();
+
+    @NonBinding
+    String note();
+}
+''')
+        Class<?> fish = context.classLoader.loadClass('avofnested.Fish')
+        Annotation sameRegion = locatedOn(context, 'avofnested.SameRegion')
+        Annotation otherRegionNote = locatedOn(context, 'avofnested.OtherRegionNote')
+
+        expect: 'the factory reads every member, the non-binding ones of the qualifier and of the nested annotation alike'
+        AnnotationValue.of(sameRegion).values.keySet() == ['region', 'note'] as Set
+        (AnnotationValue.of(sameRegion).values.region as AnnotationValue).values.keySet() == ['value', 'note'] as Set
+
+        and: 'the qualifier leaves out its own non-binding member'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(sameRegion)).size() == 1
+
+        and: 'but compares the nested annotation whole, non-binding member included'
+        context.getBeanDefinitions(fish, Qualifiers.byAnnotation(otherRegionNote)).isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    private static Annotation locatedOn(ApplicationContext context, String className) {
+        Class<?> holder = context.classLoader.loadClass(className)
+        Annotation annotation = holder.annotations.find { it.annotationType().simpleName == 'Located' }
+        assert annotation != null
+        return annotation
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
@@ -16,13 +16,11 @@
 package io.micronaut.inject.qualifiers;
 
 import io.micronaut.context.annotation.NonBinding;
-import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
-import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanType;
@@ -119,101 +117,33 @@ final class AnnotationMetadataQualifier<T> extends FilteringQualifier<T> {
 
     /**
      * The members of an annotation instance that take part in the comparison of two qualifiers, or {@code null}
-     * when one of them cannot be read.
-     */
-    @Nullable
-    private static Map<CharSequence, Object> resolveAnnotationBindingValues(Annotation annotation) {
-        Map<CharSequence, Object> bindingValues = new LinkedHashMap<>();
-        for (Method member : annotation.annotationType().getDeclaredMethods()) {
-            if (member.getParameterCount() != 0 || member.isSynthetic() || member.isAnnotationPresent(NonBinding.class)) {
-                continue;
-            }
-            Object value = readMember(annotation, member);
-            if (value == null) {
-                return null;
-            }
-            bindingValues.put(member.getName(), asMemberValue(value));
-        }
-        return bindingValues;
-    }
-
-    /**
-     * A member read off an annotation instance, or {@code null} when it cannot be read: the annotation type is
-     * not open to this module, or the instance would not answer for the member. A member of an annotation is
-     * never null itself, so the two do not overlap.
+     * when one of them cannot be read: the annotation type is not open to this module, or the instance would not
+     * answer for the member.
+     *
+     * <p>The members are read as {@link AnnotationValue#of(Annotation)} records them, which is the form the
+     * metadata of an annotated element records them in, so that the two sides of the comparison are the same
+     * values. {@link NonBinding} excludes a member from the comparison of the qualifier it is declared on, which is
+     * the annotation on the element, so a nested annotation is read whole.</p>
      *
      * <p>A qualifier that cannot read one of its members cannot compare it either, and it goes on qualifying by
      * its type alone rather than by the members it did manage to read.</p>
      */
     @Nullable
-    private static Object readMember(Annotation annotation, Method member) {
+    private static Map<CharSequence, Object> resolveAnnotationBindingValues(Annotation annotation) {
+        AnnotationValue<Annotation> annotationValue;
         try {
-            return ReflectionUtils.invokeInaccessibleMethod(annotation, member);
-        } catch (RuntimeException e) {
+            annotationValue = AnnotationValue.of(annotation);
+        } catch (IllegalStateException e) {
             // the member of an annotation this module cannot read is a member it cannot compare
             return null;
         }
-    }
-
-    /**
-     * A member value read off an annotation instance, as the metadata of an annotated element records it: a class
-     * is recorded as an {@link AnnotationClassValue}, an enum by the name of its constant and a nested annotation
-     * as an {@link AnnotationValue}, so that the two sides of the comparison are the same values.
-     */
-    private static Object asMemberValue(Object value) {
-        if (value instanceof Class<?> type) {
-            return new AnnotationClassValue<>(type);
-        }
-        if (value instanceof Enum<?> constant) {
-            return constant.name();
-        }
-        if (value instanceof Annotation nested) {
-            return asAnnotationValue(nested);
-        }
-        if (value instanceof Class<?>[] types) {
-            AnnotationClassValue<?>[] classValues = new AnnotationClassValue[types.length];
-            for (int i = 0; i < types.length; i++) {
-                classValues[i] = new AnnotationClassValue<>(types[i]);
-            }
-            return classValues;
-        }
-        if (value instanceof Enum<?>[] constants) {
-            String[] names = new String[constants.length];
-            for (int i = 0; i < constants.length; i++) {
-                names[i] = constants[i].name();
-            }
-            return names;
-        }
-        if (value instanceof Annotation[] nested) {
-            AnnotationValue<?>[] annotationValues = new AnnotationValue[nested.length];
-            for (int i = 0; i < nested.length; i++) {
-                annotationValues[i] = asAnnotationValue(nested[i]);
-            }
-            return annotationValues;
-        }
-        return value;
-    }
-
-    private static AnnotationValue<Annotation> asAnnotationValue(Annotation nested) {
-        return new AnnotationValue<>(nested.annotationType().getName(), resolveAllValues(nested));
-    }
-
-    /**
-     * Every member of a nested annotation. {@link NonBinding} excludes a member from the comparison of the
-     * qualifier it is declared on, which is the annotation on the element, so a nested one is read whole.
-     */
-    private static Map<CharSequence, Object> resolveAllValues(Annotation annotation) {
-        Map<CharSequence, Object> values = new LinkedHashMap<>();
+        Map<CharSequence, Object> bindingValues = new LinkedHashMap<>(annotationValue.getValues());
         for (Method member : annotation.annotationType().getDeclaredMethods()) {
-            if (member.getParameterCount() != 0 || member.isSynthetic()) {
-                continue;
-            }
-            Object value = readMember(annotation, member);
-            if (value != null) {
-                values.put(member.getName(), asMemberValue(value));
+            if (member.isAnnotationPresent(NonBinding.class)) {
+                bindingValues.remove(member.getName());
             }
         }
-        return values;
+        return bindingValues;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
@@ -33,7 +33,6 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -137,7 +136,9 @@ final class AnnotationMetadataQualifier<T> extends FilteringQualifier<T> {
             // the member of an annotation this module cannot read is a member it cannot compare
             return null;
         }
-        Map<CharSequence, Object> bindingValues = new LinkedHashMap<>(annotationValue.getValues());
+        Map<CharSequence, Object> values = annotationValue.getValues();
+        Map<CharSequence, Object> bindingValues = CollectionUtils.newLinkedHashMap(values.size());
+        bindingValues.putAll(values);
         for (Method member : annotation.annotationType().getDeclaredMethods()) {
             if (member.isAnnotationPresent(NonBinding.class)) {
                 bindingValues.remove(member.getName());


### PR DESCRIPTION
## The problem

`Qualifiers.byAnnotation(Annotation)` (#12928) reads the members off a live annotation and stores them the way compiled metadata stores them: a `Class` as an `AnnotationClassValue`, an enum by the name of its constant, a nested annotation as an `AnnotationValue`, arrays of each likewise. That is what lets a qualifier built at runtime compare equal to one compiled. The conversion lived in private helpers of `AnnotationMetadataQualifier` (`resolveAnnotationBindingValues`, `readMember`, `asMemberValue`, `asAnnotationValue`, `resolveAllValues`).

Any framework built on Micronaut that is handed annotation instances at runtime needs exactly this conversion. The Jakarta CDI implementation ([micronaut-cdi](https://github.com/micronaut-projects/micronaut-cdi)) is handed them constantly (`Instance.select(Annotation...)`, `Event.select(...)`, `BeanContainer.isMatchingBean(Set<Annotation>)`, synthetic-bean qualifiers) and had to carry its own copy of the reader, in two places (`CdiAnnotations.valueOf`/`storedForm` and `SynthesisRunner.membersOf`). The copy drifted from core's: it did not convert a nested annotation member, so a qualifier such as `@Located(region = @Region("east"))` selected by its literal was unsatisfied, because the live `Region` proxy never equalled the stored `AnnotationValue`. That has since been fixed downstream, but no downstream should have to carry the copy at all.

## The API

In `core`, on `io.micronaut.core.annotation.AnnotationValue`:

```java
public static <T extends Annotation> AnnotationValue<T> of(T annotation)
```

It reads every zero-argument, non-synthetic member of `annotation.annotationType().getDeclaredMethods()` off the instance (via `ReflectionUtils.invokeInaccessibleMethod`), members left at their default included since a live instance answers every one of them, and returns an `AnnotationValue` named after `annotationType().getName()` with `RetentionPolicy.RUNTIME`.

Conversion rules, the same ones `asMemberValue` applied:

| Reflection returns | Recorded as |
|---|---|
| `Class` | `AnnotationClassValue` |
| `Enum` | its `name()` |
| nested `Annotation` | `AnnotationValue.of(nested)`, recursively, every member |
| `Class[]` / `Enum[]` / `Annotation[]` | an array of the converted form |
| anything else (primitives, `String`, arrays of either) | as is |

A member that cannot be read, because the annotation type is not open to this module or because the instance throws (or answers `null`), is reported with an `IllegalStateException` naming the member and the annotation type. It is never silently skipped.

`@NonBinding` is **not** applied by the factory. Whether a member takes part in the comparison of two qualifiers is the qualifier's concern, not the conversion's, and `NonBinding` lives in `inject` anyway.

## What changes in `inject`

`AnnotationMetadataQualifier.fromAnnotation` now calls `AnnotationValue.of(annotation)` and then drops the members whose declaring method carries `@NonBinding`. The private reader helpers are deleted. Its observable behaviour is preserved:

- a member that cannot be read: the factory's exception is caught and the qualifier falls back to comparing by type alone (`null`), as before;
- no binding member left: `null`, as before;
- `@NonBinding` on a member of a *nested* annotation is not honoured; the nested annotation is compared whole, as before (`resolveAllValues` read it whole; the factory does too). This is now covered by a test rather than assumed.

## What deliberately does not change

- `Qualifiers.byAnnotation(Annotation)` and its behaviour, including the specs added in #12928, which pass unchanged.
- `@NonBinding` handling: it stays in the qualifier.
- `AnnotationValue.equals`: still compares the annotation name and the declared `getValues()` maps (same size, `AnnotationUtil.areEqual` per member, so arrays element-wise and nested `AnnotationValue`s recursively). Defaults are not consulted by `equals`; that is what `matches` is for.

## Tests

- `core`: `AnnotationValueOfAnnotationSpec` covers primitive/String members, enum, class, nested annotation, arrays of enum/class/nested annotation, defaults being present, equality of two instances written the same way, and the unreadable-member exception and message.
- `inject-java`: `AnnotationValueOfAnnotationSpec` compiles a qualifier with nested-annotation, enum, class and array members, and asserts that `AnnotationValue.of(literal)` `equals` (both directions, same `hashCode`) the `AnnotationValue` the bean definition was compiled with, member by member and as a whole, and that a bean is resolved by the live literal. This is the exact equality the CDI bug turned on. A second feature confirms that `@NonBinding` on a nested annotation's member is not honoured.
- Existing `QualifierMemberSpec` (inject-java) and `QualifierByAnnotationSpec` (inject) from #12928 pass unchanged.

Ran locally:

- `./gradlew :micronaut-core:test :micronaut-inject:test :micronaut-core-processor:test`: core 7393 tests, 0 failures, 2 skipped, inject 312 tests, 0 failures, core-processor has no test sources (`NO-SOURCE`).
- `./gradlew :micronaut-inject-java:test`: 4962 tests, 0 failures, 8 skipped.
- `:micronaut-core:checkstyleMain :micronaut-inject:checkstyleMain` pass.

## Two corner cases that are not identical to before

Both arise only when readability differs *per member* — an annotation proxy that throws for one member and answers the rest. When the whole type is inaccessible, every path already fell back to comparing by type alone, exactly as before.

- An unreadable member annotated `@NonBinding` used to be skipped before it was read, so it did not force the type-only fallback. The factory now reads every member first, so it throws and the qualifier falls back to type-only.
- An unreadable member of a *nested* annotation used to be silently left out of the nested value. It now throws, and the qualifier falls back to type-only.

Both follow from the factory refusing to silently drop a member it cannot read, which is the behaviour a general-purpose reader should have. Flagged here so the choice is a reviewed one rather than an accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

