### PR TITLE
Do not discard Fetch Metadata that is only partly recognised

### DIFF
--- a/http/src/main/java/io/micronaut/http/Destination.java
+++ b/http/src/main/java/io/micronaut/http/Destination.java
@@ -18,7 +18,15 @@ package io.micronaut.http;
 import org.jspecify.annotations.Nullable;
 
 /**
+ * The request destination values of the {@code Sec-Fetch-Dest} header.
+ *
+ * <p>The Fetch specification and the specifications that extend it keep adding destinations, so
+ * this list is a snapshot rather than a closed set: a newer client can legitimately send a
+ * destination absent from it. {@link #of(String)} answers {@code null} for such a value, and
+ * {@link SecFetch} keeps the rest of the metadata readable rather than discarding it.
+ *
  * @see <a href="https://www.w3.org/TR/fetch-metadata/#sec-fetch-dest-header">Sec-Fetch-Dest</a>
+ * @see <a href="https://fetch.spec.whatwg.org/#concept-request-destination">Request destination</a>
  * @since 5.1.12
  */
 public enum Destination {
@@ -45,6 +53,7 @@ public enum Destination {
     TEXT("text"),
     TRACK("track"),
     VIDEO("video"),
+    WEBIDENTITY("webidentity"),
     WORKER("worker"),
     XSLT("xslt");
 
@@ -58,7 +67,9 @@ public enum Destination {
      * Finds the destination for the given Fetch Metadata value.
      *
      * @param value The destination value
-     * @return The matching destination, or {@code null} if there is no match
+     * @return The matching destination, or {@code null} if there is no match. A {@code null} here
+     * means the value is not one this version lists, which includes destinations added to the
+     * specification since
      * @since 5.1.12
      */
     public static @Nullable Destination of(String value) {

--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -232,8 +232,16 @@ public interface HttpRequest<B> extends HttpMessage<B> {
     /**
      * Gets the Fetch Metadata request headers.
      *
-     * @return The Fetch Metadata, or {@code null} if the request does not contain
-     * all recognized Fetch Metadata headers
+     * <p>Individual components of the result are {@code null} when the corresponding header is
+     * absent or carries an unrecognised value; the headers that did parse stay readable.
+     *
+     * @return The Fetch Metadata, or {@code null} if the request carries none of the
+     * {@code Sec-Fetch-*} headers.
+     * <p><strong>A {@code null} return means only that the client sent no Fetch Metadata</strong>
+     * — an older browser, or a non-browser client — and is not an indication that the request is
+     * safe. Resource isolation policies should decide deliberately what to do with unclassified
+     * requests rather than treating {@code null} as an implicit allow
+     * @see SecFetch#of(HttpHeaders)
      * @see SecFetch
      * @since 5.1.12
      */

--- a/http/src/main/java/io/micronaut/http/Mode.java
+++ b/http/src/main/java/io/micronaut/http/Mode.java
@@ -40,7 +40,8 @@ public enum Mode {
      * Finds the request mode for the given wire value.
      *
      * @param value The request mode value
-     * @return The matching mode, or {@code null} if there is no match
+     * @return The matching mode, or {@code null} if there is no match. {@link SecFetch}
+     * reports such a value as a {@code null} component and keeps the rest of the metadata readable
      * @since 5.1.12
      */
     public static @Nullable Mode of(String value) {

--- a/http/src/main/java/io/micronaut/http/SecFetch.java
+++ b/http/src/main/java/io/micronaut/http/SecFetch.java
@@ -22,29 +22,47 @@ import java.util.Optional;
 /**
  * The Fetch Metadata request headers.
  *
+ * <p>Each component is populated independently: a header that is absent, or that carries a value
+ * this version does not recognise, yields a {@code null} component while the headers that did
+ * parse remain readable. An unrecognised {@code Sec-Fetch-Dest} therefore does not hide the site
+ * and mode, which is what a resource isolation policy needs in order to fail closed on the part it
+ * could not classify rather than on the whole request.
+ *
  * @see <a href="https://www.w3.org/TR/fetch-metadata/#sec-fetch-dest-header">Sec-Fetch-Dest</a>
  * @see <a href="https://www.w3.org/TR/fetch-metadata/#sec-fetch-mode-header">Sec-Fetch-Mode</a>
  * @see <a href="https://www.w3.org/TR/fetch-metadata/#sec-fetch-site-header">Sec-Fetch-Site</a>
  * @see <a href="https://www.w3.org/TR/fetch-metadata/#sec-fetch-user-header">Sec-Fetch-User</a>
- * @param site The relationship between the request initiator and requested resource
- * @param mode The request mode
- * @param dest The request destination
- * @param user Whether the request was initiated by user activation
+ * @param site The relationship between the request initiator and requested resource, or
+ * {@code null} if {@code Sec-Fetch-Site} was absent or carried an unrecognised value
+ * @param mode The request mode, or {@code null} if {@code Sec-Fetch-Mode} was absent or carried an
+ * unrecognised value
+ * @param dest The request destination, or {@code null} if {@code Sec-Fetch-Dest} was absent or
+ * carried a value not listed by {@link Destination}. The Fetch specification keeps adding
+ * destinations, so a newer client can legitimately send one this version does not know
+ * @param user Whether the request was initiated by user activation. Only {@code Sec-Fetch-User:
+ * ?1} yields {@code true}; an absent header, the structured field boolean {@code ?0}, and any
+ * unrecognised value all yield {@code false}
  * @since 5.1.12
  */
 public record SecFetch(
-    Site site,
-    Mode mode,
-    Destination dest,
+    @Nullable Site site,
+    @Nullable Mode mode,
+    @Nullable Destination dest,
     boolean user
 ) {
+
+    /**
+     * The only {@code Sec-Fetch-User} value a conforming client sends.
+     */
+    private static final String USER_ACTIVATED = "?1";
 
     /**
      * Creates Fetch Metadata from the request headers.
      *
      * @param request The HTTP request
-     * @return The Fetch Metadata, or {@code null} if the request does not contain
-     * all recognized Fetch Metadata headers
+     * @return The Fetch Metadata, or {@code null} if the request carries none of the Fetch
+     * Metadata headers. See {@link #of(HttpHeaders)} for what a {@code null} return does and does
+     * not tell a caller
      * @since 5.1.12
      */
     public static @Nullable SecFetch of(HttpRequest<?> request) {
@@ -54,34 +72,34 @@ public record SecFetch(
     /**
      * Creates Fetch Metadata from the given headers.
      *
+     * <p>The result is best effort. Headers that parse are reported; those that are absent or
+     * carry an unrecognised value become {@code null} components. Headers that could not be
+     * classified never suppress the ones that could, so a request whose {@code Sec-Fetch-Dest} is
+     * unknown still reports its site and mode.
+     *
      * @param headers The HTTP headers
-     * @return The Fetch Metadata, or {@code null} if the headers do not contain
-     * all recognized Fetch Metadata headers
+     * @return The Fetch Metadata, or {@code null} if none of {@code Sec-Fetch-Site},
+     * {@code Sec-Fetch-Mode}, {@code Sec-Fetch-Dest} and {@code Sec-Fetch-User} is present.
+     * <p><strong>A {@code null} return means only that the client sent no Fetch Metadata at all</strong>
+     * — an older browser, or a non-browser client — and carries no assurance that the request is
+     * safe. Likewise a {@code null} component means "not classified", not "harmless". Resource
+     * isolation policies should decide deliberately what to do with unclassified requests rather
+     * than treating {@code null} as an implicit allow
      * @since 5.1.12
      */
     public static @Nullable SecFetch of(HttpHeaders headers) {
-        Site site = headers.findFirst(HttpHeaders.SEC_FETCH_SITE)
-            .map(Site::of)
-            .orElse(null);
-        if (site == null) {
-            return null;
-        }
-        Mode mode = headers.findFirst(HttpHeaders.SEC_FETCH_MODE)
-            .map(Mode::of)
-            .orElse(null);
-        if (mode == null) {
-            return null;
-        }
-        Destination destination = headers.findFirst(HttpHeaders.SEC_FETCH_DEST)
-            .map(Destination::of)
-            .orElse(null);
-        if (destination == null) {
-            return null;
-        }
+        Optional<String> siteHeader = headers.findFirst(HttpHeaders.SEC_FETCH_SITE);
+        Optional<String> modeHeader = headers.findFirst(HttpHeaders.SEC_FETCH_MODE);
+        Optional<String> destHeader = headers.findFirst(HttpHeaders.SEC_FETCH_DEST);
         Optional<String> userHeader = headers.findFirst(HttpHeaders.SEC_FETCH_USER);
-        if (userHeader.isPresent() && !"?1".equals(userHeader.get())) {
+        if (siteHeader.isEmpty() && modeHeader.isEmpty() && destHeader.isEmpty() && userHeader.isEmpty()) {
             return null;
         }
-        return new SecFetch(site, mode, destination, userHeader.isPresent());
+        return new SecFetch(
+            siteHeader.map(Site::of).orElse(null),
+            modeHeader.map(Mode::of).orElse(null),
+            destHeader.map(Destination::of).orElse(null),
+            userHeader.filter(USER_ACTIVATED::equals).isPresent()
+        );
     }
 }

--- a/http/src/main/java/io/micronaut/http/Site.java
+++ b/http/src/main/java/io/micronaut/http/Site.java
@@ -39,7 +39,8 @@ public enum Site {
      * Finds the site relationship for the given Fetch Metadata value.
      *
      * @param value The site relationship value
-     * @return The matching site relationship, or {@code null} if there is no match
+     * @return The matching site relationship, or {@code null} if there is no match. {@link SecFetch}
+     * reports such a value as a {@code null} component and keeps the rest of the metadata readable
      * @since 5.1.12
      */
     public static @Nullable Site of(String value) {

--- a/http/src/test/java/io/micronaut/http/DestinationTest.java
+++ b/http/src/test/java/io/micronaut/http/DestinationTest.java
@@ -15,16 +15,63 @@
  */
 package io.micronaut.http;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DestinationTest {
+
+    /**
+     * The destination values the specification lists, so that this enum drifting away from the
+     * specification fails here rather than silently dropping metadata at runtime.
+     *
+     * @see <a href="https://fetch.spec.whatwg.org/#concept-request-destination">Destination</a>
+     */
+    private static final Set<String> SPECIFICATION_VALUES = Set.of(
+        "empty",
+        "audio",
+        "audioworklet",
+        "document",
+        "embed",
+        "fencedframe",
+        "font",
+        "frame",
+        "iframe",
+        "image",
+        "json",
+        "manifest",
+        "object",
+        "paintworklet",
+        "report",
+        "script",
+        "serviceworker",
+        "sharedworker",
+        "speculationrules",
+        "style",
+        "text",
+        "track",
+        "video",
+        "webidentity",
+        "worker",
+        "xslt"
+    );
+
+    @Test
+    void listsExactlyTheDestinationValuesOfTheSpecification() {
+        Set<String> declared = Stream.of(Destination.values())
+            .map(Destination::toString)
+            .collect(Collectors.toSet());
+
+        assertEquals(SPECIFICATION_VALUES, declared);
+    }
 
     @ParameterizedTest
     @MethodSource

--- a/http/src/test/java/io/micronaut/http/ModeTest.java
+++ b/http/src/test/java/io/micronaut/http/ModeTest.java
@@ -15,16 +15,42 @@
  */
 package io.micronaut.http;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ModeTest {
+
+    /**
+     * The mode values the specification lists, so that this enum drifting away from the
+     * specification fails here rather than silently dropping metadata at runtime.
+     *
+     * @see <a href="https://www.w3.org/TR/fetch-metadata/#sec-fetch-mode-header">Mode</a>
+     */
+    private static final Set<String> SPECIFICATION_VALUES = Set.of(
+        "same-origin",
+        "no-cors",
+        "cors",
+        "navigate",
+        "websocket"
+    );
+
+    @Test
+    void listsExactlyTheModeValuesOfTheSpecification() {
+        Set<String> declared = Stream.of(Mode.values())
+            .map(Mode::toString)
+            .collect(Collectors.toSet());
+
+        assertEquals(SPECIFICATION_VALUES, declared);
+    }
 
     @ParameterizedTest
     @MethodSource

--- a/http/src/test/java/io/micronaut/http/SecFetchTest.java
+++ b/http/src/test/java/io/micronaut/http/SecFetchTest.java
@@ -34,17 +34,58 @@ class SecFetchTest {
     }
 
     @Test
-    void returnsNullWhenFetchMetadataIsIncompleteOrUnknown() {
-        HttpRequest<?> incompleteRequest = HttpRequest.GET("/")
+    void returnsNullOnlyWhenNoFetchMetadataHeaderIsPresent() {
+        HttpRequest<?> request = HttpRequest.GET("/");
+
+        assertNull(request.getSecFetch());
+        assertNull(SecFetch.of(request));
+    }
+
+    @Test
+    void aSingleFetchMetadataHeaderIsEnoughToProduceMetadata() {
+        HttpRequest<?> request = HttpRequest.GET("/")
+            .header(HttpHeaders.SEC_FETCH_SITE, Site.CROSS_SITE.toString());
+
+        assertEquals(new SecFetch(Site.CROSS_SITE, null, null, false), request.getSecFetch());
+    }
+
+    @Test
+    void missingHeadersLeaveTheOthersReadable() {
+        HttpRequest<?> request = HttpRequest.GET("/")
             .header(HttpHeaders.SEC_FETCH_SITE, Site.SAME_ORIGIN.toString())
             .header(HttpHeaders.SEC_FETCH_MODE, Mode.CORS.toString());
-        HttpRequest<?> unknownRequest = HttpRequest.GET("/")
+
+        assertEquals(new SecFetch(Site.SAME_ORIGIN, Mode.CORS, null, false), request.getSecFetch());
+    }
+
+    @Test
+    void anUnrecognisedSiteLeavesTheModeAndDestinationReadable() {
+        HttpRequest<?> request = HttpRequest.GET("/")
             .header(HttpHeaders.SEC_FETCH_SITE, "unknown")
             .header(HttpHeaders.SEC_FETCH_MODE, Mode.CORS.toString())
             .header(HttpHeaders.SEC_FETCH_DEST, Destination.JSON.toString());
 
-        assertNull(SecFetch.of(incompleteRequest));
-        assertNull(SecFetch.of(unknownRequest));
+        assertEquals(new SecFetch(null, Mode.CORS, Destination.JSON, false), request.getSecFetch());
+    }
+
+    @Test
+    void anUnrecognisedDestinationLeavesTheSiteAndModeReadable() {
+        HttpRequest<?> request = HttpRequest.GET("/")
+            .header(HttpHeaders.SEC_FETCH_SITE, Site.CROSS_SITE.toString())
+            .header(HttpHeaders.SEC_FETCH_MODE, Mode.NAVIGATE.toString())
+            .header(HttpHeaders.SEC_FETCH_DEST, "destination-added-after-this-release");
+
+        assertEquals(new SecFetch(Site.CROSS_SITE, Mode.NAVIGATE, null, false), request.getSecFetch());
+    }
+
+    @Test
+    void metadataThatIsEntirelyUnrecognisedIsStillDistinguishableFromNoMetadata() {
+        HttpRequest<?> request = HttpRequest.GET("/")
+            .header(HttpHeaders.SEC_FETCH_SITE, "unknown")
+            .header(HttpHeaders.SEC_FETCH_MODE, "unknown")
+            .header(HttpHeaders.SEC_FETCH_DEST, "unknown");
+
+        assertEquals(new SecFetch(null, null, null, false), request.getSecFetch());
     }
 
     @Test
@@ -58,13 +99,32 @@ class SecFetchTest {
     }
 
     @Test
-    void invalidUserHeaderValueMakesFetchMetadataUnknown() {
+    void falseUserHeaderMeansRequestWasNotUserActivated() {
         HttpRequest<?> request = HttpRequest.GET("/")
             .header(HttpHeaders.SEC_FETCH_SITE, Site.SAME_ORIGIN.toString())
             .header(HttpHeaders.SEC_FETCH_MODE, Mode.CORS.toString())
             .header(HttpHeaders.SEC_FETCH_DEST, Destination.JSON.toString())
             .header(HttpHeaders.SEC_FETCH_USER, "?0");
 
-        assertNull(SecFetch.of(request));
+        assertEquals(new SecFetch(Site.SAME_ORIGIN, Mode.CORS, Destination.JSON, false), request.getSecFetch());
+    }
+
+    @Test
+    void invalidUserHeaderValueMeansRequestWasNotUserActivated() {
+        HttpRequest<?> request = HttpRequest.GET("/")
+            .header(HttpHeaders.SEC_FETCH_SITE, Site.SAME_ORIGIN.toString())
+            .header(HttpHeaders.SEC_FETCH_MODE, Mode.CORS.toString())
+            .header(HttpHeaders.SEC_FETCH_DEST, Destination.JSON.toString())
+            .header(HttpHeaders.SEC_FETCH_USER, "true");
+
+        assertEquals(new SecFetch(Site.SAME_ORIGIN, Mode.CORS, Destination.JSON, false), request.getSecFetch());
+    }
+
+    @Test
+    void aUserHeaderOnItsOwnProducesMetadata() {
+        HttpRequest<?> request = HttpRequest.GET("/")
+            .header(HttpHeaders.SEC_FETCH_USER, "?1");
+
+        assertEquals(new SecFetch(null, null, null, true), request.getSecFetch());
     }
 }

--- a/http/src/test/java/io/micronaut/http/SiteTest.java
+++ b/http/src/test/java/io/micronaut/http/SiteTest.java
@@ -15,16 +15,41 @@
  */
 package io.micronaut.http;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class SiteTest {
+
+    /**
+     * The site values the specification lists, so that this enum drifting away from the
+     * specification fails here rather than silently dropping metadata at runtime.
+     *
+     * @see <a href="https://www.w3.org/TR/fetch-metadata/#sec-fetch-site-header">Site</a>
+     */
+    private static final Set<String> SPECIFICATION_VALUES = Set.of(
+        "cross-site",
+        "same-origin",
+        "same-site",
+        "none"
+    );
+
+    @Test
+    void listsExactlyTheSiteValuesOfTheSpecification() {
+        Set<String> declared = Stream.of(Site.values())
+            .map(Site::toString)
+            .collect(Collectors.toSet());
+
+        assertEquals(SPECIFICATION_VALUES, declared);
+    }
 
     @ParameterizedTest
     @MethodSource


### PR DESCRIPTION
## What

`SecFetch.of` collapsed to `null` whenever **any one** of `Sec-Fetch-Site` / `Sec-Fetch-Mode` / `Sec-Fetch-Dest` was absent or carried a value the corresponding enum did not list, and also whenever `Sec-Fetch-User` held anything other than `?1` — including the structured-field-legal `?0`.

Each header is now parsed independently and the record's components are nullable:

```java
public record SecFetch(@Nullable Site site, @Nullable Mode mode, @Nullable Destination dest, boolean user)
```

`SecFetch.of` returns `null` **only** when none of the four `Sec-Fetch-*` headers is present.

## Why

These headers exist for resource isolation policies, so the old behaviour fails open. A filter written the obvious way

```java
SecFetch f = request.getSecFetch();
if (f == null) { /* old browser, allow */ }
```

allows precisely the requests whose metadata could not be classified. A single unrecognised `Sec-Fetch-Dest` also made the site and mode unreachable even though both had parsed fine.

`Destination` is a closed enum against a list the Fetch specification keeps extending, so a browser sending a newer destination silently produced no metadata at all — and `webidentity` (FedCM) was already missing from the enum, so that was not hypothetical.

## Changes

- **`SecFetch`** — nullable `site` / `mode` / `dest`; headers that parse stay readable when their neighbours do not. Metadata that is *entirely* unrecognised yields `SecFetch[null, null, null, false]`, which a policy can tell apart from a client that sent no Fetch Metadata at all.
- **`Sec-Fetch-User`** — read rather than used as a veto. Only `?1` yields `true`; `?0` and any other value yield `false` instead of discarding the whole record. Per the spec a conforming client only sends `?1`, but `?0` is a legal structured field boolean and throwing away the site, mode and destination because of it is worse than reading it.
- **`Destination`** — added `WEBIDENTITY`. Verified against [WHATWG Fetch](https://fetch.spec.whatwg.org/#concept-request-destination) and [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest); `sharedstorageworklet` and `dictionary` are *not* destinations, and the existing `fencedframe`, `speculationrules` and `text` are all correct.
- **Javadoc** — both `SecFetch.of` overloads and `HttpRequest.getSecFetch()` now state that `null` means the client sent no Fetch Metadata (an older or non-browser client), **not** that the request is safe, and that a `null` component means "not classified", not "harmless".
- **Tests** — `SecFetchTest` goes 4 → 11 tests covering partial, unrecognised and mixed metadata. `SiteTest`, `ModeTest` and `DestinationTest` each gained a set-equality test against a hard-coded specification list, so both a missing value and a bogus one fail the build rather than silently dropping metadata at runtime.

## Design note

The `Site` / `Mode` / `Destination` enums stay **closed**, with `of` still returning `null` for an unrecognised value. The alternative considered was an `UNKNOWN` constant on each enum; keeping the "unrecognised" signal on the record instead avoids forcing a new case into every exhaustive switch in consumer code.

## For the reviewer

This changes the semantics of an API released in 5.1.12 and is **source breaking** for callers that dereference `site()`, `mode()` or `dest()` without a null check. The API is two weeks old (v5.1.12 Aug 21, v5.1.13 Aug 28) and there are no consumers of it inside this repository, but it is not purely theoretical. It lands on 5.2.x only, with no back-compat shim — 5.1.x keeps what it shipped. Worth a line in the 5.2 release notes.

The `@since 5.1.12` tags are left as-is since they mark when the members appeared; if you would rather they mark the changed semantics, say so and I will move them.

`./gradlew :micronaut-http:test` passes — BUILD SUCCESSFUL, no failures in any test class in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
