### PR TITLE
Apply the review feedback from #12993

### DIFF
--- a/function/src/test/groovy/io/micronaut/function/FunctionBeanIndexedLookupSpec.groovy
+++ b/function/src/test/groovy/io/micronaut/function/FunctionBeanIndexedLookupSpec.groovy
@@ -17,7 +17,6 @@ package io.micronaut.function
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Specification
 
 /**
@@ -36,8 +35,11 @@ class FunctionBeanIndexedLookupSpec extends Specification {
         and: 'and by scanning every bean definition, which is what the index replaces'
         Collection<BeanDefinition<?>> scanned = context.getAllBeanDefinitions().findAll { it.hasStereotype(FunctionBean) }
 
-        then: 'the factory-method functions are actually present'
-        indexed*.stringValue(FunctionBean)*.get().toSorted().containsAll(['fullname', 'round', 'supplier', 'upper'])
+        then: 'every definition names the function it declares'
+        indexed.every { it.stringValue(FunctionBean).isPresent() }
+
+        and: 'the factory-method functions are actually present'
+        indexed.collect { it.stringValue(FunctionBean).get() }.toSorted().containsAll(['fullname', 'round', 'supplier', 'upper'])
 
         and: 'both answer the same beans'
         indexed*.beanType.name.toSorted() == scanned*.beanType.name.toSorted()

--- a/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/indexed/SelfIndexedAnnotationSpec.groovy
@@ -3,7 +3,6 @@ package io.micronaut.inject.indexed
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.qualifiers.Qualifiers
 
 /**
  * An annotation that is meta-annotated with {@code @Indexed} by its own type indexes every bean carrying it,

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1663,7 +1663,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             Class<?> indexedType = filteringQualifier.getIndexedType();
             if (indexedType != null) {
                 // the compile-time index holds every bean this qualifier selects, so there is nothing to filter
-                return (Collection) getBeanDefinitions(Argument.of(indexedType));
+                @SuppressWarnings("unchecked")
+                Argument<Object> indexedArgument = (Argument<Object>) Argument.of(indexedType);
+                return getBeanDefinitions(indexedArgument);
             }
             // Keep anonymous
             Predicate<BeanDefinitionReference<Object>> predicate = new Predicate<>() {

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointIndexedLookupSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointIndexedLookupSpec.groovy
@@ -18,8 +18,6 @@ package io.micronaut.management.endpoint
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.Environment
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.BeanDefinitionReference
-import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.management.endpoint.annotation.Endpoint
 import spock.lang.Specification
 
@@ -48,7 +46,7 @@ class EndpointIndexedLookupSpec extends Specification {
         indexed*.beanType.name == scanned*.beanType.name
 
         and: 'every one of them carries the index, which is what makes the lookup exhaustive'
-        indexed.every { Endpoint in ((BeanDefinitionReference<?>) it).indexes }
+        context.getBeanDefinitionReferences().findAll { Endpoint in it.indexes }*.beanType.containsAll(indexed*.beanType)
 
         cleanup:
         context.close()

--- a/messaging/src/test/groovy/io/micronaut/messaging/MessageListenerIndexedLookupSpec.groovy
+++ b/messaging/src/test/groovy/io/micronaut/messaging/MessageListenerIndexedLookupSpec.groovy
@@ -17,7 +17,6 @@ package io.micronaut.messaging
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.messaging.annotation.MessageListener
 import spock.lang.Specification
 


### PR DESCRIPTION
Applies the review feedback on #12993, which merged before the comments could be pushed.

Stacked on #12960, same as #12993 was.

## Copilot

- **Raw `Collection` cast in `DefaultBeanContext`** — the cast is now on the `Argument` alone, so the
  unchecked conversion is contained and the return type stays fully generic:
  ```java
  @SuppressWarnings("unchecked")
  Argument<Object> indexedArgument = (Argument<Object>) Argument.of(indexedType);
  return getBeanDefinitions(indexedArgument);
  ```
- **`Optional.get()` in a spread chain** (`FunctionBeanIndexedLookupSpec`) — presence is asserted first,
  so a definition without the attribute fails on its own assertion rather than throwing mid-chain.
- **`BeanDefinition` cast to `BeanDefinitionReference`** (`EndpointIndexedLookupSpec`) — dropped rather
  than guarded; the index is asserted at reference level via `getBeanDefinitionReferences()`.
- **Unused imports** — removed. Four unused `Qualifiers` imports (one more than was flagged, in
  `SelfIndexedAnnotationSpec`) and one unused `BeanDefinitionReference` import. They were left behind
  when the specs switched from comparing against `byStereotype` to comparing against a real full scan.
- **`@since` on `FilteringQualifier.getIndexedType()`** — left as is. `5.2.0` is correct
  (`projectVersion=5.2.0-SNAPSHOT`), and the sibling `AnnotationStereotypeQualifier` already carries
  `@since 3.0.0` under the same `@Internal`.

## On the `ScopedProxyCircularDependencySpec` flake

I previously suspected the `LinkedHashSet` change in #12993 caused this. **That was wrong** — I traced it,
and the cause is unrelated to #12993. Recording it here since it came up in this review.

`io.micronaut.aop.scope.ScopedProxyCircularDependencySpec` fails intermittently with "Recursive update"
out of the `ConcurrentHashMap.computeIfAbsent` in its `TestCustomScope`. Two things combine:

**1. The custom scope is always entered re-entrantly.** Creating the `@TestScope` `Produced` bean needs
its `@Factory @Prototype SelfConsumingFactory`. `findCustomScope` hits this branch:

```java
if (scopeAnnotation == Prototype.class) {
    // a prototype bean has no lifecycle of its own, so a scope declared on the
    // injection point (such as @InjectScope) still applies to it
    return findInjectionPointDeclaredScope(resolutionContext);
}
```

At that moment the current segment is the factory-method segment for `Produced`, whose argument carries
`@TestScope`. So the prototype *factory* inherits the scope of the bean it produces, and is created
through the same `CustomScope`, nesting a second `getOrCreate` inside the first. Tracing the scope shows
this on **every** run, including the ones that pass:

```
enter depth=1 id=@Named('self') produced def=Definition: test.Produced Factory: test.SelfConsumingFactory#produce
enter depth=2 id=selfConsumingFactory    def=Definition: test.SelfConsumingFactory
exit  depth=2
exit  depth=1
```

**2. Whether the nesting throws is random per JVM.** `computeIfAbsent` raises "Recursive update" only
when the nested call lands in the same bin. The keys are `BeanKey`s whose hash is
`argument.typeHashCode()` = `ObjectUtils.hash(type, typeParameters)`, and `Class.hashCode()` is identity
based, so the bin layout differs on every JVM run.

That accounts for the intermittency, and for why it never reproduced in isolation (10/10 passes) while
appearing in full-suite runs.

It is not from #12993: `findCustomScope` is byte-identical before and after it, the whole diff is the two
hunks in `getBeanDefinitions(Qualifier)` and `collectBeanCandidates`, and the behaviour traces back to
#12934. My earlier tally (0 failures in 11 runs before, 3 in ~17 after) was too small to mean anything —
at a ~15% per-run rate, 0/11 has probability 0.85^11, about 17%.

Worth fixing separately: a prototype bean acquiring the scope of the bean it is a *factory for* looks
unintended, and any real `CustomScope` built on `computeIfAbsent` is exposed to the same re-entrancy.
Happy to open an issue or a PR for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
