### PR TITLE
Do not derive an interceptor binding for a kind that is already declared

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/InterceptorBindingMembers.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/InterceptorBindingMembers.java
@@ -33,6 +33,7 @@ import io.micronaut.inject.visitor.VisitorContext;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -70,6 +71,17 @@ public final class InterceptorBindingMembers implements AnnotationRemapper {
             return List.of(annotationValue.mutate().replaceStereotypes(retainable).build());
         }
 
+        // A declared `@InterceptorBinding` stereotype already says everything about the kind it names, members
+        // included. The binding derived from `@Around` and friends carries no members, so for a kind that is
+        // already spelled out it would only add an occurrence matching anything. The stereotypes come in no
+        // guaranteed order, so gather the declared kinds before building any binding.
+        Set<InterceptorKind> declaredKinds = EnumSet.noneOf(InterceptorKind.class);
+        for (AnnotationValue<?> stereotype : annotationValue.getStereotypes()) {
+            if (InterceptorBinding.class.getName().equals(stereotype.getAnnotationName())) {
+                declaredKinds.add(stereotype.enumValue("kind", InterceptorKind.class).orElse(InterceptorKind.AROUND));
+            }
+        }
+
         List<AnnotationValueBuilder<?>> interceptorBindings = new ArrayList<>();
         for (AnnotationValue<?> stereotype : annotationValue.getStereotypes()) {
             String stereotypeName = stereotype.getAnnotationName();
@@ -79,15 +91,15 @@ public final class InterceptorBindingMembers implements AnnotationRemapper {
                 // occurrences of the binding annotation, which it retains
                 newInterceptorBinding = stereotype.mutate()
                         .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName));
-            } else if (Around.class.getName().equals(stereotypeName)) {
+            } else if (Around.class.getName().equals(stereotypeName) && !declaredKinds.contains(InterceptorKind.AROUND)) {
                 newInterceptorBinding = AnnotationValue.builder(InterceptorBinding.class)
                         .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName))
                         .member("kind", InterceptorKind.AROUND);
-            } else if (Introduction.class.getName().equals(stereotypeName)) {
+            } else if (Introduction.class.getName().equals(stereotypeName) && !declaredKinds.contains(InterceptorKind.INTRODUCTION)) {
                 newInterceptorBinding = AnnotationValue.builder(InterceptorBinding.class)
                         .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName))
                         .member("kind", InterceptorKind.INTRODUCTION);
-            } else if (AroundConstruct.class.getName().equals(stereotypeName)) {
+            } else if (AroundConstruct.class.getName().equals(stereotypeName) && !declaredKinds.contains(InterceptorKind.AROUND_CONSTRUCT)) {
                 newInterceptorBinding = AnnotationValue.builder(InterceptorBinding.class)
                         .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName))
                         .member("kind", InterceptorKind.AROUND_CONSTRUCT);

