### PR TITLE
Register binder constructors for native images

### DIFF
--- a/core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core/reachability-metadata.json
+++ b/core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core/reachability-metadata.json
@@ -1,0 +1,37 @@
+{
+  "reflection": [
+    {
+      "type": "io.micronaut.core.bind.annotation.AbstractArgumentBinder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.micronaut.core.convert.ConversionService"
+          ]
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "io.micronaut.core.convert.ConversionService",
+            "io.micronaut.core.type.Argument"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.micronaut.core.bind.DefaultExecutableBinder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/core/src/test/groovy/io/micronaut/core/bind/NativeReachabilityMetadataSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/bind/NativeReachabilityMetadataSpec.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.bind
+
+import spock.lang.Specification
+
+class NativeReachabilityMetadataSpec extends Specification {
+
+    void "registers dynamically invoked binder constructors"() {
+        expect:
+        NativeReachabilityMetadataSpec.classLoader
+            .getResource('META-INF/native-image/io.micronaut/micronaut-core/reachability-metadata.json')
+            .text.contains('io.micronaut.core.bind.annotation.AbstractArgumentBinder')
+        NativeReachabilityMetadataSpec.classLoader
+            .getResource('META-INF/native-image/io.micronaut/micronaut-core/reachability-metadata.json')
+            .text.contains('io.micronaut.core.bind.DefaultExecutableBinder')
+    }
+}


### PR DESCRIPTION
native guide runs fail when dynamically invoking AbstractArgumentBinder(ConversionService) and DefaultExecutableBinder(Map): these constructors are not reachable in the native image.

Add narrow Micronaut Core reachability metadata for the exact constructors and a packaging regression spec.

Validation:
- jq empty core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core/reachability-metadata.json
- :micronaut-core:test was started but interrupted after dependency compilation; no native build was run.