### PR TITLE
Answer a self-indexed stereotype qualifier from the compile-time index

### DIFF
--- a/function/src/main/java/io/micronaut/function/FunctionBean.java
+++ b/function/src/main/java/io/micronaut/function/FunctionBean.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.function;
 
+import io.micronaut.core.annotation.Indexed;
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.core.annotation.EntryPoint;
@@ -41,6 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Singleton
 @Executable
 @EntryPoint
+@Indexed(FunctionBean.class)
 public @interface FunctionBean {
 
     /**

--- a/function/src/test/groovy/io/micronaut/function/FunctionBeanIndexedLookupSpec.groovy
+++ b/function/src/test/groovy/io/micronaut/function/FunctionBeanIndexedLookupSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+/**
+ * {@code @FunctionBean} is declared on factory methods as well as on types, so the compile-time index
+ * has to be written from the producing method's metadata for the index to replace the stereotype scan.
+ */
+class FunctionBeanIndexedLookupSpec extends Specification {
+
+    void "test function beans declared on factory methods are enumerable through the compile-time index"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when: 'the beans are looked up through the index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(FunctionBean)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(FunctionBean) }
+
+        then: 'the factory-method functions are actually present'
+        indexed*.stringValue(FunctionBean)*.get().toSorted().containsAll(['fullname', 'round', 'supplier', 'upper'])
+
+        and: 'both answer the same beans'
+        indexed*.beanType.name.toSorted() == scanned*.beanType.name.toSorted()
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedAnnotationSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.inject.indexed
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+
+/**
+ * An annotation that is meta-annotated with {@code @Indexed} by its own type indexes every bean carrying it,
+ * so a processor of that annotation can look the beans up by it instead of scanning every bean definition.
+ */
+class SelfIndexedAnnotationSpec extends AbstractTypeElementSpec {
+
+    void "test beans carrying a self-indexed annotation are enumerable by the annotation type"() {
+        given:
+        ApplicationContext context = buildContext('sidx.One', '''
+package sidx;
+
+import io.micronaut.core.annotation.Indexed;
+import jakarta.inject.Singleton;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Singleton
+@Indexed(Marked.class)
+@interface Marked {
+}
+
+@Marked
+class One {
+}
+
+@Marked
+class Two {
+}
+
+@Singleton
+class NotMarked {
+}
+
+@Marked
+class Base {
+}
+
+class Sub extends Base {
+}
+''')
+        Class<?> marked = context.classLoader.loadClass('sidx.Marked')
+
+        when: 'the beans are looked up through the compile-time index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(marked)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(marked) }
+
+        then: 'both answer the same beans'
+        indexed*.beanType.name.toSorted() == scanned*.beanType.name.toSorted()
+        indexed*.beanType.name.toSorted() == ['sidx.Base', 'sidx.One', 'sidx.Two']
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedInheritanceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedInheritanceSpec.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.inject.indexed
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+
+/**
+ * The compile-time index has to answer a self-indexed annotation exactly as scanning every bean definition
+ * would, including for an annotation inherited from a supertype.
+ */
+class SelfIndexedInheritanceSpec extends AbstractTypeElementSpec {
+
+    void "test a self-indexed annotation inherited from a supertype is answered by the index"() {
+        given:
+        ApplicationContext context = buildContext('inh.Base', '''
+package inh;
+
+import io.micronaut.core.annotation.Indexed;
+import jakarta.inject.Singleton;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Singleton
+@Indexed(Marked.class)
+@interface Marked {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@Singleton
+@Indexed(InheritedMarked.class)
+@interface InheritedMarked {
+}
+
+@Marked
+class Base {
+}
+
+class Sub extends Base {
+}
+
+@InheritedMarked
+class InheritedBase {
+}
+
+class InheritedSub extends InheritedBase {
+}
+''')
+        Class<?> marked = context.classLoader.loadClass('inh.Marked')
+        Class<?> inheritedMarked = context.classLoader.loadClass('inh.InheritedMarked')
+
+        when: 'each annotation is answered by the index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(marked)
+        Collection<BeanDefinition<?>> inheritedIndexed = context.getBeanDefinitions(inheritedMarked)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = scanFor(context, marked)
+        Collection<BeanDefinition<?>> inheritedScanned = scanFor(context, inheritedMarked)
+
+        then: 'a plain annotation selects only the type it is declared on'
+        indexed*.beanType.simpleName.toSorted() == ['Base']
+
+        and: 'an @Inherited one also selects the subtype that inherits it'
+        inheritedIndexed*.beanType.simpleName.toSorted() == ['InheritedBase', 'InheritedSub']
+
+        and: 'the index agrees with the scan, in the same order, in both cases'
+        indexed*.beanType.name == scanned*.beanType.name
+        inheritedIndexed*.beanType.name == inheritedScanned*.beanType.name
+
+        and: 'the stereotype qualifier answers the same, since it now takes the index'
+        context.getBeanDefinitions(Qualifiers.byStereotype(marked))*.beanType.name == scanned*.beanType.name
+
+        cleanup:
+        context.close()
+    }
+
+    private static Collection<BeanDefinition<?>> scanFor(ApplicationContext context, Class<?> stereotype) {
+        context.getAllBeanDefinitions().findAll { it.hasStereotype(stereotype) }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1660,6 +1660,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         }
         Collection<BeanDefinition<Object>> candidates;
         if (qualifier instanceof FilteringQualifier<Object> filteringQualifier) {
+            Class<?> indexedType = filteringQualifier.getIndexedType();
+            if (indexedType != null) {
+                // the compile-time index holds every bean this qualifier selects, so there is nothing to filter
+                return (Collection) getBeanDefinitions(Argument.of(indexedType));
+            }
             // Keep anonymous
             Predicate<BeanDefinitionReference<Object>> predicate = new Predicate<>() {
                 @Override
@@ -2131,7 +2136,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         Iterator<BeanDefinition<T>> iterator = beanDefinitions.iterator();
         Set<BeanDefinition<T>> candidates;
         if (iterator.hasNext()) {
-            candidates = new HashSet<>();
+            candidates = new LinkedHashSet<>();
             while (iterator.hasNext()) {
                 BeanDefinition<T> candidate = iterator.next();
                 if (collectIterables && candidate.isConfigurationProperties()) {

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationStereotypeQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationStereotypeQualifier.java
@@ -20,6 +20,10 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.inject.BeanType;
 
+import io.micronaut.core.annotation.Indexed;
+import io.micronaut.core.annotation.Nullable;
+
+import java.lang.annotation.Annotation;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -35,10 +39,49 @@ final class AnnotationStereotypeQualifier<T> extends FilteringQualifier<T> {
     final String stereotype;
 
     /**
+     * The annotation type when this qualifier selects the beans that a self-indexed annotation is declared on,
+     * which the compile-time index answers exhaustively. Null otherwise.
+     */
+    @Nullable
+    private final Class<? extends Annotation> indexedType;
+
+    /**
      * @param stereotype The stereotype
      */
     AnnotationStereotypeQualifier(String stereotype) {
         this.stereotype = Objects.requireNonNull(stereotype, "Stereotype cannot be null");
+        this.indexedType = null;
+    }
+
+    /**
+     * @param stereotype The stereotype annotation
+     */
+    AnnotationStereotypeQualifier(Class<? extends Annotation> stereotype) {
+        Objects.requireNonNull(stereotype, "Stereotype cannot be null");
+        this.stereotype = stereotype.getName();
+        this.indexedType = isSelfIndexed(stereotype) ? stereotype : null;
+    }
+
+    /**
+     * An annotation meta-annotated with {@link Indexed} by its own type indexes every bean it is declared on,
+     * so the index holds all of them and nothing else.
+     *
+     * @param stereotype The stereotype annotation
+     * @return True if the annotation indexes the beans carrying it by itself
+     */
+    private static boolean isSelfIndexed(Class<? extends Annotation> stereotype) {
+        for (Indexed indexed : stereotype.getAnnotationsByType(Indexed.class)) {
+            if (indexed.value() == stereotype) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    @Nullable
+    public Class<?> getIndexedType() {
+        return indexedType;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/FilteringQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/FilteringQualifier.java
@@ -17,6 +17,7 @@ package io.micronaut.inject.qualifiers;
 
 import io.micronaut.context.Qualifier;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.BeanType;
 import io.micronaut.inject.QualifiedBeanType;
 
@@ -34,6 +35,19 @@ import java.util.stream.Stream;
  */
 @Internal
 public abstract class FilteringQualifier<T> implements Qualifier<T> {
+
+    /**
+     * The type the beans this qualifier selects are indexed by, when the compile-time index is an exhaustive
+     * answer for it. A qualifier that reports one can be answered by looking that type up in the index instead
+     * of filtering every bean definition reference.
+     *
+     * @return The indexed type, or {@code null} when the qualifier has to be answered by filtering
+     * @since 5.2.0
+     */
+    @Nullable
+    public Class<?> getIndexedType() {
+        return null;
+    }
 
     @Override
     public <BT extends BeanType<T>> Stream<BT> reduce(Class<T> beanType, Stream<BT> candidates) {

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
@@ -315,7 +315,7 @@ public class Qualifiers {
         if (instance != null) {
             return instance;
         }
-        return new AnnotationStereotypeQualifier<>(stereotype.getName());
+        return new AnnotationStereotypeQualifier<>(stereotype);
     }
 
     /**

--- a/management/src/main/java/io/micronaut/management/endpoint/annotation/Endpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/annotation/Endpoint.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.management.endpoint.annotation;
 
+import io.micronaut.core.annotation.Indexed;
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.Requires;
@@ -41,6 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Singleton
 @ConfigurationReader(basePrefix = EndpointConfiguration.PREFIX)
 @Requires(condition = EndpointEnabledCondition.class)
+@Indexed(Endpoint.class)
 public @interface Endpoint {
 
     /**

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointIndexedLookupSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointIndexedLookupSpec.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.management.endpoint.annotation.Endpoint
+import spock.lang.Specification
+
+/**
+ * {@code @Endpoint} is meta-annotated with {@code @Indexed(Endpoint)}, so the endpoint beans a
+ * {@code BeanDefinitionProcessor<Endpoint>} is handed are looked up through the compile-time index
+ * instead of by scanning every bean definition reference.
+ */
+class EndpointIndexedLookupSpec extends Specification {
+
+    void "test endpoint beans are enumerable through the compile-time index"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                ['endpoints.all.enabled': true, 'endpoints.all.sensitive': false], Environment.TEST)
+
+        when: 'the beans are looked up through the index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(Endpoint)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(Endpoint) }
+
+        then: 'endpoints are actually present'
+        !indexed.isEmpty()
+
+        and: 'both answer the same beans, in the same order, which the endpoint routes are registered in'
+        indexed*.beanType.name == scanned*.beanType.name
+
+        and: 'every one of them carries the index, which is what makes the lookup exhaustive'
+        indexed.every { Endpoint in ((BeanDefinitionReference<?>) it).indexes }
+
+        cleanup:
+        context.close()
+    }
+}

--- a/messaging/src/main/java/io/micronaut/messaging/annotation/MessageListener.java
+++ b/messaging/src/main/java/io/micronaut/messaging/annotation/MessageListener.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.messaging.annotation;
 
+import io.micronaut.core.annotation.Indexed;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.DefaultScope;
 import jakarta.inject.Singleton;
@@ -38,5 +39,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
 @Bean
 @DefaultScope(Singleton.class)
+@Indexed(MessageListener.class)
 public @interface MessageListener {
 }

--- a/messaging/src/test/groovy/io/micronaut/messaging/MessageListenerIndexedLookupSpec.groovy
+++ b/messaging/src/test/groovy/io/micronaut/messaging/MessageListenerIndexedLookupSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.messaging
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.messaging.annotation.MessageListener
+import spock.lang.Specification
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+
+/**
+ * {@code @MessageListener} is the stereotype the transport specific listener annotations are built on,
+ * so indexing it by itself indexes every listener bean without those annotations doing anything.
+ */
+class MessageListenerIndexedLookupSpec extends Specification {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @MessageListener
+    @interface TransportListener {
+    }
+
+    @TransportListener
+    static class OneListener {
+    }
+
+    @TransportListener
+    static class TwoListener {
+    }
+
+    void "test beans carrying a transport annotation built on @MessageListener are indexed by it"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when: 'the listeners are looked up through the index'
+        Collection<BeanDefinition<?>> indexed = context.getBeanDefinitions(MessageListener)
+
+        and: 'and by scanning every bean definition, which is what the index replaces'
+        Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(MessageListener) }
+
+        then: 'the listeners are found through an annotation that never mentions @Indexed itself'
+        indexed*.beanType.name.containsAll([OneListener.name, TwoListener.name])
+
+        and: 'both answer the same beans, in the same order'
+        indexed*.beanType.name == scanned*.beanType.name
+
+        cleanup:
+        context.close()
+    }
+}

--- a/websocket/src/main/java/io/micronaut/websocket/annotation/ServerWebSocket.java
+++ b/websocket/src/main/java/io/micronaut/websocket/annotation/ServerWebSocket.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.websocket.annotation;
 
+import io.micronaut.core.annotation.Indexed;
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.context.annotation.DefaultScope;
 import io.micronaut.core.util.StringUtils;
@@ -40,6 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @WebSocketComponent
 @DefaultScope(Singleton.class)
+@Indexed(ServerWebSocket.class)
 public @interface ServerWebSocket {
 
     /**


### PR DESCRIPTION
Stacked on #12960.

## Summary

#12960 makes `BeanDefinitionReference.getIndexes()` a real index key at runtime. Because that key is an
arbitrary `Class`, it can be an **annotation type** — which turns the framework's most common
"find every bean annotated `@X`" scan into an index lookup.

Answering that question today means `getBeanDefinitions(Qualifiers.byStereotype(X))`, which tests the
annotation metadata of **every bean definition reference in the application**, once per caller. An
annotation meta-annotated with `@Indexed` by its own type instead has the beans carrying it indexed at
compile time, and that index is exhaustive for it:

```java
@Retention(RUNTIME)
@Target(TYPE)
@Singleton
@Indexed(Endpoint.class)   // beans annotated @Endpoint are now enumerable by Endpoint.class
public @interface Endpoint { ... }
```

Core already had this idea, but hardcoded: `processedBeans`, `parallelBeans`, `proxyTargetBeans` and
`eagerInitBeans` are four bespoke fields in `DefaultBeanDefinitionService`, one per use case, each of
which needed a core change to add. This generalises them — any annotation gets its own bucket with no
core change, so downstream modules can do it for their own annotations.

## How it is wired

`AnnotationStereotypeQualifier` reports the annotation type through a new
`FilteringQualifier.getIndexedType()`, and `DefaultBeanContext.getBeanDefinitions(Qualifier)` takes the
index when a type is reported. `FilteringQualifier` is already public `@Internal` and already
type-checked in `DefaultBeanContext`, so this adds one method and no new class.

That means **no call site changes**: every existing caller of `Qualifiers.byStereotype(...)`, in core and
downstream, gets the lookup for free. An annotation that is not self-indexed reports null and keeps the
scan, so `@Indexed` stays a pure optimisation hint — remove it and the behaviour is unchanged.

## Benefit

Measured on a context with 808 bean definitions:

| | full scan | index |
|---|---|---|
| first (cold) lookup — the startup path | 2.66 ms | 0.17 ms |
| warm, per lookup | 46.5 us | 4.6 us |

The scan is linear in reference count (9.2 us at 208 references, 46.5 us at 808); the index is not. The
cost is paid per caller, so an application multiplies it by its number of processors.

## Reusability

Four annotations are indexed by themselves, which covers every full-scan call site in core:

| Site | Annotation | Consumers |
|---|---|---|
| `BeanDefinitionProcessorListener` | `@Endpoint` | `EndpointSensitivityProcessor`, `AbstractEndpointRouteBuilder` |
| | `@ServerWebSocket` | `ServerWebSocketProcessor` |
| | `@FunctionBean` | `DefaultLocalFunctionRegistry` |
| `MessagingApplication` | `@MessageListener` | — |

`@MessageListener` is the clearest reuse case: it is the stereotype the transport specific annotations
are built on, so indexing it indexes every `@KafkaListener` / `@RabbitListener` / `@JmsListener` bean
transitively, **without those annotations mentioning `@Indexed` at all**.

`@FunctionBean` is also declared on factory methods, which works because the index is written from the
producing method's metadata. A Java `@Inherited` annotation on a supertype is also answered correctly —
the index picks up the subtypes that inherit it.

`@Scheduled` and `@Mapper` are deliberately not indexed: they are
`@Executable(processOnStartup = true)`, so they go through `getProcessedBeans()`, which is already
indexed. `ExecutableMethodProcessorListener` only scans for processors the compiler has stamped
`@Deprecated` for not being `processOnStartup`.

Sites checked and found **not** to be candidates: `DefaultWebSocketBeanRegistry`, `RecoveryInterceptor`
and `DefaultReplacesDefinition` apply the stereotype as a filter on an already typed lookup rather than
scanning; `RefreshScope` scans already-created singletons, not definitions.

## Ordering fix

`collectBeanCandidates` collected into a `HashSet`, so `getBeanDefinitions(Class)` answered in an
identity-hash order that **differed on every JVM run**:

```
run 1: ThreadDumpEndpoint, CEndpoint, BEndpoint, BeansEndpoint, ServerStopEndpoint, ...
run 2: InfoEndpoint, CEndpoint, BEndpoint, URIPattern, AEndpoint, BeansEndpoint, ...
run 3: HealthEndpoint, LoggersEndpoint, EnvironmentEndpoint, ServerStopEndpoint, ...
```

The scan it replaces answers in bean definition reference order, and `AbstractEndpointRouteBuilder`
registers endpoint routes in that order, so taking the index would have made route registration
non-deterministic — it surfaced as an intermittent 404 in `LoggersEndpointSpec`. Collecting into a
`LinkedHashSet` keeps the reference order, makes the two agree exactly, and removes a pre-existing
source of run-to-run variation in every typed lookup.

## Tests

Each spec compares the index against a real full scan
(`getAllBeanDefinitions().findAll { it.hasStereotype(x) }`), not against `byStereotype`, which now takes
the index itself.

- `SelfIndexedAnnotationSpec` — a self-indexed annotation indexes every bean carrying it.
- `SelfIndexedInheritanceSpec` — a plain annotation selects only the type it is declared on; an
  `@Inherited` one also selects the subtypes that inherit it, through the index as well.
- `EndpointIndexedLookupSpec` — the real `@Endpoint`, asserting the same beans **in the same order**,
  which is the order the endpoint routes are registered in.
- `FunctionBeanIndexedLookupSpec` — `@FunctionBean` on factory methods.
- `MessageListenerIndexedLookupSpec` — a transport annotation built on `@MessageListener` is indexed
  transitively.

`inject`, `inject-java` (5083), `management` (159), `context` (342), `router` (117), `websocket`,
`function`, `function-web`, `messaging` and `http-server` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
