### PR TITLE
Let a custom scope lock bean creation per bean rather than for the whole scope

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/OtherThread.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/OtherThread.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+/**
+ * Runs a creation on another thread and waits a bounded time for it, which is what a {@code @PostConstruct}
+ * that hands work to a pool and joins it does.
+ */
+final class OtherThread {
+
+    static final long WAIT_MILLIS = 1000;
+
+    private OtherThread() {
+    }
+
+    static boolean creates(Runnable creation) throws InterruptedException {
+        Thread thread = new Thread(creation, "other-scope-creation");
+        thread.setDaemon(true);
+        thread.start();
+        thread.join(WAIT_MILLIS);
+        return !thread.isAlive();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanDependent.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanDependent.java
@@ -1,0 +1,18 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+/**
+ * A bean whose creation creates another bean of the same scope on the same thread.
+ */
+@PerBeanScope
+public class PerBeanDependent {
+
+    private final PerBeanOther other;
+
+    public PerBeanDependent(PerBeanOther other) {
+        this.other = other;
+    }
+
+    public PerBeanOther getOther() {
+        return other;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanFaulty.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanFaulty.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@PerBeanScope
+public class PerBeanFaulty {
+
+    public static final AtomicInteger ATTEMPTS = new AtomicInteger();
+
+    public PerBeanFaulty() {
+        ATTEMPTS.incrementAndGet();
+        throw new RuntimeException("Bad things");
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanLockingScopeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanLockingScopeSpec.groovy
@@ -1,0 +1,115 @@
+package io.micronaut.inject.scope.custom.perbean
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanCreationException
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class PerBeanLockingScopeSpec extends Specification {
+
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+
+    void "under the scope-wide lock a creation cannot wait for another thread creating a bean of the scope"() {
+        when:
+        def waiter = context.getBean(ScopeWideWaiter)
+
+        then: "the other thread only got to create its bean once the waiter's creation released the lock"
+        !waiter.otherCreatedInTime
+        context.getBean(ScopeWideOther)
+    }
+
+    void "under a lock per bean a creation can wait for another thread creating a bean of the scope"() {
+        when:
+        def waiter = context.getBean(PerBeanWaiter)
+
+        then:
+        waiter.otherCreatedInTime
+        context.getBean(PerBeanOther)
+    }
+
+    void "under a lock per bean concurrent resolutions of one bean create it once"() {
+        given:
+        int threads = 8
+        def executor = Executors.newFixedThreadPool(threads)
+        def start = new CountDownLatch(1)
+
+        when:
+        def futures = (1..threads).collect {
+            executor.submit({
+                start.await()
+                context.getBean(PerBeanRaced)
+            } as java.util.concurrent.Callable<PerBeanRaced>)
+        }
+        start.countDown()
+        def beans = futures.collect { it.get(10, TimeUnit.SECONDS) }
+
+        then:
+        beans.toSet().size() == 1
+        PerBeanRaced.CONSTRUCTIONS.get() == 1
+
+        cleanup:
+        executor.shutdownNow()
+    }
+
+    void "under a lock per bean a creation creates another bean of the scope on the same thread"() {
+        when:
+        def dependent = context.getBean(PerBeanDependent)
+
+        then:
+        dependent.other.is(context.getBean(PerBeanOther))
+    }
+
+    void "under a lock per bean a failed creation is not held and is attempted again"() {
+        when:
+        context.getBean(PerBeanFaulty)
+
+        then:
+        thrown(BeanCreationException)
+        PerBeanFaulty.ATTEMPTS.get() == 1
+
+        when:
+        context.getBean(PerBeanFaulty)
+
+        then:
+        thrown(BeanCreationException)
+        PerBeanFaulty.ATTEMPTS.get() == 2
+        !context.getBean(PerBeanScopeImpl).beans.values().any { it.definition().beanType == PerBeanFaulty }
+    }
+
+    void "under a lock per bean remove destroys the bean and the next resolution creates a new one"() {
+        given:
+        def scope = context.getBean(PerBeanScopeImpl)
+        def first = context.getBean(PerBeanOther)
+        def id = scope.beans.find { it.value.bean().is(first) }.key
+
+        when:
+        def removed = scope.remove(id)
+
+        then:
+        removed.present
+        removed.get().is(first)
+        first.destroyed
+        !scope.beans.containsKey(id)
+
+        when:
+        def second = context.getBean(PerBeanOther)
+
+        then:
+        !second.is(first)
+        !second.destroyed
+    }
+
+    void "under a lock per bean the scope answers the registration of a bean it holds"() {
+        given:
+        def bean = context.getBean(PerBeanOther)
+
+        expect:
+        context.getBean(PerBeanScopeImpl).findBeanRegistration(bean).get().bean.is(bean)
+        context.findBeanRegistration(bean).present
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanOther.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanOther.java
@@ -1,0 +1,18 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+import jakarta.annotation.PreDestroy;
+
+@PerBeanScope
+public class PerBeanOther {
+
+    private boolean destroyed;
+
+    @PreDestroy
+    void destroy() {
+        destroyed = true;
+    }
+
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanRaced.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanRaced.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A bean many threads resolve at once; its construction is slow enough for them to pile up.
+ */
+@PerBeanScope
+public class PerBeanRaced {
+
+    public static final AtomicInteger CONSTRUCTIONS = new AtomicInteger();
+
+    public PerBeanRaced() throws InterruptedException {
+        CONSTRUCTIONS.incrementAndGet();
+        Thread.sleep(100);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanScope.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+import jakarta.inject.Scope;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A scope whose beans are created under a lock per bean identifier.
+ */
+@Documented
+@Retention(RUNTIME)
+@Scope
+public @interface PerBeanScope {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanScopeImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanScopeImpl.java
@@ -1,0 +1,38 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+import io.micronaut.context.scope.AbstractConcurrentCustomScope;
+import io.micronaut.context.scope.CreatedBean;
+import io.micronaut.inject.BeanIdentifier;
+import jakarta.inject.Singleton;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Singleton
+public class PerBeanScopeImpl extends AbstractConcurrentCustomScope<PerBeanScope> {
+
+    private final Map<BeanIdentifier, CreatedBean<?>> beans = new ConcurrentHashMap<>();
+
+    public PerBeanScopeImpl() {
+        super(PerBeanScope.class, true);
+    }
+
+    public Map<BeanIdentifier, CreatedBean<?>> getBeans() {
+        return beans;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return true;
+    }
+
+    @Override
+    protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+        return beans;
+    }
+
+    @Override
+    public void close() {
+        destroyScope(beans);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanWaiter.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanWaiter.java
@@ -1,0 +1,28 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+import io.micronaut.context.BeanContext;
+import jakarta.annotation.PostConstruct;
+
+/**
+ * A bean of the per-bean-locking scope whose creation waits for another thread to create another bean of the
+ * same scope.
+ */
+@PerBeanScope
+public class PerBeanWaiter {
+
+    private final BeanContext beanContext;
+    private boolean otherCreatedInTime;
+
+    public PerBeanWaiter(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @PostConstruct
+    void init() throws InterruptedException {
+        otherCreatedInTime = OtherThread.creates(() -> beanContext.getBean(PerBeanOther.class));
+    }
+
+    public boolean isOtherCreatedInTime() {
+        return otherCreatedInTime;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/ScopeWideOther.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/ScopeWideOther.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+import io.micronaut.inject.scope.custom.AnotherConcurrentScope;
+
+@AnotherConcurrentScope
+public class ScopeWideOther {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/ScopeWideWaiter.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/ScopeWideWaiter.java
@@ -1,0 +1,29 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.inject.scope.custom.AnotherConcurrentScope;
+import jakarta.annotation.PostConstruct;
+
+/**
+ * A bean of the scope-wide-locking scope whose creation waits for another thread to create another bean of
+ * the same scope.
+ */
+@AnotherConcurrentScope
+public class ScopeWideWaiter {
+
+    private final BeanContext beanContext;
+    private boolean otherCreatedInTime;
+
+    public ScopeWideWaiter(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @PostConstruct
+    void init() throws InterruptedException {
+        otherCreatedInTime = OtherThread.creates(() -> beanContext.getBean(ScopeWideOther.class));
+    }
+
+    public boolean isOtherCreatedInTime() {
+        return otherCreatedInTime;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
@@ -29,13 +29,19 @@ import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Abstract implementation of the custom scope interface that simplifies defining new scopes using the Map interface.
  *
- * <p>Note this implementation uses a single{@link ReentrantReadWriteLock} to lock the entire scope hence it is designed for scopes that will hold a small amount of beans. For implementations that hold many beans it is recommended to use a lock per {@link BeanIdentifier}.</p>
+ * <p>By default this implementation uses a single {@link ReentrantReadWriteLock} to lock the entire scope, and holds
+ * its write lock while a bean is created, hence it is designed for scopes that will hold a small amount of beans whose
+ * creation never waits on another thread. A scope that holds many beans, or whose beans may wait during creation for
+ * another thread that creates a bean of the same scope, should opt into a lock per {@link BeanIdentifier} through
+ * {@link #AbstractConcurrentCustomScope(Class, boolean)}.</p>
  *
  * @param <A> The annotation type
  * @author graemerocher
@@ -44,9 +50,11 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public abstract class AbstractConcurrentCustomScope<A extends Annotation> implements CustomScope<A>, LifeCycle<AbstractConcurrentCustomScope<A>>, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractConcurrentCustomScope.class);
     private final Class<A> annotationType;
+    private final boolean lockPerBean;
     private final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
     private final Lock r = rwl.readLock();
     private final Lock w = rwl.writeLock();
+    private final ConcurrentMap<BeanIdentifier, Object> creationLocks = new ConcurrentHashMap<>();
 
     /**
      * A custom scope annotation.
@@ -54,7 +62,29 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
      * @param annotationType The annotation type
      */
     protected AbstractConcurrentCustomScope(Class<A> annotationType) {
+        this(annotationType, false);
+    }
+
+    /**
+     * A custom scope annotation, choosing how creation is locked.
+     *
+     * <p>With {@code lockPerBean} the scope-wide lock is not used at all. A bean is created under a lock that belongs
+     * to its {@link BeanIdentifier} alone, so that beans of different identifiers are created in parallel, a creation
+     * may wait for another thread that creates a bean of the same scope, and the fast path of a bean already held
+     * is a plain lookup. {@link #remove(BeanIdentifier)} takes the same lock, so it still waits for a creation of that
+     * identifier in flight and then destroys what was created. {@link #destroyScope(Map)} and
+     * {@link #findBeanRegistration(Object)} work on the scope map without any lock, which is why the map returned by
+     * {@link #getScopeMap(boolean)} must then be a {@link ConcurrentMap}: {@link #getOrCreate(BeanCreationContext)}
+     * rejects any other map with an {@link IllegalStateException}. The lock objects live as long as the scope, one
+     * per identifier ever created or removed through it.</p>
+     *
+     * @param annotationType The annotation type
+     * @param lockPerBean    Whether to lock creation per {@link BeanIdentifier} rather than for the whole scope
+     * @since 5.2.0
+     */
+    protected AbstractConcurrentCustomScope(Class<A> annotationType, boolean lockPerBean) {
         this.annotationType = Objects.requireNonNull(annotationType, "Annotation type cannot be null");
+        this.lockPerBean = lockPerBean;
     }
 
     /**
@@ -78,6 +108,15 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
 
     @Override
     public final AbstractConcurrentCustomScope<A> stop() {
+        if (lockPerBean) {
+            try {
+                destroyScope(getScopeMap(false));
+            } catch (IllegalStateException e) {
+                // scope map not available in current context
+            }
+            close();
+            return this;
+        }
         w.lock();
         try {
             try {
@@ -99,6 +138,10 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
      * @param scopeMap The scope map
      */
     protected void destroyScope(@Nullable Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
+        if (lockPerBean) {
+            destroyScopeLockingPerBean(scopeMap);
+            return;
+        }
         w.lock();
         try {
             if (CollectionUtils.isNotEmpty(scopeMap)) {
@@ -120,6 +163,9 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
     @SuppressWarnings("unchecked")
     @Override
     public final <T> T getOrCreate(BeanCreationContext<T> creationContext) {
+        if (lockPerBean) {
+            return getOrCreateLockingPerBean(creationContext);
+        }
         r.lock();
         try {
             final Map<BeanIdentifier, CreatedBean<?>> scopeMap = Objects.requireNonNull(getScopeMap(true));
@@ -169,6 +215,9 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
         if (identifier == null) {
             return Optional.empty();
         }
+        if (lockPerBean) {
+            return removeLockingPerBean(identifier);
+        }
         w.lock();
         try {
             final Map<BeanIdentifier, CreatedBean<?>> scopeMap;
@@ -210,7 +259,9 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
     @SuppressWarnings("unchecked")
     @Override
     public final <T> Optional<BeanRegistration<T>> findBeanRegistration(T bean) {
-        r.lock();
+        if (!lockPerBean) {
+            r.lock();
+        }
         try {
             final Map<BeanIdentifier, CreatedBean<?>> scopeMap;
             try {
@@ -237,7 +288,82 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
             }
             return Optional.empty();
         } finally {
-            r.unlock();
+            if (!lockPerBean) {
+                r.unlock();
+            }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getOrCreateLockingPerBean(BeanCreationContext<T> creationContext) {
+        final Map<BeanIdentifier, CreatedBean<?>> scopeMap = Objects.requireNonNull(getScopeMap(true));
+        if (!(scopeMap instanceof ConcurrentMap)) {
+            throw new IllegalStateException("The scope map of @" + annotationType.getSimpleName()
+                + " must be a ConcurrentMap when creation is locked per bean, but is " + scopeMap.getClass().getName());
+        }
+        final BeanIdentifier id = creationContext.id();
+        CreatedBean<?> createdBean = scopeMap.get(id);
+        if (createdBean != null) {
+            return (T) createdBean.bean();
+        }
+        // the lock is allocated in the map, never the bean: a creation that resolves another bean of this scope
+        // would otherwise be a recursive update of the map
+        final Object lock = creationLocks.computeIfAbsent(id, key -> new Object());
+        synchronized (lock) {
+            // re-check
+            createdBean = scopeMap.get(id);
+            if (createdBean == null) {
+                createdBean = doCreate(creationContext);
+                scopeMap.put(id, createdBean);
+            }
+            return (T) createdBean.bean();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Optional<T> removeLockingPerBean(BeanIdentifier identifier) {
+        final Map<BeanIdentifier, CreatedBean<?>> scopeMap;
+        try {
+            scopeMap = getScopeMap(false);
+        } catch (IllegalStateException e) {
+            return Optional.empty();
+        }
+        if (scopeMap == null) {
+            return Optional.empty();
+        }
+        final CreatedBean<?> createdBean;
+        // under the identifier's lock so that a creation of the identifier in flight is waited for and then removed,
+        // as under the scope-wide lock
+        synchronized (creationLocks.computeIfAbsent(identifier, key -> new Object())) {
+            createdBean = scopeMap.remove(identifier);
+        }
+        if (createdBean == null) {
+            return Optional.empty();
+        }
+        try {
+            createdBean.close();
+        } catch (BeanDestructionException e) {
+            handleDestructionException(e);
+        }
+        //noinspection ConstantConditions
+        return (Optional<T>) Optional.ofNullable(createdBean.bean());
+    }
+
+    private void destroyScopeLockingPerBean(@Nullable Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
+        if (CollectionUtils.isEmpty(scopeMap)) {
+            return;
+        }
+        // each entry is taken out before it is closed, so that two destructions of one map close each bean once
+        for (BeanIdentifier id : scopeMap.keySet()) {
+            final CreatedBean<?> createdBean = scopeMap.remove(id);
+            if (createdBean != null) {
+                try {
+                    createdBean.close();
+                } catch (BeanDestructionException e) {
+                    handleDestructionException(e);
+                }
+            }
+        }
+        scopeMap.clear();
     }
 }

--- a/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -349,13 +350,32 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
         return (Optional<T>) Optional.ofNullable(createdBean.bean());
     }
 
+    /**
+     * The identifier of any one entry of the map, or {@code null} where it holds none.
+     *
+     * @param scopeMap The scope map
+     * @return An identifier, or {@code null}
+     */
+    @Nullable
+    private static BeanIdentifier firstIdentifierOf(Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
+        final Iterator<BeanIdentifier> identifiers = scopeMap.keySet().iterator();
+        return identifiers.hasNext() ? identifiers.next() : null;
+    }
+
     private void destroyScopeLockingPerBean(@Nullable Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
         if (CollectionUtils.isEmpty(scopeMap)) {
             return;
         }
-        // each entry is taken out before it is closed, so that two destructions of one map close each bean once
-        for (BeanIdentifier id : scopeMap.keySet()) {
-            final CreatedBean<?> createdBean = scopeMap.remove(id);
+        // the map is drained rather than cleared: each entry is taken out before it is closed, so that two
+        // destructions of one map close each bean once, and a bean that another thread put there while the
+        // destruction runs is closed by the pass that finds it instead of being dropped by a clear(). Nothing
+        // holds creation off in this mode, so the drain repeats until the map stays empty
+        for (BeanIdentifier id = firstIdentifierOf(scopeMap); id != null; id = firstIdentifierOf(scopeMap)) {
+            final CreatedBean<?> createdBean;
+            // under the identifier's lock, so that a creation of it in flight is waited for and then taken out
+            synchronized (creationLocks.computeIfAbsent(id, key -> new Object())) {
+                createdBean = scopeMap.remove(id);
+            }
             if (createdBean != null) {
                 try {
                     createdBean.close();
@@ -364,6 +384,5 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
                 }
             }
         }
-        scopeMap.clear();
     }
 }

--- a/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
@@ -5,7 +5,9 @@ import io.micronaut.inject.BeanIdentifier
 import jakarta.inject.Singleton
 import spock.lang.Specification
 
+import java.util.LinkedHashSet
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -247,6 +249,23 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         scope.getOrCreate(creationContext).is(bean)
     }
 
+    void "under a lock per bean a bean put there while the scope is destroyed is closed, not dropped"() {
+        given: "a map that gains one more entry the first time the destruction asks what is left"
+        def late = new TestCreatedBean(id: BeanIdentifier.of("late"), bean: new Object())
+        def latecomer = new LatecomerMap(late: late)
+        def scope = new TestScope(true, latecomer)
+        scope.getOrCreate(new TestCreationContext(BeanIdentifier.of("early")))
+        def early = latecomer.get(BeanIdentifier.of("early"))
+
+        when:
+        scope.destroyScope(latecomer)
+
+        then: "the one that arrived during the destruction is closed too, and nothing is left behind"
+        early.closed
+        late.closed
+        latecomer.isEmpty()
+    }
+
     void "under a lock per bean the scope map must be a concurrent map"() {
         given:
         def scope = new TestScope(true, new HashMap<BeanIdentifier, CreatedBean<?>>())
@@ -276,6 +295,42 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
 
         where:
         lockPerBean << [false, true]
+    }
+
+    /**
+     * A scope map that puts one more entry in the first time its keys are read, standing for a bean created by
+     * another thread while the scope is being destroyed.
+     */
+    static class LatecomerMap implements ConcurrentMap<BeanIdentifier, CreatedBean<?>> {
+
+        @Delegate
+        final ConcurrentMap<BeanIdentifier, CreatedBean<?>> delegate = new ConcurrentHashMap<>()
+
+        CreatedBean<?> late
+        boolean arrived
+
+        /**
+         * A snapshot, so that what arrives after this view is taken is not seen through it — which is what a
+         * destruction that reads the keys once and then clears the map would miss.
+         */
+        @Override
+        Set<BeanIdentifier> keySet() {
+            return new LinkedHashSet<BeanIdentifier>(delegate.keySet())
+        }
+
+        /**
+         * Stands for another thread creating a bean of this scope while the destruction is under way: the first
+         * entry taken out is followed by one more arriving.
+         */
+        @Override
+        CreatedBean<?> remove(Object key) {
+            def removed = delegate.remove(key)
+            if (!arrived) {
+                arrived = true
+                delegate.put(late.id(), late)
+            }
+            return removed
+        }
     }
 
     static class TestScope extends AbstractConcurrentCustomScope<Singleton> {

--- a/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
@@ -6,12 +6,15 @@ import jakarta.inject.Singleton
 import spock.lang.Specification
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 class AbstractConcurrentCustomScopeSpec extends Specification {
 
     void "remove evicts the bean so the next resolution creates a new instance"() {
         given:
-        def scope = new TestScope()
         def id = BeanIdentifier.of("myBean")
         def creationContext = new TestCreationContext(id)
 
@@ -37,11 +40,13 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         !second.is(first)
         creationContext.created.size() == 2
         !creationContext.created[1].closed
+
+        where:
+        scope << [new TestScope(), new TestScope(true)]
     }
 
     void "remove of an unknown identifier is empty and leaves the scope untouched"() {
         given:
-        def scope = new TestScope()
         def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"))
         def bean = scope.getOrCreate(creationContext)
 
@@ -52,14 +57,243 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         !removed.present
         scope.scopeMap.size() == 1
         scope.getOrCreate(creationContext).is(bean)
+
+        where:
+        scope << [new TestScope(), new TestScope(true)]
+    }
+
+    void "stop destroys the beans and closes the scope"() {
+        given:
+        def first = new TestCreationContext(BeanIdentifier.of("first"))
+        def second = new TestCreationContext(BeanIdentifier.of("second"))
+        scope.getOrCreate(first)
+        scope.getOrCreate(second)
+
+        when:
+        scope.stop()
+
+        then:
+        first.created[0].closed
+        second.created[0].closed
+        scope.scopeMap.isEmpty()
+        scope.closed
+
+        where:
+        scope << [new TestScope(), new TestScope(true)]
+    }
+
+    void "the registration of a held bean is found and an unknown bean is not"() {
+        given:
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"))
+        def bean = scope.getOrCreate(creationContext)
+
+        expect:
+        scope.findBeanRegistration(bean).get().bean.is(bean)
+        !scope.findBeanRegistration(new Object()).present
+
+        where:
+        scope << [new TestScope(), new TestScope(true)]
+    }
+
+    void "under the scope-wide lock a creation cannot wait for another thread creating another bean of the scope"() {
+        given:
+        def scope = new TestScope()
+        def other = new TestCreationContext(BeanIdentifier.of("other"))
+        def otherThread = new AtomicReference<Thread>()
+        def waiting = new TestCreationContext(BeanIdentifier.of("waiting"), {
+            def thread = new Thread({ scope.getOrCreate(other) })
+            otherThread.set(thread)
+            thread.start()
+            thread.join(300)
+            assert thread.alive: "the other thread should still be blocked on the scope-wide lock"
+        })
+
+        when:
+        scope.getOrCreate(waiting)
+        otherThread.get().join(5000)
+
+        then: "the other thread only got to create once the waiting creation released the lock"
+        !otherThread.get().alive
+        scope.scopeMap.size() == 2
+    }
+
+    void "under a lock per bean a creation can wait for another thread creating another bean of the scope"() {
+        given:
+        def scope = new TestScope(true)
+        def other = new TestCreationContext(BeanIdentifier.of("other"))
+        def waiting = new TestCreationContext(BeanIdentifier.of("waiting"), {
+            def thread = new Thread({ scope.getOrCreate(other) })
+            thread.start()
+            thread.join(5000)
+            assert !thread.alive: "the other thread should have created its bean while this creation waited"
+        })
+
+        when:
+        scope.getOrCreate(waiting)
+
+        then:
+        scope.scopeMap.size() == 2
+        other.created.size() == 1
+        waiting.created.size() == 1
+    }
+
+    void "under a lock per bean concurrent creations of one identifier create once and hand out the same bean"() {
+        given:
+        def scope = new TestScope(true)
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"), { Thread.sleep(100) })
+        int threads = 8
+        def executor = Executors.newFixedThreadPool(threads)
+        def start = new CountDownLatch(1)
+
+        when:
+        def futures = (1..threads).collect {
+            executor.submit({
+                start.await()
+                scope.getOrCreate(creationContext)
+            } as java.util.concurrent.Callable<Object>)
+        }
+        start.countDown()
+        def beans = futures.collect { it.get(10, TimeUnit.SECONDS) }
+
+        then:
+        creationContext.created.size() == 1
+        beans.toSet().size() == 1
+        scope.scopeMap.size() == 1
+
+        cleanup:
+        executor.shutdownNow()
+    }
+
+    void "under a lock per bean creations of different identifiers run in parallel"() {
+        given:
+        def scope = new TestScope(true)
+        int threads = 4
+        def executor = Executors.newFixedThreadPool(threads)
+        // every creation waits for all the others to have begun, which only parallel creations can
+        def allCreating = new CountDownLatch(threads)
+        def contexts = (1..threads).collect {
+            new TestCreationContext(BeanIdentifier.of("bean$it"), {
+                allCreating.countDown()
+                assert allCreating.await(5, TimeUnit.SECONDS): "the other creations should be in flight too"
+            })
+        }
+
+        when:
+        def futures = contexts.collect { ctx -> executor.submit({ scope.getOrCreate(ctx) } as java.util.concurrent.Callable<Object>) }
+        futures.each { it.get(10, TimeUnit.SECONDS) }
+
+        then:
+        scope.scopeMap.size() == threads
+
+        cleanup:
+        executor.shutdownNow()
+    }
+
+    void "under a lock per bean remove waits for a creation of the identifier in flight and destroys what it created"() {
+        given:
+        def scope = new TestScope(true)
+        def id = BeanIdentifier.of("myBean")
+        def creating = new CountDownLatch(1)
+        def release = new CountDownLatch(1)
+        def creationContext = new TestCreationContext(id, {
+            creating.countDown()
+            release.await(5, TimeUnit.SECONDS)
+        })
+        def removed = new AtomicReference<Optional<Object>>()
+
+        when:
+        def creator = Thread.start { scope.getOrCreate(creationContext) }
+        creating.await(5, TimeUnit.SECONDS)
+        def remover = Thread.start { removed.set(scope.remove(id)) }
+        remover.join(300)
+
+        then: "the remover waits for the creation"
+        remover.alive
+        removed.get() == null
+
+        when:
+        release.countDown()
+        creator.join(5000)
+        remover.join(5000)
+
+        then:
+        !creator.alive
+        !remover.alive
+        removed.get().present
+        removed.get().get().is(creationContext.created[0].bean)
+        creationContext.created[0].closed
+        scope.scopeMap.isEmpty()
+    }
+
+    void "under a lock per bean a failed creation leaves nothing behind and the next creation succeeds"() {
+        given:
+        def scope = new TestScope(true)
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"), { throw new IllegalStateException("Bad things") })
+
+        when:
+        scope.getOrCreate(creationContext)
+
+        then:
+        thrown(IllegalStateException)
+        scope.scopeMap.isEmpty()
+
+        when:
+        creationContext.onCreate = {}
+        def bean = scope.getOrCreate(creationContext)
+
+        then:
+        bean != null
+        scope.scopeMap.size() == 1
+        scope.getOrCreate(creationContext).is(bean)
+    }
+
+    void "under a lock per bean the scope map must be a concurrent map"() {
+        given:
+        def scope = new TestScope(true, new HashMap<BeanIdentifier, CreatedBean<?>>())
+
+        when:
+        scope.getOrCreate(new TestCreationContext(BeanIdentifier.of("myBean")))
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.contains("ConcurrentMap")
+    }
+
+    void "under a lock per bean a scope map that is not available is handled as under the scope-wide lock"() {
+        given:
+        def scope = new TestScope(lockPerBean, null)
+
+        expect:
+        !scope.remove(BeanIdentifier.of("myBean")).present
+        !scope.findBeanRegistration(new Object()).present
+        scope.stop().closed
+
+        when:
+        scope.getOrCreate(new TestCreationContext(BeanIdentifier.of("myBean")))
+
+        then:
+        thrown(IllegalStateException)
+
+        where:
+        lockPerBean << [false, true]
     }
 
     static class TestScope extends AbstractConcurrentCustomScope<Singleton> {
 
-        final Map<BeanIdentifier, CreatedBean<?>> scopeMap = new ConcurrentHashMap<>()
+        final Map<BeanIdentifier, CreatedBean<?>> scopeMap
+        boolean closed
 
         TestScope() {
-            super(Singleton)
+            this(false)
+        }
+
+        TestScope(boolean lockPerBean) {
+            this(lockPerBean, new ConcurrentHashMap<>())
+        }
+
+        TestScope(boolean lockPerBean, Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
+            super(Singleton, lockPerBean)
+            this.scopeMap = scopeMap
         }
 
         @Override
@@ -69,11 +303,15 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
 
         @Override
         protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+            if (scopeMap == null) {
+                throw new IllegalStateException("No scope map")
+            }
             return scopeMap
         }
 
         @Override
         void close() {
+            closed = true
             destroyScope(scopeMap)
         }
     }
@@ -82,9 +320,11 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
 
         final BeanIdentifier id
         final List<TestCreatedBean> created = []
+        Runnable onCreate
 
-        TestCreationContext(BeanIdentifier id) {
+        TestCreationContext(BeanIdentifier id, Runnable onCreate = {}) {
             this.id = id
+            this.onCreate = onCreate
         }
 
         @Override
@@ -99,6 +339,7 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
 
         @Override
         CreatedBean<Object> create() {
+            onCreate.run()
             def createdBean = new TestCreatedBean(id: id, bean: new Object())
             created << createdBean
             return createdBean


### PR DESCRIPTION
## The deadlock

`AbstractConcurrentCustomScope.getOrCreate` takes the scope's `ReentrantReadWriteLock` write lock and holds it
around `doCreate`, that is around the bean's constructor, its injections and its `@PostConstruct`. Every bean of
the scope is therefore created mutually exclusively with every other bean of the scope, in the whole JVM, even
where the scope hands back a map per request. And a creation that waits for another thread to create a bean
of the same scope — a `@PostConstruct` that hands work to a pool and joins it, an application-scoped bean
warming a cache through a request-scoped worker — waits for a thread that is blocked on the lock the waiting
creation holds. The class javadoc says it is meant for "a small amount of beans" and recommends "a lock per
`BeanIdentifier`" to anyone holding more; this change offers that lock in the class itself.

Reproduced first, on the unchanged class: a bean of an `AbstractConcurrentCustomScope` whose `@PostConstruct`
starts a thread that resolves another bean of the same scope and joins it for one second. The thread is still
blocked when the second is up (`waiter.otherCreatedInTime == false`); without the timeout the two threads wait
for each other forever.

## The design

A second, protected constructor `AbstractConcurrentCustomScope(Class<A> annotationType, boolean lockPerBean)`.
With `lockPerBean` the scope-wide lock is not used at all:

- **Creation** looks the bean up in the scope map, and on a miss creates it under a monitor that belongs to
  its `BeanIdentifier` alone, re-checking the map once inside. `doCreate` runs under no scope-wide lock, so beans
  of different identifiers are created in parallel and a creation may wait for a thread creating another bean
  of the scope. It is the pattern `SingletonScope` already uses for singletons, with one difference: the lock
  objects are kept for the life of the scope (one per identifier ever created or removed through the scope,
  which is bounded by definitions times qualifiers) instead of being removed after the creation, so that a
  failed creation cannot leave two late-comers holding different locks for one identifier and both creating.
- **`remove(BeanIdentifier)`** takes the same per-identifier monitor before taking the entry out of the map, so
  it still waits for a creation of that identifier in flight and then destroys what was created, exactly as
  it did under the write lock; the bean is closed outside the monitor.
- **`destroyScope(Map)`** and **`stop()`** take no lock. Each entry is removed from the map before it is
  closed, so two destructions of one map close each bean once; then the map is cleared.
- **`findBeanRegistration(Object)`** iterates the map without a lock.

The map returned by `getScopeMap(boolean)` must therefore be a `ConcurrentMap` in this mode; `getOrCreate`
rejects any other map with an `IllegalStateException` naming the requirement, so a subclass that opts in with
a `HashMap` fails at its first resolution rather than corrupting silently.

## Why a constructor flag, and the opt-in guarantee

Default behaviour is untouched: the one-argument constructor delegates with `lockPerBean = false`, and every
existing code path — the read-lock fast path, the write-locked creation, `remove`, `destroyScope`, `stop`,
`findBeanRegistration` — is the same code under the same lock. `RequestCustomScope` in `micronaut-http` and
every subclass outside this repository keep their exact semantics without recompiling; they call the
constructor they always called. A flag was preferred to a sibling abstract class because every `protected`
hook (`getScopeMap`, `doCreate`, `destroyScope`, `handleDestructionException`) and the `final` public methods
are shared verbatim, a subclass opts in by changing one `super(...)` call, and code that types a scope as
`AbstractConcurrentCustomScope<A>` keeps working with either mode. A sibling class would have duplicated the
class for the sake of one branch per method.

## Pitfalls handled

- **`computeIfAbsent` with the creation inside** would throw `IllegalStateException: Recursive update` the
  moment a creation resolved another bean of the same scope. Only the lock object is allocated in a
  `computeIfAbsent`; the creation itself runs under a plain `synchronized` block, which is also re-entrant, so a
  creation resolving another bean of the scope on the same thread, or the same bean (which core's circular
  dependency detection handles, as before), behaves as under the re-entrant write lock.
- **`remove` racing an in-flight creation** waits on the identifier's monitor and then removes and destroys the
  new bean, the semantics of the write lock, without holding up creations of other identifiers.
- **`destroyScope` / `stop` racing an in-flight creation** sees the same two orderings as before: a creation
  that finished puts its bean in the map and it is destroyed; one that has not yet put it is not seen, and the
  bean lands in the map afterwards, as it did when the creation acquired the write lock after the destruction.
  No third outcome was introduced.
- **The fast path** for a bean already held is a single `ConcurrentMap.get`: no lock, no allocation. The
  scope-wide mode's fast path (a read lock) is unchanged.
- **Per-request maps**: `getScopeMap(true)` is called once per resolution as before and may throw
  `IllegalStateException` when no request is present; `getScopeMap(false)` may return `null` or throw in
  `remove`, `findBeanRegistration` and `stop`, which is handled as in the scope-wide mode.

## Tests

`inject`, `AbstractConcurrentCustomScopeSpec`: the existing behaviours (remove, unknown identifier, stop,
registration lookup, unavailable map) run for both modes; the scope-wide mode is shown to block a creation
that waits for another thread creating another bean; the per-bean mode is shown to complete it, to create one
bean for eight concurrent resolutions of one identifier, to create four identifiers in parallel, to have
`remove` wait for an in-flight creation and destroy its result, to hold nothing after a failed creation and
create on the next attempt, and to reject a non-concurrent scope map.

`inject-java`, `PerBeanLockingScopeSpec` with real beans and a real context: the scope-wide reproduction above,
and for a scope opting in: the waiting `@PostConstruct` completes, eight threads resolving one bean construct it
once, a bean constructor-injecting another bean of the scope is created on the same thread, a bean whose
constructor throws is not held and is attempted again, `remove` destroys the bean and the next resolution is
fresh, and the scope answers the registration of a bean it holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
