### PR TITLE
Return the resolved values from getAnnotationValuesByName

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -988,7 +988,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             results = List.of();
         }
         annotationValuesByType.put(annotationType, results);
-        return List.of();
+        return results;
     }
 
     protected <T extends Annotation> AnnotationValue<T> newAnnotationValue(String annotationType, Map<CharSequence, Object> values) {

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.inject.annotation
 
 import io.micronaut.context.annotation.EachBean
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.AnnotationValue
@@ -111,6 +112,20 @@ class AnnotationMetadataSpec extends Specification {
         noExceptionThrown()
         deprecated != null
         deprecated.annotationType() == Deprecated
+    }
+
+    void "test getAnnotationValuesByName resolves a repeatable annotation stored under its own name"() {
+        given:
+        MutableAnnotationMetadata metadata = new MutableAnnotationMetadata()
+        metadata.addAnnotation(Requires.name, [property: "foo"])
+
+        when: "the repeatable annotation is not wrapped in its container"
+        List<AnnotationValue<Requires>> values = metadata.getAnnotationValuesByName(Requires.name)
+
+        then: "it is resolved by its own name, consistently with the type based variant"
+        values.size() == 1
+        values[0].stringValue("property").get() == "foo"
+        metadata.getAnnotationValuesByType(Requires).size() == 1
     }
 
     AnnotationMetadata newMetadata(AnnotationValueBuilder... builders) {


### PR DESCRIPTION
`DefaultAnnotationMetadata.getAnnotationValuesByName` computed the fallback result for a repeatable annotation stored under its own name rather than wrapped in its container, cached it into `annotationValuesByType`, and then returned `List.of()` instead of it.

The `Class`-based `getAnnotationValuesByType` has the same fallback branch and returns it, so the two overloads disagreed on identical metadata:

```java
var m = new MutableAnnotationMetadata();
m.addAnnotation(Requires.class.getName(), Map.of("property", "foo"));

m.getAnnotationValuesByType(Requires.class);           // [@Requires(property=foo)]
m.getAnnotationValuesByName(Requires.class.getName()); // []
```

Caching a value that is never returned is also self-inconsistent — `getAnnotationValuesByType` reads that same map. The branch dates back to when the method was lifted out of `getAnnotationValuesByType` in 314ae63892, where the inner `return results` was lost.

The Java annotation processor always wraps a repeatable in its container, so this is not reachable from compile-time metadata, but metadata built at runtime does reach it — and real callers sit on that path (`ServiceLoaderFeature` for `@Requires`, `InterceptorBindingQualifier` for `@InterceptorBinding`, both repeatable).

Found while working on https://github.com/micronaut-projects/micronaut-core/pull/12963, left out of that PR to keep its scope.

### Testing

A spec covering the changed line; verified non-vacuous (reverting the one-line fix makes it fail). `:micronaut-inject:test` and `:micronaut-inject-java:test` (5004 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)