### PR TITLE
Read a member held in a collection value by value, as one held in an array

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -717,6 +718,9 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
             return AnnotationClassValue.ZERO_ANNOTATION_CLASS_VALUES;
         }
         Object o = values.get(member);
+        if (o instanceof Collection<?> collection) {
+            o = heldValues(collection);
+        }
         if (o instanceof AnnotationClassValue<?> annotationClassValue) {
             return new AnnotationClassValue[]{annotationClassValue};
         }
@@ -728,6 +732,17 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         }
         if (o instanceof String[] classNames) {
             return Arrays.stream(classNames).map(AnnotationValue::getAnnotationClassValue).toArray(AnnotationClassValue[]::new);
+        }
+        if (o instanceof Object[] entries) {
+            List<AnnotationClassValue<?>> classValues = new ArrayList<>(entries.length);
+            for (Object entry : entries) {
+                if (entry instanceof AnnotationClassValue<?> annotationClassValue) {
+                    classValues.add(annotationClassValue);
+                } else if (entry instanceof CharSequence className) {
+                    classValues.add(getAnnotationClassValue(className.toString()));
+                }
+            }
+            return classValues.toArray(AnnotationClassValue.ZERO_ANNOTATION_CLASS_VALUES);
         }
         return AnnotationClassValue.ZERO_ANNOTATION_CLASS_VALUES;
     }
@@ -1368,6 +1383,12 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
             }
             return Optional.empty();
         }
+        if (v instanceof Collection<?> collection) {
+            Iterator<?> i = collection.iterator();
+            if (i.hasNext() && i.next() instanceof AnnotationValue<?> value && value.getAnnotationName().equals(typeName)) {
+                return Optional.of((AnnotationValue<T>) value);
+            }
+        }
         return Optional.empty();
     }
 
@@ -1392,6 +1413,12 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
             }
             return Optional.empty();
         }
+        if (v instanceof Collection<?> collection) {
+            Iterator<?> i = collection.iterator();
+            if (i.hasNext() && i.next() instanceof AnnotationValue<?> value) {
+                return Optional.of((AnnotationValue<T>) value);
+            }
+        }
         return Optional.empty();
     }
 
@@ -1412,8 +1439,12 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         if (attributes.isEmpty()) {
             return "@" + annotationName;
         } else {
-            return "@" + annotationName + "(" + attributes.entrySet().stream().map(entry -> entry.getKey() + "=" + toStringValue(entry.getValue())).collect(
-                    Collectors.joining(", ")) + ")";
+            // the members in name order: the map holds them in whichever order the builder filled it in, so a
+            // rendering that followed it would read differently for the same annotation described two ways
+            return "@" + annotationName + "(" + attributes.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey(Comparator.comparing(CharSequence::toString)))
+                .map(entry -> entry.getKey() + "=" + toStringValue(entry.getValue()))
+                .collect(Collectors.joining(", ")) + ")";
         }
     }
 
@@ -1622,6 +1653,14 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
             }
             return newArray;
         }
+        if (value instanceof Collection<?> collection) {
+            String[] newArray = new String[collection.size()];
+            int i = 0;
+            for (Object entry : collection) {
+                newArray[i++] = entry == null ? null : entry.toString();
+            }
+            return newArray;
+        }
         return new String[]{value.toString()};
     }
 
