### PR TITLE
Destroy a proxy's retained interceptors from `destroyBean(Object)`

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/Intercepted.java
+++ b/aop/src/main/java/io/micronaut/aop/Intercepted.java
@@ -55,9 +55,14 @@ public interface Intercepted extends InterceptedBean {
      * <p>Proxies whose target declares no lifecycle binding, and proxies generated before this existed, keep the
      * empty default; the runtime then resolves interceptors by binding as it always did.</p>
      *
+     * <p>The context reads the same list through {@link InterceptedBean#$interceptorRegistrations()} when
+     * {@code destroyBean(Object)} is handed a proxy it tracks no registration for, so the non-singleton interceptors
+     * are destroyed with their target there too.</p>
+     *
      * @return The retained interceptor registrations, never {@code null}
      * @since 5.2.0
      */
+    @Override
     @Internal
     @UsedByGeneratedCode
     // The $ prefix marks this as generated-code infrastructure and keeps it clear of any method on the proxied type.

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorReuseSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleInterceptorReuseSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.aop.lifecycle
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.Intercepted
 import io.micronaut.context.ApplicationContext
 
 class LifecycleInterceptorReuseSpec extends AbstractTypeElementSpec {
@@ -393,6 +394,7 @@ class Holder {
 
     // destroyBean(Object) cannot find a registration for a bean created with createBean, so the registrations
     // owned by that bean are not available to the dispose call and pre destroy still resolves a new interceptor.
+    // This bean has constructor advice but no around proxy, so nothing retains the registrations for it.
     void 'test a prototype created through createBean reuses the interceptor up to post construct'() {
         given:
         ApplicationContext context = buildContext('''
@@ -452,6 +454,90 @@ class Product {
 
         cleanup:
         context.close()
+    }
+
+    // A proxied bean is different: the proxy retains the registrations it was constructed with, so destroyBean(Object)
+    // can hand them to the untracked registration it builds and the prototype interceptor dies with its target.
+    void 'test destroyBean(Object) destroys the prototype interceptor a proxied prototype retained'() {
+        given:
+        ApplicationContext context = buildContext('''
+package reuse.destroyproxied;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class PrototypeInterceptor implements MethodInterceptor<Object, Object> {
+    static int instances;
+    static int destroyed;
+
+    PrototypeInterceptor() { instances++; }
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+
+    @PreDestroy
+    void destroy() { destroyed++; }
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class SingletonInterceptor implements MethodInterceptor<Object, Object> {
+    static int destroyed;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+
+    @PreDestroy
+    void destroy() { destroyed++; }
+}
+
+@Prototype
+@Tracked
+class MyBean {
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> prototypeInterceptor = context.classLoader.loadClass('reuse.destroyproxied.PrototypeInterceptor')
+        Class<?> singletonInterceptor = context.classLoader.loadClass('reuse.destroyproxied.SingletonInterceptor')
+
+        when:
+        def bean = context.createBean(context.classLoader.loadClass('reuse.destroyproxied.MyBean'))
+        bean.work()
+        context.destroyBean(bean)
+
+        then: 'the prototype interceptor the proxy retained is destroyed with its target, exactly once'
+        bean instanceof Intercepted
+        prototypeInterceptor.instances == 1
+        prototypeInterceptor.destroyed == 1
+
+        and: 'the singleton interceptor bound to the same bean outlives the target'
+        singletonInterceptor.destroyed == 0
+
+        when:
+        context.close()
+
+        then: 'closing the context destroys the singleton once and does not destroy the prototype again'
+        prototypeInterceptor.destroyed == 1
+        singletonInterceptor.destroyed == 1
     }
 
     void 'test an intercepted bean resolved as a nested dependency is not confused with its consumer'() {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -99,6 +99,7 @@ import io.micronaut.inject.ReplacesDefinition;
 import io.micronaut.inject.UnsafeExecutionHandle;
 import io.micronaut.inject.ValidatedBeanDefinition;
 import io.micronaut.inject.provider.AbstractProviderDefinition;
+import io.micronaut.inject.proxy.InterceptedBean;
 import io.micronaut.inject.proxy.InterceptedBeanProxy;
 import io.micronaut.inject.qualifiers.AnyQualifier;
 import io.micronaut.inject.qualifiers.FilteringQualifier;
@@ -1121,10 +1122,47 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             if (beanDefinition.isPresent()) {
                 BeanDefinition<T> definition = beanDefinition.get();
                 BeanKey<T> key = new BeanKey<>(definition, definition.getDeclaredQualifier());
-                destroyBean(BeanRegistration.of(this, key, definition, bean));
+                destroyBean(BeanRegistration.of(this, key, definition, bean, retainedInterceptorDependents(bean)));
             }
         }
         return bean;
+    }
+
+    /**
+     * The interceptor registrations a proxy retained, narrowed to the ones that live and die with their target.
+     *
+     * <p>{@link #destroyBean(Object)} builds a registration of its own only when the context tracks none for the
+     * instance, which is the case for a bean created with {@code createBean}. The dependents the tracked path would
+     * have carried were never recorded, so on that path a {@code @Prototype} interceptor was never destroyed with
+     * its target. A generated proxy that retained its interceptor registrations for lifecycle interception is the
+     * one thing that survived from creation to destruction, and those registrations stand in for the missing
+     * dependents.</p>
+     *
+     * <p>Singleton interceptors are left out, because a singleton is never a dependent of one target: the tracked
+     * path resolves it from the singleton scope instead of creating it for the bean, and destroying it here would
+     * take it away from every other bean it advises. This is the same rule
+     * {@link #destroyBean(BeanRegistration, boolean)} applies when it skips a singleton proxy definition destroyed
+     * as a dependent; here it has to cover plain definitions too, since an interceptor is rarely proxied itself.</p>
+     *
+     * @param bean The bean being destroyed
+     * @return The non-singleton interceptor registrations to destroy with the bean, or {@code null} if there are none
+     */
+    @Nullable
+    private static List<BeanRegistration<?>> retainedInterceptorDependents(Object bean) {
+        if (!(bean instanceof InterceptedBean intercepted)) {
+            return null;
+        }
+        List<? extends BeanRegistration<?>> registrations = intercepted.$interceptorRegistrations();
+        if (registrations.isEmpty()) {
+            return null;
+        }
+        List<BeanRegistration<?>> dependents = new ArrayList<>(registrations.size());
+        for (BeanRegistration<?> registration : registrations) {
+            if (!registration.beanDefinition.isSingleton()) {
+                dependents.add(registration);
+            }
+        }
+        return dependents.isEmpty() ? null : dependents;
     }
 
     @Override
@@ -1217,7 +1255,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
      *
      * <p>The registrations are retained by the bean registration created alongside the bean. Beans created through
      * {@code createBean} and destroyed through {@code destroyBean(Object)} have no bean registration and therefore
-     * retain the existing fresh-resolution behaviour.</p>
+     * retain the existing fresh-resolution behaviour, unless a generated proxy retained the registrations itself,
+     * in which case {@code destroyBean(Object)} destroys the non-singleton ones with the target.</p>
      *
      * @param definition    The disposable definition
      * @param registration  The registration of the bean being destroyed

--- a/inject/src/main/java/io/micronaut/inject/proxy/InterceptedBean.java
+++ b/inject/src/main/java/io/micronaut/inject/proxy/InterceptedBean.java
@@ -15,8 +15,11 @@
  */
 package io.micronaut.inject.proxy;
 
+import io.micronaut.context.BeanRegistration;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.ExecutableMethod;
+
+import java.util.List;
 
 /**
  * An internal interface implemented by generated proxy classes.
@@ -36,5 +39,22 @@ public interface InterceptedBean {
      */
     default ExecutableMethod<?, ?>[] interceptedMethods() {
         return new ExecutableMethod[0];
+    }
+
+    /**
+     * The interceptor registrations the proxy retained when it was constructed.
+     *
+     * <p>Declared here, in the inject module, so that the context can reach them without depending on the AOP
+     * module. A proxy is the only thing that survives from a bean's creation to its destruction, and when the
+     * context tracks no registration for the instance the registrations it retained are the only record of the
+     * interceptors created for it. {@code io.micronaut.aop.Intercepted} narrows the element type.</p>
+     *
+     * @return The retained interceptor registrations, never {@code null}
+     * @since 5.2.0
+     */
+    // The $ prefix marks this as generated-code infrastructure and keeps it clear of any method on the proxied type.
+    @SuppressWarnings({"checkstyle:MethodName", "java:S100"})
+    default List<? extends BeanRegistration<?>> $interceptorRegistrations() {
+        return List.of();
     }
 }

--- a/src/main/docs/guide/aop/interceptorLifecycle.adoc
+++ b/src/main/docs/guide/aop/interceptorLifecycle.adoc
@@ -114,14 +114,15 @@ explains the one case that behaves differently:
 |The bean's registration in the context
 |construct, post-construct, pre-destroy
 
-|A ann:context.annotation.Prototype[] created with `createBean` and destroyed with `destroyBean(Object)`
+|A ann:context.annotation.Prototype[] with ann:aop.AroundConstruct[] advice and no proxy, created with `createBean` and destroyed with `destroyBean(Object)`
 |Nothing; the context tracks no registration for it
 |construct and post-construct only
 |===
 
 NOTE: In the last row the context has no registration for the instance, so nothing links its destruction back to what
-it was created with, and `PRE_DESTROY` resolves a new interceptor. Prototypes injected into other beans, and prototypes
-destroyed through their `BeanRegistration`, are unaffected.
+it was created with, and `PRE_DESTROY` resolves a new interceptor. A proxied bean created and destroyed the same way
+is unaffected: the proxy retained its registrations and `destroyBean(Object)` destroys the non-singleton ones with the
+target. Prototypes injected into other beans, and prototypes destroyed through their `BeanRegistration`, are unaffected.
 
 == Ordering
 


### PR DESCRIPTION
## The row #12922 left

Since #12922 a proxied bean's interception phases share one interceptor instance, and that instance is destroyed as a dependent of its target: the `BeanRegistration` created alongside the bean carries the non-singleton interceptors in its dependents, and `destroyBean(BeanRegistration)` walks them. `DefaultBeanContext.destroyBean(T bean)` has a second path, though. When the context tracks no registration for the instance, which is the case for a bean obtained from `createBean(...)`, it builds one on the spot:

```java
destroyBean(BeanRegistration.of(this, key, definition, bean));
```

That overload carries no dependents. The interceptor still intercepted `PRE_DESTROY`, because `MethodInterceptorChain` reads it from `Intercepted.$interceptorRegistrations()`, but the interceptor's own `@PreDestroy` never ran. The Interceptor Life Cycle page listed this row as the one exception: "construct and post-construct only".

## The fix

The proxy is the only object that survives from a bean's creation to its destruction, and since #12922 it retains the registrations it was constructed with. The fallback now hands the non-singleton ones to the registration it builds, through the `BeanRegistration.of(...)` overload that takes dependents, so they are destroyed as dependents exactly as on the tracked path:

```java
destroyBean(BeanRegistration.of(this, key, definition, bean, retainedInterceptorDependents(bean)));
```

`retainedInterceptorDependents` returns `null` for anything that is not an `InterceptedBean`, for a proxy whose list is empty (no lifecycle binding on the target, or a proxy compiled before 5.2.0), and when every retained registration is a singleton; `BeanRegistration.of` then builds the same registration it built before.

The `inject` module cannot see `io.micronaut.aop.Intercepted`, so the accessor is declared on `io.micronaut.inject.proxy.InterceptedBean` as `List<? extends BeanRegistration<?>> $interceptorRegistrations()` and `Intercepted` now overrides it covariantly with its existing `List<BeanRegistration<Interceptor<?, ?>>>`. The erasure is unchanged, so proxies generated against the 5.2.0 snapshots (`AopProxyWriter` overrides the method looked up on `Intercepted`) keep overriding the same method.

Only the fallback path changes. Beans destroyed through their registration already carried the dependents.

## The singleton filter

A registration is passed as a dependent only when `registration.getBeanDefinition().isSingleton()` is false. Non-singleton here means the interceptor's own definition is not singleton-scoped: `@Prototype`, no scope, or a custom scope.

Why singletons are excluded: a singleton is never a dependent of one target. On the tracked path `resolveBeanRegistration` serves a singleton from `singletonScope` and only calls `createRegistration(..., dependent = true)` for everything else, so singletons never reach a target's dependents there either; destroying one from here would take it away from every other bean it advises. `destroyBean(BeanRegistration, boolean)` applies the same rule when it short-circuits a singleton `ProxyBeanDefinition` destroyed as a dependent; the filter here has to cover plain definitions too, because an interceptor is rarely proxied itself, so the singleton check runs on the definition regardless of whether it is a proxy definition.

Custom-scoped interceptors pass the filter and are then handled the way the tracked path handles them: their registration's definition is the scoped `ProxyBeanDefinition`, and `destroyProxyTargetBean(registration, dependent = true)` returns without touching the scope.

## Tests

`LifecycleInterceptorReuseSpec` (inject-java) gains `test destroyBean(Object) destroys the prototype interceptor a proxied prototype retained`: a `@Prototype` `MethodInterceptor` with a `@PreDestroy` counter and a `@Singleton` one, both bound to an `@Around` + `PRE_DESTROY` binding on a `@Prototype` bean; `createBean(MyBean)`, `work()`, `destroyBean(instance)`. Before the fix:

```
Condition not satisfied:
prototypeInterceptor.destroyed == 1
|                    |         |
|                    0         false
```

After: the prototype interceptor is one instance and destroyed exactly once, the singleton interceptor is not destroyed by `destroyBean(instance)` and is destroyed once by `context.close()`, which also does not destroy the prototype again.

The pre-existing `createBean` spec for a bean with constructor advice and no proxy is unchanged (nothing retains registrations for that shape); its comment and the docs table row now say so explicitly, and the note describes the proxied case as covered.

Runs on this branch: `:micronaut-inject:test` 312 tests, 0 failures; `:micronaut-inject-java:test` 4961 tests, 0 failures, 8 skipped (the spec itself 14/14); `:micronaut-aop:test` has no test classes (0 tests). `:micronaut-inject:checkstyleMain` is disabled by the build convention; forced on with the repository's `config/checkstyle/checkstyle.xml` it reports 306 pre-existing violations in `inject`, none in `aop`, and none on a line this change adds. `spotlessCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
