### PR TITLE
Let a custom scope registered at runtime reach beans resolved before it

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/runtime/RuntimeRegistered.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/runtime/RuntimeRegistered.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.scope.runtime;
+
+import jakarta.inject.Scope;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A scope whose {@link io.micronaut.context.scope.CustomScope} is only registered at runtime.
+ */
+@Documented
+@Retention(RUNTIME)
+@Scope
+public @interface RuntimeRegistered {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/runtime/RuntimeRegisteredBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/runtime/RuntimeRegisteredBean.java
@@ -1,0 +1,5 @@
+package io.micronaut.inject.scope.runtime;
+
+@RuntimeRegistered
+public class RuntimeRegisteredBean {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/runtime/RuntimeRegisteredScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/runtime/RuntimeRegisteredScope.java
@@ -1,0 +1,48 @@
+package io.micronaut.inject.scope.runtime;
+
+import io.micronaut.context.scope.BeanCreationContext;
+import io.micronaut.context.scope.CreatedBean;
+import io.micronaut.context.scope.CustomScope;
+import io.micronaut.inject.BeanIdentifier;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Deliberately not a bean: a test registers it through {@link io.micronaut.context.RuntimeBeanDefinition}.
+ */
+public class RuntimeRegisteredScope implements CustomScope<RuntimeRegistered> {
+    private final Map<BeanIdentifier, CreatedBean<?>> beans = new ConcurrentHashMap<>();
+    private final AtomicInteger created = new AtomicInteger();
+
+    public int getCreated() {
+        return created.get();
+    }
+
+    @Override
+    public Class<RuntimeRegistered> annotationType() {
+        return RuntimeRegistered.class;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getOrCreate(BeanCreationContext<T> context) {
+        return (T) beans.computeIfAbsent(context.id(), key -> {
+            created.incrementAndGet();
+            return context.create();
+        }).bean();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Optional<T> remove(BeanIdentifier identifier) {
+        CreatedBean<?> createdBean = beans.remove(identifier);
+        if (createdBean != null) {
+            createdBean.close();
+            return (Optional<T>) Optional.of(createdBean.bean());
+        }
+        return Optional.empty();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/runtime/RuntimeRegisteredScopeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/runtime/RuntimeRegisteredScopeSpec.groovy
@@ -1,0 +1,61 @@
+package io.micronaut.inject.scope.runtime
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.RuntimeBeanDefinition
+import io.micronaut.context.scope.CustomScope
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import java.util.function.Supplier
+
+class RuntimeRegisteredScopeSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run()
+
+    void "a custom scope registered at runtime applies to a bean that was resolved before the registration"() {
+        when: "the bean is resolved while no scope for its annotation exists"
+        def first = context.getBean(RuntimeRegisteredBean)
+        def second = context.getBean(RuntimeRegisteredBean)
+
+        then: "it is created as a dependent bean"
+        !first.is(second)
+
+        when: "a scope for the annotation is registered at runtime"
+        def scope = new RuntimeRegisteredScope()
+        context.registerBeanDefinition(RuntimeBeanDefinition.builder(CustomScope, { -> scope } as Supplier<CustomScope>)
+            .typeArguments(Argument.of(RuntimeRegistered))
+            .singleton(true)
+            .build())
+
+        then: "the scope itself is visible to the locator"
+        context.getBean(CustomScope, Qualifiers.byTypeArguments(RuntimeRegistered)).is(scope)
+
+        when: "the bean is resolved again"
+        def third = context.getBean(RuntimeRegisteredBean)
+        def fourth = context.getBean(RuntimeRegisteredBean)
+
+        then: "it goes through the scope"
+        scope.created == 1
+        third.is(fourth)
+    }
+
+    void "a custom scope registered at runtime applies to a bean first resolved after the registration"() {
+        given:
+        def scope = new RuntimeRegisteredScope()
+        context.registerBeanDefinition(RuntimeBeanDefinition.builder(CustomScope, { -> scope } as Supplier<CustomScope>)
+            .typeArguments(Argument.of(RuntimeRegistered))
+            .singleton(true)
+            .build())
+
+        when:
+        def first = context.getBean(RuntimeRegisteredBean)
+        def second = context.getBean(RuntimeRegisteredBean)
+
+        then:
+        scope.created == 1
+        first.is(second)
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1653,7 +1653,12 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     @Override
     public <B> BeanContext registerBeanDefinition(RuntimeBeanDefinition<B> definition) {
         beanDefinitionProvider.addBeanDefinition(definition);
-        purgeCacheForBeanType(definition.getBeanType());
+        Class<B> beanType = definition.getBeanType();
+        purgeCacheForBeanType(beanType);
+        if (CustomScope.class.isAssignableFrom(beanType)) {
+            // a bean of this scope resolved earlier left the scope's absence recorded in the registry
+            customScopeRegistry.invalidate();
+        }
         return this;
     }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultCustomScopeRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultCustomScopeRegistry.java
@@ -114,6 +114,13 @@ public class DefaultCustomScopeRegistry implements CustomScopeRegistry {
         });
     }
 
+    @Override
+    public void invalidate() {
+        // only the misses: a scope that was found keeps the beans it holds, and dropping it here would
+        // let a second lookup of the same scope bean create a second instance of a non-singleton one
+        scopes.values().removeIf(Optional::isEmpty);
+    }
+
     private static final class InjectScopeImpl implements CustomScope<InjectScope>, LifeCycle<InjectScopeImpl> {
 
         private final List<CreatedBean<?>> currentCreatedBeans = new ArrayList<>(2);

--- a/inject/src/main/java/io/micronaut/context/scope/CustomScopeRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/scope/CustomScopeRegistry.java
@@ -80,4 +80,14 @@ public interface CustomScopeRegistry {
     default <T> Optional<BeanRegistration<T>> findBeanRegistration(T bean) {
         return Optional.empty();
     }
+
+    /**
+     * Forgets that no scope was found for an annotation, so that the next lookup for it consults
+     * the bean context again. Called when a {@link CustomScope} is registered after the context started,
+     * since a lookup made before then may have recorded the scope's absence.
+     *
+     * @since 5.2.0
+     */
+    default void invalidate() {
+    }
 }


### PR DESCRIPTION
A `CustomScope` registered after the context started, through
`registerBeanDefinition(RuntimeBeanDefinition.builder(CustomScope.class, …).typeArguments(Argument.of(MyScope.class))…)`,
is silently ignored for any scope annotation whose bean was resolved before the registration. The bean keeps being
created as a dependent bean: a new instance on every `getBean`, never handed to the scope's `getOrCreate`, with no
warning. Whether a runtime-registered scope works therefore depends on bean ordering: it does as long as nothing of
that scope happens to be resolved first.

The cause is a permanent negative cache. `DefaultCustomScopeRegistry.findScope` is
`scopes.computeIfAbsent(name, … beanLocator.findBean(CustomScope.class, byExactTypeArgumentName(name)))`, so a miss is
stored as `Optional.empty()` for the life of the context. `DefaultBeanContext.registerBeanDefinition` purges the bean
candidate caches for the new definition's type, but never the scope registry, so the later `findCustomScope` for the
bean still sees the recorded miss, returns null, and `createRegistration` builds a plain dependent bean.

The fix adds `CustomScopeRegistry.invalidate()`, a `default` no-op so no existing implementor breaks.
`DefaultCustomScopeRegistry` implements it by dropping only the empty entries: a scope that was found keeps the
beans it holds, and dropping it too would let a later lookup of a non-singleton scope bean create a second scope
instance. `DefaultBeanContext.registerBeanDefinition` calls it only when the registered definition's bean type is a
`CustomScope`, next to the existing candidate-cache purge. Nothing changes on the resolution path: `findScope` is
untouched, and the registration path already pays for four cache purges, so a fifth `removeIf` over a map with a
handful of entries is noise there. The check uses `getBeanType()` for the same reason `purgeCacheForBeanType` does:
if the definition exposes types that exclude `CustomScope` the lookup would not find it anyway and the invalidation is
merely a harmless re-lookup.

Adds `RuntimeRegisteredScopeSpec` (inject-java): a bean annotated with a `@Scope` meta-annotation that has no
compile-time `CustomScope` is resolved twice (two instances), then a `CustomScope` for that annotation is registered
through a `RuntimeBeanDefinition`, and the bean is resolved twice more. Without the change the scope's `getOrCreate`
is never called (`scope.created == 1` fails with `0`); with it the two later resolutions return the same instance
through the scope. A second feature method covers registration before any resolution, which already worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
