### PR TITLE
Describe the enclosing instance of an inner class constructor

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -102,6 +102,10 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
     private static final String FIELD_BEAN_CONSTRUCTORS_REFERENCES = "$CONSTRUCTORS_REFERENCES";
     private static final String FIELD_ENUM_CONSTANTS_REFERENCES = "$ENUM_CONSTANTS_REFERENCES";
     private static final String METADATA_METHOD_SUFFIX = "$metadata";
+    /**
+     * The name the JDK gives the synthetic enclosing instance parameter of an inner class constructor.
+     */
+    private static final String ENCLOSING_INSTANCE_PARAMETER_NAME = "this$0";
     private static final java.lang.reflect.Method FIND_PROPERTY_BY_INDEX_METHOD =
         ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanIntrospection.class, "getPropertyByIndex", int.class);
 
@@ -1055,7 +1059,36 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
                 ordered.add(0, instantiatingConstructor);
             }
         }
-        return ordered;
+        return ordered.stream().map(BeanIntrospectionWriter::withEnclosingInstanceParameter).toList();
+    }
+
+    /**
+     * The constructor of a non-static inner class takes the enclosing instance as an implicit first
+     * parameter. {@link java.lang.reflect.Constructor#getParameterTypes()} reports it, the source level
+     * view of the element does not. Describe it, so that a described constructor lines up with its
+     * reflective counterpart and can be instantiated through
+     * {@link io.micronaut.core.beans.BeanConstructor#instantiate(Object...)}.
+     *
+     * @param constructor The declared constructor
+     * @return The constructor, with the enclosing instance parameter prepended if one is implied
+     */
+    private static MethodElement withEnclosingInstanceParameter(MethodElement constructor) {
+        if (!(constructor instanceof ConstructorElement)) {
+            // a static creator takes no enclosing instance
+            return constructor;
+        }
+        ClassElement declaringType = constructor.getDeclaringType();
+        if (!declaringType.isInner() || declaringType.isStatic()) {
+            return constructor;
+        }
+        ClassElement enclosingType = declaringType.getEnclosingType().orElse(null);
+        if (enclosingType == null) {
+            return constructor;
+        }
+        return constructor.withParameters(ArrayUtils.concat(
+            new ParameterElement[]{ParameterElement.of(enclosingType, ENCLOSING_INSTANCE_PARAMETER_NAME)},
+            constructor.getParameters()
+        ));
     }
 
     private static boolean isSameConstructor(MethodElement a, MethodElement b) {

--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
@@ -395,6 +395,15 @@ public interface BeanIntrospection<T> extends AnnotationMetadataDelegate, BeanIn
      * every described constructor is returned, including its own annotation metadata and the
      * annotation metadata of its parameters.</p>
      *
+     * <p>A described constructor reports the parameters of its JVM signature, which for a non-static
+     * inner class means that {@link BeanConstructor#getArguments()} starts with the implicit enclosing
+     * instance, named {@code this$0}, exactly as {@link java.lang.reflect.Constructor#getParameterTypes()}
+     * reports it. The enclosing instance must therefore be passed first to
+     * {@link BeanConstructor#instantiate(Object...)}. {@link #getConstructor()} and
+     * {@link #getConstructorArguments()} keep the source level view and never describe it, so for a
+     * non-static inner class the first element of this list does not report the same arguments as
+     * {@link #getConstructor()}.</p>
+     *
      * @return Every described constructor of the type, {@link #getConstructor()} first
      * @since 5.2.0
      */

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -13,6 +13,7 @@ import io.micronaut.core.beans.BeanMethod
 import io.micronaut.core.beans.BeanProperty
 import io.micronaut.core.beans.UnsafeBeanProperty
 import io.micronaut.core.reflect.exception.InstantiationException
+import io.micronaut.core.type.Argument
 import io.micronaut.core.type.GenericPlaceholder
 import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor
 import io.micronaut.inject.visitor.introspections.Person
@@ -2710,5 +2711,28 @@ class Order {
         then:
         introspection.getConstructors().size() == 1
         introspection.getConstructors()[0].arguments.length == introspection.constructor.arguments.length
+    }
+
+    // a non-static inner class is never introspected here: TypeElementVisitorTransform skips it
+    void "a described constructor of a static nested class does not describe an enclosing instance"() {
+        when:
+        def introspection = buildBeanIntrospection('test.CustomerService$Nested', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+class CustomerService {
+    @Introspected(constructors = true)
+    static class Nested {
+        String name
+        Nested(String name) { this.name = name }
+    }
+}
+''')
+
+        then:
+        Argument.toClassArray(introspection.getConstructors()[0].arguments) ==
+            introspection.beanType.getDeclaredConstructors()[0].parameterTypes
+        introspection.getConstructors()[0].arguments.length == 1
     }
 }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -6416,6 +6416,146 @@ class Order {
         introspection.getConstructors()[0].arguments.length == 1
     }
 
+    void "a described constructor of a non-static inner class describes the enclosing instance"() {
+        given:
+        def introspection = buildBeanIntrospection('test.CustomerService$InnerClass', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.NotNull;
+
+class CustomerService {
+    @Introspected(constructors = true)
+    public class InnerClass {
+        public InnerClass(@NotNull String s) {}
+    }
+}
+''')
+
+        when:
+        def described = introspection.getConstructors()[0]
+
+        then: 'the described arguments line up with the reflective signature'
+        introspection.getConstructors().size() == 1
+        Argument.toClassArray(described.arguments) ==
+            introspection.beanType.getDeclaredConstructors()[0].parameterTypes
+
+        and: 'the enclosing instance comes first, under the name the JDK gives it'
+        described.arguments.length == 2
+        described.arguments[0].name == 'this$0'
+        described.arguments[0].type.name == 'test.CustomerService'
+
+        and: 'the source level parameter keeps its annotations'
+        described.arguments[1].type == String
+        described.arguments[1].annotationMetadata.hasAnnotation(NotNull)
+    }
+
+    void "a described constructor of a non-static inner class instantiates with the enclosing instance"() {
+        given:
+        def introspection = buildBeanIntrospection('test.CustomerService$InnerClass', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+class CustomerService {
+    @Introspected(constructors = true)
+    public class InnerClass {
+        private final String name;
+        public InnerClass(String name) { this.name = name; }
+        public String getName() { return name; }
+    }
+}
+''')
+        def enclosing = introspection.getConstructors()[0].arguments[0].type
+            .getDeclaredConstructor().tap { it.accessible = true }.newInstance()
+
+        when:
+        def inner = introspection.getConstructors()[0].instantiate(enclosing, "abc")
+
+        then:
+        introspection.getRequiredProperty("name", String).get(inner) == "abc"
+
+        when: 'the enclosing instance is left out'
+        introspection.getConstructors()[0].instantiate("abc")
+
+        then:
+        thrown(InstantiationException)
+    }
+
+    void "a constructor of a non-static inner class annotated as executable describes the enclosing instance"() {
+        given:
+        def introspection = buildBeanIntrospection('test.CustomerService$InnerClass', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+import jakarta.validation.constraints.NotNull;
+
+class CustomerService {
+    @Introspected
+    public class InnerClass {
+        @Executable
+        public InnerClass(@NotNull String s) {}
+    }
+}
+''')
+
+        expect:
+        Argument.toClassArray(introspection.getConstructors()[0].arguments) ==
+            introspection.beanType.getDeclaredConstructors()[0].parameterTypes
+    }
+
+    void "a described constructor of a static nested class does not describe an enclosing instance"() {
+        given:
+        def introspection = buildBeanIntrospection('test.CustomerService$Nested', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+class CustomerService {
+    @Introspected(constructors = true)
+    public static class Nested {
+        public Nested(String s) {}
+    }
+}
+''')
+
+        expect:
+        Argument.toClassArray(introspection.getConstructors()[0].arguments) ==
+            introspection.beanType.getDeclaredConstructors()[0].parameterTypes
+        introspection.getConstructors()[0].arguments.length == 1
+        introspection.getConstructors()[0].arguments.length == introspection.constructor.arguments.length
+    }
+
+    void "the instantiating constructor of a non-static inner class is unchanged"() {
+        given: 'the same inner class built with and without the member'
+        def source = '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+class CustomerService {
+    @Introspected(%s)
+    public class InnerClass {
+        public InnerClass(String s) {}
+    }
+}
+'''
+        def baseline = buildBeanIntrospection('test.CustomerService$InnerClass', String.format(source, ''))
+        def described = buildBeanIntrospection('test.CustomerService$InnerClass', String.format(source, 'constructors = true'))
+
+        expect: 'an inner class is still not buildable through the introspection itself'
+        described.constructorArguments.length == baseline.constructorArguments.length
+        described.constructorArguments.length == 0
+        described.constructor.arguments.length == 0
+
+        when:
+        described.instantiate()
+
+        then:
+        thrown(InstantiationException)
+    }
+
     void "@Executable on a constructor does not override an explicit @Creator"() {
         given:
         def introspection = buildBeanIntrospection('test.Order', '''

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -29,6 +29,7 @@ import javax.persistence.Version
 import jakarta.validation.Constraint
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import java.lang.reflect.Field
 
@@ -2674,6 +2675,107 @@ class Order(val name: String) {
 
         then:
         introspection.getRequiredProperty("name", String).get(order) == "abc"
+    }
+
+    void "a described constructor of a Kotlin inner class describes the enclosing instance"() {
+        when:
+        def introspection = buildBeanIntrospection('test.CustomerService$InnerClass', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+import jakarta.validation.constraints.NotNull
+
+class CustomerService {
+    @Introspected(constructors = true)
+    inner class InnerClass(@NotNull val s: String)
+}
+''')
+        def described = introspection.getConstructors()[0]
+
+        then: 'the described arguments line up with the reflective signature'
+        introspection.getConstructors().size() == 1
+        Argument.toClassArray(described.arguments) ==
+            introspection.beanType.getDeclaredConstructors()[0].parameterTypes
+
+        and: 'the enclosing instance comes first, under the name the JDK gives it'
+        described.arguments.length == 2
+        described.arguments[0].name == 'this$0'
+        described.arguments[0].type.name == 'test.CustomerService'
+
+        and: 'the source level parameter keeps its annotations'
+        described.arguments[1].type == String
+        described.arguments[1].annotationMetadata.hasAnnotation(NotNull)
+    }
+
+    void "a described constructor of a Kotlin inner class instantiates with the enclosing instance"() {
+        when:
+        def introspection = buildBeanIntrospection('test.CustomerService$InnerClass', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+class CustomerService {
+    @Introspected(constructors = true)
+    inner class InnerClass(val name: String)
+}
+''')
+        def enclosing = introspection.getConstructors()[0].arguments[0].type
+            .getDeclaredConstructor().tap { it.accessible = true }.newInstance()
+        def inner = introspection.getConstructors()[0].instantiate(enclosing, "abc")
+
+        then:
+        introspection.getRequiredProperty("name", String).get(inner) == "abc"
+
+        when: 'the enclosing instance is left out'
+        introspection.getConstructors()[0].instantiate("abc")
+
+        then:
+        thrown(InstantiationException)
+    }
+
+    void "a described constructor of a Kotlin nested class does not describe an enclosing instance"() {
+        when:
+        def introspection = buildBeanIntrospection('test.CustomerService$Nested', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+class CustomerService {
+    @Introspected(constructors = true)
+    class Nested(val name: String)
+}
+''')
+
+        then:
+        Argument.toClassArray(introspection.getConstructors()[0].arguments) ==
+            introspection.beanType.getDeclaredConstructors()[0].parameterTypes
+        introspection.getConstructors()[0].arguments.length == 1
+        introspection.getConstructors()[0].arguments.length == introspection.constructor.arguments.length
+    }
+
+    void "a secondary constructor of a Kotlin inner class describes the enclosing instance"() {
+        when:
+        def introspection = buildBeanIntrospection('test.CustomerService$InnerClass', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+class CustomerService {
+    @Introspected(constructors = true)
+    inner class InnerClass(val name: String) {
+        constructor() : this("none")
+    }
+}
+''')
+
+        then: 'every described constructor carries the enclosing instance'
+        introspection.getConstructors().size() == 2
+        introspection.getConstructors()*.arguments*.length.toSorted() == [1, 2]
+        introspection.getConstructors().every { it.arguments[0].name == 'this$0' }
+
+        and: 'each matches its reflective counterpart'
+        introspection.beanType.getDeclaredConstructors().collect { it.parameterTypes.length }.toSorted() ==
+            introspection.getConstructors()*.arguments*.length.toSorted()
     }
 
     void "a data class describes its constructor"() {


### PR DESCRIPTION
Follow-up to #12909.

## Problem

`BeanIntrospection.getConstructors()` reported the *source level* parameters of an inner class constructor, leaving out the enclosing instance that `java.lang.reflect.Constructor.getParameterTypes()` reports first:

```java
class CustomerService {
    @Introspected(constructors = true)
    public class InnerClass {
        public InnerClass(@NotNull String s) {}
    }
}
```

| | before | reflective signature |
|---|---|---|
| `getConstructors()[0].getArguments()` | `[String s]` | `[CustomerService, String]` |

Two consequences:

1. A consumer looking a constructor up by its reflective parameter types — as the Jakarta Bean Validation specification does — never matched. This is the last constructor case still excluded from the Jakarta TCK: `ExecutableDescriptorTest#testGetParameterDescriptorsForConstructorOfInnerClass`.
2. The generated `instantiateConstructorInternal` dispatch emitted `new InnerClass(String)` — a constructor that does not exist — so `getConstructors()[0].instantiate("x")` failed with `NoSuchMethodError` on both Java and Kotlin.

## Change

Describe the enclosing instance as a leading `this$0` argument on every described constructor of a non-static inner class, so a described constructor lines up with its reflective counterpart and can actually be instantiated:

```java
introspection.getConstructors().get(0).instantiate(customerService, "abc"); // now works
```

The transformation is applied in `getOrderedDeclaredConstructors()`, after the instantiating-constructor match, so `isSameConstructor` still compares untransformed elements — doing it in `visitDeclaredConstructor` instead made Kotlin report a duplicate constructor. Ordering and the instantiate dispatch share that list, so the generated invocation is `new InnerClass(outer, s)`, the real JVM signature. Static creators are skipped via an `instanceof ConstructorElement` guard.

The instantiating view is untouched: `getConstructor()`, `getConstructorArguments()` and `instantiate` keep the source level parameters they reported before, and a Java inner class is still not buildable through the introspection itself. That divergence is now documented on `getConstructors()`.

## Why describe it rather than add a lookup helper

The alternative was to keep the source level view and add a helper that matches a `java.lang.reflect.Constructor` to a `BeanConstructor` ignoring the synthetic parameter. The TCK rules that out: after looking the constructor up by `(CustomerService.class, String.class)`, `ExecutableDescriptorTest` asserts `descriptor.getParameterDescriptors().size() == 2`. A lookup helper fixes the match but leaves the descriptor reporting one parameter, and the test still fails. Describing the parameter satisfies both and adds no API surface.

The usual risk of changing `BeanConstructor.getArguments()` semantics does not apply: `getConstructors()` is `@since 5.2.0` on `5.2.0-SNAPSHOT`, so no released version ever had the old semantics — and for inner classes the old semantics produced a `NoSuchMethodError`.

## Tests

5 in Java, 4 in Kotlin, 1 in Groovy: argument/reflection equality, `instantiate(outer, "abc")` round-trip, a static-nested control, Kotlin secondary constructors, and a baseline-vs-described test pinning that `getConstructorArguments()`/`instantiate()` are unchanged.

`:micronaut-inject-java:test`, `:micronaut-inject-kotlin:test`, `:micronaut-inject-java-test:test`, `:micronaut-inject-groovy:test`, `:micronaut-core:test` and `:micronaut-inject:test` all pass. japicmp passes — the API did not grow.

## Notes

- **Groovy is unaffected.** `TypeElementVisitorTransform` (line 84) never visits a non-static inner class, so one is never introspected at all. Verified as pre-existing by reverting the writer change; the Groovy test covers the static-nested no-regression case only.
- **Pre-existing, left alone:** for a Kotlin `inner class`, `getConstructorArguments()` returns `[String s]` and `introspection.instantiate("x")` throws `NoSuchMethodError`. `KotlinClassElement.resolvedPrimaryConstructor` falls back to `declaration.primaryConstructor`, bypassing the `isInner() && !isStatic()` guard that `ClassElement.getPrimaryConstructor()` applies, so Kotlin records an instantiating constructor Java does not. Independent of #12909 and worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)