### PR TITLE
Reject header values holding a character above U+00FF

### DIFF
--- a/http/src/main/java/io/micronaut/http/CaseInsensitiveMutableHttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/CaseInsensitiveMutableHttpHeaders.java
@@ -193,17 +193,23 @@ public final class CaseInsensitiveMutableHttpHeaders implements MutableHttpHeade
         //  HTAB           = %x09 ; horizontal tab
         //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
         //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
+        //
+        //  The rule is defined over octets, so anything above 0xFF is not a header value at all.
+        //  Such a character cannot be written to the wire: encoders either substitute it (Netty
+        //  replaces it with '?') or reject the value late and out of context (the JDK HTTP client
+        //  throws from its own builder), so it is rejected here instead. Characters in 0x80-0xFF
+        //  remain valid obs-text, which is what a non-ASCII Content-Disposition filename uses.
         if (value.isEmpty()) {
             return -1;
         }
         int b = value.charAt(0);
-        if (b < 0x21 || b == 0x7F) {
+        if (b < 0x21 || b == 0x7F || b > 0xFF) {
             return 0;
         }
         int length = value.length();
         for (int i = 1; i < length; i++) {
             b = value.charAt(i);
-            if (b < 0x20 && b != 0x09 || b == 0x7F) {
+            if (b < 0x20 && b != 0x09 || b == 0x7F || b > 0xFF) {
                 return i;
             }
         }

--- a/http/src/test/groovy/io/micronaut/http/CaseInsensitiveMutableHttpHeadersSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/CaseInsensitiveMutableHttpHeadersSpec.groovy
@@ -173,6 +173,45 @@ class CaseInsensitiveMutableHttpHeadersSpec extends Specification {
         cex.message == "The header value for 'foo' contains prohibited character 0xa at index 3."
     }
 
+    void "cannot add a header value with a character that is not an octet"() {
+        given:
+        CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(ConversionService.SHARED)
+
+        when: "a character above 0xFF whose low byte is a line feed"
+        headers.add("foo", "bar" + ((char) 0x010A) + "Origin: localhost")
+
+        then:
+        IllegalArgumentException ex = thrown()
+        ex.message == "The header value for 'foo' contains prohibited character 0x10a at index 3."
+
+        when: "the value starts with one"
+        headers.add("foo", "" + ((char) 0x010A) + "bar")
+
+        then:
+        IllegalArgumentException fex = thrown()
+        fex.message == "The header value for 'foo' contains prohibited character 0x10a at index 0."
+
+        when: "it arrives through the defaults constructor"
+        new CaseInsensitiveMutableHttpHeaders(ConversionService.SHARED, "foo": ["bar" + ((char) 0x010A)])
+
+        then:
+        IllegalArgumentException cex = thrown()
+        cex.message == "The header value for 'foo' contains prohibited character 0x10a at index 3."
+    }
+
+    void "obs-text remains a valid header value"() {
+        given:
+        CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(ConversionService.SHARED)
+        String disposition = 'attachment; filename="r' + ((char) 0xE9) + 'sum' + ((char) 0xE9) + '.pdf"'
+
+        when: "the value only uses characters that are representable as a single octet"
+        headers.add("Content-Disposition", disposition)
+
+        then: "it is accepted, as RFC 7230 obs-text (%x80-FF)"
+        noExceptionThrown()
+        headers.get("Content-Disposition") == disposition
+    }
+
     void "can switch off validation"() {
         given:
         CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(false, ConversionService.SHARED)

--- a/http/src/test/groovy/io/micronaut/http/CaseInsensitiveMutableHttpHeadersSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/CaseInsensitiveMutableHttpHeadersSpec.groovy
@@ -212,6 +212,76 @@ class CaseInsensitiveMutableHttpHeadersSpec extends Specification {
         headers.get("Content-Disposition") == disposition
     }
 
+    void "the octet boundary is U+00FF"() {
+        given:
+        CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(ConversionService.SHARED)
+        String highest = "" + ((char) 0x00FF)
+
+        when: "the highest character that is still a single octet is used"
+        headers.add("foo", highest + "bar" + highest)
+
+        then: "it is accepted, as the last obs-text character"
+        noExceptionThrown()
+        headers.get("foo") == highest + "bar" + highest
+
+        when: "the very next character is used at the start of the value"
+        headers.add("foo", "" + ((char) 0x0100) + "bar")
+
+        then:
+        IllegalArgumentException ex = thrown()
+        ex.message == "The header value for 'foo' contains prohibited character 0x100 at index 0."
+
+        when: "the very next character is used inside the value"
+        headers.add("foo", "bar" + ((char) 0x0100))
+
+        then:
+        IllegalArgumentException iex = thrown()
+        iex.message == "The header value for 'foo' contains prohibited character 0x100 at index 3."
+    }
+
+    void "cannot add a header value that starts with a character that is not field-vchar"() {
+        given:
+        CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(ConversionService.SHARED)
+
+        when: "the value starts with a space"
+        headers.add("foo", " bar")
+
+        then:
+        IllegalArgumentException ex = thrown()
+        ex.message == "The header value for 'foo' contains prohibited character 0x20 at index 0."
+
+        when: "the value starts with a delete character"
+        headers.add("foo", "" + ((char) 0x7F) + "bar")
+
+        then:
+        IllegalArgumentException dex = thrown()
+        dex.message == "The header value for 'foo' contains prohibited character 0x7f at index 0."
+    }
+
+    void "cannot add a header value holding a delete character"() {
+        given:
+        CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(ConversionService.SHARED)
+
+        when:
+        headers.add("foo", "bar" + ((char) 0x7F) + "baz")
+
+        then:
+        IllegalArgumentException ex = thrown()
+        ex.message == "The header value for 'foo' contains prohibited character 0x7f at index 3."
+    }
+
+    void "a horizontal tab is allowed inside a header value"() {
+        given:
+        CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(ConversionService.SHARED)
+
+        when: "the only character below 0x20 that field-content allows is used"
+        headers.add("foo", "bar\tbaz")
+
+        then:
+        noExceptionThrown()
+        headers.get("foo") == "bar\tbaz"
+    }
+
     void "can switch off validation"() {
         given:
         CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(false, ConversionService.SHARED)

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -8,6 +8,14 @@ This applies to both normal redirects and preserve-body redirects (`307` and `30
 
 If needed, this behavior can be customized through `HttpClientConfiguration`.
 
+=== Header values may no longer contain characters above U+00FF
+
+`SimpleHttpHeaders` (and the `CaseInsensitiveMutableHttpHeaders` behind it, used when Netty is not on the classpath) now rejects a header value containing a character above `U+00FF` with an `IllegalArgumentException`.
+
+RFC 7230 defines a header value over octets — `field-vchar = VCHAR / obs-text`, where `obs-text` is `%x80-FF` — so a character that is not representable as a single octet is not a valid header value. Previously such a value was accepted and then handled inconsistently by whichever transport sent it: Netty substitutes `?` for each offending character, while the JDK HTTP client throws from its own request builder. The value is now rejected where it is set, naming the header and the offending index.
+
+Characters in `%x80-FF` are unaffected and remain valid, so a `Content-Disposition` filename using Latin-1 accented characters continues to work. Only characters above `U+00FF` — for example CJK text or emoji — are rejected, and those were already being replaced with `?` on the wire.
+
 == 5.0
 
 === Core Changes


### PR DESCRIPTION
## What

`CaseInsensitiveMutableHttpHeaders.verifyValidHeaderValueCharSequence` compared full `char` values, so anything from `U+0100` up passed validation. RFC 7230 defines a header value over octets — `field-vchar = VCHAR / obs-text`, `obs-text` being `%x80-FF` — so a character that is not representable as a single octet is not a valid header value in the first place. `headers.add("X-Test", "aĊb")` was accepted and stored.

The validator now rejects characters above `0xFF` in both branches.

## This is not a response-splitting hole

The worry with `U+010A` is a downstream encoder narrowing the `char` to a byte, turning it into a bare `0x0A` in a header value (CWE-113). Checked all three encoders empirically against Netty 4.2.17.Final (the managed version) and JDK 25:

| Path | `"aĊb"` | Wire bytes |
|---|---|---|
| Netty HTTP/1.1 response encoder | `a?b` | `61 3F 62` |
| Netty HTTP/1.1 request encoder | `a?b` | `61 3F 62` |
| Netty HTTP/2 HPACK encoder | `a?b` | `61 3F 62` |
| JDK `HttpClient` | rejected | `IllegalArgumentException: invalid header value` |

`"xčĊInjected: 1"` likewise encodes as `x??Injected: 1`. No splitting on any path.

The mechanism is not the `US_ASCII` charset named in Netty's `HttpHeadersEncoder.writeAscii` — that would mangle Latin-1 too, and it does not. `ByteBuf.setCharSequence` routes through Netty's `AsciiString.c2b`:

```java
public static byte c2b(char c) {
    return (byte) ((c > MAX_CHAR_VALUE) ? '?' : c);   // MAX_CHAR_VALUE = 255
}
```

which is why `é` (`U+00E9`) survives as the legitimate obs-text octet `0xE9` while anything above `U+00FF` becomes `?`.

## Why tighten it anyway

What the gap produced was inconsistency rather than a vulnerability: one transport silently mangled the value, the other threw from inside the JDK's own request builder, far from the code that set the header. Rejecting at the point of use gives one early error that names the header and the offending index, in the same style as the other validation failures, and stops the correctness of this class depending on `AsciiString.c2b`'s `> 255` guard continuing to hold.

## Compatibility

The common non-ASCII case is unaffected. A `Content-Disposition` filename using Latin-1 accented characters — `résumé.pdf` is `U+00E9` twice — stays under `0xFF`, is valid obs-text, and is still accepted; there is a test pinning that.

Only characters above `U+00FF` (CJK, emoji, Cyrillic past Latin-1) are rejected, and those were never working: Netty already wrote `???.pdf` and the JDK client already threw. No application that gets correct bytes on the wire today stops working. Noted in `breaks.adoc`.

Blast radius is narrow: the only production consumer of this class is `SimpleHttpHeaders`, which `DefaultHttpFactories` uses when Netty is absent. The Netty server path uses `NettyHttpHeaders` and never touches it.

## Reviewer notes

- `SimpleHttpHeaders` has no non-validating constructor, so its users have no opt-out the way a direct `CaseInsensitiveMutableHttpHeaders(false, …)` caller does. Left alone deliberately — happy to add one if preferred.
- The header **name** validator in this class has a related defect (it compares `(byte) token.charAt(i)`, so `U+0141` narrows to `'A'` and a non-ASCII header name is accepted). That fix is in flight separately, so `validateCharSequenceToken` is untouched here to avoid a collision.

## Verification

`./gradlew :micronaut-http:test :micronaut-http-netty:test :micronaut-http-client-core:test` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)