### PR TITLE
Do not assert an exact reply count in the Python websocket specs

### DIFF
--- a/test-suite-python/src/test/python/micronaut/docs/http/server/netty/websocket/PojoWebSocketSpec.py
+++ b/test-suite-python/src/test/python/micronaut/docs/http/server/netty/websocket/PojoWebSocketSpec.py
@@ -32,15 +32,17 @@ class PojoWebSocketSpec:
         assert fred.getTopic() == "stuff"
         assert fred.getUsername() == "fred"
         assert bob.getUsername() == "bob"
-        self.awaitReply(fred.getReplies(), "[bob] Joined!", 1)
+        self.awaitReply(fred.getReplies(), "[bob] Joined!")
 
         fred.send(Message("Hello bob!"))
-        self.awaitReply(bob.getReplies(), "[fred] Hello bob!", 1)
+        self.awaitReply(bob.getReplies(), "[fred] Hello bob!")
+        assert not self.containsText(fred.getReplies(), "[fred] Hello bob!")
+        assert not self.containsText(bob.getReplies(), "[bob] Joined!")
 
         bob.send(Message("Hi fred. How are things?"))
-        self.awaitReply(fred.getReplies(), "[bob] Hi fred. How are things?", 2)
+        self.awaitReply(fred.getReplies(), "[bob] Hi fred. How are things?")
+        assert not self.containsText(bob.getReplies(), "[bob] Hi fred. How are things?")
         assert self.containsText(bob.getReplies(), "[fred] Hello bob!")
-        assert bob.getReplies().size() == 1
 
         assert fred.sendAsync(Message("foo")).get().getText() == "foo"
         assert Flux.from_(fred.sendRx(Message("bar"))).blockFirst().getText() == "bar"
@@ -48,13 +50,15 @@ class PojoWebSocketSpec:
         bob.close()
         fred.close()
 
-    def awaitReply(self, replies, expected: str, size: int) -> None:
+    def awaitReply(self, replies, expected: str) -> None:
+        # The reply count is deliberately not asserted: a broadcast only skips the session that
+        # sent it, so whether a client sees an earlier client's "Joined!" depends on whether it
+        # connected before that broadcast was delivered.
         for _ in range(150):
-            if self.containsText(replies, expected) and replies.size() == size:
+            if self.containsText(replies, expected):
                 return
             TimeUnit.MILLISECONDS.sleep(100)
         assert self.containsText(replies, expected)
-        assert replies.size() == size
 
     def containsText(self, replies, expected: str) -> bool:
         iterator = replies.iterator()

--- a/test-suite-python/src/test/python/micronaut/docs/http/server/netty/websocket/SimpleTextWebSocketSpec.py
+++ b/test-suite-python/src/test/python/micronaut/docs/http/server/netty/websocket/SimpleTextWebSocketSpec.py
@@ -34,15 +34,17 @@ class SimpleTextWebSocketSpec:
         assert fred.getTopic() == "stuff"
         assert fred.getUsername() == "fred"
         assert bob.getUsername() == "bob"
-        self.awaitReply(fred.getReplies(), "[bob] Joined!", 1)
+        self.awaitReply(fred.getReplies(), "[bob] Joined!")
 
         fred.send("Hello bob!")
-        self.awaitReply(bob.getReplies(), "[fred] Hello bob!", 1)
+        self.awaitReply(bob.getReplies(), "[fred] Hello bob!")
+        assert not fred.getReplies().contains("[fred] Hello bob!")
+        assert not bob.getReplies().contains("[bob] Joined!")
 
         bob.send("Hi fred. How are things?")
-        self.awaitReply(fred.getReplies(), "[bob] Hi fred. How are things?", 2)
+        self.awaitReply(fred.getReplies(), "[bob] Hi fred. How are things?")
+        assert not bob.getReplies().contains("[bob] Hi fred. How are things?")
         assert bob.getReplies().contains("[fred] Hello bob!")
-        assert bob.getReplies().size() == 1
 
         assert fred.sendAsync("foo").get() == "foo"
         assert Flux.from_(fred.sendRx("bar")).blockFirst() == "bar"
@@ -56,10 +58,12 @@ class SimpleTextWebSocketSpec:
         assert not bob.getSession().isOpen()
         assert not fred.getSession().isOpen()
 
-    def awaitReply(self, replies, expected: str, size: int) -> None:
+    def awaitReply(self, replies, expected: str) -> None:
+        # The reply count is deliberately not asserted: a broadcast only skips the session that
+        # sent it, so whether a client sees an earlier client's "Joined!" depends on whether it
+        # connected before that broadcast was delivered.
         for _ in range(30):
-            if replies.contains(expected) and replies.size() == size:
+            if replies.contains(expected):
                 return
             TimeUnit.MILLISECONDS.sleep(100)
         assert replies.contains(expected)
-        assert replies.size() == size


### PR DESCRIPTION
`test-suite-python`'s `PojoWebSocketSpec` fails intermittently on `5.2.x` — for example [this run](https://github.com/micronaut-projects/micronaut-core/actions/runs/33840921485) on 5.2.x itself, where it failed all three attempts.

The failure is `assert replies.size() == size` after bob has already received `[fred] Hello bob!`. A broadcast only skips the session that *sent* it, so fred's `[fred] Joined!` broadcast reaches bob whenever bob's session was registered before that broadcast was delivered. That ordering is not guaranteed by `connect(...).blockFirst()` returning, so bob's reply count is genuinely nondeterministic.

The Groovy spec these were ported from (`test-suite/src/test/groovy/io/micronaut/docs/http/server/netty/websocket/PojoWebSocketSpec.groovy`) never asserts a count for bob — it asserts the reply that must arrive plus the self-broadcasts that must not. This does the same in the two Python ports, keeping the negative assertions that actually pin the broadcaster's contract:

- `PojoWebSocketSpec.py`
- `SimpleTextWebSocketSpec.py` — the same over-assertion, not yet observed failing

Both pass locally with `./gradlew :test-suite-python:test --tests '*WebSocketSpec*' -Ppython-ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)