### PR TITLE
Find a bean definition by its compiled class

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/AmbiguousProxyTargetFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/AmbiguousProxyTargetFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.proxytarget;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Factory
+@Requires(property = "spec.name", value = "ProxyTargetDefinitionLookupSpec")
+class AmbiguousProxyTargetFactory {
+
+    @Singleton
+    @Mutating("value")
+    AmbiguousProxyTarget first() {
+        return () -> "first";
+    }
+
+    @Singleton
+    @Mutating("value")
+    AmbiguousProxyTarget second() {
+        return () -> "second";
+    }
+}
+
+interface AmbiguousProxyTarget {
+    String value();
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/ProxyTargetDefinitionLookupSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/ProxyTargetDefinitionLookupSpec.groovy
@@ -18,31 +18,48 @@ class ProxyTargetDefinitionLookupSpec extends Specification {
 
     @Shared
     @AutoCleanup
-    ApplicationContext context = ApplicationContext.run()
+    ApplicationContext context = ApplicationContext.run(['spec.name': 'ProxyTargetDefinitionLookupSpec'])
 
-    void "a proxy definition finds the very target definition the context resolves"() {
+    void "the context finds the very target definition for a proxy definition"() {
         when: "the definition of a bean whose methods are proxied is obtained"
         BeanDefinition<ProxyingClass> proxy = context.getBeanDefinition(ProxyingClass)
 
         then: "it is the proxy standing in front of the class that was written"
         proxy instanceof ProxyBeanDefinition
 
-        when: "the target is asked for by identity and by type"
+        when: "the target is asked for by its definition and by type"
         ProxyBeanDefinition<ProxyingClass> proxyDefinition = (ProxyBeanDefinition<ProxyingClass>) proxy
-        Optional<BeanDefinition<ProxyingClass>> byIdentity = proxyDefinition.findTargetDefinition(context)
+        Optional<BeanDefinition<ProxyingClass>> byDefinition = context.findProxyTargetBeanDefinition(proxy)
         BeanDefinition<ProxyingClass> byType = context.getProxyTargetBeanDefinition(ProxyingClass, null)
 
         then: "both answer with the same instance"
-        byIdentity.isPresent()
-        byIdentity.get().is(byType)
-        !byIdentity.get().isProxy()
-        byIdentity.get().getClass() == proxyDefinition.getTargetDefinitionType()
+        byDefinition.isPresent()
+        byDefinition.get().is(byType)
+        !byDefinition.get().isProxy()
+        byDefinition.get().getClass() == proxyDefinition.getTargetDefinitionType()
 
         and: "the registry lookup the default delegates to answers the same"
         context.findBeanDefinitionByDefinitionClass(proxyDefinition.getTargetDefinitionType()).get().is(byType)
 
         and: "the proxy definition is itself reachable through its own class"
         context.findBeanDefinitionByDefinitionClass(proxy.getClass()).get().is(proxy)
+    }
+
+    void "a proxy definition identifies its target when its target type is ambiguous"() {
+        given: "two proxied factory products with the same target type"
+        List<ProxyBeanDefinition<AmbiguousProxyTarget>> proxies = context.allBeanDefinitions
+            .findAll { it instanceof ProxyBeanDefinition && it.targetType == AmbiguousProxyTarget }
+            .collect { (ProxyBeanDefinition<AmbiguousProxyTarget>) it }
+
+        expect: "type resolution alone cannot select either target"
+        proxies.size() == 2
+        context.findProxyTargetBeanDefinition(AmbiguousProxyTarget, null).isEmpty()
+
+        and: "each proxy resolves its own compiled target definition"
+        proxies.every { proxy ->
+            Optional<BeanDefinition<AmbiguousProxyTarget>> target = context.findProxyTargetBeanDefinition(proxy)
+            target.isPresent() && target.get().getClass() == proxy.targetDefinitionType
+        }
     }
 
     void "a definition that is not a proxy is found by its own class"() {

--- a/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/ProxyTargetDefinitionLookupSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/ProxyTargetDefinitionLookupSpec.groovy
@@ -120,6 +120,26 @@ class ProxyTargetDefinitionLookupSpec extends Specification {
         found.get().getClass() == resolved.getClass()
     }
 
+    void "the interface default keeps looking past a reference that shares a definition name"() {
+        given: "a reference that answers the name of a real definition but does not load as it"
+        BeanDefinition<ArgMutatingInterceptor> resolved = context.getBeanDefinition(ArgMutatingInterceptor)
+        BeanDefinitionReference<Object> collision = Stub(BeanDefinitionReference) {
+            getBeanDefinitionName() >> resolved.getClass().name
+            isEnabled(_) >> true
+            isEnabled(_, _) >> true
+            load() >> Stub(BeanDefinition)
+            load(_) >> Stub(BeanDefinition)
+        }
+        List<BeanDefinitionReference<Object>> references = [collision] + context.getBeanDefinitionReferences().toList()
+
+        expect: "the name it shares, as class loaders can make happen, does not hide the definition asked for"
+        registryOver(registryType, references)
+            .findBeanDefinitionByDefinitionClass(resolved.getClass()).get().getClass() == resolved.getClass()
+
+        where:
+        registryType << [BeanDefinitionRegistry, BeanContext]
+    }
+
     /**
      * A registry of the given interface whose only knowledge is a fixed reference list; every default method of the
      * interface runs as written, every other method is refused, so the test exercises the default and nothing else.

--- a/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/ProxyTargetDefinitionLookupSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/ProxyTargetDefinitionLookupSpec.groovy
@@ -1,0 +1,122 @@
+package io.micronaut.aop.proxytarget
+
+import io.micronaut.context.AbstractInitializableBeanDefinition
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanContext
+import io.micronaut.context.BeanDefinitionRegistry
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.inject.ProxyBeanDefinition
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Proxy
+
+class ProxyTargetDefinitionLookupSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run()
+
+    void "a proxy definition finds the very target definition the context resolves"() {
+        when: "the definition of a bean whose methods are proxied is obtained"
+        BeanDefinition<ProxyingClass> proxy = context.getBeanDefinition(ProxyingClass)
+
+        then: "it is the proxy standing in front of the class that was written"
+        proxy instanceof ProxyBeanDefinition
+
+        when: "the target is asked for by identity and by type"
+        ProxyBeanDefinition<ProxyingClass> proxyDefinition = (ProxyBeanDefinition<ProxyingClass>) proxy
+        Optional<BeanDefinition<ProxyingClass>> byIdentity = proxyDefinition.findTargetDefinition(context)
+        BeanDefinition<ProxyingClass> byType = context.getProxyTargetBeanDefinition(ProxyingClass, null)
+
+        then: "both answer with the same instance"
+        byIdentity.isPresent()
+        byIdentity.get().is(byType)
+        !byIdentity.get().isProxy()
+        byIdentity.get().getClass() == proxyDefinition.getTargetDefinitionType()
+
+        and: "the registry lookup the default delegates to answers the same"
+        context.findBeanDefinitionByDefinitionClass(proxyDefinition.getTargetDefinitionType()).get().is(byType)
+
+        and: "the proxy definition is itself reachable through its own class"
+        context.findBeanDefinitionByDefinitionClass(proxy.getClass()).get().is(proxy)
+    }
+
+    void "a definition that is not a proxy is found by its own class"() {
+        given:
+        BeanDefinition<ArgMutatingInterceptor> definition = context.getBeanDefinition(ArgMutatingInterceptor)
+
+        expect:
+        !(definition instanceof ProxyBeanDefinition)
+        context.findBeanDefinitionByDefinitionClass(definition.getClass()).get().is(definition)
+    }
+
+    void "a class that is not a compiled definition is not found"() {
+        expect:
+        context.findBeanDefinitionByDefinitionClass(AbstractInitializableBeanDefinition).isEmpty()
+    }
+
+    void "the definition class lookup rejects null"() {
+        when:
+        context.findBeanDefinitionByDefinitionClass(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    void "the interface default finds a definition on a registry that does not override it"() {
+        given: "a registry that only knows its references and inherits everything else"
+        BeanDefinition<ArgMutatingInterceptor> resolved = context.getBeanDefinition(ArgMutatingInterceptor)
+        BeanDefinitionRegistry registry = registryOver(BeanDefinitionRegistry, context.getBeanDefinitionReferences())
+
+        when:
+        Optional<BeanDefinition<ArgMutatingInterceptor>> found = registry.findBeanDefinitionByDefinitionClass(resolved.getClass())
+
+        then: "the default loads the one matching reference"
+        found.isPresent()
+        found.get().getClass() == resolved.getClass()
+        found.get().beanType == ArgMutatingInterceptor
+
+        and: "a class no reference was compiled as is not found"
+        registry.findBeanDefinitionByDefinitionClass(AbstractInitializableBeanDefinition).isEmpty()
+
+        when:
+        registry.findBeanDefinitionByDefinitionClass(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    void "the interface default answers only an enabled definition when the registry is a bean context"() {
+        given: "a bean context that does not override the lookup"
+        BeanDefinition<ArgMutatingInterceptor> resolved = context.getBeanDefinition(ArgMutatingInterceptor)
+        BeanContext registry = registryOver(BeanContext, context.getBeanDefinitionReferences())
+
+        when:
+        Optional<BeanDefinition<ArgMutatingInterceptor>> found = registry.findBeanDefinitionByDefinitionClass(resolved.getClass())
+
+        then:
+        found.isPresent()
+        found.get().getClass() == resolved.getClass()
+    }
+
+    /**
+     * A registry of the given interface whose only knowledge is a fixed reference list; every default method of the
+     * interface runs as written, every other method is refused, so the test exercises the default and nothing else.
+     */
+    private static <R> R registryOver(Class<R> type, Collection<BeanDefinitionReference<Object>> references) {
+        InvocationHandler handler = { Object proxy, java.lang.reflect.Method method, Object[] args ->
+            if (method.name == 'getBeanDefinitionReferences') {
+                return references
+            }
+            if (method.default) {
+                return InvocationHandler.invokeDefault(proxy, method, args)
+            }
+            throw new UnsupportedOperationException("not part of this test: " + method)
+        }
+        return type.cast(Proxy.newProxyInstance(type.classLoader, [type] as Class[], handler))
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -451,8 +451,8 @@ public interface BeanDefinitionRegistry {
      * identity: the compiled definition class itself, such as the one a
      * {@link ProxyBeanDefinition#getTargetDefinitionType() proxy names as its target}. The definition returned
      * is the instance the registry uses for every other lookup, so it can be compared by identity with them.
-     * Unmatched definitions are never loaded; the match is on the name a
-     * {@link BeanDefinitionReference#getBeanDefinitionName() reference reports}.</p>
+     * Definitions whose names do not match are never loaded; the matching definition is then verified against
+     * the requested class.</p>
      *
      * <p>Only definitions generated at compile time have a class of their own. A
      * {@link RuntimeBeanDefinition} shares its class with every other runtime definition and is not found here.</p>
@@ -481,12 +481,16 @@ public interface BeanDefinitionRegistry {
                     return Optional.empty();
                 }
                 BeanDefinition<Object> definition = reference.load(context);
-                if (definition == null || !definition.isEnabled(context)) {
+                if (definition == null || definition.getClass() != definitionClass || !definition.isEnabled(context)) {
                     return Optional.empty();
                 }
                 return Optional.of((BeanDefinition<T>) definition);
             }
-            return Optional.ofNullable((BeanDefinition<T>) reference.load());
+            BeanDefinition<Object> definition = reference.load();
+            if (definition == null || definition.getClass() != definitionClass) {
+                return Optional.empty();
+            }
+            return Optional.of((BeanDefinition<T>) definition);
         }
         return Optional.empty();
     }

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -445,6 +445,53 @@ public interface BeanDefinitionRegistry {
     }
 
     /**
+     * Obtain the {@link BeanDefinition} that was compiled as the given definition class.
+     *
+     * <p>Every other lookup on this registry resolves by bean type and qualifier. This one resolves by
+     * identity: the compiled definition class itself, such as the one a
+     * {@link ProxyBeanDefinition#getTargetDefinitionType() proxy names as its target}. The definition returned
+     * is the instance the registry uses for every other lookup, so it can be compared by identity with them.
+     * Unmatched definitions are never loaded; the match is on the name a
+     * {@link BeanDefinitionReference#getBeanDefinitionName() reference reports}.</p>
+     *
+     * <p>Only definitions generated at compile time have a class of their own. A
+     * {@link RuntimeBeanDefinition} shares its class with every other runtime definition and is not found here.</p>
+     *
+     * <p>The default walks {@link #getBeanDefinitionReferences()} and loads the one reference whose name matches.
+     * Whether a definition is enabled can only be decided against a {@link BeanContext}, so a registry that is not
+     * one answers with the loaded definition as it is; a registry that is one answers only with an enabled definition.
+     * Implementations that cache loaded definitions should override this so the instance returned is the one they
+     * resolve elsewhere.</p>
+     *
+     * @param definitionClass The class of the compiled definition
+     * @param <T>             The bean type
+     * @return An {@link Optional} of the definition, empty when no enabled definition was compiled as that class
+     * @since 5.2.0
+     */
+    @SuppressWarnings("unchecked")
+    default <T> Optional<BeanDefinition<T>> findBeanDefinitionByDefinitionClass(Class<? extends BeanDefinition<T>> definitionClass) {
+        Objects.requireNonNull(definitionClass, "Definition class cannot be null");
+        String definitionName = definitionClass.getName();
+        for (BeanDefinitionReference<Object> reference : getBeanDefinitionReferences()) {
+            if (!definitionName.equals(reference.getBeanDefinitionName())) {
+                continue;
+            }
+            if (this instanceof BeanContext context) {
+                if (!reference.isEnabled(context)) {
+                    return Optional.empty();
+                }
+                BeanDefinition<Object> definition = reference.load(context);
+                if (definition == null || !definition.isEnabled(context)) {
+                    return Optional.empty();
+                }
+                return Optional.of((BeanDefinition<T>) definition);
+            }
+            return Optional.ofNullable((BeanDefinition<T>) reference.load());
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Obtain the proxy {@link BeanDefinition} for the bean of type and qualifier.
      *
      * @param beanType  The type

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -451,13 +451,15 @@ public interface BeanDefinitionRegistry {
      * identity: the compiled definition class itself, such as the one a
      * {@link ProxyBeanDefinition#getTargetDefinitionType() proxy names as its target}. The definition returned
      * is the instance the registry uses for every other lookup, so it can be compared by identity with them.
-     * Definitions whose names do not match are never loaded; the matching definition is then verified against
+     * Definitions whose names do not match are never loaded; a matching definition is then verified against
      * the requested class.</p>
      *
      * <p>Only definitions generated at compile time have a class of their own. A
      * {@link RuntimeBeanDefinition} shares its class with every other runtime definition and is not found here.</p>
      *
-     * <p>The default walks {@link #getBeanDefinitionReferences()} and loads the one reference whose name matches.
+     * <p>The default walks {@link #getBeanDefinitionReferences()} and loads every reference whose name matches
+     * until one of them turns out to be the requested class, so a name shared by two references, as class loaders
+     * can make happen, does not hide the definition that was asked for.
      * Whether a definition is enabled can only be decided against a {@link BeanContext}, so a registry that is not
      * one answers with the loaded definition as it is; a registry that is one answers only with an enabled definition.
      * Implementations that cache loaded definitions should override this so the instance returned is the one they
@@ -472,25 +474,22 @@ public interface BeanDefinitionRegistry {
     default <T> Optional<BeanDefinition<T>> findBeanDefinitionByDefinitionClass(Class<? extends BeanDefinition<T>> definitionClass) {
         Objects.requireNonNull(definitionClass, "Definition class cannot be null");
         String definitionName = definitionClass.getName();
+        BeanContext context = this instanceof BeanContext beanContext ? beanContext : null;
         for (BeanDefinitionReference<Object> reference : getBeanDefinitionReferences()) {
             if (!definitionName.equals(reference.getBeanDefinitionName())) {
                 continue;
             }
-            if (this instanceof BeanContext context) {
-                if (!reference.isEnabled(context)) {
-                    return Optional.empty();
+            if (context == null) {
+                BeanDefinition<Object> definition = reference.load();
+                if (definition != null && definition.getClass() == definitionClass) {
+                    return Optional.of((BeanDefinition<T>) definition);
                 }
+            } else if (reference.isEnabled(context)) {
                 BeanDefinition<Object> definition = reference.load(context);
-                if (definition == null || definition.getClass() != definitionClass || !definition.isEnabled(context)) {
-                    return Optional.empty();
+                if (definition != null && definition.getClass() == definitionClass && definition.isEnabled(context)) {
+                    return Optional.of((BeanDefinition<T>) definition);
                 }
-                return Optional.of((BeanDefinition<T>) definition);
             }
-            BeanDefinition<Object> definition = reference.load();
-            if (definition == null || definition.getClass() != definitionClass) {
-                return Optional.empty();
-            }
-            return Optional.of((BeanDefinition<T>) definition);
         }
         return Optional.empty();
     }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1587,6 +1587,15 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     }
 
     @Override
+    public <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(BeanDefinition<T> proxyBeanDefinition) {
+        ArgumentUtils.requireNonNull("proxyBeanDefinition", proxyBeanDefinition);
+        if (proxyBeanDefinition instanceof ProxyBeanDefinition<T> proxyDefinition) {
+            return findBeanDefinitionByDefinitionClass(proxyDefinition.getTargetDefinitionType());
+        }
+        return Optional.empty();
+    }
+
+    @Override
     @SuppressWarnings("java:S2789") // performance optimization
     public <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1581,6 +1581,12 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     }
 
     @Override
+    public <T> Optional<BeanDefinition<T>> findBeanDefinitionByDefinitionClass(Class<? extends BeanDefinition<T>> definitionClass) {
+        ArgumentUtils.requireNonNull("definitionClass", definitionClass);
+        return Optional.ofNullable(beanDefinitionProvider.findBeanDefinitionByDefinitionClass(this, definitionClass));
+    }
+
+    @Override
     @SuppressWarnings("java:S2789") // performance optimization
     public <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);

--- a/inject/src/main/java/io/micronaut/context/beans/BeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/BeanDefinitionService.java
@@ -197,6 +197,22 @@ public sealed interface BeanDefinitionService permits DefaultBeanDefinitionServi
     List<BeanDefinitionReference<Object>> getBeanReferences();
 
     /**
+     * Finds the bean definition that was compiled as the given definition class.
+     *
+     * <p>The lookup is by the definition's own class name, as reported by
+     * {@link BeanDefinitionReference#getBeanDefinitionName()}, so unmatched definitions are never loaded.
+     * The instance returned is the one this service hands out for every other lookup.</p>
+     *
+     * @param beanContext     the bean context to eliminate disabled beans
+     * @param definitionClass the class of the compiled definition
+     * @param <T>             the bean type
+     * @return the enabled definition compiled as that class, or {@code null} if there is none
+     * @since 5.2.0
+     */
+    @Nullable
+    <T> BeanDefinition<T> findBeanDefinitionByDefinitionClass(BeanContext beanContext, Class<? extends BeanDefinition<T>> definitionClass);
+
+    /**
      * Registers a bean configuration.
      *
      * @param configuration the configuration to register

--- a/inject/src/main/java/io/micronaut/context/beans/BeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/BeanDefinitionService.java
@@ -199,8 +199,10 @@ public sealed interface BeanDefinitionService permits DefaultBeanDefinitionServi
     /**
      * Finds the bean definition that was compiled as the given definition class.
      *
-     * <p>The lookup is by the definition's own class name, as reported by
-     * {@link BeanDefinitionReference#getBeanDefinitionName()}, so unmatched definitions are never loaded.
+     * <p>Candidates are narrowed by the definition's own class name, as reported by
+     * {@link BeanDefinitionReference#getBeanDefinitionName()}, so unmatched definitions are never loaded; each
+     * candidate is then loaded until one of them is the requested class, so a name that two references share,
+     * as separate class loaders can make happen, does not hide the definition that was asked for.
      * The instance returned is the one this service hands out for every other lookup.</p>
      *
      * @param beanContext     the bean context to eliminate disabled beans

--- a/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
@@ -220,25 +220,29 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
         if (current == null) {
             return null;
         }
-        String definitionName = definitionClass.getName();
-        BeanDefinitionProducer producer = findProducerByDefinitionName(current.all, definitionName);
-        if (producer == null) {
+        BeanDefinition<T> definition = findDefinitionByDefinitionClass(current.all, beanContext, definitionClass);
+        if (definition == null) {
             // A proxied bean is disabled in the main list and its target is kept apart, see createBeans
-            producer = findProducerByDefinitionName(current.proxyTargetBeans, definitionName);
+            definition = findDefinitionByDefinitionClass(current.proxyTargetBeans, beanContext, definitionClass);
         }
-        if (producer == null) {
-            return null;
-        }
-        BeanDefinition<T> definition = producer.getDefinitionIfEnabled(beanContext, null, beanResolutionCustomizer, null, null, null);
-        return definition != null && definition.getClass() == definitionClass ? definition : null;
+        return definition;
     }
 
     @Nullable
-    private static BeanDefinitionProducer findProducerByDefinitionName(List<BeanDefinitionProducer> producers, String definitionName) {
+    private <T> BeanDefinition<T> findDefinitionByDefinitionClass(List<BeanDefinitionProducer> producers,
+                                                                 BeanContext beanContext,
+                                                                 Class<? extends BeanDefinition<T>> definitionClass) {
+        String definitionName = definitionClass.getName();
         for (BeanDefinitionProducer producer : producers) {
             BeanDefinitionReference<?> reference = producer.reference;
-            if (reference != null && definitionName.equals(reference.getBeanDefinitionName())) {
-                return producer;
+            if (reference == null || !definitionName.equals(reference.getBeanDefinitionName())) {
+                continue;
+            }
+            // The name is only a cheap filter: two references can carry the same name across class loaders,
+            // so keep looking until one of them loads as the requested class
+            BeanDefinition<T> definition = producer.getDefinitionIfEnabled(beanContext, null, beanResolutionCustomizer, null, null, null);
+            if (definition != null && definition.getClass() == definitionClass) {
+                return definition;
             }
         }
         return null;

--- a/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
@@ -229,7 +229,8 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
         if (producer == null) {
             return null;
         }
-        return producer.getDefinitionIfEnabled(beanContext, null, beanResolutionCustomizer, null, null, null);
+        BeanDefinition<T> definition = producer.getDefinitionIfEnabled(beanContext, null, beanResolutionCustomizer, null, null, null);
+        return definition != null && definition.getClass() == definitionClass ? definition : null;
     }
 
     @Nullable

--- a/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
@@ -48,6 +48,7 @@ import jakarta.inject.Singleton;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -108,6 +109,18 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
     private final ClassLoader classLoader;
     @Nullable
     private Beans beans;
+
+    /**
+     * The producers of {@link #beans}, keyed by the definition name their reference reports. Built on the first
+     * lookup by definition class and dropped as soon as the producers are rebuilt, which the {@link Beans} the
+     * index was built from detects. Only a {@link io.micronaut.context.RuntimeBeanDefinition} is added to a live
+     * {@code Beans}, and the name it generates is never a compiled definition class name, so an index built
+     * before such an addition cannot answer a lookup wrongly.
+     */
+    @Nullable
+    @SuppressWarnings("java:S3077")
+    private volatile ProducersByDefinitionName producersByDefinitionName;
+
     private final BeanResolutionCustomizer beanResolutionCustomizer;
 
     private final List<BeanDefinitionProducer> additionalBeanDefinitions = new ArrayList<>();
@@ -220,24 +233,11 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
         if (current == null) {
             return null;
         }
-        BeanDefinition<T> definition = findDefinitionByDefinitionClass(current.all, beanContext, definitionClass);
-        if (definition == null) {
-            // A proxied bean is disabled in the main list and its target is kept apart, see createBeans
-            definition = findDefinitionByDefinitionClass(current.proxyTargetBeans, beanContext, definitionClass);
+        List<BeanDefinitionProducer> candidates = producersByDefinitionName(current).get(definitionClass.getName());
+        if (candidates == null) {
+            return null;
         }
-        return definition;
-    }
-
-    @Nullable
-    private <T> BeanDefinition<T> findDefinitionByDefinitionClass(List<BeanDefinitionProducer> producers,
-                                                                 BeanContext beanContext,
-                                                                 Class<? extends BeanDefinition<T>> definitionClass) {
-        String definitionName = definitionClass.getName();
-        for (BeanDefinitionProducer producer : producers) {
-            BeanDefinitionReference<?> reference = producer.reference;
-            if (reference == null || !definitionName.equals(reference.getBeanDefinitionName())) {
-                continue;
-            }
+        for (BeanDefinitionProducer producer : candidates) {
             // The name is only a cheap filter: two references can carry the same name across class loaders,
             // so keep looking until one of them loads as the requested class
             BeanDefinition<T> definition = producer.getDefinitionIfEnabled(beanContext, null, beanResolutionCustomizer, null, null, null);
@@ -246,6 +246,28 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
             }
         }
         return null;
+    }
+
+    private Map<String, List<BeanDefinitionProducer>> producersByDefinitionName(Beans current) {
+        ProducersByDefinitionName cached = producersByDefinitionName;
+        if (cached != null && cached.beans == current) {
+            return cached.index;
+        }
+        Map<String, List<BeanDefinitionProducer>> index = new HashMap<>();
+        indexByDefinitionName(index, current.all);
+        // A proxied bean is disabled in the main list and its target is kept apart, see createBeans
+        indexByDefinitionName(index, current.proxyTargetBeans);
+        producersByDefinitionName = new ProducersByDefinitionName(current, index);
+        return index;
+    }
+
+    private static void indexByDefinitionName(Map<String, List<BeanDefinitionProducer>> index, List<BeanDefinitionProducer> producers) {
+        for (BeanDefinitionProducer producer : producers) {
+            BeanDefinitionReference<?> reference = producer.reference;
+            if (reference != null) {
+                index.computeIfAbsent(reference.getBeanDefinitionName(), name -> new ArrayList<>(1)).add(producer);
+            }
+        }
     }
 
     @Override
@@ -616,6 +638,9 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
             refs = list;
         }
         return refs;
+    }
+
+    private record ProducersByDefinitionName(Beans beans, Map<String, List<BeanDefinitionProducer>> index) {
     }
 
     private record Beans(

--- a/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
+++ b/inject/src/main/java/io/micronaut/context/beans/DefaultBeanDefinitionService.java
@@ -214,6 +214,36 @@ public final class DefaultBeanDefinitionService implements BeanDefinitionService
     }
 
     @Override
+    @Nullable
+    public <T> BeanDefinition<T> findBeanDefinitionByDefinitionClass(BeanContext beanContext, Class<? extends BeanDefinition<T>> definitionClass) {
+        Beans current = beans;
+        if (current == null) {
+            return null;
+        }
+        String definitionName = definitionClass.getName();
+        BeanDefinitionProducer producer = findProducerByDefinitionName(current.all, definitionName);
+        if (producer == null) {
+            // A proxied bean is disabled in the main list and its target is kept apart, see createBeans
+            producer = findProducerByDefinitionName(current.proxyTargetBeans, definitionName);
+        }
+        if (producer == null) {
+            return null;
+        }
+        return producer.getDefinitionIfEnabled(beanContext, null, beanResolutionCustomizer, null, null, null);
+    }
+
+    @Nullable
+    private static BeanDefinitionProducer findProducerByDefinitionName(List<BeanDefinitionProducer> producers, String definitionName) {
+        for (BeanDefinitionProducer producer : producers) {
+            BeanDefinitionReference<?> reference = producer.reference;
+            if (reference != null && definitionName.equals(reference.getBeanDefinitionName())) {
+                return producer;
+            }
+        }
+        return null;
+    }
+
+    @Override
     public <B> Iterable<BeanDefinition<B>> getBeanDefinitions(BeanResolutionContext beanResolutionContext,
                                                               Argument<B> beanType,
                                                               @Nullable Predicate<BeanDefinitionReference<B>> refPredicate,

--- a/inject/src/main/java/io/micronaut/inject/ProxyBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/ProxyBeanDefinition.java
@@ -15,6 +15,11 @@
  */
 package io.micronaut.inject;
 
+import io.micronaut.context.BeanDefinitionRegistry;
+
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * Marker interface for a {@link BeanDefinition} that is an AOP proxy.
  *
@@ -33,6 +38,22 @@ public interface ProxyBeanDefinition<T> extends BeanDefinition<T> {
      * @return The target type
      */
     Class<T> getTargetType();
+
+    /**
+     * Finds the definition this proxy stands in front of.
+     *
+     * <p>{@link BeanDefinitionRegistry#findProxyTargetBeanDefinition(BeanDefinition)} answers by re-resolving the
+     * proxy's type and qualifier. This answers by identity: the definition compiled as
+     * {@link #getTargetDefinitionType()}, the same instance the registry resolves for it.</p>
+     *
+     * @param registry The registry holding the definitions
+     * @return An {@link Optional} of the target definition, empty when the registry does not hold it
+     * @since 5.2.0
+     */
+    default Optional<BeanDefinition<T>> findTargetDefinition(BeanDefinitionRegistry registry) {
+        Objects.requireNonNull(registry, "Registry cannot be null");
+        return registry.findBeanDefinitionByDefinitionClass(getTargetDefinitionType());
+    }
 
     @Override
     default boolean isProxy() {

--- a/inject/src/main/java/io/micronaut/inject/ProxyBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/ProxyBeanDefinition.java
@@ -15,11 +15,6 @@
  */
 package io.micronaut.inject;
 
-import io.micronaut.context.BeanDefinitionRegistry;
-
-import java.util.Objects;
-import java.util.Optional;
-
 /**
  * Marker interface for a {@link BeanDefinition} that is an AOP proxy.
  *
@@ -38,22 +33,6 @@ public interface ProxyBeanDefinition<T> extends BeanDefinition<T> {
      * @return The target type
      */
     Class<T> getTargetType();
-
-    /**
-     * Finds the definition this proxy stands in front of.
-     *
-     * <p>{@link BeanDefinitionRegistry#findProxyTargetBeanDefinition(BeanDefinition)} answers by re-resolving the
-     * proxy's type and qualifier. This answers by identity: the definition compiled as
-     * {@link #getTargetDefinitionType()}, the same instance the registry resolves for it.</p>
-     *
-     * @param registry The registry holding the definitions
-     * @return An {@link Optional} of the target definition, empty when the registry does not hold it
-     * @since 5.2.0
-     */
-    default Optional<BeanDefinition<T>> findTargetDefinition(BeanDefinitionRegistry registry) {
-        Objects.requireNonNull(registry, "Registry cannot be null");
-        return registry.findBeanDefinitionByDefinitionClass(getTargetDefinitionType());
-    }
 
     @Override
     default boolean isProxy() {


### PR DESCRIPTION
## Why

A ProxyBeanDefinition exposes the compiled class of the definition it proxies through getTargetDefinitionType(). Resolving only by bean type and qualifier can be ambiguous when multiple proxy targets have the same type, so it cannot reliably identify that exact compiled target definition.

## Changes

- Add BeanDefinitionRegistry.findBeanDefinitionByDefinitionClass(Class), a default lookup for a generated definition class.
- Narrow candidates by the BeanDefinitionReference-reported name, then verify the loaded definition has the exact requested Class identity. This avoids a false match when a name collision involves different class loaders.
- DefaultBeanContext uses its BeanDefinitionService fast path, which returns the cached definition instance from either the normal or proxy-target producer list.
- DefaultBeanContext overrides the existing findProxyTargetBeanDefinition(BeanDefinition) API for ProxyBeanDefinition instances and resolves the proxy target through its compiled definition class.
- Do not add another public method to ProxyBeanDefinition. Other BeanDefinitionRegistry implementations retain the existing interface-default behavior.
- RuntimeBeanDefinition is intentionally out of scope because runtime definitions share their implementation class.

## Tests

ProxyTargetDefinitionLookupSpec verifies:

- lookup of proxied, non-proxied, disabled, and invalid definitions by compiled class;
- the exact proxy target definition is returned by DefaultBeanContext; and
- two proxied factory products with the same target type are each resolved to their own compiled target definition, while type-only proxy-target lookup is ambiguous.

## Compatibility

The new registry method is a default interface method, so existing BeanDefinitionRegistry implementations remain source-compatible. It is an additive API for the 5.2.0 minor release.