### PR TITLE
Keep a generated introspection name usable as a file name

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -94,6 +94,11 @@ import java.util.stream.IntStream;
 @Internal
 final class BeanIntrospectionWriter implements OriginatingElements, Buildable<List<OutputObjectDef>> {
     private static final String INTROSPECTION_SUFFIX = "$Introspection";
+    /**
+     * The longest name a generated introspection may have. The name is used as a single file name
+     * component, and file systems commonly cap those at 255 bytes.
+     */
+    private static final int MAX_INTROSPECTION_NAME_LENGTH = 240;
 
     private static final String FIELD_CONSTRUCTOR_ANNOTATION_METADATA = "$FIELD_CONSTRUCTOR_ANNOTATION_METADATA";
     private static final String FIELD_CONSTRUCTOR_ARGUMENTS = "$CONSTRUCTOR_ARGUMENTS";
@@ -1163,12 +1168,44 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
     }
 
     private static String computeShortIntrospectionName(String packageName, String className) {
-        final String shortName = NameUtils.getSimpleName(className);
-        return packageName + ".$" + shortName + INTROSPECTION_SUFFIX;
+        return computeIntrospectionName(packageName, NameUtils.getSimpleName(className), className);
     }
 
     private static String computeIntrospectionName(String packageName, String className) {
-        return packageName + ".$" + className.replace('.', '_') + INTROSPECTION_SUFFIX;
+        return computeIntrospectionName(packageName, className.replace('.', '_'), className);
+    }
+
+    /**
+     * Computes the name of the generated introspection, shortening it if it would be too long to
+     * be used as a file name.
+     *
+     * <p>The name is written to the file system twice: as {@code <name>.class} and, more
+     * importantly, as the file name of the
+     * {@code META-INF/micronaut/io.micronaut.core.beans.BeanIntrospectionReference/<name>} service
+     * descriptor, where the whole name including the package is a single path segment. Most file
+     * systems reject a path segment longer than 255 bytes, which an introspection generated on
+     * behalf of another element exceeds as soon as the package is deeply nested, because such a
+     * name repeats the fully qualified class name after the package.</p>
+     *
+     * @param packageName The package the introspection is generated into
+     * @param simpleName  The name of the introspection within that package, without the marker or suffix
+     * @param className   The introspected type, used to keep a shortened name unique
+     * @return The introspection name
+     */
+    private static String computeIntrospectionName(String packageName, String simpleName, String className) {
+        String introspectionName = packageName + ".$" + simpleName + INTROSPECTION_SUFFIX;
+        if (introspectionName.length() <= MAX_INTROSPECTION_NAME_LENGTH) {
+            return introspectionName;
+        }
+        // Keep the tail of the name, which carries the simple name of the introspected type, and
+        // make it unique again with a stable hash of the type the introspection is generated for
+        String hash = "_" + Integer.toHexString(className.hashCode());
+        int available = MAX_INTROSPECTION_NAME_LENGTH - packageName.length() - 2 - hash.length() - INTROSPECTION_SUFFIX.length();
+        if (available < 1) {
+            // the package alone is already too long, nothing but the hash can be kept
+            return packageName + ".$" + hash.substring(1) + INTROSPECTION_SUFFIX;
+        }
+        return packageName + ".$" + simpleName.substring(simpleName.length() - available) + hash + INTROSPECTION_SUFFIX;
     }
 
     /**

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -6079,6 +6079,47 @@ class Unrelated2 {}
         context?.close()
     }
 
+    void "test the name of an introspection generated for another element stays usable as a file name"() {
+        given:
+        // The name of an introspection generated on behalf of another element repeats the fully
+        // qualified name of the introspected type after the package, and it is written out as a
+        // single file name component of the BeanIntrospectionReference service descriptor. File
+        // systems reject a name longer than 255 bytes, which a deeply nested package exceeds.
+        def pkg = 'deep234567.deep234567.deep234567.deep234567.deep234567.deep234567.deep234567.deep234567.deep234567.deep234567'
+        ApplicationContext context = buildContext("${pkg}.Holder", """
+package ${pkg};
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(classNames = {"${pkg}.Outer\$Nested"})
+class Holder {}
+
+class Outer {
+    static class Nested {
+        private String name;
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+}
+""")
+
+        when:
+        def reference = context.classLoader
+                .getResources("META-INF/micronaut/io.micronaut.core.beans.BeanIntrospectionReference/")
+                .collect { it.toString().substring(it.toString().lastIndexOf('/') + 1) }
+                .findAll { it.startsWith(pkg) }
+                .collect { context.classLoader.loadClass(it).newInstance() }
+                .find { it.beanType.name == "${pkg}.Outer\$Nested".toString() }
+
+        then:
+        reference instanceof BeanIntrospectionReference
+        reference.getClass().name.length() <= 240
+        reference.load().getProperty("name").isPresent()
+
+        cleanup:
+        context?.close()
+    }
+
     void "test a nested type imported with ClassImport is introspected once"() {
         given:
         ApplicationContext context = buildContext('test.Holder', '''

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/VisitorAddedIntrospectedClassNamesSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/VisitorAddedIntrospectedClassNamesSpec.groovy
@@ -1,0 +1,151 @@
+package io.micronaut.inject.visitor.beans
+
+import io.micronaut.annotation.processing.TypeElementVisitorProcessor
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.annotation.processing.test.JavaParser
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.beans.BeanIntrospectionReference
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ElementQuery
+import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+import io.micronaut.validation.visitor.ValidationVisitor
+import org.jspecify.annotations.NonNull
+
+import javax.annotation.processing.SupportedAnnotationTypes
+
+/**
+ * A {@link TypeElementVisitor} can make an otherwise unannotated nested type introspectable by
+ * naming it on the {@link Introspected} annotation it adds to the enclosing type. The nested type
+ * is never handed to the processor itself, so the introspection is generated on behalf of the
+ * enclosing type and carries its name.
+ */
+class VisitorAddedIntrospectedClassNamesSpec extends AbstractTypeElementSpec {
+
+    void "test a nested type named on classNames added by a visitor is introspected once"() {
+        given:
+        ApplicationContext context = buildContext('test.Outer', '''
+package test;
+
+class Outer {
+    static class Nested {
+        private String name;
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+}
+
+class Other {
+    static class OtherNested {
+        private String name;
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+}
+''')
+
+        when:
+        def reference = context.classLoader.loadClass('test.$test_Outer$Nested$Introspection').newInstance()
+
+        then:
+        reference instanceof BeanIntrospectionReference
+        reference.load().beanType.name == 'test.Outer$Nested'
+        introspectionsOf(context, 'test.Outer$Nested').size() == 1
+        introspectionsOf(context, 'test.Other$OtherNested').size() == 1
+
+        cleanup:
+        context?.close()
+    }
+
+    void "test a nested type named by a visitor and by a source declared importer is introspected once"() {
+        given:
+        ApplicationContext context = buildContext('test.Holder', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(classNames = {"test.Outer$Nested"})
+class Holder {}
+
+class Outer {
+    static class Nested {
+        private String name;
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+}
+''')
+
+        expect:
+        introspectionsOf(context, 'test.Outer$Nested').size() == 1
+
+        cleanup:
+        context?.close()
+    }
+
+    private static List<String> introspectionsOf(ApplicationContext context, String beanTypeName) {
+        return context.classLoader
+                .getResources("META-INF/micronaut/io.micronaut.core.beans.BeanIntrospectionReference/")
+                .collect { it.toString().substring(it.toString().lastIndexOf('/') + 1) }
+                .findAll { it.startsWith('test.') }
+                .findAll { context.classLoader.loadClass(it).newInstance().beanType.name == beanTypeName }
+    }
+
+    @Override
+    protected JavaParser newJavaParser() {
+        return new JavaParser() {
+            @Override
+            protected TypeElementVisitorProcessor getTypeElementVisitorProcessor() {
+                return new MyTypeElementVisitorProcessor()
+            }
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    static class MyTypeElementVisitorProcessor extends TypeElementVisitorProcessor {
+        @NonNull
+        @Override
+        protected Collection<TypeElementVisitor> findTypeElementVisitors() {
+            return [new IntrospectNestedVisitor(), new ValidationVisitor(), new IntrospectedTypeElementVisitor()]
+        }
+    }
+
+    /**
+     * Runs before the introspection visitor and names every unannotated static nested type on the
+     * {@link Introspected} annotation it adds to the enclosing type.
+     */
+    static class IntrospectNestedVisitor implements TypeElementVisitor<Object, Object> {
+
+        @Override
+        int getOrder() {
+            return 88
+        }
+
+        @Override
+        VisitorKind getVisitorKind() {
+            return VisitorKind.ISOLATING
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (!element.getName().startsWith('test.')) {
+                return
+            }
+            String[] unannotatedNestedTypes = element.getEnclosedElements(ElementQuery.ALL_INNER_CLASSES.onlyDeclared())
+                    .stream()
+                    .filter(nested -> nested.isStatic() && !nested.isInterface() && !nested.isEnum() && !nested.isRecord())
+                    .filter(nested -> nested.getAnnotationMetadata().getAnnotationNames().isEmpty())
+                    .map(ClassElement::getName)
+                    .toArray(String[]::new)
+            element.annotate(Introspected.class, builder -> {
+                builder.member("accessKind", Introspected.AccessKind.FIELD, Introspected.AccessKind.METHOD)
+                builder.member("visibility", Introspected.Visibility.ANY)
+                if (unannotatedNestedTypes.length > 0) {
+                    builder.member("classNames", unannotatedNestedTypes)
+                }
+            })
+        }
+    }
+}


### PR DESCRIPTION
An introspection generated on behalf of another element — via `@Introspected(classNames)`, `@Introspected(classes)` or `@ClassImport` — is named `<targetPackage>.$<flattened fully qualified name>$Introspection`, so it repeats the fully qualified name of the introspected type after the package.

That name is also written out as a **single file name component** of the service descriptor:

```
META-INF/micronaut/io.micronaut.core.beans.BeanIntrospectionReference/<name>
```

File systems cap a path segment at 255 bytes (APFS, ext4, NTFS), so a deeply nested package overflows it and the compilation fails:

```
Failed to generate class: 'org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel.$org_hibernate_beanvalidation_tck_tests_xmlconfiguration_constraintdeclaration_containerelementlevel_ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank$Introspection':
Unable to generate Bean entry at path: META-INF/micronaut/io.micronaut.core.beans.BeanIntrospectionReference/...
```

That name is 278 characters. The `ENAMETOOLONG` from `Filer.createResource` is what surfaces as `Unable to generate Bean entry at path`.

## Fix

`BeanIntrospectionWriter` now shortens a name that would exceed 240 characters, keeping the tail — which carries the simple name of the introspected type — and making it unique again with a stable hash of that type. A name that already fits is byte-for-byte unchanged, so no build that works today gets a new name.

## Reproduced against the Jakarta Validation TCK

Found while making otherwise unannotated nested types introspectable in micronaut-validation's TCK harness (their constraints live in XML, so the round never hands them to the processor; naming them from the enclosing class is the only way in). Before the change the deployment fails to compile and the tests are skipped; after it, they compile and run.

It also explains which imports work today and which do not: `constraints.containerelement` produces a 237-character name and fits, while `xmlconfiguration.constraintdeclaration.containerelementlevel` produces 278 and does not.

## Tests

- `BeanIntrospectionSpec` — an imported introspection in a deep package: the name stays within the limit and the introspection still loads and works. Fails without the change (247 > 240).
- `VisitorAddedIntrospectedClassNamesSpec` — a `TypeElementVisitor` adding `@Introspected(classNames = …)` for unannotated nested types, and a nested type named by both a visitor and a source declaration. Both assert exactly one introspection per bean type.

`:micronaut-inject-java:test`, `:micronaut-inject-java-test:test`, `:micronaut-inject-groovy:test` (4962 tests), `:micronaut-core-processor:test` and `:micronaut-inject-groovy-test:test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
