### PR TITLE
Let a runtime bean definition carry its own disposer

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionDisposerSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionDisposerSpec.groovy
@@ -1,0 +1,176 @@
+package io.micronaut.inject.beans
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanContext
+import io.micronaut.context.BeanRegistration
+import io.micronaut.context.RuntimeBeanDefinition
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.DisposableBeanDefinition
+import spock.lang.Specification
+
+import java.util.function.BiConsumer
+
+class RuntimeBeanDefinitionDisposerSpec extends Specification {
+
+    void 'test a runtime bean definition built without a disposer is not disposable'() {
+        given:
+        RuntimeBeanDefinition<Foo> definition = RuntimeBeanDefinition.builder(Foo, () -> new Foo())
+                .build()
+
+        expect:
+        !(definition instanceof DisposableBeanDefinition)
+    }
+
+    void 'test a runtime bean definition built with a disposer is disposable'() {
+        given:
+        RuntimeBeanDefinition<Foo> definition = RuntimeBeanDefinition.builder(Foo, () -> new Foo())
+                .disposer((BiConsumer<BeanContext, Foo>) { ctx, bean -> bean.disposed++ })
+                .build()
+
+        expect:
+        definition instanceof DisposableBeanDefinition
+        definition.beanType == Foo
+        !definition.singleton
+    }
+
+    void 'test the disposer runs once when a dependent bean registration is closed'() {
+        given:
+        def calls = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(RuntimeBeanDefinition.builder(Foo, () -> new Foo())
+                        .scope(Prototype)
+                        .disposer((BiConsumer<BeanContext, Foo>) { ctx, bean -> calls << [ctx, bean]; bean.disposed++ })
+                        .build())
+                .build()
+                .start()
+
+        when:
+        BeanRegistration<Foo> registration = context.getBeanRegistration(Foo, null)
+        Foo foo = registration.bean
+
+        then:
+        foo.disposed == 0
+        calls.isEmpty()
+
+        when:
+        registration.close()
+
+        then:
+        foo.disposed == 1
+        calls.size() == 1
+        calls[0][0].is(context)
+        calls[0][1].is(foo)
+
+        when: 'the registration is closed a second time'
+        registration.close()
+
+        then: 'the disposer does not run again'
+        foo.disposed == 1
+        calls.size() == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the disposer of a singleton runs once when the context is closed'() {
+        given:
+        def calls = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(RuntimeBeanDefinition.builder(Foo, () -> new Foo())
+                        .singleton(true)
+                        .disposer((BiConsumer<BeanContext, Foo>) { ctx, bean -> calls << [ctx, bean]; bean.disposed++ })
+                        .build())
+                .build()
+                .start()
+        Foo foo = context.getBean(Foo)
+
+        when:
+        context.close()
+
+        then:
+        foo.disposed == 1
+        calls.size() == 1
+        calls[0][0].is(context)
+        calls[0][1].is(foo)
+    }
+
+    void 'test the disposer runs when the bean instance is destroyed through the context'() {
+        given:
+        def calls = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(RuntimeBeanDefinition.builder(Foo, () -> new Foo())
+                        .singleton(true)
+                        .disposer((BiConsumer<BeanContext, Foo>) { ctx, bean -> calls << [ctx, bean]; bean.disposed++ })
+                        .build())
+                .build()
+                .start()
+        Foo foo = context.getBean(Foo)
+
+        when:
+        context.destroyBean(foo)
+
+        then:
+        foo.disposed == 1
+        calls.size() == 1
+        calls[0][0].is(context)
+        calls[0][1].is(foo)
+
+        when: 'the context is closed afterwards'
+        context.close()
+
+        then: 'the already destroyed singleton is not disposed again'
+        foo.disposed == 1
+        calls.size() == 1
+    }
+
+    void 'test the disposer receives the bean resolution context factory instance'() {
+        given:
+        def calls = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(RuntimeBeanDefinition.builder(Foo, resolutionContext -> new Foo())
+                        .singleton(true)
+                        .disposer((BiConsumer<BeanContext, Foo>) { ctx, bean -> calls << bean })
+                        .build())
+                .build()
+                .start()
+        Foo foo = context.getBean(Foo)
+
+        when:
+        context.close()
+
+        then:
+        calls == [foo]
+    }
+
+    void 'test a disposing runtime bean definition keeps the rest of the builder configuration'() {
+        given:
+        RuntimeBeanDefinition<Foo> definition = RuntimeBeanDefinition.builder(Foo, () -> new Foo())
+                .named("foo")
+                .exposedTypes(IFoo)
+                .singleton(true)
+                .disposer((BiConsumer<BeanContext, Foo>) { ctx, bean -> bean.disposed++ })
+                .build()
+
+        expect:
+        definition instanceof DisposableBeanDefinition
+        definition.singleton
+        definition.exposedTypes == [IFoo] as Set
+        definition.declaredQualifier.toString().contains("foo")
+
+        when:
+        def foo = new Foo()
+        BeanDefinition<Foo> asDefinition = definition
+        ((DisposableBeanDefinition<Foo>) asDefinition).dispose(BeanContext.build(), foo)
+
+        then:
+        foo.disposed == 1
+    }
+
+    static interface IFoo {
+    }
+
+    static class Foo implements IFoo {
+        int disposed = 0
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -28,6 +28,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.DisposableBeanDefinition;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.qualifiers.ClosestTypeArgumentQualifier;
 import io.micronaut.inject.qualifiers.PrimaryQualifier;
@@ -44,17 +45,22 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
  * Default implementation of {@link RuntimeBeanDefinition<T>}.
+ *
+ * <p>A definition built with a disposer is a {@link Disposable}, which is the only subclass, so that a definition
+ * built without one is not a {@link DisposableBeanDefinition} and the context never has to dispose of it.</p>
+ *
  * @param <T> The bean type
  * @author graemerocher
  * @since 3.6.0
  */
 @Experimental
-final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditional implements RuntimeBeanDefinition<T> {
+sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditional implements RuntimeBeanDefinition<T> {
     private static final AtomicInteger REF_COUNT = new AtomicInteger(0);
     private static final String MSG_BEAN_TYPE_CANNOT_BE_NULL = "Bean type cannot be null";
     private final Argument<T> beanType;
@@ -233,6 +239,46 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
     }
 
     /**
+     * A runtime bean definition built with a disposer.
+     *
+     * <p>Only this subclass is a {@link DisposableBeanDefinition}: the context disposes of a bean only when its
+     * definition is one, so a definition built without a disposer keeps the behaviour it had before disposers
+     * existed. The disposer takes no {@link BeanResolutionContext} because a runtime built bean has no injection
+     * points or lifecycle advice of its own that a resolution context could carry into the disposal, so
+     * {@link #dispose(BeanContext, Object)} skips creating one.</p>
+     *
+     * @param <T> The bean type
+     * @since 5.2.0
+     */
+    static final class Disposable<T> extends DefaultRuntimeBeanDefinition<T> implements DisposableBeanDefinition<T> {
+        private final BiConsumer<BeanContext, T> disposer;
+
+        Disposable(Argument<T> beanType,
+                   Function<BeanResolutionContext, T> beanFactory,
+                   @Nullable Qualifier<T> qualifier,
+                   @Nullable AnnotationMetadata annotationMetadata,
+                   boolean isSingleton,
+                   @Nullable Class<? extends Annotation> scope,
+                   Class<?>[] exposedTypes,
+                   @Nullable Map<Class<?>, List<Argument<?>>> typeArguments,
+                   BiConsumer<BeanContext, T> disposer) {
+            super(beanType, beanFactory, qualifier, annotationMetadata, isSingleton, scope, exposedTypes, typeArguments);
+            this.disposer = Objects.requireNonNull(disposer, "Disposer cannot be null");
+        }
+
+        @Override
+        public T dispose(BeanContext context, T bean) {
+            disposer.accept(context, bean);
+            return bean;
+        }
+
+        @Override
+        public T dispose(BeanResolutionContext resolutionContext, BeanContext context, T bean) {
+            return dispose(context, bean);
+        }
+    }
+
+    /**
      * Implementation of {@link RuntimeBeanDefinition.Builder}.
      * @param <B> The bean
      */
@@ -251,6 +297,8 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
         private Map<Class<?>, List<Argument<?>>> typeArguments;
         @Nullable
         private Class<? extends B> replacesType;
+        @Nullable
+        private BiConsumer<BeanContext, B> disposer;
 
         RuntimeBeanBuilder(Argument<B> beanType, Supplier<B> supplier) {
             this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
@@ -337,6 +385,12 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
         }
 
         @Override
+        public Builder<B> disposer(@Nullable BiConsumer<BeanContext, B> disposer) {
+            this.disposer = disposer;
+            return this;
+        }
+
+        @Override
         public RuntimeBeanDefinition<B> build() {
             if (replacesType != null) {
                 MutableAnnotationMetadata mutableAnnotationMetadata;
@@ -355,6 +409,19 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
                     values.put("named", named.getName());
                 }
                 mutableAnnotationMetadata.addAnnotation(Replaces.class.getName(), values);
+            }
+            if (disposer != null) {
+                return new Disposable<>(
+                    beanType,
+                    beanFactory,
+                    qualifier,
+                    annotationMetadata,
+                    singleton,
+                    scope,
+                    exposedTypes,
+                    typeArguments,
+                    disposer
+                );
             }
             return new DefaultRuntimeBeanDefinition<>(
                 beanType,

--- a/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -311,6 +312,25 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
          * @return This builder
          */
         Builder<B> annotationMetadata(@Nullable AnnotationMetadata annotationMetadata);
+
+        /**
+         * The disposer to run when an instance created by this definition is destroyed.
+         *
+         * <p>The disposer is invoked once per instance, after the
+         * {@link io.micronaut.context.event.BeanPreDestroyEventListener} instances and before the
+         * {@link io.micronaut.context.event.BeanDestroyedEventListener} instances, whenever the instance is destroyed
+         * by the {@link BeanContext}: when the {@link BeanRegistration} of a non-singleton is closed, when a singleton
+         * is destroyed through {@link BeanContext#destroyBean(Object)} or when the context itself is closed.</p>
+         *
+         * <p>A definition built with a disposer is a {@link io.micronaut.inject.DisposableBeanDefinition}; a
+         * definition built without one is not, so existing definitions keep their current behaviour.</p>
+         *
+         * @param disposer The disposer, receiving the bean context and the instance being destroyed, or {@code null}
+         *                 to clear a previously set disposer
+         * @return This builder
+         * @since 5.2.0
+         */
+        Builder<B> disposer(@Nullable BiConsumer<BeanContext, B> disposer);
 
         /**
          * Builds the runtime bean.


### PR DESCRIPTION
## The need

`RuntimeBeanDefinition.Builder` lets a framework build a bean at runtime with a qualifier, scope, singleton flag, exposed types, type arguments, annotation metadata and a replacement target, but it has no way to say what disposes of an instance. `DefaultRuntimeBeanDefinition` is not a `DisposableBeanDefinition`, so the context has no hook to call when such a bean is destroyed.

Jakarta CDI's build-compatible extensions describe synthetic beans that carry a disposal function alongside their creation function (section 2.10.5). A CDI implementation on top of Micronaut builds those beans as runtime bean definitions and today has to run the disposal function from a JVM-wide `BeanPreDestroyEventListener<Object>` combined with an identity map from instance back to the synthetic bean, because the definition itself cannot be asked to dispose of what it created. That listener runs for every bean destroyed in the context, only to find that almost none of them are synthetic.

## The API

```java
RuntimeBeanDefinition.builder(Connection.class, () -> pool.open())
    .singleton(true)
    .disposer((context, connection) -> pool.release(connection))
    .build();
```

`Builder<B> disposer(@Nullable BiConsumer<BeanContext, B> disposer)` (`@since 5.2.0`) records what disposes of an instance. The definition returned by `build()` then implements `DisposableBeanDefinition<B>`, and the context runs the disposer once per instance from the same place it runs `@PreDestroy` hooks: after the `BeanPreDestroyEventListener` instances, before the `BeanDestroyedEventListener` instances, whether the instance goes through `BeanRegistration.close()`, `BeanContext.destroyBean(instance)` or `BeanContext.close()`.

The disposer receives the `BeanContext` and the instance, not a `BeanResolutionContext`, mirroring the simpler `DisposableBeanDefinition.dispose(BeanContext, T)`. A runtime built bean has no injection points or lifecycle advice of its own, so there is nothing a resolution context could carry into its disposal; the built definition overrides `dispose(BeanContext, T)` directly and skips creating the throwaway `DefaultBeanResolutionContext` the interface's default would allocate.

## What does not change

Only a definition built with a disposer is a `DisposableBeanDefinition`. It is a dedicated subclass, `DefaultRuntimeBeanDefinition.Disposable`, the sole permitted subclass of the now sealed `DefaultRuntimeBeanDefinition`. A definition built without a disposer is exactly the class it was before, so:

- `DefaultBeanContext.destroyBean` still skips the dispose step for it (`definition instanceof DisposableBeanDefinition` stays false);
- `BeanDefinitionDelegate.create` still wraps it in a plain delegate, not a `LifeCycleDelegate`;
- container elements resolved through `getBeanRegistrations` still get the no-op registration rather than a disposing one;
- the package-private constructor `DefaultBeanContext` uses to expose itself as a bean is untouched.

`RuntimeBeanDefinition` is `@Experimental`; the new builder method is abstract like the other builder methods added since 3.6.0, and `RuntimeBeanBuilder` is its only implementation in core.

## Tests

`inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionDisposerSpec.groovy` covers:

- a definition built without a disposer is not a `DisposableBeanDefinition`; one built with a disposer is, and keeps its other builder configuration (qualifier, exposed types, singleton flag);
- a `@Prototype` definition: `getBeanRegistration` then `close()` runs the disposer exactly once with the context and the instance, and a second `close()` does not run it again;
- a singleton definition: `context.close()` runs the disposer once;
- `context.destroyBean(instance)` runs the disposer once and a later `context.close()` does not run it again;
- the resolution-context factory overload composes with a disposer.

Before the change the six features that call `disposer(...)` fail with `MissingMethodException` at run time (Groovy binds the call dynamically, so the missing API surfaces when the feature runs rather than at compilation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