@@ -1678,6 +1717,24 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
     }
 
     /**
+     * The values a collection holds, in an array of the type they would be held in had the metadata been
+     * generated: a metadata built at runtime accumulates the occurrences of a repeatable annotation in a
+     * collection, where a generated one holds them in an {@link AnnotationValue} array, and the accessors that
+     * map over a member value by value are to answer the same either way.
+     *
+     * @param collection The collection
+     * @return The values it holds, in an array
+     */
+    private static Object[] heldValues(Collection<?> collection) {
+        for (Object held : collection) {
+            if (!(held instanceof AnnotationValue)) {
+                return collection.toArray();
+            }
+        }
+        return collection.toArray(new AnnotationValue<?>[0]);
+    }
+
+    /**
      * The class values for the given value.
      *
      * @param value The value
@@ -1690,6 +1747,9 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         // A class can be present at compilation time
         if (value == null) {
             return null;
+        }
+        if (value instanceof Collection<?> collection) {
+            value = heldValues(collection);
         }
         if (value instanceof AnnotationClassValue<?> annotationClassValue) {
             Class<?> type = annotationClassValue.getType().orElse(null);

--- a/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueSpec.groovy
@@ -364,6 +364,52 @@ class AnnotationValueSpec extends Specification {
         av.isFalse("six")
     }
 
+    void "a member held in a collection is read through every branch an array is read through"() {
+        given:
+        def bar = AnnotationValue.builder(Bar).build()
+
+        expect: "a collection of class names reads as class values, as an array of them does"
+        def names = new AnnotationValue("test.Types", [value: ["java.lang.String", "java.util.Random"] as LinkedHashSet] as Map<CharSequence, Object>)
+        names.annotationClassValues("value")*.name == ["java.lang.String", "java.util.Random"]
+        names.annotationClassValues("absent").length == 0
+
+        and: "a collection holding only annotations is read as the array of them a generated metadata would hold"
+        def annotations = new AnnotationValue("test.Types", [value: [bar] as LinkedHashSet] as Map<CharSequence, Object>)
+        annotations.classValues("value") == [] as Class[]
+        annotations.annotationClassValues("value").length == 0
+
+        and: "an empty collection holds nothing to read"
+        def empty = new AnnotationValue("test.Types", [value: [] as LinkedHashSet] as Map<CharSequence, Object>)
+        empty.classValues("value") == [] as Class[]
+        !empty.getAnnotation("value").isPresent()
+
+        and: "an entry bound to null is rendered as one, rather than failing"
+        def nulls = new AnnotationValue("test.Strings", [value: ["a", null]] as Map<CharSequence, Object>)
+        nulls.stringValues("value") == ["a", null] as String[]
+    }
+
+    void "getAnnotation() reads the first occurrence out of a collection, as it does out of an array"() {
+        given:
+        def bar = AnnotationValue.builder(Bar).build()
+        def held = new AnnotationValue("test.Foo",
+            [bars: [bar] as LinkedHashSet, plain: ["one"] as LinkedHashSet] as Map<CharSequence, Object>)
+
+        expect: "the occurrence is read when its type matches, and not when it does not"
+        held.getAnnotation("bars", Bar).get() == bar
+        !held.getAnnotation("bars", Baz).isPresent()
+        held.getAnnotation("bars").get() == bar
+
+        and: "a collection holding something other than an annotation holds no occurrence"
+        !held.getAnnotation("plain", Bar).isPresent()
+        !held.getAnnotation("plain").isPresent()
+
+        and: "nor does an empty collection, or a member the annotation does not bind"
+        def empty = new AnnotationValue("test.Foo", [bars: [] as LinkedHashSet] as Map<CharSequence, Object>)
+        !empty.getAnnotation("bars", Bar).isPresent()
+        !held.getAnnotation("missing", Bar).isPresent()
+        !held.getAnnotation("missing").isPresent()
+    }
+
     void "test getAnnotation()"() {
         given:
         def innerAv = AnnotationValue.builder(Bar.class).build()
@@ -449,3 +495,5 @@ class AnnotationValueSpec extends Specification {
 }
 
 @interface Bar {}
+
+@interface Baz {}

--- a/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueSpec.groovy
@@ -13,6 +13,50 @@ class AnnotationValueSpec extends Specification {
         av.toString() == "@test.Foo(value=10)"
     }
 
+    void "toString() renders the members in name order, whichever order they are held in"() {
+        given: "the same annotation with its members held in either order"
+        def declared = new AnnotationValue("test.Sized", [min: 2, max: 4] as Map<CharSequence, Object>)
+        def reversed = new AnnotationValue("test.Sized", [max: 4, min: 2] as Map<CharSequence, Object>)
+
+        expect: "a builder fills the map in whichever order it reads the members, which the rendering does not follow"
+        declared.toString() == "@test.Sized(max=4, min=2)"
+        reversed.toString() == declared.toString()
+    }
+
+    /**
+     * A metadata built at runtime accumulates the occurrences of a repeatable annotation in a collection, where a
+     * generated one holds them in an array. The accessors that map over a member value by value are to answer the
+     * same over either shape, rather than stringifying the whole collection as one value.
+     */
+    void "the accessors read a member held in a collection value by value, as they read an array"() {
+        given:
+        def one = AnnotationValue.builder("test.Tag").value("one").build()
+        def two = AnnotationValue.builder("test.Tag").value("two").build()
+        def collected = new AnnotationValue("test.Tags", [value: [one, two] as LinkedHashSet] as Map<CharSequence, Object>)
+        def arrayed = new AnnotationValue("test.Tags", [value: [one, two] as AnnotationValue[]] as Map<CharSequence, Object>)
+
+        expect: "one string per occurrence, rather than one string holding the whole collection"
+        collected.stringValues("value") == arrayed.stringValues("value")
+        collected.stringValues("value").length == 2
+
+        and: "the same for the accessors that parse each string"
+        def numbers = new AnnotationValue("test.Nums", [value: ["1", "2"] as LinkedHashSet] as Map<CharSequence, Object>)
+        numbers.intValues("value") == [1, 2] as int[]
+        numbers.longValues("value") == [1L, 2L] as long[]
+        numbers.doubleValues("value") == [1d, 2d] as double[]
+
+        and: "and for the ones that read a member holding classes"
+        def classes = new AnnotationValue("test.Types", [value: [new AnnotationClassValue<Object>(AnnotationValueSpec),
+                                                                new AnnotationClassValue<Object>(Specification)] as LinkedHashSet] as Map<CharSequence, Object>)
+        classes.classValues("value") == [AnnotationValueSpec, Specification] as Class[]
+        classes.annotationClassValues("value").length == 2
+
+        and: "the singular accessors answer from the first occurrence, as they do over an array"
+        collected.stringValue("value") == arrayed.stringValue("value")
+        collected.getAnnotation("value") == arrayed.getAnnotation("value")
+        collected.getAnnotations("value") == arrayed.getAnnotations("value")
+    }
+
     void "the reserved stereotypes member is read through getStereotypes() and hidden from the attributes"() {
         given:
         def size = AnnotationValue.builder("jakarta.validation.constraints.Size").member("min", 3).build()

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
@@ -128,6 +128,21 @@ class AnnotationMetadataSpec extends Specification {
         metadata.getAnnotationValuesByType(Requires).size() == 1
     }
 
+    void "test the occurrences of a repeatable annotation are read out one value per occurrence"() {
+        given: "a repeatable annotation added twice, which a metadata built at runtime accumulates in a collection"
+        MutableAnnotationMetadata metadata = new MutableAnnotationMetadata()
+        metadata.addDeclaredRepeatable("foo.Tags", AnnotationValue.builder("foo.Tag").value("one").build(), RetentionPolicy.RUNTIME)
+        metadata.addDeclaredRepeatable("foo.Tags", AnnotationValue.builder("foo.Tag").value("two").build(), RetentionPolicy.RUNTIME)
+
+        expect: "the member holds both occurrences"
+        metadata.getAnnotationValuesByName("foo.Tag").size() == 2
+
+        and: "and the accessors that map over it answer one value per occurrence, not one holding the whole collection"
+        metadata.stringValues("foo.Tags", AnnotationMetadata.VALUE_MEMBER).length == 2
+        metadata.stringValues("foo.Tags", AnnotationMetadata.VALUE_MEMBER) ==
+            ['@foo.Tag(value=one)', '@foo.Tag(value=two)'] as String[]
+    }
+
     AnnotationMetadata newMetadata(AnnotationValueBuilder... builders) {
 
         def values = builders.collect({ it.build() })


### PR DESCRIPTION
`AnnotationMetadata.stringValues(String annotation, String member)` answers differently depending on which implementation holds the metadata, for a member that holds the occurrences of a repeatable annotation.

For an element carrying `@Tag("one") @Tag("two")`, where `@Tag` is `@Repeatable(Tags.class)`:

- `DefaultAnnotationMetadata`, read back from the bytecode the processors write — `stringValues("...Tags", "value")` returns **length 2**, one string per occurrence.
- `MutableAnnotationMetadata`, built at runtime — the same call returns **length 1**, a single string holding the whole collection: `["[@Tag(value=one), @Tag(value=two)]"]`.

## Cause

The two hold the container's `value` member in different shapes: `DefaultAnnotationMetadata` holds an `AnnotationValue[]`, where `MutableAnnotationMetadata` accumulates the occurrences into a `LinkedHashSet`. The value accessors that map element-wise over an array do not do so over a `Collection`, so the collection is stringified as one value. `getValue(...)` agrees on both sides — the divergence is confined to the accessors that convert per element.

This is not specific to reflectively built metadata: any code path that builds a `MutableAnnotationMetadata` at runtime and adds a repeatable annotation is affected. `AbstractAnnotationMetadataBuilder` also builds a `MutableAnnotationMetadata`, so the compile-time builder holds the same set shape before it is written out; only the written form is an array.

## The change

All in `AnnotationValue`, teaching the accessors to treat a `Collection` the way they treat an array:

- `resolveStringValues` maps a collection element by element. This is the one that fixes the report — every primitive plural accessor (`booleanValues`, `byteValues`, `shortValues`, `intValues`, `longValues`, `floatValues`, `doubleValues`) funnels through it, as does `DefaultAnnotationMetadata.stringValues`.
- `resolveClassValues` and `annotationClassValues` normalise a collection through a new private `heldValues` helper, which hands back an `AnnotationValue[]` when that is what the collection holds, so the flattening branch still applies. `annotationClassValues` gained the `Object[]` branch needed to read the result.
- The singular `getAnnotation(member)` / `getAnnotation(member, type)` read the first occurrence out of a collection, which the plural `getAnnotations` already did.

`getRawSingleValue` and `resolveEnumValues` already handled `Iterable`, so `stringValue`, `intValue`, `classValue`, `enumValue`, `enumValues` and `enumValuesSet` needed nothing.

## `toString()` member ordering

`toString()` now renders the members in name order. The shape above is not the only thing that differs between the two builders: they also fill their member maps in different orders — neither declaration nor use-site order — so the same annotation rendered `@Sized(min=2, max=4)` from one and `@Sized(max=4, min=2)` from the other. Since `stringValue`/`stringValues` over a member holding annotation values render through `toString()`, the accessors could not be compared across the two builders without this.

`equals`, `hashCode` and `matches` are already order-insensitive, so this makes the rendering consistent with them and independent of which builder produced the value. No existing test in the repository asserts on a multi-member annotation rendering.

## Tests

- `AnnotationValueSpec`: the collection shape read through `stringValues`/`intValues`/`longValues`/`doubleValues`/`classValues`/`annotationClassValues` and the singular accessors, compared against the array shape; and order-independent `toString()`.
- `AnnotationMetadataSpec`: the reported symptom directly — two `addDeclaredRepeatable` calls on a `MutableAnnotationMetadata`, then `stringValues(container, "value").length == 2`.

Green: `core` (7391), `inject` (343), `inject-java` (5078), `inject-groovy` (1067), plus `:micronaut-core:checkstyleMain`.

Found by the metadata parity sweep on #12977, which currently has to skip the string accessors for a member holding annotation values. Once this lands, that skip and the test pinning the divergence can go — I have that follow-up ready locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
