### PR TITLE
Control the order in which singletons are destroyed

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -29,6 +29,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Indexed;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NextMajorVersion;
+import io.micronaut.core.annotation.Order;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.processing.definition.ElementBeanDefinitionBuilder;
@@ -638,6 +639,11 @@ sealed class DeclaredBeanElementCreator<R> extends AbstractBeanElementCreator<R>
 
         ClassElement finalInterfaceToAdapt1 = interfaceToAdapt;
         interfaceToAdapt.annotate(Indexed.class, builder -> builder.member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(finalInterfaceToAdapt1.getName())));
+
+        // The adapter is a bean of its own, so an @Order declared on the adapted method (which wins over one declared
+        // on the class) has to be carried over for the adapter to be ordered, e.g. among event listeners
+        methodAnnotationMetadata.intValue(Order.class)
+            .ifPresent(order -> finalInterfaceToAdapt1.annotate(Order.class, builder -> builder.value(order)));
 
         MutableAnnotationMetadata proxyAnnotationMetadata = MutableAnnotationMetadata.of(
             new AnnotationMetadataHierarchy(classElement, interfaceToAdapt)

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/destroyorder/BeanDestructionOrderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/destroyorder/BeanDestructionOrderSpec.groovy
@@ -1,0 +1,286 @@
+package io.micronaut.inject.lifecycle.destroyorder
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.core.annotation.Order
+
+/**
+ * The order in which singletons are destroyed when the context is closed.
+ */
+class BeanDestructionOrderSpec extends AbstractTypeElementSpec {
+
+    static final String HEADER = '''
+package test;
+
+import io.micronaut.context.BeanProvider;
+import io.micronaut.context.event.ShutdownEvent;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.runtime.event.annotation.EventListener;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+class Log {
+    static final List<String> EVENTS = new CopyOnWriteArrayList<>();
+    static void add(String event) { EVENTS.add(event); }
+}
+'''
+
+    void "field injected dependency #dependency outlives dependent #dependent"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + """
+@Singleton
+class $dependent {
+    @Inject $dependency dependency;
+    @PreDestroy void close() { Log.add("dependent"); }
+}
+@Singleton
+class $dependency {
+    @PreDestroy void close() { Log.add("dependency"); }
+}
+""")
+        def log = ctx.classLoader.loadClass('test.Log')
+        ctx.getBean(ctx.classLoader.loadClass("test.$dependency"))
+        ctx.getBean(ctx.classLoader.loadClass("test.$dependent"))
+
+        expect:
+        ctx.getBeanDefinition(ctx.classLoader.loadClass("test.$dependent")).requiredComponents == [ctx.classLoader.loadClass("test.$dependency")] as Set
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS == ['dependent', 'dependency']
+
+        where:
+        dependent  | dependency
+        'Consumer' | 'Producer'
+        'Producer' | 'Consumer'
+        'Alpha'    | 'Beta'
+        'Beta'     | 'Alpha'
+    }
+
+    void "@Value fields are not dependencies"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+@Singleton
+class Configured {
+    @io.micronaut.context.annotation.Value("${foo.bar:default}") String value;
+    @Inject Dependency dependency;
+}
+@Singleton
+class Dependency {
+}
+''')
+
+        expect:
+        ctx.getBeanDefinition(ctx.classLoader.loadClass("test.Configured")).requiredComponents == [ctx.classLoader.loadClass("test.Dependency")] as Set
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "constructor and method injected dependencies outlive dependents"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+@Singleton
+class Service {
+    Service(Repository repository) {}
+    @Inject void setCache(Cache cache) {}
+    @PreDestroy void close() { Log.add("service"); }
+}
+@Singleton
+class Repository {
+    Repository(DataSource dataSource) {}
+    @PreDestroy void close() { Log.add("repository"); }
+}
+@Singleton
+class Cache {
+    @PreDestroy void close() { Log.add("cache"); }
+}
+@Singleton
+class DataSource {
+    @PreDestroy void close() { Log.add("dataSource"); }
+}
+''')
+        def log = ctx.classLoader.loadClass('test.Log')
+        ['DataSource', 'Cache', 'Repository', 'Service'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS.indexOf('service') < log.EVENTS.indexOf('repository')
+        log.EVENTS.indexOf('service') < log.EVENTS.indexOf('cache')
+        log.EVENTS.indexOf('repository') < log.EVENTS.indexOf('dataSource')
+    }
+
+    void "@Order controls the destruction order of independent beans, lowest first"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+@Singleton @Order(30)
+class Producer {
+    @PreDestroy void close() { Log.add("producer"); }
+}
+@Singleton @Order(10)
+class Consumer {
+    @PreDestroy void close() { Log.add("consumer"); }
+}
+@Singleton @Order(20)
+class Dao {
+    @PreDestroy void close() { Log.add("dao"); }
+}
+@Singleton @Order(-5)
+class Cache {
+    @PreDestroy void close() { Log.add("cache"); }
+}
+@Singleton
+class Unordered {
+    @PreDestroy void close() { Log.add("unordered"); }
+}
+''')
+        def log = ctx.classLoader.loadClass('test.Log')
+        ['Producer', 'Unordered', 'Dao', 'Cache', 'Consumer'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS == ['cache', 'unordered', 'consumer', 'dao', 'producer']
+    }
+
+    void "Ordered interface controls the destruction order of independent beans"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+@Singleton
+class Second implements Ordered {
+    public int getOrder() { return 2; }
+    @PreDestroy void close() { Log.add("second"); }
+}
+@Singleton
+class First implements Ordered {
+    public int getOrder() { return 1; }
+    @PreDestroy void close() { Log.add("first"); }
+}
+@Singleton
+class Third implements Ordered {
+    public int getOrder() { return 3; }
+    @PreDestroy void close() { Log.add("third"); }
+}
+''')
+        def log = ctx.classLoader.loadClass('test.Log')
+        ['Third', 'First', 'Second'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS == ['first', 'second', 'third']
+    }
+
+    void "dependencies take precedence over @Order"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+@Singleton @Order(1)
+class Producer {
+    @PreDestroy void close() { Log.add("producer"); }
+}
+@Singleton @Order(2)
+class Consumer {
+    Consumer(Producer producer) {}
+    @PreDestroy void close() { Log.add("consumer"); }
+}
+@Singleton @Order(3)
+class Other {
+    @PreDestroy void close() { Log.add("other"); }
+}
+''')
+        def log = ctx.classLoader.loadClass('test.Log')
+        ['Producer', 'Consumer', 'Other'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS == ['consumer', 'producer', 'other']
+    }
+
+    void "beans of equal precedence are destroyed in a stable order"() {
+        given:
+        def source = new StringBuilder(HEADER)
+        def names = (0..<12).collect { "Bean${String.format('%02d', it)}" }
+        names.each { name ->
+            source << """
+@Singleton
+class $name {
+    @PreDestroy void close() { Log.add("$name"); }
+}
+"""
+        }
+        ApplicationContext ctx = buildContext(source.toString())
+        def log = ctx.classLoader.loadClass('test.Log')
+        names.reverse().each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS == names
+    }
+
+    void "a dependency cycle is destroyed starting with the highest precedence bean"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+@Singleton @Order(2)
+class A {
+    A(BeanProvider<B> b) {}
+    @PreDestroy void close() { Log.add("a"); }
+}
+@Singleton @Order(1)
+class B {
+    B(BeanProvider<A> a) {}
+    @PreDestroy void close() { Log.add("b"); }
+}
+''')
+        def log = ctx.classLoader.loadClass('test.Log')
+        ['A', 'B'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS == ['b', 'a']
+    }
+
+    void "@Order on @EventListener methods orders ShutdownEvent listeners"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+@Singleton
+class Hooks {
+    @Order(3) @EventListener void closeProducer(ShutdownEvent event) { Log.add("producer"); }
+    @Order(1) @EventListener void stopConsumer(ShutdownEvent event) { Log.add("consumer"); }
+    @Order(2) @EventListener void flushDao(ShutdownEvent event) { Log.add("dao"); }
+}
+@Singleton @Order(10)
+class ClassOrdered {
+    @EventListener void onShutdown(ShutdownEvent event) { Log.add("classOrdered"); }
+    @Order(0) @EventListener void methodOverridesClass(ShutdownEvent event) { Log.add("methodOverridesClass"); }
+}
+''')
+        def log = ctx.classLoader.loadClass('test.Log')
+        ['Hooks', 'ClassOrdered'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
+
+        expect:
+        ctx.getBeanDefinitions(ApplicationEventListener).collect { it.intValue(Order).orElse(0) }.sort() == [0, 1, 2, 3, 10]
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS == ['methodOverridesClass', 'consumer', 'dao', 'producer', 'classOrdered']
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/destroyorder/BeanDestructionOrderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/destroyorder/BeanDestructionOrderSpec.groovy
@@ -3,10 +3,11 @@ package io.micronaut.inject.lifecycle.destroyorder
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.context.exceptions.BeanInstantiationException
 import io.micronaut.core.annotation.Order
 
 /**
- * The order in which singletons are destroyed when the context is closed.
+ * The order in which singletons are created and destroyed.
  */
 class BeanDestructionOrderSpec extends AbstractTypeElementSpec {
 
@@ -14,9 +15,11 @@ class BeanDestructionOrderSpec extends AbstractTypeElementSpec {
 package test;
 
 import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.DependsOn;
+import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.event.ShutdownEvent;
 import io.micronaut.core.annotation.Order;
-import io.micronaut.core.order.Ordered;
 import io.micronaut.runtime.event.annotation.EventListener;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
@@ -119,97 +122,134 @@ class DataSource {
         log.EVENTS.indexOf('repository') < log.EVENTS.indexOf('dataSource')
     }
 
-    void "@Order controls the destruction order of independent beans, lowest first"() {
+    void "@DependsOn creates the dependency first and destroys it last"() {
         given:
         ApplicationContext ctx = buildContext(HEADER + '''
