### PR TITLE
Fail fast when adding a method definition after inheriting the super ones

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -987,7 +987,10 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     private void addInjectionMethod(MethodDefinition<ClassElement, MethodElement> methodDefinition) {
         if (inheritedMethodDefinitions) {
-            // the definitions are already present at the index of the super definition
+            if (!allMethods.contains(methodDefinition)) {
+                throw new IllegalStateException("Cannot add the method definition " + methodDefinition + " to " + this + " after the method definitions of the super bean definition have been inherited");
+            }
+            // the definition is already present at the index of the super definition
             return;
         }
         allMethods.add(methodDefinition);


### PR DESCRIPTION
## What

`BeanDefinitionWriter.addInjectionMethod` now throws an `IllegalStateException` naming the method definition when `inheritedMethodDefinitions` is set and the definition is not already in `allMethods`, instead of silently returning.

## Why

A proxy bean definition extends its target's definition and reuses the target's `$INJECTION_METHODS` array at runtime, so `inheritMethodDefinitions` (added in 88d07edeb5) copies the parent's `allMethods` list to keep the generated indexes aligned. After that copy, `addInjectionMethod` returned without adding anything.

That is correct only for definitions the parent already holds: `ProxyingBeanDefinitionWriter.processAlreadyVisitedMethods` re-adds the very same `MethodDefinition` objects, so `allMethods.indexOf` finds them. But a definition the parent does *not* hold — arriving via `addPostConstruct`, `addPreDestroy` or `addMethodInjection` — would be dropped from `allMethods`, and `doInjectMethod` would then compute `allMethods.indexOf(methodDefinition)` = `-1` and generate code indexing `$INJECTION_METHODS[-1]`: bad bytecode discovered only at runtime.

`inheritMethodDefinitions` already throws when methods were added *before* inheriting; this closes the other side of the same invariant.

## Notes for reviewers

- This is fail-fast hardening, not a live bug fix. Nothing reaches the new throw today — `ProxyingBeanDefinitionWriter.processAlreadyVisitedMethods` is the only caller of `inheritMethodDefinitions`, and it only re-adds the parent's own post-construct and pre-destroy definitions.
- The guard uses `allMethods.contains(...)`, the same equality as the `indexOf` calls that would otherwise return `-1`, so it fires on exactly the definitions that would produce the broken index and stays a no-op on the normal re-add path.

## Verification

- `./gradlew :micronaut-inject-java:test --tests 'io.micronaut.aop.*'` — BUILD SUCCESSFUL
- `./gradlew :micronaut-inject-java:test --tests 'io.micronaut.inject.*'` — BUILD SUCCESSFUL
- `PreDestroyInterceptorCompileSpec` re-run in isolation: 1 test, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)