### PR TITLE
Do not break a destruction cycle at a bean the cycle requires

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/destroyorder/BeanDestructionOrderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/destroyorder/BeanDestructionOrderSpec.groovy
@@ -296,6 +296,34 @@ class B {
         log.EVENTS == ['a', 'b']
     }
 
+    void "a bean required by a dependency cycle is not used to break the cycle"() {
+        given:
+        ApplicationContext ctx = buildContext(HEADER + '''
+@Singleton
+class Aardvark {
+    @PreDestroy void close() { Log.add("aardvark"); }
+}
+@Singleton
+class Beta {
+    Beta(BeanProvider<Gamma> gamma, Aardvark aardvark) {}
+    @PreDestroy void close() { Log.add("beta"); }
+}
+@Singleton
+class Gamma {
+    Gamma(BeanProvider<Beta> beta) {}
+    @PreDestroy void close() { Log.add("gamma"); }
+}
+''')
+        def log = ctx.classLoader.loadClass('test.Log')
+        ['Aardvark', 'Beta', 'Gamma'].each { ctx.getBean(ctx.classLoader.loadClass("test.$it")) }
+
+        when:
+        ctx.close()
+
+        then: "the cycle is broken at Beta, the first bean on the cycle, so Aardvark still outlives it"
+        log.EVENTS == ['beta', 'aardvark', 'gamma']
+    }
+
     void "@Order on @EventListener methods orders ShutdownEvent listeners"() {
         given:
         ApplicationContext ctx = buildContext(HEADER + '''

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -115,11 +115,13 @@ import org.slf4j.LoggerFactory;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.AbstractMap;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -3501,8 +3503,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
      *
      * <p>A bean is destroyed before every bean it requires, whether the requirement comes from an injection point or
      * from {@link DependsOn}, so that a dependency outlives its dependents. Where the dependencies leave the order
-     * open, beans are destroyed in bean name order so that the sequence is stable between runs. Dependency cycles are
-     * broken by destroying the first bean of the cycle in that order.</p>
+     * open, beans are destroyed in bean name order so that the sequence is stable between runs. A dependency cycle
+     * cannot satisfy that guarantee for every one of its members, so it is broken by destroying the first bean in
+     * name order that lies on a cycle; beans that merely depend on a cycle are never chosen to break it.</p>
      *
      * @param beans The registrations
      * @return The registrations in destruction order
@@ -3555,14 +3558,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 ready.add(i);
             }
         }
-        int nextCycleCandidate = 0;
         while (sorted.size() < size) {
             if (ready.isEmpty()) {
-                // every remaining bean is part of a dependency cycle, break it at the first bean
-                while (destroyed[nextCycleCandidate]) {
-                    nextCycleCandidate++;
-                }
-                ready.add(nextCycleCandidate);
+                // the remaining beans are a cycle plus whatever the cycle requires, so break the cycle itself
+                ready.add(findCycleNode(dependencies, destroyed));
             }
             final int i = ready.poll();
             if (destroyed[i]) {
@@ -3577,6 +3576,39 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             }
         }
         return sorted;
+    }
+
+    /**
+     * Finds the first not yet destroyed node in index order that lies on a dependency cycle of the remaining graph.
+     *
+     * @param dependencies The dependencies of every node
+     * @param destroyed    The nodes that have already been sorted
+     * @return The index of the node to break the cycle at
+     */
+    private int findCycleNode(List<List<Integer>> dependencies, boolean[] destroyed) {
+        final boolean[] visited = new boolean[destroyed.length];
+        final Deque<Integer> stack = new ArrayDeque<>();
+        for (int candidate = 0; candidate < destroyed.length; candidate++) {
+            if (destroyed[candidate]) {
+                continue;
+            }
+            // the candidate is on a cycle when it can reach itself along the dependencies of the remaining nodes
+            Arrays.fill(visited, false);
+            stack.clear();
+            stack.push(candidate);
+            while (!stack.isEmpty()) {
+                for (int next : dependencies.get(stack.pop())) {
+                    if (next == candidate) {
+                        return candidate;
+                    }
+                    if (!destroyed[next] && !visited[next]) {
+                        visited[next] = true;
+                        stack.push(next);
+                    }
+                }
+            }
+        }
+        throw new IllegalStateException("No dependency cycle found among the remaining singletons");
     }
 
     @Override


### PR DESCRIPTION
## What

`topologicalSort` in `DefaultBeanContext` orders singletons for destruction so that a bean is always destroyed before the beans it requires. Its cycle-breaking fallback was wrong.

When Kahn's algorithm runs out of ready nodes, the old code assumed every remaining bean was part of a dependency cycle and broke at the first remaining bean in name order:

```java
// every remaining bean is part of a dependency cycle, break it at the first bean
while (destroyed[nextCycleCandidate]) {
    nextCycleCandidate++;
}
```

The remaining nodes are those still having `dependents > 0` — that is the cycle **plus everything the cycle requires**. Picking the first remaining node can therefore select an ordinary dependency and destroy it before its dependent, which is exactly the guarantee the sort exists to provide.

Concretely, with three singletons `Aardvark`, `Beta` and `Gamma` where `Beta` and `Gamma` require each other and `Beta` also requires `Aardvark`: every node starts with `dependents > 0`, so `ready` is empty on the very first iteration and `Aardvark` (index 0) is chosen — destroyed before `Beta`, which requires it.

## How

The cycle is now broken at the first bean in name order that actually lies on a cycle of the remaining graph. A new `findCycleNode` helper scans the not yet destroyed nodes in index order and returns the first one that can reach itself along `dependencies`, restricted to undestroyed nodes, using an iterative DFS with a reused `visited` array.

The `nextCycleCandidate` monotonic cursor is dropped: a correct scan has to restart from index 0 each time, since a later break may need an earlier index. Cost is O(V+E) per candidate examined, and it is only paid when a cycle actually exists — negligible for the number of singletons in a context. Ordering stays deterministic (name order remains the tie-break).

The misleading comment and the method javadoc are updated to state the new rule.

## Notes for reviewers

- `findCycleNode` throws `IllegalStateException` if no cycle is found. That is unreachable by construction: `ready` can only empty while nodes remain when the remaining subgraph contains a cycle.
- Regression bug was introduced by 40227fc38d (#12965), so this is not in a released version.

## Test

Added `"a bean required by a dependency cycle is not used to break the cycle"` to the existing `BeanDestructionOrderSpec`, covering the Aardvark/Beta/Gamma shape and asserting the exact destruction order `['beta', 'aardvark', 'gamma']`.

Verified both directions with `./gradlew :micronaut-inject-java:test --tests '*BeanDestructionOrderSpec*'`:

- with the fix, all 14 tests in the spec pass;
- with the source fix reverted and the test kept, the new test fails and the other 13 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