--- a/inject-java/src/test/groovy/io/micronaut/aop/binding/AroundBindingMembersSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/binding/AroundBindingMembersSpec.groovy
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.binding
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.InterceptorKind
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.inject.qualifiers.InterceptorBindingQualifier
+
+/**
+ * An annotation carrying both {@code @Around} and {@code @InterceptorBinding} records one interceptor binding
+ * per kind: the binding {@code @Around} would derive carries no members, and saying nothing is not what the
+ * declared {@code @InterceptorBinding} of the same kind means, so it is not written.
+ */
+class AroundBindingMembersSpec extends AbstractTypeElementSpec {
+
+    private static final String SOURCE = '''
+package aroundbindingmembers;
+
+import io.micronaut.aop.*;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.AROUND, bindMembers = true)
+@interface Zone {
+    String value() default "north";
+}
+
+@Singleton
+@Zone("north")
+class NorthInterceptor implements MethodInterceptor<Object, Object> {
+
+    static final List<String> INTERCEPTED = new ArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        INTERCEPTED.add(context.getTarget().getClass().getSimpleName());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Zone
+class DefaultedTarget {
+    String work() {
+        return "done";
+    }
+}
+
+@Singleton
+@Zone("north")
+class DeclaredTarget {
+    String work() {
+        return "done";
+    }
+}
+
+@Singleton
+@Zone("south")
+class OtherTarget {
+    String work() {
+        return "done";
+    }
+}
+'''
+
+    void 'an interceptor binding by members is bound by them when the annotation also carries @Around'() {
+        given:
+        def context = buildContext(SOURCE)
+        def intercepted = context.classLoader.loadClass('aroundbindingmembers.NorthInterceptor').INTERCEPTED
+        intercepted.clear()
+
+        when: 'a target declaring the default, one writing it down, and one declaring something else are called'
+        ['DefaultedTarget', 'DeclaredTarget', 'OtherTarget'].each {
+            def bean = context.getBean(context.classLoader.loadClass("aroundbindingmembers.$it"))
+            bean.work()
+        }
+
+        then: 'the interceptor bound to @Zone("north") ran on the first two and not on the third'
+        intercepted.findAll { it.contains('DefaultedTarget') }.size() == 1
+        intercepted.findAll { it.contains('DeclaredTarget') }.size() == 1
+        intercepted.findAll { it.contains('OtherTarget') }.isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'the memberless binding @Around would derive is not recorded next to the declared one'() {
+        given:
+        def context = buildContext(SOURCE)
+
+        when:
+        def bindings = context.getBeanDefinition(context.classLoader.loadClass('aroundbindingmembers.OtherTarget'))
+                .getAnnotationMetadata()
+                .getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING)
+                .findAll { it.stringValue().isPresent() }
+
+        then: 'the single binding for the kind is the declared one, the one that binds by members'
+        bindings.size() == 1
+        bindings[0].enumValue('kind', InterceptorKind).get() == InterceptorKind.AROUND
+        bindings[0].booleanValue('bindMembers').get()
+
+        and: 'it resolves to the occurrence the bean declared'
+        def metadata = context.getBeanDefinition(context.classLoader.loadClass('aroundbindingmembers.OtherTarget'))
+                .getAnnotationMetadata()
+        InterceptorBindingQualifier.resolveBoundOccurrences(bindings[0], metadata).first().stringValue().get() == 'south'
+
+        cleanup:
+        context.close()
+    }
+
+    void 'a binding of another kind still derives its own from @Around'() {
+        given:
+        def context = buildContext('''
+package aroundbindingmemberskinds;
+
+import io.micronaut.aop.*;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Both {
+}
+
+@Singleton
+@Both
+class BothTarget {
+    String work() {
+        return "done";
+    }
+}
+''')
+
+        when:
+        def kinds = context.getBeanDefinition(context.classLoader.loadClass('aroundbindingmemberskinds.BothTarget'))
+                .getAnnotationMetadata()
+                .getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING)
+                .findAll { it.stringValue().isPresent() }
+                .collect { it.enumValue('kind', InterceptorKind).get() }
+
+        then: 'the kinds differ, so both bindings are written'
+        kinds.toSorted() == [InterceptorKind.AROUND, InterceptorKind.POST_CONSTRUCT].toSorted()
+
+        cleanup:
+        context.close()
+    }
+}


### PR DESCRIPTION
## What

`InterceptorBindingMembers` emits one `@InterceptorBinding` per interceptor stereotype it finds. An annotation meta-annotated with both `@Around` and `@InterceptorBinding(kind = AROUND, bindMembers = true)` therefore recorded **two** bindings for the same annotation and the same kind:

```java
@Retention(RUNTIME)
@Target({ElementType.TYPE, ElementType.METHOD})
@Around
@InterceptorBinding(kind = InterceptorKind.AROUND, bindMembers = true)
@interface Zone { String value() default "north"; }
```

A `@Zone("south")` bean recorded `(value=[Zone], kind=AROUND, bindMembers=true)` — the declared one, which binds by members — and next to it `(value=[Zone], kind=AROUND)` derived from the `@Around` branch, which binds nothing.

The derived binding says nothing the declared one does not already say, and an occurrence that binds nothing matches anything.

## How

A first pass gathers the kinds the `InterceptorBinding` branch produces (`kind` defaults to `AROUND` when unspecified); the `@Around` / `@Introduction` / `@AroundConstruct` branches are then skipped for those kinds. Two passes because the stereotype list comes in no guaranteed order.

Kinds that differ are untouched: `@Around` alongside `@InterceptorBinding(kind = POST_CONSTRUCT)` still produces both bindings. `AroundBindingMembersSpec` covers that case as well as the deduplicated one.

## For the reviewer

This is a generation change only — it is **not** on its own a fix for the matching bug the duplicate used to cause (the memberless binding matched anything, so an interceptor bound to `@Zone("north")` intercepted a `@Zone("south")` bean). Metadata in already-published jars still carries the duplicate, so the matching layer has to cope with it regardless; that fix belongs in `DefaultInterceptorRegistry.matches` / `InterceptorBindingQualifier` and is not part of this PR.

## Verification

- `./gradlew :micronaut-inject-java:test --tests 'io.micronaut.aop.*'` — 3511 tests pass
- `./gradlew :micronaut-inject-kotlin:test --tests 'io.micronaut.kotlin.processing.aop.*'` — 331 pass (3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)