### PR TITLE
Forget the remembered annotation types when a KSP round ends

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -147,6 +147,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * The annotation types seen with their native element during the processing, by annotation name. The
      * fallback for {@link #getAnnotationMirror(String)} when an implementation cannot resolve an annotation type
      * from its name alone, so that aliases can be derived again for an annotation the tree already holds.
+     *
+     * <p>The entries are native elements of the session that produced them, so an implementation whose builder
+     * outlives a processing round has to clear them at that boundary with
+     * {@link #clearProcessedAnnotationTypes()}.</p>
      */
     private final Map<String, T> processedAnnotationTypes = new HashMap<>();
 
@@ -1960,6 +1964,20 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 }
             }
         }
+    }
+
+    /**
+     * Forgets the annotation types remembered during the processing, which are the fallback used to derive the
+     * aliases of an annotation the retained tree holds and to decide whether one is {@link Retainable}.
+     *
+     * <p>An implementation that rebuilds its builder for every processing round need not call this. One that
+     * reuses a builder across rounds has to call it at the boundary: the entries are native elements of the
+     * session that has ended, and the map is keyed by annotation name, so a later round would hit and be handed
+     * a dead element rather than miss.</p>
+     */
+    @Internal
+    public void clearProcessedAnnotationTypes() {
+        processedAnnotationTypes.clear();
     }
 
     /**

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
@@ -297,12 +297,14 @@ internal class KotlinVisitorContext(
         // old session, so they must go: reading one afterwards throws
         // KaInvalidLifetimeOwnerAccessException ("PSI has changed since creation"). The
         // node-keyed memos would merely miss, since the nodes are new objects, but classByNameCache
-        // is keyed on a String and would hit and hand back a dead declaration.
+        // and the builder's remembered annotation types are keyed on a String and would hit and hand
+        // back a dead declaration.
         binaryNameCache.clear()
         annotationTypeCache.clear()
         repeatableContainerCache.clear()
         jvmNameCache.clear()
         classByNameCache.clear()
+        annotationMetadataBuilder.clearProcessedAnnotationTypes()
         this.resolver = resolver
         annotationMetadataBuilder.resolver = resolver
         nativeElementsHelper.resolver = resolver


### PR DESCRIPTION
Targets `claude/stereotype-origin-metadata` rather than `5.2.x`, because the map it fixes is introduced there by #12968. Raised separately so it can be reviewed on its own; fold it into that branch if you would rather.

## The problem

`AbstractAnnotationMetadataBuilder` remembers every annotation type it saw together with its native element, keyed by annotation name:

```java
private final Map<String, T> processedAnnotationTypes = new HashMap<>();
```

It is the fallback for `getAnnotationMirror(String)` where an implementation cannot resolve an annotation type from a name alone, and it is read from two places: deriving the aliases of an annotation the retained tree holds, and `isRetainable`, which reaches it for every occurrence whose stereotypes were not computed and hands the element to `lookupOrBuildForType`.

The entries are symbols of the session that produced them, and the map is never cleared.

`KotlinVisitorContext` is reused across a processing round rather than rebuilt — `TypeElementSymbolProcessor` constructs it once and calls `updateResolver` on every later round — and `updateResolver` already clears five memos for exactly this reason. Its own comment states the failure mode:

```kotlin
// A new resolver means a new round and a new Analysis API session, and this context is
// reused across that boundary rather than rebuilt. Every memo below holds symbols from the
// old session, so they must go: reading one afterwards throws
// KaInvalidLifetimeOwnerAccessException ("PSI has changed since creation"). The
// node-keyed memos would merely miss, since the nodes are new objects, but classByNameCache
// is keyed on a String and would hit and hand back a dead declaration.
```

The builder's map is the shape that comment warns about — String-keyed, holding symbols — and it lives on `annotationMetadataBuilder`, whose `resolver` is reassigned two lines below the clears, but it was not among them. On a later round a lookup hits, returns a symbol of the session that has ended, and `lookupOrBuildForType` builds metadata from it.

## The change

Clear it alongside the others, through an `@Internal` method on the builder since the field is private.

`javac` keeps one builder for the whole task, but its `Element`s stay valid across rounds, so nothing is needed there; Groovy constructs a context per source unit and its builders do not outlive one. The method is documented so that a future implementation reusing a builder across rounds knows it has to call it.

## Verification

`:micronaut-core-processor:compileJava`, `:micronaut-inject-kotlin:compileKotlin` and `:micronaut-core-processor:checkstyleMain` pass.

**I could not run `:micronaut-inject-kotlin:test`** — Maven Central returns 429 for the kotest and KSP artifacts through my environment, on every attempt across this session, so only the test dependencies are unavailable while the main compile succeeds. The defect also needs multi-round processing to surface, which I do not believe the current specs exercise, so a green Kotlin suite would not have been evidence either way. The reasoning above is from the code and from `updateResolver`'s own comment; it deserves a look from someone who can run KSP locally, and ideally a spec that processes more than one round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsC8h2GPcMqjceUzHkuGX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsC8h2GPcMqjceUzHkuGX8)_