### PR TITLE
Enumerate beans by their @Indexed types even when not implemented

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/Indexed.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Indexed.java
@@ -28,6 +28,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * An annotation that can be used on types where there may be many implementations of a
  * particular interface. This triggers building of an index internal to the bean context that speeds up bean lookups by type.
  *
+ * <p>A bean is enumerable through {@code BeanContext.getBeanDefinitions(Class)} by every type it is indexed by,
+ * whether the annotation is declared on the bean, inherited from a stereotype annotation or added at compile time,
+ * even if the bean does not implement that type. Injecting or resolving a bean instance
+ * (for example via {@code BeanContext.getBean(Class)}) by a type the bean does not implement remains unsupported.</p>
+ *
  * @since 1.1
  * @author graemerocher
  */

--- a/function/src/main/java/io/micronaut/function/FunctionBean.java
+++ b/function/src/main/java/io/micronaut/function/FunctionBean.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.function;
 
+import io.micronaut.core.annotation.Indexed;
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.core.annotation.EntryPoint;
@@ -41,6 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Singleton
 @Executable
 @EntryPoint
+@Indexed(FunctionBean.class)
 public @interface FunctionBean {
 
     /**

--- a/function/src/test/groovy/io/micronaut/function/FunctionBeanIndexedLookupSpec.groovy
+++ b/function/src/test/groovy/io/micronaut/function/FunctionBeanIndexedLookupSpec.groovy
@@ -17,7 +17,6 @@ package io.micronaut.function
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Specification
 
 /**
@@ -36,8 +35,11 @@ class FunctionBeanIndexedLookupSpec extends Specification {
         and: 'and by scanning every bean definition, which is what the index replaces'
         Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(FunctionBean) }
 
-        then: 'the factory-method functions are actually present'
-        indexed*.stringValue(FunctionBean)*.get().toSorted().containsAll(['fullname', 'round', 'supplier', 'upper'])
+        then: 'every definition names the function it declares'
+        indexed.every { it.stringValue(FunctionBean).isPresent() }
+
+        and: 'the factory-method functions are actually present'
+        indexed.collect { it.stringValue(FunctionBean).get() }.toSorted().containsAll(['fullname', 'round', 'supplier', 'upper'])
 
         and: 'both answer the same beans'
         indexed*.beanType.name.toSorted() == scanned*.beanType.name.toSorted()

--- a/function/src/test/groovy/io/micronaut/function/FunctionBeanIndexedLookupSpec.groovy
+++ b/function/src/test/groovy/io/micronaut/function/FunctionBeanIndexedLookupSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+/**
+ * {@code @FunctionBean} is declared on factory methods as well as on types, so the compile-time index
+ * has to be written from the producing method's metadata for the index to replace the stereotype scan.
+ */
+class FunctionBeanIndexedLookupSpec extends Specification {
+
+    void "test function beans declared on factory methods are enumerable through the compile-time index"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when: 'the beans are looked up through the index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(FunctionBean)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(FunctionBean) }
+
+        then: 'the factory-method functions are actually present'
+        indexed*.stringValue(FunctionBean)*.get().toSorted().containsAll(['fullname', 'round', 'supplier', 'upper'])
+
+        and: 'both answer the same beans'
+        indexed*.beanType.name.toSorted() == scanned*.beanType.name.toSorted()
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/scope/CustomScopeReentrancySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/scope/CustomScopeReentrancySpec.groovy
@@ -1,0 +1,105 @@
+package io.micronaut.aop.scope
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+/**
+ * A bean produced by a factory method declares its scope on the produced bean, not on the factory. Resolving
+ * the factory through that scope would re-enter it for a second bean while the first is still being created,
+ * which a scope backed by {@code ConcurrentHashMap.computeIfAbsent} answers with "Recursive update" whenever
+ * the two bean keys happen to share a bin.
+ */
+class CustomScopeReentrancySpec extends AbstractTypeElementSpec {
+
+    void "test a prototype factory is not resolved through the scope of the bean it produces"() {
+        given:
+        ApplicationContext context = buildContext('test.Produced', '''
+package test;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.scope.BeanCreationContext;
+import io.micronaut.context.scope.CustomScope;
+import io.micronaut.inject.BeanIdentifier;
+import jakarta.inject.Scope;
+import jakarta.inject.Singleton;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+@interface CountingScope {
+}
+
+@Singleton
+class CountingCustomScope implements CustomScope<CountingScope> {
+    public static final AtomicInteger DEPTH = new AtomicInteger();
+    public static final AtomicInteger MAX_DEPTH = new AtomicInteger();
+
+    private final ConcurrentMap<BeanIdentifier, Object> beans = new ConcurrentHashMap<>();
+
+    @Override
+    public Class<CountingScope> annotationType() {
+        return CountingScope.class;
+    }
+
+    @Override
+    public <T> T getOrCreate(BeanCreationContext<T> creationContext) {
+        int depth = DEPTH.incrementAndGet();
+        MAX_DEPTH.accumulateAndGet(depth, Math::max);
+        try {
+            return (T) beans.computeIfAbsent(creationContext.id(), id -> creationContext.create().bean());
+        } finally {
+            DEPTH.decrementAndGet();
+        }
+    }
+
+    @Override
+    public <T> Optional<T> remove(BeanIdentifier identifier) {
+        return Optional.ofNullable((T) beans.remove(identifier));
+    }
+}
+
+@Factory
+@Prototype
+class ProducingFactory {
+    @Bean
+    @CountingScope
+    Produced produce() {
+        return new Produced();
+    }
+}
+
+class Produced {
+    public String ping() {
+        return "ok";
+    }
+}
+''')
+        Class<?> producedType = context.classLoader.loadClass('test.Produced')
+        Class<?> scopeType = context.classLoader.loadClass('test.CountingCustomScope')
+
+        when: 'the scoped bean is created through its prototype factory'
+        def produced = context.getBean(producedType)
+
+        then: 'it is created'
+        produced.ping() == 'ok'
+
+        and: 'the scope was entered once, not re-entered to resolve the factory itself'
+        maxDepth(scopeType) == 1
+
+        cleanup:
+        context.close()
+    }
+
+    private static int maxDepth(Class<?> scopeType) {
+        def field = scopeType.getDeclaredField('MAX_DEPTH')
+        field.setAccessible(true)
+        ((java.util.concurrent.atomic.AtomicInteger) field.get(null)).get()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/FactoryIndexLeakSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/FactoryIndexLeakSpec.groovy
@@ -1,0 +1,96 @@
+package io.micronaut.inject.indexed
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.event.BeanDestroyedEventListener
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.BeanDefinition
+
+/**
+ * A factory that is itself an event listener indexes its produced beans by the listener type too, even though
+ * they do not implement it. Resolving the listeners must not try to instantiate one of those as a listener.
+ */
+class FactoryIndexLeakSpec extends AbstractTypeElementSpec {
+
+    void "test a factory that is an event listener does not make its product a listener"() {
+        given:
+        ApplicationContext context = buildContext('leak.Product', '''
+package leak;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+
+class Product {
+}
+
+@Factory
+class ProductFactory implements BeanDestroyedEventListener<Product> {
+    static boolean destroyed;
+
+    @Singleton
+    Product product() {
+        return new Product();
+    }
+
+    @Override
+    public void onDestroyed(@NonNull BeanDestroyedEvent<Product> event) {
+        destroyed = true;
+    }
+}
+''')
+        Class<?> productType = context.classLoader.loadClass('leak.Product')
+
+        when: 'the product is created and the context is shut down, which resolves the destroyed listeners'
+        context.getBean(productType)
+        context.close()
+
+        then: 'the product is not instantiated as a listener'
+        noExceptionThrown()
+
+        and: 'the factory did receive the event'
+        context.classLoader.loadClass('leak.ProductFactory').destroyed
+    }
+
+    void "test the product is still enumerable by the index but is not a listener candidate"() {
+        given:
+        ApplicationContext context = buildContext('leak2.Product', '''
+package leak2;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+
+class Product {
+}
+
+@Factory
+class ProductFactory implements BeanDestroyedEventListener<Product> {
+    @Singleton
+    Product product() {
+        return new Product();
+    }
+
+    @Override
+    public void onDestroyed(@NonNull BeanDestroyedEvent<Product> event) {
+    }
+}
+''')
+        Class<?> productType = context.classLoader.loadClass('leak2.Product')
+
+        expect: 'the product carries the index inherited from its factory'
+        context.getBeanDefinitions(BeanDestroyedEventListener)*.beanType.contains(productType)
+
+        and: 'but it is not a candidate for the listener type, so it must never be resolved as one'
+        !context.getBeanDefinitions(BeanDestroyedEventListener)
+            .find { it.beanType == productType }
+            .isCandidateBean(Argument.of(BeanDestroyedEventListener))
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/IndexedByVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/IndexedByVisitorSpec.groovy
@@ -1,0 +1,215 @@
+package io.micronaut.inject.indexed
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.RuntimeBeanDefinition
+import io.micronaut.context.exceptions.NoSuchBeanException
+import io.micronaut.core.annotation.AnnotationClassValue
+import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.core.annotation.Indexed
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+/**
+ * A bean annotated with {@code @Indexed(Marker.class)} is enumerable via {@code getBeanDefinitions(Marker)}
+ * even when it does not implement {@code Marker}, but it is never provided as a {@code Marker} instance.
+ */
+class IndexedByVisitorSpec extends AbstractTypeElementSpec {
+
+    void "test a bean indexed by a visitor with a type it does not implement is enumerable by that type"() {
+        given:
+        ApplicationContext context = buildContext('idx.Test', '''
+package idx;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+class Test {
+}
+
+interface Marker {
+}
+''')
+        Class<?> test = context.classLoader.loadClass('idx.Test')
+        Class<?> marker = context.classLoader.loadClass('idx.Marker')
+
+        expect:
+        !marker.isAssignableFrom(test)
+
+        when:
+        Collection<BeanDefinition<?>> definitions = context.getBeanDefinitions(marker)
+
+        then:
+        definitions*.beanType == [test]
+        ((BeanDefinitionReference<?>) definitions[0]).indexes.toList() == [marker]
+        !definitions[0].isCandidateBean(Argument.of(marker))
+        definitions[0].isCandidateBean(Argument.of(test))
+
+        and: 'the bean is indexed once by its own type'
+        context.getBeanDefinitions(test)*.beanType == [test]
+        context.getBean(test).is(context.getBean(test))
+
+        and: 'the bean is not provided as an instance of the indexed type'
+        !context.containsBean(marker)
+        context.getBeansOfType(marker).isEmpty()
+        context.findBeanDefinition(marker).isEmpty()
+
+        when:
+        context.getBean(marker)
+
+        then:
+        NoSuchBeanException e = thrown()
+        e.message.contains('idx.Marker')
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a bean indexed through a stereotype or directly is enumerable alongside real implementations"() {
+        given:
+        ApplicationContext context = buildContext('idx2.Test', '''
+package idx2;
+
+import io.micronaut.core.annotation.Indexed;
+import jakarta.inject.Singleton;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+
+@Singleton
+@MarkerStereotype
+class Test {
+}
+
+@Singleton
+@Indexed(Marker.class)
+class DirectlyIndexed {
+}
+
+@Singleton
+class Impl implements Marker {
+}
+
+@Singleton
+class Consumer {
+    final List<Marker> markers;
+
+    Consumer(List<Marker> markers) {
+        this.markers = markers;
+    }
+}
+
+interface Marker {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Indexed(Marker.class)
+@interface MarkerStereotype {
+}
+''')
+        Class<?> test = context.classLoader.loadClass('idx2.Test')
+        Class<?> directlyIndexed = context.classLoader.loadClass('idx2.DirectlyIndexed')
+        Class<?> impl = context.classLoader.loadClass('idx2.Impl')
+        Class<?> marker = context.classLoader.loadClass('idx2.Marker')
+        Class<?> consumer = context.classLoader.loadClass('idx2.Consumer')
+
+        expect:
+        !marker.isAssignableFrom(test)
+        !marker.isAssignableFrom(directlyIndexed)
+
+        when:
+        Collection<BeanDefinition<?>> definitions = context.getBeanDefinitions(marker)
+
+        then: 'all indexed beans and the real implementation are enumerable'
+        definitions*.beanType.toSet() == [test, directlyIndexed, impl].toSet()
+        definitions.size() == 3
+
+        and: 'only the real implementation is resolved as an instance'
+        context.getBean(marker).getClass() == impl
+        context.getBeansOfType(marker)*.getClass() == [impl]
+        context.getBean(consumer).markers*.getClass() == [impl]
+        context.findBeanDefinition(marker).get().beanType == impl
+        context.containsBean(marker)
+
+        and: 'the indexed beans are still available by their own types'
+        context.getBean(test) != null
+        context.getBean(directlyIndexed) != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a runtime registered bean definition with an index is enumerable by the indexed type"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        RuntimeBeanDefinition<RuntimeBean> delegate = RuntimeBeanDefinition.builder(RuntimeBean, () -> new RuntimeBean())
+                .singleton(true)
+                .build()
+        RuntimeBeanDefinition<RuntimeBean> definition = new IndexedRuntimeBeanDefinition(delegate: delegate)
+        context.registerBeanDefinition(definition)
+
+        expect:
+        !RuntimeMarker.isAssignableFrom(RuntimeBean)
+        context.getBeanDefinitions(RuntimeMarker)*.beanType == [RuntimeBean]
+        context.getBeanDefinitions(RuntimeBean)*.beanType == [RuntimeBean]
+        context.getBean(RuntimeBean) != null
+        !context.containsBean(RuntimeMarker)
+        context.getBeansOfType(RuntimeMarker).isEmpty()
+
+        when:
+        context.getBean(RuntimeMarker)
+
+        then:
+        thrown(NoSuchBeanException)
+
+        cleanup:
+        context.close()
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        [new IndexingVisitor()]
+    }
+
+    static class IndexingVisitor implements TypeElementVisitor<Object, Object> {
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.name == 'idx.Test') {
+                element.annotate(Indexed) { builder ->
+                    builder.member("value", new AnnotationClassValue<>("idx.Marker"))
+                }
+            }
+        }
+
+        @Override
+        VisitorKind getVisitorKind() {
+            return VisitorKind.ISOLATING
+        }
+    }
+
+    static class RuntimeBean {
+    }
+
+    static interface RuntimeMarker {
+    }
+
+    static class IndexedRuntimeBeanDefinition implements RuntimeBeanDefinition<RuntimeBean> {
+        @Delegate(excludes = ["getTargetAnnotationMetadata"])
+        RuntimeBeanDefinition<RuntimeBean> delegate
+
+        @Override
+        Class<?>[] getIndexes() {
+            return [RuntimeMarker] as Class<?>[]
+        }
+
+        @Override
+        AnnotationMetadata getTargetAnnotationMetadata() {
+            return delegate.getTargetAnnotationMetadata()
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/IndexedByVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/IndexedByVisitorSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.inject.indexed
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.RuntimeBeanDefinition
+import io.micronaut.context.event.BeanDestroyedEventListener
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.core.annotation.AnnotationClassValue
 import io.micronaut.core.annotation.AnnotationMetadata
@@ -196,6 +197,51 @@ interface Marker {
     @Override
     protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
         [new IndexingVisitor()]
+    }
+
+    void "test a bean indexed by a listener interface it does not implement is not treated as a listener"() {
+        given: "a factory that is a listener, and so is indexed by the listener type its produced bean inherits"
+        ApplicationContext context = buildContext('idx.Recorded', '''
+package idx;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+
+class Recorded {
+}
+
+@Factory
+class RecordedFactory implements BeanDestroyedEventListener<Recorded> {
+
+    static boolean destroyed;
+
+    @Singleton
+    Recorded recorded() {
+        return new Recorded();
+    }
+
+    @Override
+    public void onDestroyed(@NonNull BeanDestroyedEvent<Recorded> event) {
+        destroyed = true;
+    }
+}
+''')
+        Class<?> recorded = context.classLoader.loadClass('idx.Recorded')
+        Class<?> factory = context.classLoader.loadClass('idx.RecordedFactory')
+
+        expect: "the produced bean is enumerable by the inherited index, though it is no listener"
+        !BeanDestroyedEventListener.isAssignableFrom(recorded)
+
+        when: "the produced bean is created, then destroyed with the context, which dispatches to the listeners"
+        def bean = context.getBean(recorded)
+        context.close()
+
+        then: "the factory listener ran and the produced bean was never cast to one"
+        bean != null
+        factory.destroyed
     }
 
     static class IndexingVisitor implements TypeElementVisitor<Object, Object> {

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/IndexedByVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/IndexedByVisitorSpec.groovy
@@ -25,6 +25,7 @@ class IndexedByVisitorSpec extends AbstractTypeElementSpec {
         ApplicationContext context = buildContext('idx.Test', '''
 package idx;
 
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 @Singleton
@@ -33,9 +34,21 @@ class Test {
 
 interface Marker {
 }
+
+@Singleton
+@Requires(missingBeans = Marker.class)
+class MissingMarkerCondition {
+}
+
+@Singleton
+@Requires(beans = Marker.class)
+class PresentMarkerCondition {
+}
 ''')
         Class<?> test = context.classLoader.loadClass('idx.Test')
         Class<?> marker = context.classLoader.loadClass('idx.Marker')
+        Class<?> missingMarkerCondition = context.classLoader.loadClass('idx.MissingMarkerCondition')
+        Class<?> presentMarkerCondition = context.classLoader.loadClass('idx.PresentMarkerCondition')
 
         expect:
         !marker.isAssignableFrom(test)
@@ -57,6 +70,8 @@ interface Marker {
         !context.containsBean(marker)
         context.getBeansOfType(marker).isEmpty()
         context.findBeanDefinition(marker).isEmpty()
+        context.containsBean(missingMarkerCondition)
+        !context.containsBean(presentMarkerCondition)
 
         when:
         context.getBean(marker)
@@ -75,6 +90,7 @@ interface Marker {
 package idx2;
 
 import io.micronaut.core.annotation.Indexed;
+import io.micronaut.context.BeanProvider;
 import jakarta.inject.Singleton;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -97,9 +113,11 @@ class Impl implements Marker {
 @Singleton
 class Consumer {
     final List<Marker> markers;
+    final BeanProvider<Marker> provider;
 
-    Consumer(List<Marker> markers) {
+    Consumer(List<Marker> markers, BeanProvider<Marker> provider) {
         this.markers = markers;
+        this.provider = provider;
     }
 }
 
@@ -132,6 +150,10 @@ interface Marker {
         context.getBean(marker).getClass() == impl
         context.getBeansOfType(marker)*.getClass() == [impl]
         context.getBean(consumer).markers*.getClass() == [impl]
+        context.getBean(consumer).provider.present
+        context.getBean(consumer).provider.unique
+        context.getBean(consumer).provider.resolvable
+        context.getBean(consumer).provider.get().getClass() == impl
         context.findBeanDefinition(marker).get().beanType == impl
         context.containsBean(marker)
 
@@ -146,6 +168,7 @@ interface Marker {
     void "test a runtime registered bean definition with an index is enumerable by the indexed type"() {
         given:
         ApplicationContext context = ApplicationContext.run()
+        assert context.getBeanDefinitions(RuntimeMarker).isEmpty()
         RuntimeBeanDefinition<RuntimeBean> delegate = RuntimeBeanDefinition.builder(RuntimeBean, () -> new RuntimeBean())
                 .singleton(true)
                 .build()

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/NonIndexedStereotypeLookupSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/NonIndexedStereotypeLookupSpec.groovy
@@ -58,10 +58,10 @@ class Neither {
         Class<?> marked = context.classLoader.loadClass('nidx.Marked')
 
         expect: 'the plain annotation reports no indexed type, so the qualifier is answered by scanning'
-        ((FilteringQualifier) Qualifiers.byStereotype(plain)).getIndexedType() == null
+        ((FilteringQualifier) Qualifiers.byStereotype(plain)).getIndexedArgument() == null
 
         and: 'while the indexed one does take the index'
-        ((FilteringQualifier) Qualifiers.byStereotype(marked)).getIndexedType() == marked
+        ((FilteringQualifier) Qualifiers.byStereotype(marked)).getIndexedArgument().type == marked
 
         when: 'the plain stereotype is resolved the way it always was'
         Collection<BeanDefinition<?>> scanned = context.getBeanDefinitions(Qualifiers.byStereotype(plain))
@@ -109,7 +109,7 @@ class MarkedTwo {
         Class<?> marked = context.classLoader.loadClass('nidx2.Marked')
 
         expect: 'the qualifier built from the annotation name keeps the scan, having no type to index by'
-        ((FilteringQualifier) Qualifiers.byStereotype(marked.name)).getIndexedType() == null
+        ((FilteringQualifier) Qualifiers.byStereotype(marked.name)).getIndexedArgument() == null
 
         when: 'the same annotation is resolved by name and by type'
         Collection<BeanDefinition<?>> byName = context.getBeanDefinitions(Qualifiers.byStereotype(marked.name))

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/NonIndexedStereotypeLookupSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/NonIndexedStereotypeLookupSpec.groovy
@@ -1,0 +1,125 @@
+package io.micronaut.inject.indexed
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.FilteringQualifier
+import io.micronaut.inject.qualifiers.Qualifiers
+
+/**
+ * {@code @Indexed} is only an optimisation hint. An annotation without it is still answered by filtering every
+ * bean definition reference, which is what {@code getBeanDefinitions(Qualifier)} did for every annotation
+ * before the index was consulted.
+ */
+class NonIndexedStereotypeLookupSpec extends AbstractTypeElementSpec {
+
+    void "test a stereotype that is not indexed is still resolved by scanning"() {
+        given:
+        ApplicationContext context = buildContext('nidx.PlainOne', '''
+package nidx;
+
+import io.micronaut.core.annotation.Indexed;
+import jakarta.inject.Singleton;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Singleton
+@interface Plain {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Singleton
+@Indexed(Marked.class)
+@interface Marked {
+}
+
+@Plain
+class PlainOne {
+}
+
+@Plain
+class PlainTwo {
+}
+
+@Marked
+class MarkedOne {
+}
+
+@Singleton
+class Neither {
+}
+''')
+        Class<?> plain = context.classLoader.loadClass('nidx.Plain')
+        Class<?> marked = context.classLoader.loadClass('nidx.Marked')
+
+        expect: 'the plain annotation reports no indexed type, so the qualifier is answered by scanning'
+        ((FilteringQualifier) Qualifiers.byStereotype(plain)).getIndexedType() == null
+
+        and: 'while the indexed one does take the index'
+        ((FilteringQualifier) Qualifiers.byStereotype(marked)).getIndexedType() == marked
+
+        when: 'the plain stereotype is resolved the way it always was'
+        Collection<BeanDefinition<?>> scanned = context.getBeanDefinitions(Qualifiers.byStereotype(plain))
+
+        then: 'it finds exactly the beans that carry it'
+        scanned*.beanType.simpleName.toSorted() == ['PlainOne', 'PlainTwo']
+
+        and: 'which is what enumerating every bean definition answers'
+        scanned*.beanType.name == context.getAllBeanDefinitions().findAll { it.hasStereotype(plain) }*.beanType.name
+
+        and: 'the index holds nothing for it, so the scan is what did the work'
+        context.getBeanDefinitions(plain).isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a self-indexed stereotype resolved by name is answered by scanning and agrees with the index"() {
+        given:
+        ApplicationContext context = buildContext('nidx2.MarkedOne', '''
+package nidx2;
+
+import io.micronaut.core.annotation.Indexed;
+import jakarta.inject.Singleton;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Singleton
+@Indexed(Marked.class)
+@interface Marked {
+}
+
+@Marked
+class MarkedOne {
+}
+
+@Marked
+class MarkedTwo {
+}
+''')
+        Class<?> marked = context.classLoader.loadClass('nidx2.Marked')
+
+        expect: 'the qualifier built from the annotation name keeps the scan, having no type to index by'
+        ((FilteringQualifier) Qualifiers.byStereotype(marked.name)).getIndexedType() == null
+
+        when: 'the same annotation is resolved by name and by type'
+        Collection<BeanDefinition<?>> byName = context.getBeanDefinitions(Qualifiers.byStereotype(marked.name))
+        Collection<BeanDefinition<?>> byType = context.getBeanDefinitions(Qualifiers.byStereotype(marked))
+
+        then: 'the scan and the index answer the same beans, in the same order'
+        byName*.beanType.simpleName.toSorted() == ['MarkedOne', 'MarkedTwo']
+        byName*.beanType.name == byType*.beanType.name
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedAnnotationSpec.groovy
@@ -3,7 +3,6 @@ package io.micronaut.inject.indexed
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.qualifiers.Qualifiers
 
 /**
  * An annotation that is meta-annotated with {@code @Indexed} by its own type indexes every bean carrying it,

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedAnnotationSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.inject.indexed
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+
+/**
+ * An annotation that is meta-annotated with {@code @Indexed} by its own type indexes every bean carrying it,
+ * so a processor of that annotation can look the beans up by it instead of scanning every bean definition.
+ */
+class SelfIndexedAnnotationSpec extends AbstractTypeElementSpec {
+
+    void "test beans carrying a self-indexed annotation are enumerable by the annotation type"() {
+        given:
+        ApplicationContext context = buildContext('sidx.One', '''
+package sidx;
+
+import io.micronaut.core.annotation.Indexed;
+import jakarta.inject.Singleton;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Singleton
+@Indexed(Marked.class)
+@interface Marked {
+}
+
+@Marked
+class One {
+}
+
+@Marked
+class Two {
+}
+
+@Singleton
+class NotMarked {
+}
+
+@Marked
+class Base {
+}
+
+class Sub extends Base {
+}
+''')
+        Class<?> marked = context.classLoader.loadClass('sidx.Marked')
+
+        when: 'the beans are looked up through the compile-time index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(marked)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(marked) }
+
+        then: 'both answer the same beans'
+        indexed*.beanType.name.toSorted() == scanned*.beanType.name.toSorted()
+        indexed*.beanType.name.toSorted() == ['sidx.Base', 'sidx.One', 'sidx.Two']
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedInheritanceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedInheritanceSpec.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.inject.indexed
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+
+/**
+ * The compile-time index has to answer a self-indexed annotation exactly as scanning every bean definition
+ * would, including for an annotation inherited from a supertype.
+ */
+class SelfIndexedInheritanceSpec extends AbstractTypeElementSpec {
+
+    void "test a self-indexed annotation inherited from a supertype is answered by the index"() {
+        given:
+        ApplicationContext context = buildContext('inh.Base', '''
+package inh;
+
+import io.micronaut.core.annotation.Indexed;
+import jakarta.inject.Singleton;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Singleton
+@Indexed(Marked.class)
+@interface Marked {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@Singleton
+@Indexed(InheritedMarked.class)
+@interface InheritedMarked {
+}
+
+@Marked
+class Base {
+}
+
+class Sub extends Base {
+}
+
+@InheritedMarked
+class InheritedBase {
+}
+
+class InheritedSub extends InheritedBase {
+}
+''')
+        Class<?> marked = context.classLoader.loadClass('inh.Marked')
+        Class<?> inheritedMarked = context.classLoader.loadClass('inh.InheritedMarked')
+
+        when: 'each annotation is answered by the index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(marked)
+        Collection<BeanDefinition<?>> inheritedIndexed = context.getBeanDefinitions(inheritedMarked)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = scanFor(context, marked)
+        Collection<BeanDefinition<?>> inheritedScanned = scanFor(context, inheritedMarked)
+
+        then: 'a plain annotation selects only the type it is declared on'
+        indexed*.beanType.simpleName.toSorted() == ['Base']
+
+        and: 'an @Inherited one also selects the subtype that inherits it'
+        inheritedIndexed*.beanType.simpleName.toSorted() == ['InheritedBase', 'InheritedSub']
+
+        and: 'the index agrees with the scan, in the same order, in both cases'
+        indexed*.beanType.name == scanned*.beanType.name
+        inheritedIndexed*.beanType.name == inheritedScanned*.beanType.name
+
+        and: 'the stereotype qualifier answers the same, since it now takes the index'
+        context.getBeanDefinitions(Qualifiers.byStereotype(marked))*.beanType.name == scanned*.beanType.name
+
+        cleanup:
+        context.close()
+    }
+
+    private static Collection<BeanDefinition<?>> scanFor(ApplicationContext context, Class<?> stereotype) {
+        context.getAllBeanDefinitions().findAll { it.hasStereotype(stereotype) }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1709,20 +1709,23 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     @Override
     public <B> BeanContext registerBeanDefinition(RuntimeBeanDefinition<B> definition) {
         beanDefinitionProvider.addBeanDefinition(definition);
-        Class<B> beanType = definition.getBeanType();
-        purgeCacheForBeanType(beanType);
-        if (CustomScope.class.isAssignableFrom(beanType)) {
+        purgeCacheForBeanDefinition(definition);
+        if (CustomScope.class.isAssignableFrom(definition.getBeanType())) {
             // a bean of this scope resolved earlier left the scope's absence recorded in the registry
             customScopeRegistry.invalidate();
         }
         return this;
     }
 
-    private <B> void purgeCacheForBeanType(Class<B> beanType) {
-        beanCandidateCache.entrySet().removeIf(entry -> entry.getKey().isAssignableFrom(beanType));
-        beanConcreteCandidateCache.entrySet().removeIf(entry -> entry.getKey().beanType.isAssignableFrom(beanType));
-        singletonBeanRegistrations.entrySet().removeIf(entry -> entry.getKey().beanType.isAssignableFrom(beanType));
-        containsBeanCache.entrySet().removeIf(entry -> entry.getKey().beanType.isAssignableFrom(beanType));
+    private void purgeCacheForBeanDefinition(RuntimeBeanDefinition<?> definition) {
+        Class<?> beanType = definition.getBeanType();
+        Set<Class<?>> indexedTypes = CollectionUtils.setOf(definition.getIndexes());
+        Predicate<Argument<?>> isAffected = cachedType ->
+            cachedType.isAssignableFrom(beanType) || indexedTypes.contains(cachedType.getType());
+        beanCandidateCache.entrySet().removeIf(entry -> isAffected.test(entry.getKey()));
+        beanConcreteCandidateCache.entrySet().removeIf(entry -> isAffected.test(entry.getKey().beanType));
+        singletonBeanRegistrations.entrySet().removeIf(entry -> isAffected.test(entry.getKey().beanType));
+        containsBeanCache.entrySet().removeIf(entry -> isAffected.test(entry.getKey().beanType));
     }
 
     /**
@@ -2055,7 +2058,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     public final <T> Collection<BeanDefinition<T>> findBeanCandidates(@Nullable BeanResolutionContext resolutionContext,
                                                                       Argument<T> beanType,
                                                                       @Nullable BeanDefinition<?> filter) {
-        Predicate<BeanDefinition<T>> predicate = filter == null ? null : definition -> !definition.equals(filter);
+        Predicate<BeanDefinition<T>> predicate = candidate ->
+            isInjectableCandidate(beanType, candidate) && (filter == null || !candidate.equals(filter));
         return findBeanCandidates(resolutionContext, beanType, true, predicate);
     }
 
@@ -3440,6 +3444,24 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
      */
     private <T> boolean isInjectableCandidate(Argument<T> beanType, BeanDefinition<T> candidate) {
         return beanType.getType() == Object.class || beanResolutionCustomizer.isCandidateBean(beanType, candidate);
+    }
+
+    /**
+     * Whether exactly one injectable bean candidate exists for the requested type and qualifier.
+     *
+     * @param beanType  The requested bean type
+     * @param qualifier The requested qualifier
+     * @param <T>       The bean type
+     * @return True if exactly one injectable candidate exists
+     */
+    @Internal
+    public <T> boolean isUniqueBeanCandidate(Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        Collection<BeanDefinition<T>> candidates = findBeanCandidatesInternal(null, beanType);
+        candidates = applyBeanResolutionFilters(null, beanType, candidates);
+        if (qualifier != null && !candidates.isEmpty()) {
+            candidates = qualifier.filterQualified(beanType.getType(), candidates);
+        }
+        return candidates.size() == 1;
     }
 
     private <T> void addCandidateToList(@Nullable BeanResolutionContext resolutionContext,

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1718,14 +1718,33 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     }
 
     private void purgeCacheForBeanDefinition(RuntimeBeanDefinition<?> definition) {
+        if (beanCandidateCache.isEmpty() && beanConcreteCandidateCache.isEmpty() &&
+            singletonBeanRegistrations.isEmpty() && containsBeanCache.isEmpty()) {
+            return;
+        }
         Class<?> beanType = definition.getBeanType();
-        Set<Class<?>> indexedTypes = CollectionUtils.setOf(definition.getIndexes());
+        Class<?>[] indexedTypes = definition.getIndexes();
         Predicate<Argument<?>> isAffected = cachedType ->
-            cachedType.isAssignableFrom(beanType) || indexedTypes.contains(cachedType.getType());
+            isAffectedByRegistration(cachedType, beanType, indexedTypes);
         beanCandidateCache.entrySet().removeIf(entry -> isAffected.test(entry.getKey()));
         beanConcreteCandidateCache.entrySet().removeIf(entry -> isAffected.test(entry.getKey().beanType));
         singletonBeanRegistrations.entrySet().removeIf(entry -> isAffected.test(entry.getKey().beanType));
         containsBeanCache.entrySet().removeIf(entry -> isAffected.test(entry.getKey().beanType));
+    }
+
+    private static boolean isAffectedByRegistration(Argument<?> cachedType,
+                                                     Class<?> beanType,
+                                                     Class<?>[] indexedTypes) {
+        if (cachedType.isAssignableFrom(beanType)) {
+            return true;
+        }
+        Class<?> rawCachedType = cachedType.getType();
+        for (Class<?> indexedType : indexedTypes) {
+            if (indexedType == rawCachedType) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1660,6 +1660,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
         Collection<BeanDefinition<Object>> candidates;
         if (qualifier instanceof FilteringQualifier<Object> filteringQualifier) {
+            Class<?> indexedType = filteringQualifier.getIndexedType();
+            if (indexedType != null) {
+                // the compile-time index holds every bean this qualifier selects, so there is nothing to filter
+                return (Collection) getBeanDefinitions(Argument.of(indexedType));
+            }
             // Keep anonymous
             Predicate<BeanDefinitionReference<Object>> predicate = new Predicate<>() {
                 @Override
@@ -2136,7 +2141,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         Iterator<BeanDefinition<T>> iterator = beanDefinitions.iterator();
         Set<BeanDefinition<T>> candidates;
         if (iterator.hasNext()) {
-            candidates = new HashSet<>();
+            candidates = new LinkedHashSet<>();
             while (iterator.hasNext()) {
                 BeanDefinition<T> candidate = iterator.next();
                 if (collectIterables && candidate.isConfigurationProperties()) {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2949,7 +2949,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             if (scopeAnnotation == Prototype.class) {
                 // a prototype bean has no lifecycle of its own, so a scope declared on the
                 // injection point (such as @InjectScope) still applies to it
-                return findInjectionPointDeclaredScope(resolutionContext);
+                return findInjectionPointDeclaredScope(resolutionContext, definition);
             }
             CustomScope<?> customScope = customScopeRegistry.findScope(scopeAnnotation).orElse(null);
             if (customScope != null) {
@@ -2962,7 +2962,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 if (Prototype.class.getName().equals(scopeAnnotation)) {
                     // a prototype bean has no lifecycle of its own, so a scope declared on the
                     // injection point (such as @InjectScope) still applies to it
-                    return findInjectionPointDeclaredScope(resolutionContext);
+                    return findInjectionPointDeclaredScope(resolutionContext, definition);
                 }
                 CustomScope<?> customScope = customScopeRegistry.findScope(scopeAnnotation).orElse(null);
                 if (customScope != null) {
@@ -2971,7 +2971,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             }
         }
 
-        CustomScope<?> injectionPointScope = findInjectionPointDeclaredScope(resolutionContext);
+        CustomScope<?> injectionPointScope = findInjectionPointDeclaredScope(resolutionContext, definition);
         if (injectionPointScope != null) {
             return injectionPointScope;
         }
@@ -2983,18 +2983,37 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     }
 
     @Nullable
-    private CustomScope<?> findInjectionPointDeclaredScope(@Nullable BeanResolutionContext resolutionContext) {
+    private CustomScope<?> findInjectionPointDeclaredScope(@Nullable BeanResolutionContext resolutionContext,
+                                                           @Nullable BeanDefinition<?> definition) {
         if (resolutionContext != null) {
             BeanResolutionContext.Segment<?, ?> currentSegment = resolutionContext
                 .getPath()
                 .currentSegment()
                 .orElse(null);
             if (currentSegment != null) {
+                if (definition != null && isFactoryOf(definition, currentSegment.getDeclaringType())) {
+                    // the bean is the factory that produces the segment's bean rather than an injection point of
+                    // it, and a scope declared on the produced bean does not apply to its factory. Applying it
+                    // would resolve the factory through the very scope that is creating the produced bean,
+                    // re-entering that scope for a second bean while the first is still being created.
+                    return null;
+                }
                 Argument<?> argument = currentSegment.getArgument();
                 return customScopeRegistry.findDeclaredScope(argument).orElse(null);
             }
         }
         return null;
+    }
+
+    /**
+     * Whether the given definition is the factory the produced bean's definition declares its factory method on.
+     *
+     * @param definition   The definition being resolved
+     * @param producedBean The definition of the bean the current segment produces
+     * @return True if the definition is the factory of the produced bean
+     */
+    private static boolean isFactoryOf(BeanDefinition<?> definition, @Nullable BeanDefinition<?> producedBean) {
+        return producedBean != null && producedBean.getDeclaringType().orElse(null) == definition.getBeanType();
     }
 
     private <T> BeanRegistration<T> getOrCreateScopedRegistration(@Nullable BeanResolutionContext resolutionContext,

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1660,11 +1660,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
         Collection<BeanDefinition<Object>> candidates;
         if (qualifier instanceof FilteringQualifier<Object> filteringQualifier) {
-            Class<?> indexedType = filteringQualifier.getIndexedType();
-            if (indexedType != null) {
+            @SuppressWarnings("unchecked")
+            Argument<Object> indexedArgument = (Argument<Object>) filteringQualifier.getIndexedArgument();
+            if (indexedArgument != null) {
                 // the compile-time index holds every bean this qualifier selects, so there is nothing to filter
-                @SuppressWarnings("unchecked")
-                Argument<Object> indexedArgument = (Argument<Object>) Argument.of(indexedType);
                 return getBeanDefinitions(indexedArgument);
             }
             // Keep anonymous

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -3095,7 +3095,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                                                                          @Nullable Qualifier<T> qualifier,
                                                                          boolean throwNonUnique) {
 
-        Predicate<BeanDefinition<T>> predicate = candidate -> !candidate.isAbstract();
+        Predicate<BeanDefinition<T>> predicate = candidate -> !candidate.isAbstract() && isInjectableCandidate(beanType, candidate);
         Collection<BeanDefinition<T>> candidates = findBeanCandidates(resolutionContext, beanType, true, predicate);
         Optional<BeanDefinition<T>> beanDefinition = pickOneBean(beanType, qualifier, throwNonUnique, candidates);
         if (beanDefinition.isPresent()) {
@@ -3103,7 +3103,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
         Argument<T> lookupBeanType = resolveBeanLookupArgument(beanType);
         if (!lookupBeanType.equals(beanType)) {
-            candidates = findBeanCandidates(resolutionContext, lookupBeanType, true, predicate);
+            Predicate<BeanDefinition<T>> lookupPredicate = candidate -> !candidate.isAbstract() && isInjectableCandidate(lookupBeanType, candidate);
+            candidates = findBeanCandidates(resolutionContext, lookupBeanType, true, lookupPredicate);
             return pickOneBean(lookupBeanType, qualifier, throwNonUnique, candidates);
         }
         return Optional.empty();
@@ -3335,7 +3336,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
         Collection<BeanDefinition<T>> beanDefinitions = findBeanCandidatesInternal(resolutionContext, beanType);
         if (!beanDefinitions.isEmpty()) {
-            beanDefinitions = applyBeanResolutionFilters(resolutionContext, beanDefinitions);
+            beanDefinitions = applyBeanResolutionFilters(resolutionContext, beanType, beanDefinitions);
             if (qualifier != null) {
                 beanDefinitions = qualifier.filterQualified(beanType.getType(), beanDefinitions);
             }
@@ -3400,7 +3401,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
     }
 
-    private <T> Collection<BeanDefinition<T>> applyBeanResolutionFilters(@Nullable BeanResolutionContext resolutionContext, Collection<BeanDefinition<T>> candidates) {
+    private <T> Collection<BeanDefinition<T>> applyBeanResolutionFilters(@Nullable BeanResolutionContext resolutionContext,
+                                                                         Argument<T> beanType,
+                                                                         Collection<BeanDefinition<T>> candidates) {
+        Argument<T> lookupBeanType = resolveBeanLookupArgument(beanType);
         BeanResolutionContext.Segment<?, ?> segment = resolutionContext != null ? resolutionContext.getPath().peek() : null;
         BeanDefinition<?> declaringBean = null;
         Class<?> proxyTargetDefinitionType = null;
@@ -3417,9 +3421,25 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             BeanDefinition<T> c = iterator.next();
             if (c.isAbstract() || declaringBean != null && c.equals(declaringBean) || proxyTargetDefinitionType != null && proxyTargetDefinitionType.equals(c.getClass())) {
                 iterator.remove();
+            } else if (!isInjectableCandidate(beanType, c) && (lookupBeanType.equals(beanType) || !isInjectableCandidate(lookupBeanType, c))) {
+                iterator.remove();
             }
         }
         return candidates;
+    }
+
+    /**
+     * Whether the candidate can be provided as the requested type. A bean that is only enumerable by the
+     * requested type because it is {@link io.micronaut.core.annotation.Indexed} by it, without implementing it,
+     * can be listed via {@link #getBeanDefinitions(Argument)} but cannot be instantiated or injected as that type.
+     *
+     * @param beanType  The requested bean type
+     * @param candidate The candidate
+     * @param <T>       The bean type
+     * @return True if the candidate is a candidate for the requested type
+     */
+    private <T> boolean isInjectableCandidate(Argument<T> beanType, BeanDefinition<T> candidate) {
+        return beanType.getType() == Object.class || beanResolutionCustomizer.isCandidateBean(beanType, candidate);
     }
 
     private <T> void addCandidateToList(@Nullable BeanResolutionContext resolutionContext,
@@ -3485,7 +3505,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     }
 
     private <T> boolean isCandidatePresent(Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
-        final Collection<BeanDefinition<T>> candidates = findBeanCandidates(null, beanType, true, null);
+        final Collection<BeanDefinition<T>> candidates = findBeanCandidates(null, beanType, true, candidate -> isInjectableCandidate(beanType, candidate));
         if (!candidates.isEmpty()) {
             filterReplacedBeans(candidates);
             if (qualifier != null) {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1955,12 +1955,17 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     }
 
     private <T extends EventListener> Map<Class<?>, List<BeanDefinition<T>>> getTypeToListenerMap(Class<T> listenerType) {
-        final Collection<BeanDefinition<T>> beanDefinitions = getBeanDefinitions(listenerType);
+        Argument<T> listenerArgument = Argument.of(listenerType);
+        final Collection<BeanDefinition<T>> beanDefinitions = getBeanDefinitions(listenerArgument);
         if (beanDefinitions.isEmpty()) {
             return Collections.emptyMap();
         }
         final HashMap<Class<?>, List<BeanDefinition<T>>> typeToListener = CollectionUtils.newHashMap(beanDefinitions.size());
         for (BeanDefinition<T> beanCreatedDefinition : beanDefinitions) {
+            // A bean only indexed by the listener type, without implementing it, is enumerable but is not a listener
+            if (!isInjectableCandidate(listenerArgument, beanCreatedDefinition)) {
+                continue;
+            }
             List<Argument<?>> typeArguments = beanCreatedDefinition.getTypeArguments(listenerType);
             Argument<?> argument = CollectionUtils.last(typeArguments);
             if (argument == null) {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -628,11 +628,16 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (beanType == null) {
             return Optional.empty();
         }
-        Collection<BeanDefinition<T>> definitions = getBeanDefinitions(beanType);
-        if (definitions.isEmpty()) {
+        Argument<T> beanArgument = Argument.of(beanType);
+        Collection<BeanDefinition<T>> definitions = getBeanDefinitions(beanArgument);
+        // a bean enumerable by this type only because it is @Indexed by it does not have the type's methods
+        BeanDefinition<T> beanDefinition = definitions.stream()
+            .filter(definition -> isInjectableCandidate(beanArgument, definition))
+            .findFirst()
+            .orElse(null);
+        if (beanDefinition == null) {
             return Optional.empty();
         }
-        BeanDefinition<T> beanDefinition = definitions.iterator().next();
         Optional<ExecutableMethod<T, R>> foundMethod = beanDefinition.findMethod(method, arguments);
         if (foundMethod.isPresent()) {
             return foundMethod;
@@ -1903,7 +1908,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     public <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         for (BeanDefinition<T> beanDefinition : getBeanDefinitions(beanType, qualifier)) {
-            if (beanDefinition.isProxy()) {
+            // a bean enumerable by this type only because it is @Indexed by it is never a proxy of it
+            if (beanDefinition.isProxy() && isInjectableCandidate(beanType, beanDefinition)) {
                 return Optional.of(beanDefinition);
             }
         }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1663,7 +1663,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             Class<?> indexedType = filteringQualifier.getIndexedType();
             if (indexedType != null) {
                 // the compile-time index holds every bean this qualifier selects, so there is nothing to filter
-                return (Collection) getBeanDefinitions(Argument.of(indexedType));
+                @SuppressWarnings("unchecked")
+                Argument<Object> indexedArgument = (Argument<Object>) Argument.of(indexedType);
+                return getBeanDefinitions(indexedArgument);
             }
             // Keep anonymous
             Predicate<BeanDefinitionReference<Object>> predicate = new Predicate<>() {

--- a/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
@@ -191,7 +191,8 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
         Objects.requireNonNull(beans).all.add(producer);
         Class<?> beanType = reference.getBeanType();
         boolean beanTypeIndexAdded = false;
-        for (Class<?> exposedType : reference.getExposedTypes()) {
+        Set<Class<?>> exposedTypes = reference.getExposedTypes();
+        for (Class<?> exposedType : exposedTypes) {
             resolveTypeIndex(exposedType).add(producer);
             if (beanType.equals(exposedType)) {
                 beanTypeIndexAdded = true;
@@ -199,6 +200,11 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
         }
         if (!beanTypeIndexAdded) {
             resolveTypeIndex(beanType).add(producer);
+        }
+        for (Class<?> indexedType : reference.getIndexes()) {
+            if (indexedType != beanType && !exposedTypes.contains(indexedType)) {
+                resolveTypeIndex(indexedType).add(producer);
+            }
         }
     }
 
@@ -617,11 +623,20 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
         for (Class<?> indexedType : exposedTypes) {
             indexByType.computeIfAbsent(indexedType, COMPUTE_INDEXES_FN).add(beanDefinitionProducer);
         }
+        // A bean can also be enumerated by the types it is @Indexed by, even ones it does not implement
+        for (Class<?> indexedType : reference.getIndexes()) {
+            if (!exposedTypes.contains(indexedType)) {
+                indexByType.computeIfAbsent(indexedType, COMPUTE_INDEXES_FN).add(beanDefinitionProducer);
+            }
+        }
     }
 
     private static void indexDisabledBean(Map<Class<?>, List<BeanDefinitionProducer>> indexByType, BeanDefinitionReference<?> reference) {
         // For disabled beans we want to initialize the index collection, otherwise MISS will cause N search
         for (Class<?> indexedType : reference.getExposedTypes()) {
+            indexByType.computeIfAbsent(indexedType, COMPUTE_INDEXES_FN);
+        }
+        for (Class<?> indexedType : reference.getIndexes()) {
             indexByType.computeIfAbsent(indexedType, COMPUTE_INDEXES_FN);
         }
     }
@@ -750,7 +765,7 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
                     }
                 }
                 BeanDefinition<T> def = (BeanDefinition<T>) defObject;
-                if (beanType != null && !(beanType.getType().equals(Object.class) || beanResolutionCustomizer.isCandidateBean(beanType, def))) {
+                if (beanType != null && !(beanType.getType().equals(Object.class) || beanResolutionCustomizer.isCandidateBean(beanType, def) || isIndexedBy(beanType))) {
                     return null;
                 }
                 if (defPredicate != null && !defPredicate.test(def)) {
@@ -766,7 +781,7 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
                 }
                 return null;
             }
-            if (beanType != null && !(beanType.getType().equals(Object.class) || beanResolutionCustomizer.isCandidateBean(beanType, ref))) {
+            if (beanType != null && !(beanType.getType().equals(Object.class) || beanResolutionCustomizer.isCandidateBean(beanType, ref) || isIndexedBy(beanType))) {
                 return null;
             }
             if (refPredicate != null && !refPredicate.test(ref)) {
@@ -790,6 +805,27 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
                 this.definition = DEFINITION_DISABLED_SENTINEL;
                 return null;
             }
+        }
+
+        /**
+         * Whether the bean is explicitly indexed by the requested type. A bean annotated with
+         * {@code @Indexed(Marker.class)} is enumerable by {@code Marker} even when it does not implement it.
+         *
+         * @param beanType The requested bean type
+         * @return True if the bean declares an index for exactly the requested type
+         */
+        private boolean isIndexedBy(Argument<?> beanType) {
+            BeanDefinitionReference<?> ref = reference;
+            if (ref == null) {
+                return false;
+            }
+            Class<?> type = beanType.getType();
+            for (Class<?> indexedType : ref.getIndexes()) {
+                if (indexedType == type) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         void disableIfMatch(BeanDefinitionReference<?> toDisable) {

--- a/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
@@ -100,7 +100,14 @@ public final class BeanProviderDefinition extends AbstractProviderDefinition<Bea
             @Override
             public boolean isUnique() {
                 try {
-                    return context.getBeanDefinitions(argument, finalQualifier).size() == 1;
+                    if (context instanceof DefaultBeanContext defaultBeanContext) {
+                        return defaultBeanContext.isUniqueBeanCandidate(argument, finalQualifier);
+                    }
+                    return context.getBeanDefinitions(argument, finalQualifier)
+                        .stream()
+                        .filter(candidate -> candidate.isCandidateBean(argument))
+                        .limit(2)
+                        .count() == 1;
                 } catch (NoSuchBeanException e) {
                     return false;
                 }

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationStereotypeQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationStereotypeQualifier.java
@@ -20,6 +20,10 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.inject.BeanType;
 
+import io.micronaut.core.annotation.Indexed;
+import io.micronaut.core.annotation.Nullable;
+
+import java.lang.annotation.Annotation;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -35,10 +39,49 @@ final class AnnotationStereotypeQualifier<T> extends FilteringQualifier<T> {
     final String stereotype;
 
     /**
+     * The annotation type when this qualifier selects the beans that a self-indexed annotation is declared on,
+     * which the compile-time index answers exhaustively. Null otherwise.
+     */
+    @Nullable
+    private final Class<? extends Annotation> indexedType;
+
+    /**
      * @param stereotype The stereotype
      */
     AnnotationStereotypeQualifier(String stereotype) {
         this.stereotype = Objects.requireNonNull(stereotype, "Stereotype cannot be null");
+        this.indexedType = null;
+    }
+
+    /**
+     * @param stereotype The stereotype annotation
+     */
+    AnnotationStereotypeQualifier(Class<? extends Annotation> stereotype) {
+        Objects.requireNonNull(stereotype, "Stereotype cannot be null");
+        this.stereotype = stereotype.getName();
+        this.indexedType = isSelfIndexed(stereotype) ? stereotype : null;
+    }
+
+    /**
+     * An annotation meta-annotated with {@link Indexed} by its own type indexes every bean it is declared on,
+     * so the index holds all of them and nothing else.
+     *
+     * @param stereotype The stereotype annotation
+     * @return True if the annotation indexes the beans carrying it by itself
+     */
+    private static boolean isSelfIndexed(Class<? extends Annotation> stereotype) {
+        for (Indexed indexed : stereotype.getAnnotationsByType(Indexed.class)) {
+            if (indexed.value() == stereotype) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    @Nullable
+    public Class<?> getIndexedType() {
+        return indexedType;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationStereotypeQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationStereotypeQualifier.java
@@ -22,6 +22,7 @@ import io.micronaut.inject.BeanType;
 
 import io.micronaut.core.annotation.Indexed;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
 
 import java.lang.annotation.Annotation;
 import java.util.Objects;
@@ -43,14 +44,14 @@ final class AnnotationStereotypeQualifier<T> extends FilteringQualifier<T> {
      * which the compile-time index answers exhaustively. Null otherwise.
      */
     @Nullable
-    private final Class<? extends Annotation> indexedType;
+    private final Argument<?> indexedArgument;
 
     /**
      * @param stereotype The stereotype
      */
     AnnotationStereotypeQualifier(String stereotype) {
         this.stereotype = Objects.requireNonNull(stereotype, "Stereotype cannot be null");
-        this.indexedType = null;
+        this.indexedArgument = null;
     }
 
     /**
@@ -59,7 +60,7 @@ final class AnnotationStereotypeQualifier<T> extends FilteringQualifier<T> {
     AnnotationStereotypeQualifier(Class<? extends Annotation> stereotype) {
         Objects.requireNonNull(stereotype, "Stereotype cannot be null");
         this.stereotype = stereotype.getName();
-        this.indexedType = isSelfIndexed(stereotype) ? stereotype : null;
+        this.indexedArgument = isSelfIndexed(stereotype) ? Argument.of(stereotype) : null;
     }
 
     /**
@@ -80,8 +81,8 @@ final class AnnotationStereotypeQualifier<T> extends FilteringQualifier<T> {
 
     @Override
     @Nullable
-    public Class<?> getIndexedType() {
-        return indexedType;
+    public Argument<?> getIndexedArgument() {
+        return indexedArgument;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/FilteringQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/FilteringQualifier.java
@@ -17,6 +17,7 @@ package io.micronaut.inject.qualifiers;
 
 import io.micronaut.context.Qualifier;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.BeanType;
 import io.micronaut.inject.QualifiedBeanType;
 
@@ -34,6 +35,19 @@ import java.util.stream.Stream;
  */
 @Internal
 public abstract class FilteringQualifier<T> implements Qualifier<T> {
+
+    /**
+     * The type the beans this qualifier selects are indexed by, when the compile-time index is an exhaustive
+     * answer for it. A qualifier that reports one can be answered by looking that type up in the index instead
+     * of filtering every bean definition reference.
+     *
+     * @return The indexed type, or {@code null} when the qualifier has to be answered by filtering
+     * @since 5.2.0
+     */
+    @Nullable
+    public Class<?> getIndexedType() {
+        return null;
+    }
 
     @Override
     public <BT extends BeanType<T>> Stream<BT> reduce(Class<T> beanType, Stream<BT> candidates) {

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/FilteringQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/FilteringQualifier.java
@@ -18,6 +18,7 @@ package io.micronaut.inject.qualifiers;
 import io.micronaut.context.Qualifier;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanType;
 import io.micronaut.inject.QualifiedBeanType;
 
@@ -41,11 +42,14 @@ public abstract class FilteringQualifier<T> implements Qualifier<T> {
      * answer for it. A qualifier that reports one can be answered by looking that type up in the index instead
      * of filtering every bean definition reference.
      *
+     * <p>An {@link Argument} rather than a {@link Class} so that the qualifier holds the one the index is keyed
+     * by, instead of a new one being built on every lookup.</p>
+     *
      * @return The indexed type, or {@code null} when the qualifier has to be answered by filtering
      * @since 5.2.0
      */
     @Nullable
-    public Class<?> getIndexedType() {
+    public Argument<?> getIndexedArgument() {
         return null;
     }
 

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
@@ -315,7 +315,7 @@ public class Qualifiers {
         if (instance != null) {
             return instance;
         }
-        return new AnnotationStereotypeQualifier<>(stereotype.getName());
+        return new AnnotationStereotypeQualifier<>(stereotype);
     }
 
     /**

--- a/management/src/main/java/io/micronaut/management/endpoint/annotation/Endpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/annotation/Endpoint.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.management.endpoint.annotation;
 
+import io.micronaut.core.annotation.Indexed;
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.Requires;
@@ -41,6 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Singleton
 @ConfigurationReader(basePrefix = EndpointConfiguration.PREFIX)
 @Requires(condition = EndpointEnabledCondition.class)
+@Indexed(Endpoint.class)
 public @interface Endpoint {
 
     /**

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointIndexedLookupSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointIndexedLookupSpec.groovy
@@ -18,8 +18,6 @@ package io.micronaut.management.endpoint
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.Environment
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.BeanDefinitionReference
-import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.management.endpoint.annotation.Endpoint
 import spock.lang.Specification
 
@@ -48,7 +46,7 @@ class EndpointIndexedLookupSpec extends Specification {
         indexed*.beanType.name == scanned*.beanType.name
 
         and: 'every one of them carries the index, which is what makes the lookup exhaustive'
-        indexed.every { Endpoint in ((BeanDefinitionReference<?>) it).indexes }
+        context.getBeanDefinitionReferences().findAll { Endpoint in it.indexes }*.beanType.containsAll(indexed*.beanType)
 
         cleanup:
         context.close()

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointIndexedLookupSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointIndexedLookupSpec.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.management.endpoint.annotation.Endpoint
+import spock.lang.Specification
+
+/**
+ * {@code @Endpoint} is meta-annotated with {@code @Indexed(Endpoint)}, so the endpoint beans a
+ * {@code BeanDefinitionProcessor<Endpoint>} is handed are looked up through the compile-time index
+ * instead of by scanning every bean definition reference.
+ */
+class EndpointIndexedLookupSpec extends Specification {
+
+    void "test endpoint beans are enumerable through the compile-time index"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                ['endpoints.all.enabled': true, 'endpoints.all.sensitive': false], Environment.TEST)
+
+        when: 'the beans are looked up through the index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(Endpoint)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(Endpoint) }
+
+        then: 'endpoints are actually present'
+        !indexed.isEmpty()
+
+        and: 'both answer the same beans, in the same order, which the endpoint routes are registered in'
+        indexed*.beanType.name == scanned*.beanType.name
+
+        and: 'every one of them carries the index, which is what makes the lookup exhaustive'
+        indexed.every { Endpoint in ((BeanDefinitionReference<?>) it).indexes }
+
+        cleanup:
+        context.close()
+    }
+}

--- a/messaging/src/main/java/io/micronaut/messaging/annotation/MessageListener.java
+++ b/messaging/src/main/java/io/micronaut/messaging/annotation/MessageListener.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.messaging.annotation;
 
+import io.micronaut.core.annotation.Indexed;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.DefaultScope;
 import jakarta.inject.Singleton;
@@ -38,5 +39,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
 @Bean
 @DefaultScope(Singleton.class)
+@Indexed(MessageListener.class)
 public @interface MessageListener {
 }

--- a/messaging/src/test/groovy/io/micronaut/messaging/MessageListenerIndexedLookupSpec.groovy
+++ b/messaging/src/test/groovy/io/micronaut/messaging/MessageListenerIndexedLookupSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.messaging
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.messaging.annotation.MessageListener
+import spock.lang.Specification
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+
+/**
+ * {@code @MessageListener} is the stereotype the transport specific listener annotations are built on,
+ * so indexing it by itself indexes every listener bean without those annotations doing anything.
+ */
+class MessageListenerIndexedLookupSpec extends Specification {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @MessageListener
+    @interface TransportListener {
+    }
+
+    @TransportListener
+    static class OneListener {
+    }
+
+    @TransportListener
+    static class TwoListener {
+    }
+
+    void "test beans carrying a transport annotation built on @MessageListener are indexed by it"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when: 'the listeners are looked up through the index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(MessageListener)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(MessageListener) }
+
+        then: 'the listeners are found through an annotation that never mentions @Indexed itself'
+        indexed*.beanType.name.containsAll([OneListener.name, TwoListener.name])
+
+        and: 'both answer the same beans, in the same order'
+        indexed*.beanType.name == scanned*.beanType.name
+
+        cleanup:
+        context.close()
+    }
+}

--- a/messaging/src/test/groovy/io/micronaut/messaging/MessageListenerIndexedLookupSpec.groovy
+++ b/messaging/src/test/groovy/io/micronaut/messaging/MessageListenerIndexedLookupSpec.groovy
@@ -17,7 +17,6 @@ package io.micronaut.messaging
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.messaging.annotation.MessageListener
 import spock.lang.Specification
 

--- a/websocket/src/main/java/io/micronaut/websocket/annotation/ServerWebSocket.java
+++ b/websocket/src/main/java/io/micronaut/websocket/annotation/ServerWebSocket.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.websocket.annotation;
 
+import io.micronaut.core.annotation.Indexed;
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.context.annotation.DefaultScope;
 import io.micronaut.core.util.StringUtils;
@@ -40,6 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @WebSocketComponent
 @DefaultScope(Singleton.class)
+@Indexed(ServerWebSocket.class)
 public @interface ServerWebSocket {
 
     /**


### PR DESCRIPTION
## Summary

A bean annotated with `@Indexed(Marker.class)` (declared directly, through a stereotype, or added by a
`TypeElementVisitor` at compile time) is now enumerable through `BeanContext.getBeanDefinitions(Marker.class)`
even when it does not implement `Marker`.

`BeanDefinitionWriter` already emits a `$INDEXES` array and a `getIndexes()` override into every bean
definition that carries `@Indexed`, but on `5.2.x` **nothing calls `getIndexes()` at runtime** — the
runtime stopped reading it in #12066:

```
$ git grep -n 'getIndexes()' 5.2.x -- '*/src/main/*' | grep -v core-processor
inject/.../BeanDefinitionReference.java:139:   default Class<?>[] getIndexes() {   <- interface default
aop/.../InterceptorRegistryBean.java:52                                            <- override
inject/.../ApplicationEventPublisherFactory.java:98                                <- override
inject/.../AbstractProviderDefinition.java:81                                      <- override
```

Four implementations, zero call sites. The index is generated and then thrown away, so `@Indexed` only
appears to work for the three existing users, each of which indexes a type it already implements — where
the index is a redundant duplicate of an exposed type. Indexing a type the bean does *not* implement is
silently a no-op, and such beans were filtered out by `isCandidateBean` anyway.

## What this enables

The index key is an arbitrary `Class`, so a bean can be enumerated by a marker it does not implement,
and — since an annotation is a `Class` too — beans can be indexed by an annotation type. That
generalises the four hardcoded buckets in `DefaultBeanDefinitionService` (`processedBeans`,
`parallelBeans`, `proxyTargetBeans`, `eagerInitBeans`), each of which needed a core change to add.

An annotation meta-annotated with `@Indexed` by its own type has every bean carrying it indexed at
compile time, so `AnnotationStereotypeQualifier` reports that type through
`FilteringQualifier.getIndexedArgument()` and `getBeanDefinitions(Qualifier)` answers from the index
instead of filtering every bean definition reference. No call site changes: every existing caller of
`Qualifiers.byStereotype(...)` benefits, and an annotation without `@Indexed` reports null and keeps the
scan.

`@Endpoint`, `@ServerWebSocket`, `@FunctionBean` and `@MessageListener` are indexed by themselves, which
covers `EndpointSensitivityProcessor` and `AbstractEndpointRouteBuilder`, `ServerWebSocketProcessor`,
`DefaultLocalFunctionRegistry` and `MessagingApplication`. `@MessageListener` is the stereotype the
transport specific annotations are built on, so indexing it indexes every `@KafkaListener` /
`@RabbitListener` / `@JmsListener` bean transitively.

## Performance

Measured on a context with 808 bean definitions, comparing the same annotation resolved through
`Qualifiers.byStereotype(Class)` (index) against `Qualifiers.byStereotype(String)` (scan), which has no
type to index by and therefore still filters every reference:

| | scan | index |
|---|---|---|
| first lookup on a fresh context (median of 5) | 0.35 ms | 0.10 ms |
| warm, per lookup | 35.2 us | 38 ns |

Cold is about 3.4x: the first lookup is dominated by loading the bean definition classes, which both
paths pay. Warm the gap is the real one — the scan is linear in reference count and re-filters on every
call, while the index is a cache hit. The cold figure is what an application actually pays, once per
processor at startup.

The qualifier holds the `Argument` it indexes by rather than building one per lookup; that alone was
more than half the warm cost (56ns to 38ns) and it no longer allocates.

Measurement caveat: these are in-process timings with the results discarded, so the warm figure is a
lower bound rather than a JMH-grade number. The two paths are measured the same way, interleaved across
rounds, so the comparison holds even where the absolute value is optimistic.

## Changes

- `DefaultBeanDefinitionService`: compiled, runtime-registered and disabled beans are additionally
  indexed under their `getIndexes()` types that are not exposed types (no double indexing).
  `getDefinitionIfEnabled` accepts a producer whose reference is indexed by exactly the requested type.
- `DefaultBeanContext`: index-only matches are enumeration-only. They are filtered out of the instance
  lookup paths (`getBean`, `getBeansOfType`, `containsBean`, `findBeanDefinition`, collection
  injection), so `getBean(Marker.class)` throws `NoSuchBeanException` instead of returning an object
  that is not a `Marker`.
- `@Indexed` Javadoc documents the behaviour: enumerable via `getBeanDefinitions` by an indexed type;
  injecting or resolving an instance by a type the bean does not implement remains unsupported.
- Existing users that index a type they implement (`ApplicationEventPublisherFactory`,
  `AbstractProviderDefinition`, `InterceptorRegistryBean`) are unaffected.

## Tests

`IndexedByVisitorSpec` covers a visitor-added index, a stereotype-carried and a directly declared index
alongside a real implementation (only the real implementation is resolved and injected), and a
runtime-registered `RuntimeBeanDefinition` with an index.

```
:micronaut-inject:test        SUCCESS: Executed 312 tests
:micronaut-inject-java:test   SUCCESS: Executed 5007 tests (8 skipped)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
