### PR TITLE
Fix: Micronaut Python cannot start on a JVM without JVMCI

### DIFF
--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyEngineFactory.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyEngineFactory.java
@@ -31,7 +31,9 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Factory for producing a GraalVM Polyglot {@link Engine} for Python contexts.
@@ -41,6 +43,7 @@ import java.util.Map;
 @Factory
 final class GraalPyEngineFactory implements BeanDestroyedEventListener<Engine> {
     private static final Logger LOG = LoggerFactory.getLogger(GraalPyEngineFactory.class);
+    private static final Map<String, Boolean> SUPPORTED_ENGINE_OPTIONS = new ConcurrentHashMap<>();
 
     /**
      * Create the application-scoped Python engine bean.
@@ -74,10 +77,52 @@ final class GraalPyEngineFactory implements BeanDestroyedEventListener<Engine> {
      * @return A new Python polyglot engine.
      */
     static Engine buildPythonEngine(GraalPyEngineConfiguration engineConfiguration) {
-        return engineConfiguration.builder
+        Engine.Builder builder = engineConfiguration.builder
             .exceptionHandler(GraalPyExceptionHandler.RETHROW_HOST_RUNTIME_EXCEPTION)
-            .logHandler(new GraalPySlf4jLogHandler())
-            .build();
+            .logHandler(new GraalPySlf4jLogHandler());
+        // Engine.Builder#options accumulates, so an unsupported option cannot be removed once set.
+        // The support check has to happen before it is applied, not as a retry.
+        Map<String, String> supported = new LinkedHashMap<>();
+        for (Map.Entry<String, String> option : engineConfiguration.optionalOptions.entrySet()) {
+            if (isEngineOptionSupported(option.getKey())) {
+                supported.put(option.getKey(), option.getValue());
+            } else {
+                LOG.debug("GraalPy runtime does not support engine option {}, leaving it unset", option.getKey());
+            }
+        }
+        if (!supported.isEmpty()) {
+            builder.options(supported);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Whether the active Truffle runtime knows the given engine option.
+     *
+     * <p>The tuning options Micronaut sets exist only on the optimizing runtime. On the fallback
+     * runtime - any JVM without JVMCI, which includes stock OpenJDK and a GraalVM CE not started
+     * with {@code -XX:+EnableJVMCI} - setting one makes {@code build()} throw and Python then fails
+     * to start at all rather than merely running interpreted.</p>
+     *
+     * <p>The probe engine is not the cost it appears to be: it is polyglot initialization, which the
+     * real engine pays regardless, so a second creation is effectively free.</p>
+     *
+     * @param option The option name
+     * @return Whether it is supported
+     */
+    private static boolean isEngineOptionSupported(String option) {
+        Boolean known = SUPPORTED_ENGINE_OPTIONS.get(option);
+        if (known != null) {
+            return known;
+        }
+        boolean supported;
+        try (Engine probe = Engine.create()) {
+            supported = probe.getOptions().get(option) != null;
+        } catch (Exception e) {
+            supported = false;
+        }
+        SUPPORTED_ENGINE_OPTIONS.put(option, supported);
+        return supported;
     }
 
     /**
@@ -135,6 +180,11 @@ final class GraalPyEngineFactory implements BeanDestroyedEventListener<Engine> {
     static final class GraalPyEngineConfiguration {
         public static final String PREFIX = "graalpy.engine";
 
+        /**
+         * Options to apply only if the runtime recognises them.
+         */
+        final Map<String, String> optionalOptions = new LinkedHashMap<>();
+
         @ConfigurationBuilder(prefixes = "", excludes = {"out", "in", "err", "exceptionHandler", "messageTransport"})
         Engine.Builder builder = Engine.newBuilder(
             GraalPyContextCustomizers.languages(GraalPyContextCustomizers.currentClassLoader())
@@ -142,7 +192,12 @@ final class GraalPyEngineFactory implements BeanDestroyedEventListener<Engine> {
 
         GraalPyEngineConfiguration() {
             // currently GraalPy spawns too many compiler threads by default. limit to 1 for now.
-            builder.options(Map.of("engine.CompilerThreads", "1"));
+            // Only the optimizing Truffle runtime knows this option. On the fallback runtime - any
+            // JVM without JVMCI enabled, which includes stock OpenJDK and a GraalVM CE that was not
+            // started with -XX:+EnableJVMCI - setting it makes Engine.build() throw
+            // IllegalArgumentException, and Python then fails to start at all rather than merely
+            // running interpreted. Applied on a best effort basis instead, in buildPythonEngine.
+            optionalOptions.put("engine.CompilerThreads", "1");
         }
 
         /**

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAstParser.java
@@ -88,14 +88,7 @@ public final class PythonAstParser {
     }
 
     PythonAstParser(ClassLoader classLoader, boolean incremental) {
-        var contextBuilder = GraalPyResources.contextBuilder(VirtualFileSystem.newBuilder()
-                .resourceDirectory(INJECT_RESOURCES)
-                .resourceLoadingClass(PythonAstParser.class)
-                .build())
-            // Future hardening should constrain host access to the required Micronaut API surface.
-            .allowHostAccess(HostAccess.ALL)
-            .hostClassLoader(classLoader)
-            .allowHostClassLookup(name -> name.startsWith("io.micronaut"));
+        var contextBuilder = newContextBuilder(classLoader);
         if (incremental) {
             // Incremental processing is a short-lived workload. Tune GraalPy for startup latency
             // and avoid paying for a core-count-based compiler thread pool.
@@ -103,10 +96,45 @@ public final class PythonAstParser {
                 .option("engine.Mode", "latency")
                 .option("engine.CompilerThreads", "1");
         }
-        this.context = contextBuilder.build();
+        // Both of those options exist only on the optimizing Truffle runtime. On the fallback
+        // runtime - any JVM without JVMCI, which includes stock OpenJDK and a GraalVM CE not started
+        // with -XX:+EnableJVMCI - build() throws IllegalArgumentException and Pyronaut cannot compile
+        // Python at all. Tuning is not worth failing the build over, so fall back without them.
+        this.context = buildTolerantly(contextBuilder, incremental, classLoader);
         context.initialize(PYTHON);
         context.eval(COMPILE_RUNTIME_AST_SOURCE);
         runtimeAstCompiler = context.getBindings(PYTHON).getMember("_mn_compile_runtime_ast");
+    }
+
+    private static Context.Builder newContextBuilder(ClassLoader classLoader) {
+        return GraalPyResources.contextBuilder(VirtualFileSystem.newBuilder()
+                .resourceDirectory(INJECT_RESOURCES)
+                .resourceLoadingClass(PythonAstParser.class)
+                .build())
+            // Future hardening should constrain host access to the required Micronaut API surface.
+            .allowHostAccess(HostAccess.ALL)
+            .hostClassLoader(classLoader)
+            .allowHostClassLookup(name -> name.startsWith("io.micronaut"));
+    }
+
+    /**
+     * Builds the context, retrying without the optimizing-runtime tuning options if the runtime does
+     * not recognise them.
+     *
+     * @param contextBuilder The builder, already carrying the tuning options when incremental
+     * @param incremental    Whether the tuning options were applied
+     * @param classLoader    The host class loader, needed to rebuild from scratch
+     * @return The context
+     */
+    private static Context buildTolerantly(Context.Builder contextBuilder, boolean incremental, ClassLoader classLoader) {
+        try {
+            return contextBuilder.build();
+        } catch (IllegalArgumentException e) {
+            if (!incremental) {
+                throw e;
+            }
+            return newContextBuilder(classLoader).build();
+        }
     }
 
     PythonBytecodeCompiler bytecodeCompiler() {


### PR DESCRIPTION
Micronaut Python does not start on a stock JVM. Not "runs slowly" — does not start, and cannot
compile Python sources either.

## The cause

GraalPy runs on one of two Truffle runtimes: the **optimizing** runtime, which JIT-compiles guest
code and requires JVMCI, or the **fallback** runtime, a pure interpreter used whenever the
optimizing one cannot load.

`engine.CompilerThreads` sizes the guest compiler's thread pool, so it exists **only on the
optimizing runtime**. Polyglot validates option names when the engine is built, and an unknown name
throws:

```
java.lang.IllegalArgumentException: Could not find option with name engine.CompilerThreads
```

Micronaut sets it unconditionally in two places:

- `GraalPyEngineFactory.GraalPyEngineConfiguration` — *"currently GraalPy spawns too many compiler
  threads by default. limit to 1 for now."*
- `PythonAstParser`, in incremental mode, alongside `engine.Mode=latency`

The intent is a tuning knob. The effect is a hard dependency: on the fallback runtime the engine
cannot be constructed, so every Python bean fails to instantiate and the application does not start.
Because the AST parser sets it too, the **compiler** fails as well and `.py` files cannot be turned
into classes. Both ends of the pipeline are down.

## Who this affects

Wider than it looks. The fallback runtime is used on any JVM without JVMCI enabled — which is stock
OpenJDK, the common deployment. Verified there, and, less obviously, **on GraalVM CE 25 as well**,
which reports:

```
engine.CompilerThreads supported: false
JVMCI is not enabled for this JVM. Enable JVMCI using -XX:+EnableJVMCI.
```

So "run it on GraalVM" is not sufficient to avoid this.

## Reproduction

On a JDK without JVMCI enabled:

```bash
./gradlew :micronaut-inject-python:test :micronaut-inject-python-test:test :test-suite-python:test -Ppython-ci
```

## Effect of this change

Measured on this machine, OpenJDK 25, before and after:

| Suite | Before | After |
|---|---|---|
| `micronaut-inject-python` | 9 of 104 failed | **104 pass** |
| `micronaut-inject-python-test` | 304 of 586 failed | **586 pass** |
| `test-suite-python` | could not run | **196 pass** |

## The fix, and why the two call sites differ

Both now apply the options only where the runtime understands them, but they cannot do it the same
way.

`Engine.Builder#options()` **accumulates**. Once an unsupported option is on the builder it cannot be
removed, so the obvious set-then-retry does not work — the retry carries the same bad option and
throws again. I tried that first; it fixed one suite and left 304 failures in another. Support has to
be determined *before* the option is applied.

- **Engine path** — checks support and caches the answer. That check is cheaper than it looks: it is
  polyglot initialization, which the real engine pays regardless, so a second `Engine.create()`
  measures 0ms against ~116ms for the first.
- **Parser path** — constructs its own context builder, so it can simply build a fresh one without
  the tuning.

Losing the tuning on a runtime that cannot compile anyway costs nothing that matters; failing to
start costs everything.

## Related, not fixed here

Python test tasks are skipped unless `-Ppython-ci` is passed, so none of this is visible in a normal
build. That is likely why it went unnoticed: green by default locally, and presumably JVMCI-enabled
wherever CI does run them. Worth addressing separately.

## Testing

All three Python suites pass, run repeatedly. `micronaut-context` and `micronaut-inject` unaffected.
Checkstyle clean.

One caveat worth recording: two `pojo_validation` tests in `test-suite-python` failed in a single
full-suite run and passed in three subsequent full runs and 3/3 in isolation, with identical code.
That looks like pre-existing flakiness under full-suite conditions rather than anything from this
change — on unmodified `5.2.x` those tests cannot run at all — but I could not make it deterministic
enough to prove either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)