### PR TITLE
Key a parameter's and a field's mutated metadata by the declaring type, not the type it is read through

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -283,15 +283,19 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     /**
-     * Build the metadata for the given element. If the element is a method the class metadata will be included.
+     * Build the metadata for the given parameter element. The metadata is keyed by the type that <em>declares</em>
+     * the method, not by the type the method is reached through: a parameter of an inherited method is the same
+     * parameter whether it is read through the declaring class or through a subclass, so a mutation made through
+     * one must be visible through the other. Unlike a method, a parameter's metadata never includes the owning
+     * type's annotations, so nothing distinguishes it per owner.
      *
-     * @param owningType       The owning type
+     * @param declaringType    The type declaring the method
      * @param methodElement    The method element
      * @param parameterElement The parameter element
      * @return The {@link AnnotationMetadata}
      */
-    public CachedAnnotationMetadata lookupOrBuildForParameter(T owningType, T methodElement, T parameterElement) {
-        return lookupOrBuild(new Key3<>(owningType, methodElement, parameterElement), parameterElement);
+    public CachedAnnotationMetadata lookupOrBuildForParameter(T declaringType, T methodElement, T parameterElement) {
+        return lookupOrBuild(new Key3<>(declaringType, methodElement, parameterElement), parameterElement);
     }
 
     /**
@@ -316,14 +320,17 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     /**
-     * Build the metadata for the given field element excluding any class metadata.
+     * Build the metadata for the given field element excluding any class metadata. The metadata is keyed by the
+     * type that <em>declares</em> the field, not by the type the field is reached through: an inherited field is
+     * the same field whether it is read through the declaring class or through a subclass, so a mutation made
+     * through one must be visible through the other.
      *
-     * @param owningType The owningType
-     * @param element    The element
+     * @param declaringType The type declaring the field
+     * @param element       The element
      * @return The {@link CachedAnnotationMetadata}
      */
-    public CachedAnnotationMetadata lookupOrBuildForField(T owningType, T element) {
-        return lookupOrBuild(new Key2<>(owningType, element), element);
+    public CachedAnnotationMetadata lookupOrBuildForField(T declaringType, T element) {
+        return lookupOrBuild(new Key2<>(declaringType, element), element);
     }
 
     /**
@@ -2117,33 +2124,36 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     /**
-     * Key used to reference mutated metadata.
+     * Key used to reference mutated metadata. The first element is the type the entry belongs to (the owning type
+     * for a method, the declaring type for a field) so that {@link #clearMutated(Object)} can drop the entry when
+     * that type is cleared.
      *
-     * @param owningType  The element 1
-     * @param e2  The element 2
-     * @param <T> the element type
+     * @param type The type the entry belongs to
+     * @param e2   The element 2
+     * @param <T>  the element type
      */
     @Internal
-    private record Key2<T>(T owningType, T e2) implements Iterable<T> {
+    private record Key2<T>(T type, T e2) implements Iterable<T> {
         @Override
         public Iterator<T> iterator() {
-            return List.of(owningType, e2).iterator();
+            return List.of(type, e2).iterator();
         }
     }
 
     /**
-     * Key used to reference mutated metadata.
+     * Key used to reference mutated metadata. The first element is the type the entry belongs to (the declaring
+     * type for a parameter) so that {@link #clearMutated(Object)} can drop the entry when that type is cleared.
      *
-     * @param owningType  The element 1
-     * @param e2  The element 2
-     * @param e3  The element 3
-     * @param <T> the element type
+     * @param type The type the entry belongs to
+     * @param e2   The element 2
+     * @param e3   The element 3
+     * @param <T>  the element type
      */
     @Internal
-    private record Key3<T>(T owningType, T e2, T e3) implements Iterable<T> {
+    private record Key3<T>(T type, T e2, T e3) implements Iterable<T> {
         @Override
         public Iterator<T> iterator() {
-            return List.of(owningType, e2, e3).iterator();
+            return List.of(type, e2, e3).iterator();
         }
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
@@ -154,28 +154,32 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
     }
 
     /**
-     * Lookup annotation metadata for the parameter.
+     * Lookup annotation metadata for the parameter. The entry is keyed by the declaring type of the method, not
+     * by the owning type, so that a parameter of an inherited method shares one entry whichever class it is read
+     * through.
      *
      * @param parameterElement The element
      * @return The annotation metadata
      */
     protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForParameter(ParameterElement parameterElement) {
+        MethodElement methodElement = parameterElement.getMethodElement();
         return metadataBuilder.lookupOrBuildForParameter(
-            getNativeElement(parameterElement.getMethodElement().getOwningType()),
-            getNativeElement(parameterElement.getMethodElement()),
+            getNativeElement(methodElement.getDeclaringType()),
+            getNativeElement(methodElement),
             getNativeElement(parameterElement)
         );
     }
 
     /**
-     * Lookup annotation metadata for the field.
+     * Lookup annotation metadata for the field. The entry is keyed by the declaring type of the field, not by the
+     * owning type, so that an inherited field shares one entry whichever class it is read through.
      *
      * @param fieldElement The element
      * @return The annotation metadata
      */
     protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForField(FieldElement fieldElement) {
         return metadataBuilder.lookupOrBuildForField(
-            getNativeElement(fieldElement.getOwningType()),
+            getNativeElement(fieldElement.getDeclaringType()),
             getNativeElement(fieldElement)
         );
     }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
@@ -121,8 +121,8 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
     }
 
     @Override
-    public CachedAnnotationMetadata lookupOrBuildForParameter(AnnotatedNode owningType, AnnotatedNode methodElement, AnnotatedNode parameterElement) {
-        return super.lookupOrBuildForParameter(owningType, methodElement, new ExtendedParameter((MethodNode) methodElement, (Parameter) parameterElement));
+    public CachedAnnotationMetadata lookupOrBuildForParameter(AnnotatedNode declaringType, AnnotatedNode methodElement, AnnotatedNode parameterElement) {
+        return super.lookupOrBuildForParameter(declaringType, methodElement, new ExtendedParameter((MethodNode) methodElement, (Parameter) parameterElement));
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/visitors/InheritedMemberAnnotationMutationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/InheritedMemberAnnotationMutationSpec.groovy
@@ -1,0 +1,140 @@
+package io.micronaut.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ElementQuery
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+/**
+ * A parameter of an inherited method and an inherited field are the same members whether they are
+ * read through the declaring class or through a subclass, so an annotation mutation made by a
+ * visitor through the declaring class must be visible to a visitor reading them through the subclass.
+ */
+class InheritedMemberAnnotationMutationSpec extends AbstractTypeElementSpec {
+
+    void 'mutations of an inherited parameter and field made through the declaring class are visible through the subclass'() {
+        given:
+        BaseVisitor.visited = false
+        SubVisitor.reset()
+
+        when:
+        def definition = buildBeanDefinition('test.Sub', '''
+package test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import io.micronaut.context.annotation.Executable;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Marker {}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Added {}
+
+abstract class Base {
+
+    @Inject
+    @Marker
+    protected String f;
+
+    @Executable
+    public void inherited(@Marker String a) {
+    }
+}
+
+@Singleton
+class Sub extends Base {
+}
+''')
+
+        then: 'the visitor on Base ran before the visitor on Sub and both members were read through Sub'
+        BaseVisitor.visited
+        SubVisitor.baseVisitedFirst
+        SubVisitor.parameterOwner == 'test.Sub'
+        SubVisitor.fieldOwner == 'test.Sub'
+
+        and: 'the parameter read through Sub reflects the mutation made through Base'
+        SubVisitor.parameterAnnotations.contains('test.Added')
+        !SubVisitor.parameterAnnotations.contains('test.Marker')
+
+        and: 'the field read through Sub reflects the mutation made through Base'
+        SubVisitor.fieldAnnotations.contains('test.Added')
+        !SubVisitor.fieldAnnotations.contains('test.Marker')
+
+        and: 'the compiled definition of Sub, whose members are read through Sub, carries the mutation as well'
+        def argument = definition.findPossibleMethods('inherited').findAny().get().arguments[0]
+        argument.annotationMetadata.hasAnnotation('test.Added')
+        !argument.annotationMetadata.hasAnnotation('test.Marker')
+        def field = definition.injectedFields[0]
+        field.name == 'f'
+        field.asArgument().annotationMetadata.hasAnnotation('test.Added')
+        !field.asArgument().annotationMetadata.hasAnnotation('test.Marker')
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        return [new BaseVisitor(), new SubVisitor()]
+    }
+
+    /**
+     * Visits Base and swaps @Marker for @Added on the parameter of {@code inherited} and on the field {@code f}.
+     */
+    static class BaseVisitor implements TypeElementVisitor<Object, Object> {
+
+        static boolean visited
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.name != 'test.Base') {
+                return
+            }
+            def parameter = element.getEnclosedElement(ElementQuery.ALL_METHODS.named('inherited')).get().parameters[0]
+            parameter.removeAnnotation('test.Marker')
+            parameter.annotate('test.Added')
+
+            def field = element.getEnclosedElement(ElementQuery.ALL_FIELDS.named('f')).get()
+            field.removeAnnotation('test.Marker')
+            field.annotate('test.Added')
+            visited = true
+        }
+    }
+
+    /**
+     * Visits Sub and records what the inherited parameter and field look like when read through Sub.
+     */
+    static class SubVisitor implements TypeElementVisitor<Object, Object> {
+
+        static boolean baseVisitedFirst
+        static String parameterOwner
+        static String fieldOwner
+        static List<String> parameterAnnotations
+        static List<String> fieldAnnotations
+
+        static void reset() {
+            baseVisitedFirst = false
+            parameterOwner = null
+            fieldOwner = null
+            parameterAnnotations = null
+            fieldAnnotations = null
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.name != 'test.Sub') {
+                return
+            }
+            baseVisitedFirst = BaseVisitor.visited
+
+            def method = element.getEnclosedElement(ElementQuery.ALL_METHODS.named('inherited')).get()
+            parameterOwner = method.owningType.name
+            parameterAnnotations = method.parameters[0].annotationMetadata.annotationNames.asList()
+
+            def field = element.getEnclosedElement(ElementQuery.ALL_FIELDS.named('f')).get()
+            fieldOwner = field.owningType.name
+            fieldAnnotations = field.annotationMetadata.annotationNames.asList()
+        }
+    }
+}

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinElementAnnotationMetadataFactory.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinElementAnnotationMetadataFactory.kt
@@ -141,10 +141,12 @@ internal class KotlinElementAnnotationMetadataFactory(
 
     override fun lookupForParameter(parameterElement: ParameterElement): CachedAnnotationMetadata {
         val kotlinParameterElement = parameterElement as KotlinParameterElement
-        val owner = kotlinParameterElement.methodElement.owningType
+        // Keyed by the declaring type, not the owning type: a parameter of an inherited method is the same
+        // parameter whichever class it is read through, so a mutation must be visible through all of them
+        val declaringType = kotlinParameterElement.methodElement.declaringType as KotlinClassElement
         return metadataBuilder.lookupOrBuild(
             Key3(
-                getClassDefinitionCacheKey(owner),
+                getClassDefinitionCacheKey(declaringType),
                 kotlinParameterElement.methodElement.nativeType,
                 kotlinParameterElement.nativeType
             ),
@@ -154,17 +156,19 @@ internal class KotlinElementAnnotationMetadataFactory(
 
     override fun lookupForField(fieldElement: FieldElement): CachedAnnotationMetadata {
         val kotlinFieldElement = fieldElement as AbstractKotlinElement<*>
-        val owner: KotlinClassElement
+        // Keyed by the declaring type, not the owning type: an inherited field is the same field whichever
+        // class it is read through, so a mutation must be visible through all of them
+        val declaringType: KotlinClassElement
         if (kotlinFieldElement is KotlinFieldElement) {
-            owner = kotlinFieldElement.owningType as KotlinClassElement
+            declaringType = kotlinFieldElement.declaringType as KotlinClassElement
         } else if (kotlinFieldElement is KotlinEnumConstantElement) {
-            owner = kotlinFieldElement.owningType as KotlinClassElement
+            declaringType = kotlinFieldElement.declaringType as KotlinClassElement
         } else {
             throw RuntimeException("Unknown field element type ${fieldElement.javaClass}")
         }
         return metadataBuilder.lookupOrBuild(
             Key2(
-                getClassDefinitionCacheKey(owner),
+                getClassDefinitionCacheKey(declaringType),
                 kotlinFieldElement.nativeType,
             ),
             kotlinFieldElement.nativeType.element

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/annotate/InheritedParameterAnnotationMutationSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/annotate/InheritedParameterAnnotationMutationSpec.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.annotation.processing.test.annotate
+
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ElementQuery
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+import io.micronaut.python.annotation.processing.test.AbstractPythonTypeElementSpec
+
+class InheritedParameterAnnotationMutationSpec extends AbstractPythonTypeElementSpec {
+
+    void 'mutations of an inherited parameter are visible through the subclass'() {
+        given:
+        InheritedParameterMutationVisitor.reset()
+
+        when:
+        def definition = buildBeanDefinition('python', 'InheritedMutationSub', '''
+from typing import Annotated
+from jakarta.inject import Named, Singleton
+from micronaut.context.annotation import Executable
+
+class InheritedMutationBase:
+    @Executable
+    def inherited(self, value: Annotated[str, Named("marker")]) -> None:
+        pass
+
+@Singleton
+class InheritedMutationSub(InheritedMutationBase):
+    pass
+''')
+
+        then: 'the parameter read through the subclass retains the mutation made through the declaring class'
+        InheritedParameterMutationVisitor.baseVisitedFirst
+        InheritedParameterMutationVisitor.parameterOwner == 'python.InheritedMutationSub'
+        InheritedParameterMutationVisitor.parameterAnnotations.contains('test.Added')
+        !InheritedParameterMutationVisitor.parameterAnnotations.contains('jakarta.inject.Named')
+
+        and: 'the compiled bean definition carries the inherited mutation'
+        def argument = definition.findPossibleMethods('inherited').findAny().get().arguments[0]
+        argument.annotationMetadata.hasAnnotation('test.Added')
+        !argument.annotationMetadata.hasAnnotation('jakarta.inject.Named')
+    }
+
+    static class InheritedParameterMutationVisitor implements TypeElementVisitor<Object, Object> {
+
+        static boolean baseVisited
+        static boolean baseVisitedFirst
+        static String parameterOwner
+        static List<String> parameterAnnotations
+
+        static void reset() {
+            baseVisited = false
+            baseVisitedFirst = false
+            parameterOwner = null
+            parameterAnnotations = null
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.name == 'python.InheritedMutationBase') {
+                def parameter = element.getEnclosedElement(ElementQuery.ALL_METHODS.named('inherited')).get().parameters[0]
+                parameter.removeAnnotation('jakarta.inject.Named')
+                parameter.annotate('test.Added')
+                baseVisited = true
+            } else if (element.name == 'python.InheritedMutationSub') {
+                baseVisitedFirst = baseVisited
+                def method = element.getEnclosedElement(ElementQuery.ALL_METHODS.named('inherited')).get()
+                parameterOwner = method.owningType.name
+                parameterAnnotations = method.parameters[0].annotationMetadata.annotationNames.asList()
+            }
+        }
+
+        @Override
+        VisitorKind getVisitorKind() {
+            return VisitorKind.ISOLATING
+        }
+    }
+}

--- a/inject-python-test/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-python-test/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -19,4 +19,5 @@ io.micronaut.python.annotation.processing.test.CustomVisitorSpec$GetMethodVisito
 io.micronaut.python.annotation.processing.test.CustomVisitorSpec$InjectElementVisitor
 io.micronaut.python.annotation.processing.test.annotate.StereotypeVisitorSpec$StereotypeAddingVisitor
 io.micronaut.python.annotation.processing.test.annotate.AnnotationMetadataSpec$MutatingVisitor
+io.micronaut.python.annotation.processing.test.annotate.InheritedParameterAnnotationMutationSpec$InheritedParameterMutationVisitor
 io.micronaut.python.compiler.FailingTypeElementVisitor


### PR DESCRIPTION
## The problem

A `TypeElementVisitor` that mutates the annotations of a method parameter or a field (`annotate(...)` / `removeAnnotation(...)`) does so through the `MUTATED_ANNOTATION_METADATA` cache in `AbstractAnnotationMetadataBuilder`. That cache keyed a parameter's metadata as `(owningType, method, parameter)` and a field's as `(owningType, field)`, where `owningType` is the class the member was *reached through*, not the class that declares it.

An inherited member is the same member whichever class it is reached through, and its annotation hierarchy never includes the owner (a parameter's hierarchy is the overridden parameters plus the variable; a field's is the field alone). So a mutation made through the declaring class landed in a different cache entry from the one a later read through a subclass consulted, and the subclass silently saw the *unmutated* metadata.

Probe (now the regression test): `Base` declares `void inherited(@Marker String a)` and a field `@Marker String f`; `Sub extends Base` inherits both. A visitor on `Base` removes `@Marker` and adds `@Added` on the parameter and the field. A second visitor on `Sub` reads the same parameter and field through `Sub`. On 5.2.x it still saw `@Marker` and never saw `@Added`:

```
Condition not satisfied:

SubVisitor.parameterAnnotations.contains('test.Added')
|          |                    |
|          [test.Marker]        false
```

Both the removal and the addition are lost across owners, and the compiled `BeanDefinition` of `Sub` (whose injection points and executable methods are read through `Sub`) is written with the stale metadata.

## The change

The first component of the parameter and field cache keys becomes the member's **declaring** type instead of its owning type:

- `AbstractAnnotationMetadataBuilder.lookupOrBuildForParameter(T declaringType, T methodElement, T parameterElement)` — key `Key3(declaringType, method, parameter)`.
- `AbstractAnnotationMetadataBuilder.lookupOrBuildForField(T declaringType, T element)` — key `Key2(declaringType, field)`.
- `AbstractElementAnnotationMetadataFactory.lookupForParameter` / `lookupForField` pass `getMethodElement().getDeclaringType()` / `getDeclaringType()` instead of `getOwningType()`.
- `KotlinElementAnnotationMetadataFactory` builds its own keys rather than calling these methods and had the identical owner-keyed `Key3`/`Key2` for parameters and fields; it now keys on `declaringType` the same way, so the three languages behave alike.

The method signatures are unchanged in arity (only the parameter is renamed), so `GroovyAnnotationMetadataBuilder`'s override, the Groovy test helper and `PythonElementAnnotationMetadataFactory` (which already passed the declaring type) keep compiling; the Groovy override's parameter is renamed to match.

Why the declaring type rather than dropping the type from the key altogether: `AbstractAnnotationMetadataBuilder.clearMutated(Object)` walks every `Iterable` key and drops the entries that contain a class being cleared. `TypeElementVisitorProcessor`, `MixinVisitorProcessor` and `BeanDefinitionInjectProcessor` call it with a postponed class's native element to discard the partial mutations made to that class before it was postponed. Keeping the declaring type in the key preserves that: clearing `Base` still drops the entries for `Base`'s parameters and fields, exactly as before. For a member read through its own declaring class the key is byte-for-byte what it was, so nothing changes for the non-inherited case.

In Java the class component is the bare `TypeElement` (`JavaElementAnnotationMetadataFactory.getNativeElement` unwraps `JavaNativeElement.Class` to its element), in Groovy the `ClassNode`, and in Kotlin `getClassDefinitionCacheKey` strips the type, so the declaring-type component is stable however the declaring class was resolved (raw, or parameterised through the subclass).

## What deliberately does not change

`lookupOrBuildForMethod(T owningType, T element)` keeps its owning-type key. A method's metadata is where class-level annotations are merged in, so the same inherited method legitimately has different metadata when reached through different classes; that split is intentional and is untouched here.

Type-level per-use-site isolation (a type annotated at one parameter site not leaking to every other mention of that type) is unaffected: it lives in the type native elements, not in the parameter/field keys.

## Test

`inject-java/src/test/groovy/io/micronaut/visitors/InheritedMemberAnnotationMutationSpec.groovy` registers two local visitors: `BaseVisitor` (mutates the parameter and field through `Base`) and `SubVisitor` (records what the same members look like through `Sub`, including that `owningType` is `Sub`). The spec asserts `@Added` is present and `@Marker` absent both in the visitor's view through `Sub` and in the compiled `BeanDefinition` of `Sub` (executable-method argument and injected field). It fails on unmodified 5.2.x with the output quoted above and passes with this change.

Compile-time only; no runtime code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