-@Singleton @Order(30)
-class Producer {
-    @PreDestroy void close() { Log.add("producer"); }
-}
-@Singleton @Order(10)
+@Singleton
+@DependsOn(Producer.class)
 class Consumer {
-    @PreDestroy void close() { Log.add("consumer"); }
-}
-@Singleton @Order(20)
-class Dao {
-    @PreDestroy void close() { Log.add("dao"); }
-}
-@Singleton @Order(-5)
-class Cache {
-    @PreDestroy void close() { Log.add("cache"); }
+    Consumer() { Log.add("consumer created"); }
+    @PreDestroy void close() { Log.add("consumer destroyed"); }
 }
 @Singleton
-class Unordered {
-    @PreDestroy void close() { Log.add("unordered"); }
-}
-''')
-        def log = ctx.classLoader.loadClass('test.Log')
-        ['Producer', 'Unordered', 'Dao', 'Cache', 'Consumer'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
-
-        when:
-        ctx.close()
-
-        then:
-        log.EVENTS == ['cache', 'unordered', 'consumer', 'dao', 'producer']
-    }
-
-    void "Ordered interface controls the destruction order of independent beans"() {
-        given:
-        ApplicationContext ctx = buildContext(HEADER + '''
-@Singleton
-class Second implements Ordered {
-    public int getOrder() { return 2; }
-    @PreDestroy void close() { Log.add("second"); }
-}
-@Singleton
-class First implements Ordered {
-    public int getOrder() { return 1; }
-    @PreDestroy void close() { Log.add("first"); }
-}
-@Singleton
-class Third implements Ordered {
-    public int getOrder() { return 3; }
-    @PreDestroy void close() { Log.add("third"); }
-}
-''')
-        def log = ctx.classLoader.loadClass('test.Log')
-        ['Third', 'First', 'Second'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
-
-        when:
-        ctx.close()
-
-        then:
-        log.EVENTS == ['first', 'second', 'third']
-    }
-
-    void "dependencies take precedence over @Order"() {
-        given:
-        ApplicationContext ctx = buildContext(HEADER + '''
-@Singleton @Order(1)
 class Producer {
-    @PreDestroy void close() { Log.add("producer"); }
-}
-@Singleton @Order(2)
-class Consumer {
-    Consumer(Producer producer) {}
-    @PreDestroy void close() { Log.add("consumer"); }
-}
-@Singleton @Order(3)
-class Other {
-    @PreDestroy void close() { Log.add("other"); }
+    Producer() { Log.add("producer created"); }
+    @PreDestroy void close() { Log.add("producer destroyed"); }
 }
 ''')
         def log = ctx.classLoader.loadClass('test.Log')
-        ['Producer', 'Consumer', 'Other'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
+        def consumer = ctx.classLoader.loadClass("test.Consumer")
+        def producer = ctx.classLoader.loadClass("test.Producer")
+
+        when:
+        ctx.getBean(consumer)
+
+        then:
+        ctx.getBeanDefinition(consumer).requiredComponents == [producer] as Set
+        log.EVENTS == ['producer created', 'consumer created']
 
         when:
         ctx.close()
 
         then:
-        log.EVENTS == ['consumer', 'producer', 'other']
+        log.EVENTS == ['producer created', 'consumer created', 'consumer destroyed', 'producer destroyed']
     }
 
-    void "beans of equal precedence are destroyed in a stable order"() {
+    void "@DependsOn on an interface applies to every implementation"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+interface Channel {}
+@Singleton
+@DependsOn(Channel.class)
+class Consumer {
+    Consumer() { Log.add("consumer created"); }
+    @PreDestroy void close() { Log.add("consumer destroyed"); }
+}
+@Singleton
+class TopicChannel implements Channel {
+    TopicChannel() { Log.add("topic created"); }
+    @PreDestroy void close() { Log.add("topic destroyed"); }
+}
+@Singleton
+class QueueChannel implements Channel {
+    QueueChannel() { Log.add("queue created"); }
+    @PreDestroy void close() { Log.add("queue destroyed"); }
+}
+''')
+        def log = ctx.classLoader.loadClass('test.Log')
+
+        when:
+        ctx.getBean(ctx.classLoader.loadClass("test.Consumer"))
+
+        then:
+        log.EVENTS.indexOf('consumer created') == 2
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS.indexOf('consumer destroyed') == 3
+        log.EVENTS.indexOf('topic destroyed') > 3
+        log.EVENTS.indexOf('queue destroyed') > 3
+    }
+
+    void "@DependsOn on a factory method"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+class Consumer {
+    Consumer() { Log.add("consumer created"); }
+    void stop() { Log.add("consumer destroyed"); }
+}
+@Factory
+class ConsumerFactory {
+    @Singleton
+    @Bean(preDestroy = "stop")
+    @DependsOn(Producer.class)
+    Consumer consumer() { return new Consumer(); }
+}
+@Singleton
+class Producer {
+    Producer() { Log.add("producer created"); }
+    @PreDestroy void close() { Log.add("producer destroyed"); }
+}
+''')
+        def log = ctx.classLoader.loadClass('test.Log')
+
+        when:
+        ctx.getBean(ctx.classLoader.loadClass("test.Consumer"))
+
+        then:
+        log.EVENTS == ['producer created', 'consumer created']
+
+        when:
+        ctx.close()
+
+        then:
+        log.EVENTS == ['producer created', 'consumer created', 'consumer destroyed', 'producer destroyed']
+    }
+
+    void "@DependsOn on a type with no bean fails"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+interface Missing {}
+@Singleton
+@DependsOn(Missing.class)
+class Consumer {
+}
+''')
+
+        when:
+        ctx.getBean(ctx.classLoader.loadClass("test.Consumer"))
+
+        then:
+        def e = thrown(BeanInstantiationException)
+        e.message.contains('depends on [test.Missing] but no bean of that type exists')
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "beans without dependencies are destroyed in a stable order"() {
         given:
         def source = new StringBuilder(HEADER)
         def names = (0..<12).collect { "Bean${String.format('%02d', it)}" }
@@ -232,15 +272,15 @@ class $name {
         log.EVENTS == names
     }
 
-    void "a dependency cycle is destroyed starting with the highest precedence bean"() {
+    void "a dependency cycle is still destroyed"() {
         given:
         ApplicationContext ctx = buildContext(HEADER + '''
-@Singleton @Order(2)
+@Singleton
 class A {
     A(BeanProvider<B> b) {}
     @PreDestroy void close() { Log.add("a"); }
 }
-@Singleton @Order(1)
+@Singleton
 class B {
     B(BeanProvider<A> a) {}
     @PreDestroy void close() { Log.add("b"); }
@@ -253,7 +293,7 @@ class B {
         ctx.close()
 
         then:
-        log.EVENTS == ['b', 'a']
+        log.EVENTS == ['a', 'b']
     }
 
     void "@Order on @EventListener methods orders ShutdownEvent listeners"() {

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -488,7 +488,8 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
         }
         if (fieldInjection != null) {
             for (FieldReference fieldReference : fieldInjection) {
-                if (annotationMetadata != null && annotationMetadata.hasDeclaredAnnotation(AnnotationUtil.INJECT)) {
+                // Only injected fields are dependencies. @Value and @Property fields are also recorded here.
+                if (fieldReference.argument.getAnnotationMetadata().hasAnnotation(AnnotationUtil.INJECT)) {
                     argumentConsumer.accept(fieldReference.argument);
                 }
             }

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -17,6 +17,7 @@ package io.micronaut.context;
 
 import io.micronaut.context.DefaultBeanContext.ListenersSupplier;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.DependsOn;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Property;
@@ -500,6 +501,9 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
                     argumentConsumer.accept(annotationReference.argument);
                 }
             }
+        }
+        if (annotationMetadata != null) {
+            Collections.addAll(requiredComponents, annotationMetadata.classValues(DependsOn.class));
         }
         this.requiredComponents = Collections.unmodifiableSet(requiredComponents);
         return this.requiredComponents;

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -129,6 +129,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -3404,70 +3405,88 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         return false;
     }
 
-    private static <T> List<T> nullSafe(@Nullable List<T> list) {
-        if (list == null) {
-            return Collections.emptyList();
-        }
-        return list;
-    }
-
+    /**
+     * Sorts the singleton registrations into the order in which they should be destroyed.
+     *
+     * <p>A bean is destroyed before every bean it requires, so that a dependency outlives its dependents. Where the
+     * dependencies leave the order open, beans with a lower {@link io.micronaut.core.annotation.Order} value (or
+     * {@link io.micronaut.core.order.Ordered#getOrder()}) are destroyed first, and beans of equal precedence are
+     * destroyed in bean name order so that the sequence is stable between runs. Dependency cycles are broken by
+     * destroying the highest precedence bean of the cycle first.</p>
+     *
+     * @param beans The registrations
+     * @return The registrations in destruction order
+     */
     private List<BeanRegistration> topologicalSort(Collection<BeanRegistration> beans) {
-        Map<Boolean, List<BeanRegistration>> initial = beans.stream()
-            .sorted(Comparator.comparing(s -> s.getBeanDefinition().getRequiredComponents().size()))
-            .collect(Collectors.groupingBy(b -> b.getBeanDefinition().getRequiredComponents().isEmpty()));
-        List<BeanRegistration> sorted = new ArrayList<>(nullSafe(initial.get(true)));
-        List<BeanRegistration> unsorted = new ArrayList<>(nullSafe(initial.get(false)));
-        // Optimization which knows about types which are already in the sorted list
-        Set<Class<?>> satisfied = new HashSet<>();
+        final int size = beans.size();
+        // The index of a node is its precedence: lower @Order first, then bean name so the order is deterministic
+        final List<BeanRegistration> nodes = new ArrayList<>(beans);
+        nodes.sort(Comparator.<BeanRegistration>comparingInt(registration -> registration.getOrder())
+            .thenComparing(registration -> registration.getBeanDefinition().getName()));
 
-        // Optimization for types which we know are already unsatisified
-        // in a single iteration, allowing to skip the loop on unsorted elements
-        Set<Class<?>> unsatisfied = new HashSet<>();
-
-        //loop until all items have been sorted
-        while (!unsorted.isEmpty()) {
-            boolean acyclic = false;
-
-            unsatisfied.clear();
-            Iterator<BeanRegistration> i = unsorted.iterator();
-            while (i.hasNext()) {
-                BeanRegistration bean = i.next();
-                boolean found = false;
-
-                //determine if any components are in the unsorted list
-                Collection<Class<?>> components = bean.getBeanDefinition().getRequiredComponents();
-                for (Class<?> clazz : components) {
-                    if (satisfied.contains(clazz)) {
-                        continue;
-                    }
-                    if (unsatisfied.contains(clazz) || unsorted.stream()
-                        .map(BeanRegistration::getBeanDefinition)
-                        .map(BeanDefinition::getBeanType)
-                        .anyMatch(clazz::isAssignableFrom)) {
-                        found = true;
-                        unsatisfied.add(clazz);
-                        break;
-                    }
-                    satisfied.add(clazz);
-                }
-
-                //none of the required components are in the unsorted list,
-                //so it can be added to the sorted list
-                if (!found) {
-                    acyclic = true;
-                    i.remove();
-                    sorted.add(0, bean);
-                }
-            }
-
-            //rather than throw an exception here because there is a cyclical dependency
-            //just add the first item to the list and keep trying. It may be possible to
-            //see a cycle here because qualifiers are not taken into account.
-            if (!acyclic) {
-                sorted.add(0, unsorted.remove(0));
-            }
+        final Map<Class<?>, List<Integer>> nodesByType = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            nodesByType.computeIfAbsent(nodes.get(i).getBeanDefinition().getBeanType(), type -> new ArrayList<>(1)).add(i);
         }
 
+        // qualifiers are not taken into account, so every singleton assignable to a required type is a candidate
+        final Map<Class<?>, List<Integer>> candidatesByRequiredType = new HashMap<>();
+        // dependencies[i] holds the nodes that node i requires; each of them must be destroyed after node i
+        final List<List<Integer>> dependencies = new ArrayList<>(size);
+        final int[] dependents = new int[size];
+        for (int i = 0; i < size; i++) {
+            final Collection<Class<?>> required = nodes.get(i).getBeanDefinition().getRequiredComponents();
+            final List<Integer> nodeDependencies = new ArrayList<>(required.size());
+            for (Class<?> requiredType : required) {
+                final List<Integer> candidates = candidatesByRequiredType.computeIfAbsent(requiredType, type -> {
+                    final List<Integer> assignable = new ArrayList<>();
+                    for (Map.Entry<Class<?>, List<Integer>> entry : nodesByType.entrySet()) {
+                        if (type.isAssignableFrom(entry.getKey())) {
+                            assignable.addAll(entry.getValue());
+                        }
+                    }
+                    return assignable;
+                });
+                for (int j : candidates) {
+                    if (j != i && !nodeDependencies.contains(j)) {
+                        nodeDependencies.add(j);
+                        dependents[j]++;
+                    }
+                }
+            }
+            dependencies.add(nodeDependencies);
+        }
+
+        // Kahn's algorithm: repeatedly destroy the highest precedence bean that no remaining bean requires
+        final List<BeanRegistration> sorted = new ArrayList<>(size);
+        final boolean[] destroyed = new boolean[size];
+        final PriorityQueue<Integer> ready = new PriorityQueue<>(Math.max(1, size));
+        for (int i = 0; i < size; i++) {
+            if (dependents[i] == 0) {
+                ready.add(i);
+            }
+        }
+        int nextCycleCandidate = 0;
+        while (sorted.size() < size) {
+            if (ready.isEmpty()) {
+                // every remaining bean is part of a dependency cycle, break it at the highest precedence bean
+                while (destroyed[nextCycleCandidate]) {
+                    nextCycleCandidate++;
+                }
+                ready.add(nextCycleCandidate);
+            }
+            final int i = ready.poll();
+            if (destroyed[i]) {
+                continue;
+            }
+            destroyed[i] = true;
+            sorted.add(nodes.get(i));
+            for (int j : dependencies.get(i)) {
+                if (--dependents[j] == 0 && !destroyed[j]) {
+                    ready.add(j);
+                }
+            }
+        }
         return sorted;
     }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -17,6 +17,7 @@ package io.micronaut.context;
 
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.DependsOn;
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.context.annotation.Parallel;
 import io.micronaut.context.annotation.Primary;
@@ -2161,6 +2162,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         Qualifier<?> prevQualifier = resolutionContext.getCurrentQualifier();
         try {
             resolutionContext.setCurrentQualifier(declaredQualifier != null && !AnyQualifier.INSTANCE.equals(declaredQualifier) ? declaredQualifier : qualifier);
+            createDependsOnBeans(resolutionContext, beanDefinition);
             T bean;
             if (beanDefinition instanceof ParametrizedInstantiatableBeanDefinition<T> parametrizedInstantiatableBeanDefinition) {
                 Argument<Object>[] requiredArguments = parametrizedInstantiatableBeanDefinition.getRequiredArguments();
@@ -2188,6 +2190,24 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             throw new BeanInstantiationException(beanDefinition, e);
         } finally {
             resolutionContext.setCurrentQualifier(prevQualifier);
+        }
+    }
+
+    /**
+     * Creates the beans a definition declares with {@link DependsOn} so that they exist before the bean is
+     * instantiated. Being required components they are also destroyed after the bean.
+     *
+     * @param resolutionContext The resolution context
+     * @param beanDefinition    The definition about to be instantiated
+     */
+    private void createDependsOnBeans(BeanResolutionContext resolutionContext, BeanDefinition<?> beanDefinition) {
+        if (!beanDefinition.hasAnnotation(DependsOn.class)) {
+            return;
+        }
+        for (Class<?> dependency : beanDefinition.classValues(DependsOn.class)) {
+            if (getBeansOfType(resolutionContext, Argument.of(dependency)).isEmpty()) {
+                throw new BeanInstantiationException(resolutionContext, "Bean [" + beanDefinition.getName() + "] depends on [" + dependency.getName() + "] but no bean of that type exists");
+            }
         }
     }
 
@@ -3408,21 +3428,19 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     /**
      * Sorts the singleton registrations into the order in which they should be destroyed.
      *
-     * <p>A bean is destroyed before every bean it requires, so that a dependency outlives its dependents. Where the
-     * dependencies leave the order open, beans with a lower {@link io.micronaut.core.annotation.Order} value (or
-     * {@link io.micronaut.core.order.Ordered#getOrder()}) are destroyed first, and beans of equal precedence are
-     * destroyed in bean name order so that the sequence is stable between runs. Dependency cycles are broken by
-     * destroying the highest precedence bean of the cycle first.</p>
+     * <p>A bean is destroyed before every bean it requires, whether the requirement comes from an injection point or
+     * from {@link DependsOn}, so that a dependency outlives its dependents. Where the dependencies leave the order
+     * open, beans are destroyed in bean name order so that the sequence is stable between runs. Dependency cycles are
+     * broken by destroying the first bean of the cycle in that order.</p>
      *
      * @param beans The registrations
      * @return The registrations in destruction order
      */
     private List<BeanRegistration> topologicalSort(Collection<BeanRegistration> beans) {
         final int size = beans.size();
-        // The index of a node is its precedence: lower @Order first, then bean name so the order is deterministic
+        // Nodes are indexed in bean name order so that the destruction sequence is deterministic
         final List<BeanRegistration> nodes = new ArrayList<>(beans);
-        nodes.sort(Comparator.<BeanRegistration>comparingInt(registration -> registration.getOrder())
-            .thenComparing(registration -> registration.getBeanDefinition().getName()));
+        nodes.sort(Comparator.comparing(registration -> registration.getBeanDefinition().getName()));
 
         final Map<Class<?>, List<Integer>> nodesByType = new HashMap<>(size);
         for (int i = 0; i < size; i++) {
@@ -3457,7 +3475,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             dependencies.add(nodeDependencies);
         }
 
-        // Kahn's algorithm: repeatedly destroy the highest precedence bean that no remaining bean requires
+        // Kahn's algorithm: repeatedly destroy the first bean that no remaining bean requires
         final List<BeanRegistration> sorted = new ArrayList<>(size);
         final boolean[] destroyed = new boolean[size];
         final PriorityQueue<Integer> ready = new PriorityQueue<>(Math.max(1, size));
@@ -3469,7 +3487,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         int nextCycleCandidate = 0;
         while (sorted.size() < size) {
             if (ready.isEmpty()) {
-                // every remaining bean is part of a dependency cycle, break it at the highest precedence bean
+                // every remaining bean is part of a dependency cycle, break it at the first bean
                 while (destroyed[nextCycleCandidate]) {
                     nextCycleCandidate++;
                 }

--- a/inject/src/main/java/io/micronaut/context/annotation/DependsOn.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/DependsOn.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Declares that a bean depends on the beans of the given types without injecting them.
+ *
+ * <p>Every bean of each listed type is created before the annotated bean is instantiated and, for singletons,
+ * destroyed after the annotated bean has been destroyed. The annotation therefore controls both the creation and
+ * the destruction order, which is otherwise only derived from the injection points of a bean. A bean that must
+ * stop consuming messages before the publisher it feeds is closed can express that as:</p>
+ *
+ * <pre class="code">
+ * &#064;Singleton
+ * &#064;DependsOn(MessagePublisher.class)
+ * class MessageConsumer {
+ *
+ *     &#064;PreDestroy
+ *     void stop() {
+ *         // the publisher is still open here
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>The annotation is an error when no bean of a listed type exists.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.2.0
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface DependsOn {
+
+    /**
+     * The types of the beans this bean depends on.
+     *
+     * @return The bean types
+     */
+    Class<?>[] value();
+}

--- a/src/main/docs/guide/ioc/lifecycle.adoc
+++ b/src/main/docs/guide/ioc/lifecycle.adoc
@@ -36,37 +36,17 @@ NOTE: Simply implementing the `Closeable` or `AutoCloseable` interface is not en
 
 When the context is closed, singletons are destroyed in dependency order: a bean is always destroyed before the beans injected into it, whether they were injected through the constructor, a method or a field. This lets a bean use its dependencies from its `@PreDestroy` method.
 
-Where the dependencies leave the order open, annotate the beans with ann:core.annotation.Order[] or implement api:core.order.Ordered[]. Beans with a lower value are destroyed first, so a consumer that should stop reading before the producer it feeds is closed can be declared as:
+Beans that are not injected into each other but still have to be created and destroyed in a particular order can declare the dependency with ann:context.annotation.DependsOn[]. The annotated bean is created after, and destroyed before, every bean of the listed types:
 
-[source,java]
-----
-@Singleton
-@Order(1) // <1>
-class MessageConsumer {
+snippet::io.micronaut.docs.lifecycle.MessageConsumer,io.micronaut.docs.lifecycle.MessagePublisher[tags="class", indent=0]
 
-    @PreDestroy
-    void stop() {
-        // stop consuming and flush pending messages
-    }
-}
+<1> The consumer depends on the publisher without injecting it
+<2> The consumer stops while the publisher is still open, so it can publish the messages it has in flight
+<3> The publisher is closed once the consumer has stopped
 
-@Singleton
-@Order(2) // <2>
-class MessagePublisher {
+The annotation also works on factory methods and accepts interfaces, in which case every bean implementing the interface is created before and destroyed after the annotated bean. Beans not connected by any dependency are destroyed in bean name order, so the destruction sequence is the same from run to run.
 
-    @PreDestroy
-    void close() {
-        // close the connection
-    }
-}
-----
-
-<1> The consumer has the lowest value and is destroyed first
-<2> The publisher is destroyed once the consumer has stopped
-
-A dependency always outlives its dependents, regardless of the `@Order` values. Beans of equal precedence are destroyed in bean name order, so the destruction sequence is the same from run to run.
-
-TIP: Shutdown logic that spans several beans can also be placed in ann:runtime.event.annotation.EventListener[] methods for api:context.event.ShutdownEvent[], which is published before any bean is destroyed. Such methods can be ordered with ann:core.annotation.Order[] as well.
+TIP: Shutdown logic that spans several beans can also be placed in ann:runtime.event.annotation.EventListener[] methods for api:context.event.ShutdownEvent[], which is published before any bean is destroyed. Such methods can be ordered with ann:core.annotation.Order[].
 
 == Dependent Beans
 

--- a/src/main/docs/guide/ioc/lifecycle.adoc
+++ b/src/main/docs/guide/ioc/lifecycle.adoc
@@ -32,6 +32,42 @@ snippet::io.micronaut.docs.lifecycle.Connection[tags="class", indent=0]
 
 NOTE: Simply implementing the `Closeable` or `AutoCloseable` interface is not enough for a bean to be closed with the context. One of the above methods must be used.
 
+=== Destruction Order
+
+When the context is closed, singletons are destroyed in dependency order: a bean is always destroyed before the beans injected into it, whether they were injected through the constructor, a method or a field. This lets a bean use its dependencies from its `@PreDestroy` method.
+
+Where the dependencies leave the order open, annotate the beans with ann:core.annotation.Order[] or implement api:core.order.Ordered[]. Beans with a lower value are destroyed first, so a consumer that should stop reading before the producer it feeds is closed can be declared as:
+
+[source,java]
+----
+@Singleton
+@Order(1) // <1>
+class MessageConsumer {
+
+    @PreDestroy
+    void stop() {
+        // stop consuming and flush pending messages
+    }
+}
+
+@Singleton
+@Order(2) // <2>
+class MessagePublisher {
+
+    @PreDestroy
+    void close() {
+        // close the connection
+    }
+}
+----
+
+<1> The consumer has the lowest value and is destroyed first
+<2> The publisher is destroyed once the consumer has stopped
+
+A dependency always outlives its dependents, regardless of the `@Order` values. Beans of equal precedence are destroyed in bean name order, so the destruction sequence is the same from run to run.
+
+TIP: Shutdown logic that spans several beans can also be placed in ann:runtime.event.annotation.EventListener[] methods for api:context.event.ShutdownEvent[], which is published before any bean is destroyed. Such methods can be ordered with ann:core.annotation.Order[] as well.
+
 == Dependent Beans
 
 Dependent beans are the beans used in the construction of your bean.

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/DependsOnSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/DependsOnSpec.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class DependsOnSpec extends Specification {
+
+    void "test @DependsOn orders creation and destruction"() {
+        given:
+        ShutdownLog.clear()
+        ApplicationContext ctx = ApplicationContext.run()
+
+        when:
+        ctx.getBean(MessageConsumer)
+
+        then:
+        ShutdownLog.events() == ["publisher created", "consumer created"]
+
+        when:
+        ctx.stop()
+
+        then:
+        ShutdownLog.events() == ["publisher created", "consumer created", "consumer stopped", "publisher closed"]
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/MessageConsumer.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/MessageConsumer.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+// tag::class[]
+import io.micronaut.context.annotation.DependsOn
+import jakarta.annotation.PreDestroy
+import jakarta.inject.Singleton
+
+@Singleton
+@DependsOn(MessagePublisher) // <1>
+class MessageConsumer {
+
+    MessageConsumer() {
+        ShutdownLog.add("consumer created")
+    }
+
+    @PreDestroy
+    void stop() { // <2>
+        ShutdownLog.add("consumer stopped")
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/MessagePublisher.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/MessagePublisher.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+// tag::class[]
+import jakarta.annotation.PreDestroy
+import jakarta.inject.Singleton
+
+@Singleton
+class MessagePublisher {
+
+    MessagePublisher() {
+        ShutdownLog.add("publisher created")
+    }
+
+    @PreDestroy
+    void close() { // <3>
+        ShutdownLog.add("publisher closed")
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/ShutdownLog.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/ShutdownLog.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+final class ShutdownLog {
+
+    private static final List<String> EVENTS = new CopyOnWriteArrayList<>()
+
+    private ShutdownLog() {
+    }
+
+    static void add(String event) {
+        EVENTS.add(event)
+    }
+
+    static List<String> events() {
+        List.copyOf(EVENTS)
+    }
+
+    static void clear() {
+        EVENTS.clear()
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/DependsOnSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/DependsOnSpec.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.ApplicationContext
+
+class DependsOnSpec : StringSpec({
+
+    "test @DependsOn orders creation and destruction" {
+        ShutdownLog.clear()
+        val ctx = ApplicationContext.run()
+        ctx.getBean(MessageConsumer::class.java)
+
+        ShutdownLog.events() shouldBe listOf("publisher created", "consumer created")
+
+        ctx.stop()
+
+        ShutdownLog.events() shouldBe listOf("publisher created", "consumer created", "consumer stopped", "publisher closed")
+    }
+})

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/MessageConsumer.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/MessageConsumer.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+// tag::class[]
+import io.micronaut.context.annotation.DependsOn
+import jakarta.annotation.PreDestroy
+import jakarta.inject.Singleton
+
+@Singleton
+@DependsOn(MessagePublisher::class) // <1>
+class MessageConsumer {
+
+    init {
+        ShutdownLog.add("consumer created")
+    }
+
+    @PreDestroy
+    fun stop() { // <2>
+        ShutdownLog.add("consumer stopped")
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/MessagePublisher.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/MessagePublisher.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+// tag::class[]
+import jakarta.annotation.PreDestroy
+import jakarta.inject.Singleton
+
+@Singleton
+class MessagePublisher {
+
+    init {
+        ShutdownLog.add("publisher created")
+    }
+
+    @PreDestroy
+    fun close() { // <3>
+        ShutdownLog.add("publisher closed")
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/ShutdownLog.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/ShutdownLog.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+object ShutdownLog {
+
+    private val EVENTS = CopyOnWriteArrayList<String>()
+
+    fun add(event: String) {
+        EVENTS.add(event)
+    }
+
+    fun events(): List<String> = EVENTS.toList()
+
+    fun clear() {
+        EVENTS.clear()
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/lifecycle/DependsOnSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/lifecycle/DependsOnSpec.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DependsOnSpec {
+
+    @Test
+    void testDependsOnOrdersCreationAndDestruction() {
+        ShutdownLog.clear();
+        ApplicationContext ctx = ApplicationContext.run();
+        ctx.getBean(MessageConsumer.class);
+
+        assertEquals(List.of("publisher created", "consumer created"), ShutdownLog.events());
+
+        ctx.stop();
+
+        assertEquals(List.of("publisher created", "consumer created", "consumer stopped", "publisher closed"), ShutdownLog.events());
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/lifecycle/MessageConsumer.java
+++ b/test-suite/src/test/java/io/micronaut/docs/lifecycle/MessageConsumer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle;
+
+// tag::class[]
+import io.micronaut.context.annotation.DependsOn;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+@Singleton
+@DependsOn(MessagePublisher.class) // <1>
+public class MessageConsumer {
+
+    public MessageConsumer() {
+        ShutdownLog.add("consumer created");
+    }
+
+    @PreDestroy
+    void stop() { // <2>
+        ShutdownLog.add("consumer stopped");
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/lifecycle/MessagePublisher.java
+++ b/test-suite/src/test/java/io/micronaut/docs/lifecycle/MessagePublisher.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle;
+
+// tag::class[]
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class MessagePublisher {
+
+    public MessagePublisher() {
+        ShutdownLog.add("publisher created");
+    }
+
+    @PreDestroy
+    void close() { // <3>
+        ShutdownLog.add("publisher closed");
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/lifecycle/ShutdownLog.java
+++ b/test-suite/src/test/java/io/micronaut/docs/lifecycle/ShutdownLog.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+final class ShutdownLog {
+
+    private static final List<String> EVENTS = new CopyOnWriteArrayList<>();
+
+    private ShutdownLog() {
+    }
+
+    static void add(String event) {
+        EVENTS.add(event);
+    }
+
+    static List<String> events() {
+        return List.copyOf(EVENTS);
+    }
+
+    static void clear() {
+        EVENTS.clear();
+    }
+}


### PR DESCRIPTION
Closes #6493. Also covers the `@Order` annotation half of #12129.

### Problem

Singletons are destroyed in dependency order, but the sort had gaps and there was no way to declare an order between beans that are not wired together:

- `getRequiredComponents()` checked the **bean class's** metadata for `@Inject` instead of the field's, so field-injected dependencies were never considered. A field-injected dependency could be destroyed before its dependent (reproduced in 3 of 4 naming variants).
- Beans not connected by a dependency edge were destroyed in `ConcurrentHashMap` order, which is identity-hash based and changed from run to run.
- The workaround recommended in the issue, `@Order` on `@EventListener` methods for `ShutdownEvent`, did not work because the generated adapter bean carried no `@Order` metadata (class-level `@Order` and `Ordered` did work).

### Changes

- **New `@DependsOn`** (`io.micronaut.context.annotation`): lists bean types that are created before the annotated bean is instantiated and destroyed after it, without injecting them. Works on classes and factory methods, accepts interfaces (every implementation is covered), and fails with a clear `BeanInstantiationException` when a listed type has no bean. Creation is enforced in `resolveByBeanFactory`; destruction falls out of the listed types being required components.
- **`AbstractInitializableBeanDefinition.getRequiredComponents()`** reads the field argument's metadata, so `@Inject` fields are dependencies (`@Value`/`@Property` fields stay excluded), and includes `@DependsOn` types.
- **`DefaultBeanContext.topologicalSort`** is now a Kahn-style sort. A bean is destroyed before every bean it requires; where dependencies leave the order open, beans are destroyed in bean name order so the sequence is deterministic. Cycles are broken at the first bean. Candidate lookup per required type is cached.
- **`DeclaredBeanElementCreator.visitAdaptedMethod`** copies a method-level `@Order` onto the adapter bean; a method-level value overrides a class-level one.
- **Docs**: new "Destruction Order" section in the lifecycle guide with a multi-language `MessageConsumer`/`MessagePublisher` snippet backed by `DependsOnSpec` in the Java, Groovy and Kotlin test suites.

### Tests

`BeanDestructionOrderSpec` (13 cases): field injection across naming variants, `@Value` exclusion, constructor/method injection, `@DependsOn` on a class, on an interface and on a factory method, the missing-bean error, stable ordering, cycles, and `ShutdownEvent` listener ordering with method-over-class override. `DependsOnSpec` in all three language test suites verifies both creation and destruction order. Existing inject, inject-java (lifecycle/aop/context/field/constructor/factory/any), inject-groovy, inject-kotlin and test-suite lifecycle/event specs pass.

Note: `core-processor` checkstyle currently fails on `AopProxyWriter.java:188` (two blank lines). That is already on `5.2.x` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
