### PR TITLE
Three unrelated cleanups in inject, inject-python and inject-kotlin

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
@@ -66,9 +66,6 @@ internal class KotlinVisitorContext(
     var resolver: Resolver
 ) : VisitorContext {
 
-    init {
-    }
-
     private val visitorAttributes: MutableConvertibleValues<Any> = MutableConvertibleValuesMap()
     private val elementFactory: KotlinElementFactory = KotlinElementFactory(this)
     private val outputVisitor = KotlinOutputVisitor(environment, this)

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -443,7 +443,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
 
                     if (!isJunit5Test && !extendsHostClass) {
                         if (isIntrospectedBean) {
-                        builder.addMethod(
+                            builder.addMethod(
                                 MethodDef.constructor()
                                     .addModifiers(Modifier.PUBLIC)
                                     .addParameter(ParameterDef.of("value", POLYGLOT_VALUE))
@@ -463,7 +463,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                         })
                                     ));
                         } else {
-                        builder.addMethod(
+                            builder.addMethod(
                                 MethodDef.constructor()
                                     .addModifiers(Modifier.PUBLIC)
                                     .addParameter(ParameterDef.of("value", POLYGLOT_VALUE))
@@ -799,7 +799,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                         final int requiredConstructorParameterCount = requiredConstructorParameterCount(parameters);
                         final boolean hasDefaultedConstructorParameters = requiredConstructorParameterCount < parameters.length;
                         final boolean constructorParametersBackedByFields = constructorParametersBackedByFields(parameters, propertyFields);
-                            builder.addMethod(
+                        builder.addMethod(
                             constructor.addModifiers(Modifier.PUBLIC).build(((aThis, methodParameters) -> {
                                 if (isIntrospectedBean && (constructorParametersBackedByFields || hasDynamicBeanProperties)) {
                                     if (hasConfigurationBuilderProperty || hasDynamicBeanProperties) {

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/InterceptorBindingQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/InterceptorBindingQualifier.java
@@ -128,7 +128,7 @@ public final class InterceptorBindingQualifier<T> extends FilteringQualifier<T> 
             return false;
         }
         final AnnotationMetadata annotationMetadata = candidate.getAnnotationMetadata();
-        Collection<AnnotationValue<Annotation>> interceptorValues = resolveInterceptorAnnotationValues(annotationMetadata, null);
+        Collection<AnnotationValue<Annotation>> interceptorValues = resolveInterceptorAnnotationValues(annotationMetadata);
         for (AnnotationValue<?> interceptorBinding : interceptorValues) {
             final String annotationName = interceptorBinding.stringValue().orElse(null);
             if (annotationName == null || !supportedAnnotationNames.containsKey(annotationName)) {
@@ -314,9 +314,7 @@ public final class InterceptorBindingQualifier<T> extends FilteringQualifier<T> 
         }
     }
 
-    private static Collection<AnnotationValue<Annotation>> resolveInterceptorAnnotationValues(
-        AnnotationMetadata annotationMetadata,
-        @Nullable String kind) {
+    private static Collection<AnnotationValue<Annotation>> resolveInterceptorAnnotationValues(AnnotationMetadata annotationMetadata) {
         List<AnnotationValue<Annotation>> bindings = annotationMetadata.getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING);
         if (CollectionUtils.isEmpty(bindings)) {
             return Collections.emptyList();
@@ -326,9 +324,7 @@ public final class InterceptorBindingQualifier<T> extends FilteringQualifier<T> 
             if (av.stringValue().isEmpty()) {
                 continue;
             }
-            if (kind == null || av.stringValue("kind").orElse(kind).equals(kind)) {
-                result.add(av);
-            }
+            result.add(av);
         }
         return result;
     }


### PR DESCRIPTION
Three small, independent cleanups found while reviewing the codebase. They are unrelated to each other, so they are three separate commits and can be reviewed (or dropped) individually.

### 1. Drop the unused `kind` parameter of `resolveInterceptorAnnotationValues`

`InterceptorBindingQualifier.resolveInterceptorAnnotationValues` took a `@Nullable String kind` that had exactly one call site, in `doesQualify`, which passed `null`. The guard

```java
if (kind == null || av.stringValue("kind").orElse(kind).equals(kind)) {
```

therefore always took the `kind == null` branch, and the comparison against the `"kind"` member was unreachable. The parameter is removed and the binding is collected unconditionally. No behaviour change.

### 2. Restore the indentation of three `builder.addMethod(` calls in `PythonStubGenerator`

Three calls had drifted out of alignment with the blocks they sit in. Each was introduced by a separate commit that moved only the call line and left its argument list in place:

| Call | Commit | Was | Now |
| --- | --- | --- | --- |
| introspected-bean `Value` constructor | `67fc1e63f9` | 24 | 28 |
| non-introspected `Value` constructor | `2896fa0e15` | 24 | 28 |
| primary generated constructor | `019dc0b182` | 28 | 24 |

Once the call lines are back where they belong, the existing argument lists line up with them again (`MethodDef.constructor()` at call + 4), so no continuation line needed touching.

Whitespace only — three lines, no token changes, generated stubs unchanged.

### 3. Remove the empty `init { }` block of `KotlinVisitorContext`

Emptied by `0663b01d52` ("Memoize repeated Resolver calls") and dead since. The real `init` block further down the same class is untouched.

## Verification

| Task | Result |
| --- | --- |
| `:micronaut-inject:test` | 342 tests, 0 failures |
| `:micronaut-inject-kotlin:test` | 812 tests, 0 failures, 11 skipped |
| `:micronaut-inject-python-test:test -Ppython-ci` | 587 tests, 0 failures |

Item 2 is whitespace-only, so the bar for it was the Python suite passing unchanged, which it does.

Note for reviewers: `:micronaut-inject-python-test:test` is a no-op without the `python-ci` Gradle property — [build.gradle](build.gradle) disables every `Test` task in the Python modules unless it is set, so the task reports `SKIPPED` rather than running, and a plain

```
./gradlew :micronaut-inject-python-test:test
```

still ends in `BUILD SUCCESSFUL` having executed nothing. The suite has to be run as:

```
./gradlew :micronaut-inject-python-test:test -Ppython-ci
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
