### PR TITLE
fix: handle discovery health without cache implementation

### DIFF
--- a/management/src/main/java/io/micronaut/management/health/indicator/discovery/DiscoveryClientHealthIndicator.java
+++ b/management/src/main/java/io/micronaut/management/health/indicator/discovery/DiscoveryClientHealthIndicator.java
@@ -16,7 +16,10 @@
 package io.micronaut.management.health.indicator.discovery;
 
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.CompositeDiscoveryClient;
+import io.micronaut.discovery.DefaultCompositeDiscoveryClient;
 import io.micronaut.discovery.DiscoveryClient;
 import io.micronaut.discovery.ServiceInstance;
 import io.micronaut.health.HealthStatus;
@@ -47,16 +50,50 @@ import java.util.stream.Stream;
 public class DiscoveryClientHealthIndicator implements HealthIndicator {
 
     private final DiscoveryClient discoveryClient;
+    private final DiscoveryClient uncachedDiscoveryClient;
+    private final String description;
+    private final boolean hasNoChildClients;
 
     /**
      * @param discoveryClient The Discovery client
      */
     public DiscoveryClientHealthIndicator(DiscoveryClient discoveryClient) {
         this.discoveryClient = discoveryClient;
+        this.description = discoveryClient.getDescription();
+        if (discoveryClient instanceof CompositeDiscoveryClient compositeDiscoveryClient) {
+            DiscoveryClient[] childClients = compositeDiscoveryClient.getDiscoveryClients();
+            this.hasNoChildClients = childClients.length == 0;
+            this.uncachedDiscoveryClient = hasNoChildClients
+                ? discoveryClient
+                : new DefaultCompositeDiscoveryClient(childClients);
+        } else {
+            this.uncachedDiscoveryClient = discoveryClient;
+            this.hasNoChildClients = false;
+        }
     }
 
     @Override
     public Publisher<HealthResult> getResult() {
+        if (hasNoChildClients) {
+            return Flux.just(HealthResult.builder(description, HealthStatus.UP)
+                .details(Collections.singletonMap("services", Collections.emptyMap()))
+                .build());
+        }
+        return Flux.defer(() -> getResult(discoveryClient))
+            .onErrorResume(ConfigurationException.class, throwable -> {
+                if (uncachedDiscoveryClient == discoveryClient) {
+                    return Flux.error(throwable);
+                }
+                return Flux.defer(() -> getResult(uncachedDiscoveryClient));
+            })
+            .onErrorResume(throwable -> {
+                HealthResult.Builder builder = HealthResult.builder(description, HealthStatus.DOWN);
+                builder.exception(throwable);
+                return Flux.just(builder.build());
+            });
+    }
+
+    private Publisher<HealthResult> getResult(DiscoveryClient discoveryClient) {
         return Flux.from(discoveryClient.getServiceIds())
             .flatMap((Function<List<String>, Publisher<HealthResult>>) ids -> {
                 List<Flux<Map<String, List<ServiceInstance>>>> serviceMap = ids.stream()
@@ -89,10 +126,6 @@ public class DiscoveryClientHealthIndicator implements HealthIndicator {
                     ));
                     return builder.build();
                 }).flux();
-            }).onErrorResume(throwable -> {
-                HealthResult.Builder builder = HealthResult.builder(discoveryClient.getDescription(), HealthStatus.DOWN);
-                builder.exception(throwable);
-                return Flux.just(builder.build());
             });
     }
 }

--- a/management/src/test/java/io/micronaut/management/health/indicator/discovery/DiscoveryClientHealthIndicatorTest.java
+++ b/management/src/test/java/io/micronaut/management/health/indicator/discovery/DiscoveryClientHealthIndicatorTest.java
@@ -1,15 +1,28 @@
 package io.micronaut.management.health.indicator.discovery;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.CompositeDiscoveryClient;
+import io.micronaut.discovery.DiscoveryClient;
+import io.micronaut.discovery.ServiceInstance;
+import io.micronaut.health.HealthStatus;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.aggregator.DefaultHealthAggregator;
+import io.micronaut.management.health.indicator.HealthResult;
 import io.micronaut.management.health.indicator.diskspace.DiskSpaceIndicator;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,5 +49,63 @@ class DiscoveryClientHealthIndicatorTest {
             healthBeansConsumer.accept(context);
             assertTrue(context.containsBean(DiscoveryClientHealthIndicator.class));
         }
+    }
+
+    @Test
+    void healthCheckFallsBackWhenCompositeDiscoveryClientDecoratorFails() {
+        DiscoveryClient delegate = new DiscoveryClient() {
+            @Override
+            public Publisher<List<ServiceInstance>> getInstances(String serviceId) {
+                return Flux.just(Collections.singletonList(ServiceInstance.of("service", URI.create("http://localhost"))));
+            }
+
+            @Override
+            public Publisher<List<String>> getServiceIds() {
+                return Flux.just(Collections.singletonList("service"));
+            }
+
+            @Override
+            public String getDescription() {
+                return "delegate";
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        DiscoveryClient decorated = new CompositeDiscoveryClient(new DiscoveryClient[]{delegate}) {
+            @Override
+            public Publisher<List<ServiceInstance>> getInstances(String serviceId) {
+                throw new ConfigurationException("No cache configured for name: discovery-client");
+            }
+
+            @Override
+            public Publisher<List<String>> getServiceIds() {
+                throw new ConfigurationException("No cache configured for name: discovery-client");
+            }
+        };
+
+        HealthResult result = Mono.from(new DiscoveryClientHealthIndicator(decorated).getResult()).block();
+
+        assertEquals(HealthStatus.UP, result.getStatus());
+    }
+
+    @Test
+    void healthCheckReturnsHealthyWhenCompositeHasNoChildClients() {
+        DiscoveryClient decorated = new CompositeDiscoveryClient(new DiscoveryClient[0]) {
+            @Override
+            public Publisher<List<ServiceInstance>> getInstances(String serviceId) {
+                throw new ConfigurationException("No cache configured for name: discovery-client");
+            }
+
+            @Override
+            public Publisher<List<String>> getServiceIds() {
+                throw new ConfigurationException("No cache configured for name: discovery-client");
+            }
+        };
+
+        HealthResult result = Mono.from(new DiscoveryClientHealthIndicator(decorated).getResult()).block();
+
+        assertEquals(HealthStatus.UP, result.getStatus());
     }
 }


### PR DESCRIPTION
Fixes #12980

When micronaut-cache-core is present without a cache implementation, the caching discovery composite can fail with ConfigurationException. The health indicator now:

- Returns UP immediately for composites with no child clients.
- Falls back to an uncached composite when the cache decorator cannot resolve its cache.
- Preserves DOWN responses for genuine discovery failures.

Tests:
- Focused DiscoveryClientHealthIndicatorTest
- Java compilation
- Checkstyle
- Spotless