### PR TITLE
Propagate hasEvaluatedExpressions in DefaultAnnotationMetadata copies

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/EvaluatedExpressionsMetadataCopySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/EvaluatedExpressionsMetadataCopySpec.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.inject.BeanDefinition
+
+class EvaluatedExpressionsMetadataCopySpec extends AbstractTypeElementSpec {
+
+    void "test hasEvaluatedExpressions() is retained by clone() and getDeclaredMetadata()"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.Expr', '''
+package test;
+
+import io.micronaut.context.annotation.Executable;
+import jakarta.inject.Singleton;
+
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Singleton
+@CustomAnnotation("#{ 1 + 1 }")
+class Expr {
+}
+
+@Retention(RUNTIME)
+@interface CustomAnnotation {
+    String value();
+}
+''')
+
+        AnnotationMetadata annotationMetadata = definition.getAnnotationMetadata().getTargetAnnotationMetadata()
+
+        expect:
+        annotationMetadata instanceof DefaultAnnotationMetadata
+        annotationMetadata.hasEvaluatedExpressions()
+        ((DefaultAnnotationMetadata) annotationMetadata).clone().hasEvaluatedExpressions()
+        annotationMetadata.getDeclaredMetadata().hasEvaluatedExpressions()
+    }
+
+    void "test hasEvaluatedExpressions() is false for metadata without expressions"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.NoExpr', '''
+package test;
+
+import jakarta.inject.Singleton;
+
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Singleton
+@CustomAnnotation("plain")
+class NoExpr {
+}
+
+@Retention(RUNTIME)
+@interface CustomAnnotation {
+    String value();
+}
+''')
+
+        AnnotationMetadata annotationMetadata = definition.getAnnotationMetadata().getTargetAnnotationMetadata()
+
+        expect:
+        annotationMetadata instanceof DefaultAnnotationMetadata
+        !annotationMetadata.hasEvaluatedExpressions()
+        !((DefaultAnnotationMetadata) annotationMetadata).clone().hasEvaluatedExpressions()
+        !annotationMetadata.getDeclaredMetadata().hasEvaluatedExpressions()
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -172,7 +172,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 null,
                 null,
                 annotationsByStereotype,
-                hasPropertyExpressions
+                hasPropertyExpressions,
+                hasEvaluatedExpressions
         );
     }
 
@@ -1377,7 +1378,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 allStereotypes != null ? cloneMapOfMapValue(allStereotypes) : null,
                 allAnnotations != null ? cloneMapOfMapValue(allAnnotations) : null,
                 annotationsByStereotype != null ? cloneMapOfListValue(annotationsByStereotype) : null,
-                hasPropertyExpressions
+                hasPropertyExpressions,
+                hasEvaluatedExpressions
         );
         return cloned;
     }


### PR DESCRIPTION
### What changed

`DefaultAnnotationMetadata.clone()` and `DefaultAnnotationMetadata.getDeclaredMetadata()` both constructed the new instance with the 6-argument constructor, which defaults `hasEvaluatedExpressions` to `false`. Both now use the 7-argument constructor and pass the flag through.

`hasPropertyExpressions` was already propagated correctly in both methods, and `MutableAnnotationMetadata.clone()` already handled `hasEvaluatedExpressions` correctly — this looks like an oversight from when the flag was added, and only the two `DefaultAnnotationMetadata` paths were affected.

### Why it matters

The flag is a gate, not a hint:

- `AnnotationMetadataGenUtils` serializes `annotationMetadata.hasEvaluatedExpressions()` as the 7th constructor argument into generated metadata classes, so a copy made anywhere in the processing pipeline before writing bakes `false` into the bytecode permanently.
- At runtime, `EvaluatedAnnotationMetadata.wrapIfNecessary`, `ExpressionsAwareArgument`, `AbstractInitializableBeanDefinition.configure` and `RequiresCondition` all short-circuit on a `false` flag. The metadata is then never wrapped, so `EvaluatedExpressionReference` values are never evaluated and leak through as raw `#{...}` references.

### Note for reviewers

For `getDeclaredMetadata()` the flag can now over-report when the expression lives only in an inherited annotation rather than a declared one. That is harmless — it triggers a wrapper that finds nothing to evaluate — and is the same over-approximation `hasPropertyExpressions` already makes in that method.

### Tests

New `inject-java` spec `EvaluatedExpressionsMetadataCopySpec` compiles a bean carrying `@CustomAnnotation("#{ 1 + 1 }")`, unwraps the generated `DefaultAnnotationMetadata` via `getTargetAnnotationMetadata()`, and asserts the flag survives both `clone()` and `getDeclaredMetadata()`. A second case pins the negative side so the assertions aren't vacuous.

Verified by reverting the fix and re-running the spec: the positive case fails, the negative passes. With the fix in place, `:micronaut-inject:test` and `:micronaut-inject-java:test` pass — 4964 tests, 0 failures, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
