### PR TITLE
Report a mime type table that could not be loaded

### DIFF
--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -1405,7 +1405,6 @@ public class MediaType implements CharSequence {
         return MediaType.TEXT_PLAIN_TYPE;
     }
 
-    @SuppressWarnings("MagicNumber")
     private static Map<String, String> getMediaTypeFileExtensions() {
         Map<String, String> extensions = mediaTypeFileExtensions;
         if (extensions == null) {
@@ -1414,9 +1413,16 @@ public class MediaType implements CharSequence {
                 if (extensions == null) {
                     try {
                         extensions = loadMimeTypes();
-                    } catch (Exception e) {
+                    } catch (RuntimeException e) {
+                        // loadMimeTypes reports and recovers from the failures it expects, so anything
+                        // arriving here is unexpected and would otherwise leave no trace at all.
+                        LoggerFactory.getLogger(MediaType.class)
+                            .warn("Failed to load {}, media type detection by file extension is disabled", MIME_TYPES_FILE_NAME, e);
                         extensions = Collections.emptyMap();
                     }
+                    // An empty table is cached like any other. The class path does not change for the
+                    // life of the JVM, so retrying the load on every lookup would only fail again; the
+                    // warning logged by the failing branch is what explains the missing detection.
                     mediaTypeFileExtensions = extensions;
                 }
             }
@@ -1424,9 +1430,32 @@ public class MediaType implements CharSequence {
         return extensions;
     }
 
-    @SuppressWarnings("MagicNumber")
     private static Map<String, String> loadMimeTypes() {
-        try (InputStream is = MediaType.class.getClassLoader().getResourceAsStream(MIME_TYPES_FILE_NAME)) {
+        return loadMimeTypes(MediaType.class.getClassLoader());
+    }
+
+    /**
+     * Reads the file extension to media type table from the given class loader. Package private so that
+     * a test can supply a class loader that does not carry the resource, without touching the cache.
+     *
+     * @param classLoader The class loader to read the resource from, {@code null} for the bootstrap loader
+     * @return The table, or an empty map if the resource could not be found or read
+     */
+    @SuppressWarnings("MagicNumber")
+    static Map<String, String> loadMimeTypes(@Nullable ClassLoader classLoader) {
+        // A repackaged or shaded jar can drop the resource, and a class loader that cannot see it
+        // returns null rather than failing, so this has to be checked before the stream is read.
+        InputStream resource = classLoader == null
+            ? ClassLoader.getSystemResourceAsStream(MIME_TYPES_FILE_NAME)
+            : classLoader.getResourceAsStream(MIME_TYPES_FILE_NAME);
+        if (resource == null) {
+            Logger logger = LoggerFactory.getLogger(MediaType.class);
+            if (logger.isWarnEnabled()) {
+                logger.warn("Cannot find {} on the class path, media type detection by file extension is disabled", MIME_TYPES_FILE_NAME);
+            }
+            return Collections.emptyMap();
+        }
+        try (InputStream is = resource) {
             var reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.US_ASCII));
             var result = new LinkedHashMap<String, String>(100);
             String line;
@@ -1445,7 +1474,7 @@ public class MediaType implements CharSequence {
         } catch (IOException ex) {
             Logger logger = LoggerFactory.getLogger(MediaType.class);
             if (logger.isWarnEnabled()) {
-                logger.warn("Failed to load mime types for file extension detection!");
+                logger.warn("Failed to read {}, media type detection by file extension is disabled", MIME_TYPES_FILE_NAME, ex);
             }
         }
 

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -789,7 +789,9 @@ public class MediaType implements CharSequence {
 
     @SuppressWarnings("ConstantName")
     private static final String MIME_TYPES_FILE_NAME = "META-INF/http/mime.types";
-    @SuppressWarnings("java:S3077") // holds an immutable Map.copyOf or an empty map, published once under double checked locking
+    // Sonar java:S3077: the table is an immutable map, a Map.copyOf of the parsed table or an empty map
+    // when the load fails, assigned once under the double checked lock in getMediaTypeFileExtensions.
+    @SuppressWarnings("java:S3077")
     private static volatile @Nullable Map<String, String> mediaTypeFileExtensions;
     @SuppressWarnings("ConstantName")
     private static final List<Pattern> textTypePatterns = new ArrayList<>(4);
@@ -1411,15 +1413,7 @@ public class MediaType implements CharSequence {
             synchronized (MediaType.class) { // double check
                 extensions = mediaTypeFileExtensions;
                 if (extensions == null) {
-                    try {
-                        extensions = loadMimeTypes();
-                    } catch (RuntimeException e) {
-                        // loadMimeTypes reports and recovers from the failures it expects, so anything
-                        // arriving here is unexpected and would otherwise leave no trace at all.
-                        LoggerFactory.getLogger(MediaType.class)
-                            .warn("Failed to load {}, media type detection by file extension is disabled", MIME_TYPES_FILE_NAME, e);
-                        extensions = Collections.emptyMap();
-                    }
+                    extensions = loadMimeTypesReporting(MediaType.class.getClassLoader());
                     // An empty table is cached like any other. The class path does not change for the
                     // life of the JVM, so retrying the load on every lookup would only fail again; the
                     // warning logged by the failing branch is what explains the missing detection.
@@ -1430,8 +1424,24 @@ public class MediaType implements CharSequence {
         return extensions;
     }
 
-    private static Map<String, String> loadMimeTypes() {
-        return loadMimeTypes(MediaType.class.getClassLoader());
+    /**
+     * Reads the table and, as a safety net, reports and swallows any unexpected failure of the parse
+     * itself. {@link #loadMimeTypes(ClassLoader)} already recovers from the failures it expects, so
+     * dropping this would be defensible, but an unexpected one would then be thrown out of
+     * {@link #forExtension(String)}, which sits on request paths, rather than degrading quietly.
+     * Package private so that a test can reach the branch without touching the cache.
+     *
+     * @param classLoader The class loader to read the resource from, {@code null} for the bootstrap loader
+     * @return The table, or an empty map if it could not be loaded
+     */
+    static Map<String, String> loadMimeTypesReporting(@Nullable ClassLoader classLoader) {
+        try {
+            return loadMimeTypes(classLoader);
+        } catch (RuntimeException e) {
+            LoggerFactory.getLogger(MediaType.class)
+                .warn("Failed to load {}, media type detection by file extension is disabled", MIME_TYPES_FILE_NAME, e);
+            return Collections.emptyMap();
+        }
     }
 
     /**

--- a/http/src/test/java/io/micronaut/http/MediaTypeMimeTypesTest.java
+++ b/http/src/test/java/io/micronaut/http/MediaTypeMimeTypesTest.java
@@ -21,19 +21,23 @@ import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Covers the loading of {@code META-INF/http/mime.types}. Every case goes through
- * {@link MediaType#loadMimeTypes(ClassLoader)}, which does not touch the static table that
+ * {@link MediaType#loadMimeTypes(ClassLoader)} or {@link MediaType#loadMimeTypesReporting(ClassLoader)},
+ * neither of which touches the static table that
  * {@link MediaType#forExtension(String)} caches, so the cache is left intact for the rest of the suite.
  */
 class MediaTypeMimeTypesTest {
@@ -84,6 +88,46 @@ class MediaTypeMimeTypesTest {
     }
 
     @Test
+    void skipsBlankAndCommentLines() {
+        Map<String, String> types = MediaType.loadMimeTypes(new StubClassLoader("""
+            # a comment
+
+            application/json\t\t\tjson
+            text/html   html  htm
+            """));
+
+        assertEquals(Map.of("json", MediaType.APPLICATION_JSON, "html", MediaType.TEXT_HTML, "htm", MediaType.TEXT_HTML), types);
+    }
+
+    @Test
+    void theLoadedTableIsImmutable() {
+        Map<String, String> types = MediaType.loadMimeTypes(MediaTypeMimeTypesTest.class.getClassLoader());
+
+        assertThrows(UnsupportedOperationException.class, () -> types.put("json", MediaType.TEXT_PLAIN),
+            "The table is published through a volatile field, so it must not be mutable");
+    }
+
+    @Test
+    void reportingLoadReturnsTheTable() {
+        assertFalse(MediaType.loadMimeTypesReporting(MediaTypeMimeTypesTest.class.getClassLoader()).isEmpty());
+    }
+
+    @Test
+    void reportingLoadReturnsAnEmptyTableAndWarnsOnAnUnexpectedFailure() {
+        List<ILoggingEvent> events = capturingWarnings(
+            () -> assertTrue(MediaType.loadMimeTypesReporting(new ThrowingClassLoader()).isEmpty(),
+                "An unexpected failure must degrade to an empty table rather than reach forExtension")
+        );
+
+        assertEquals(1, events.size());
+        ILoggingEvent event = events.get(0);
+        assertEquals(Level.WARN, event.getLevel());
+        assertTrue(event.getFormattedMessage().contains(RESOURCE));
+        assertTrue(event.getThrowableProxy() != null && event.getThrowableProxy().getMessage().contains("mime.types blew up"),
+            "The unexpected exception must reach the logger as the cause");
+    }
+
+    @Test
     void theCachedTableIsUnaffected() {
         Optional<MediaType> json = MediaType.forExtension("json");
 
@@ -120,6 +164,37 @@ class MediaTypeMimeTypesTest {
         @Override
         public InputStream getResourceAsStream(String name) {
             return null;
+        }
+    }
+
+    /**
+     * A class loader that serves the given table instead of the one on the class path.
+     */
+    private static final class StubClassLoader extends ClassLoader {
+        private final String content;
+
+        StubClassLoader(String content) {
+            super(null);
+            this.content = content;
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            return new ByteArrayInputStream(content.getBytes(StandardCharsets.US_ASCII));
+        }
+    }
+
+    /**
+     * A class loader that fails with something other than an {@link IOException}, as the safety net expects.
+     */
+    private static final class ThrowingClassLoader extends ClassLoader {
+        ThrowingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            throw new IllegalStateException("mime.types blew up");
         }
     }
 

--- a/http/src/test/java/io/micronaut/http/MediaTypeMimeTypesTest.java
+++ b/http/src/test/java/io/micronaut/http/MediaTypeMimeTypesTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the loading of {@code META-INF/http/mime.types}. Every case goes through
+ * {@link MediaType#loadMimeTypes(ClassLoader)}, which does not touch the static table that
+ * {@link MediaType#forExtension(String)} caches, so the cache is left intact for the rest of the suite.
+ */
+class MediaTypeMimeTypesTest {
+
+    private static final String RESOURCE = "META-INF/http/mime.types";
+
+    @Test
+    void loadsTheTableFromTheClassPath() {
+        Map<String, String> types = MediaType.loadMimeTypes(MediaTypeMimeTypesTest.class.getClassLoader());
+
+        assertFalse(types.isEmpty());
+        assertEquals(MediaType.APPLICATION_JSON, types.get("json"));
+        assertEquals(MediaType.TEXT_HTML, types.get("html"));
+    }
+
+    @Test
+    void returnsAnEmptyTableAndWarnsWhenTheResourceIsMissing() {
+        List<ILoggingEvent> events = capturingWarnings(
+            () -> assertTrue(MediaType.loadMimeTypes(new ResourceHidingClassLoader()).isEmpty(),
+                "A missing mime.types must yield an empty table rather than an NPE")
+        );
+
+        assertEquals(1, events.size());
+        ILoggingEvent event = events.get(0);
+        assertEquals(Level.WARN, event.getLevel());
+        assertTrue(event.getFormattedMessage().contains(RESOURCE),
+            "The warning must name the resource, was: " + event.getFormattedMessage());
+    }
+
+    @Test
+    void returnsAnEmptyTableAndWarnsWithTheCauseWhenTheResourceCannotBeRead() {
+        List<ILoggingEvent> events = capturingWarnings(
+            () -> assertTrue(MediaType.loadMimeTypes(new FailingClassLoader()).isEmpty())
+        );
+
+        assertEquals(1, events.size());
+        ILoggingEvent event = events.get(0);
+        assertEquals(Level.WARN, event.getLevel());
+        assertTrue(event.getFormattedMessage().contains(RESOURCE));
+        assertTrue(event.getThrowableProxy() != null && event.getThrowableProxy().getMessage().contains("mime.types is unreadable"),
+            "The IOException must reach the logger as the cause");
+    }
+
+    @Test
+    void fallsBackToTheSystemResourcesForTheBootstrapClassLoader() {
+        // MediaType.class.getClassLoader() is null under the bootstrap loader, which used to NPE.
+        assertFalse(MediaType.loadMimeTypes(null).isEmpty());
+    }
+
+    @Test
+    void theCachedTableIsUnaffected() {
+        Optional<MediaType> json = MediaType.forExtension("json");
+
+        assertTrue(json.isPresent());
+        assertEquals(MediaType.APPLICATION_JSON, json.get().getName());
+        assertEquals(MediaType.TEXT_PLAIN, MediaType.forFilename("notes.no-such-extension").getName());
+    }
+
+    private static List<ILoggingEvent> capturingWarnings(Runnable runnable) {
+        var logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(MediaType.class);
+        var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        boolean additive = logger.isAdditive();
+        logger.setAdditive(false); // keep the expected warnings out of the build output
+        logger.addAppender(appender);
+        try {
+            runnable.run();
+        } finally {
+            logger.detachAppender(appender);
+            logger.setAdditive(additive);
+            appender.stop();
+        }
+        return appender.list;
+    }
+
+    /**
+     * A class loader that cannot see the resource, as a shaded or repackaged jar that dropped it.
+     */
+    private static final class ResourceHidingClassLoader extends ClassLoader {
+        ResourceHidingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            return null;
+        }
+    }
+
+    /**
+     * A class loader whose stream fails part way through the read.
+     */
+    private static final class FailingClassLoader extends ClassLoader {
+        FailingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            return new InputStream() {
+                @Override
+                public int read() throws IOException {
+                    throw new IOException("mime.types is unreadable");
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
`MediaType` loads `META-INF/http/mime.types` once, behind a double checked lock, and every failure to do so was invisible.

### The silent path

`getResourceAsStream` returns `null` when the resource is not on the class path — a shaded or repackaged jar that dropped it, or a class loader that cannot see it — so `new InputStreamReader(null, ...)` threw a `NullPointerException`. That is not an `IOException`, so `loadMimeTypes` did not catch it. It reached the `catch (Exception e)` in `getMediaTypeFileExtensions`, which installed an empty map and **logged nothing at all**. `forExtension` then returned `Optional.empty()` and `forFilename` returned `text/plain` for every file, for the life of the JVM, with nothing in the log to explain it.

`MediaType.class.getClassLoader()` is also `null` under the bootstrap loader, which NPEd one call earlier, before the stream existed.

The `IOException` branch that *was* reported discarded `ex`, so it gave no cause.

### What changed

- `loadMimeTypes` resolves the stream before wrapping it, falls back to `ClassLoader.getSystemResourceAsStream` for a `null` class loader, and warns naming the resource when the stream is `null` instead of reaching an NPE.
- The `IOException` branch passes the exception to the logger.
- `getMediaTypeFileExtensions` keeps a catch as a safety net, narrowed to `RuntimeException` and no longer silent.
- Caching an empty table is now a deliberate choice with a comment rather than a side effect of the catch.

### For the reviewer

**Why the catch was narrowed rather than dropped.** Dropping it entirely is defensible now that `loadMimeTypes` returns an empty map on every failure it expects. But an unexpected runtime failure in the parse loop would then be thrown out of `forExtension`, which sits on request paths, instead of degrading quietly as it does today. Keeping it as a logged net is the smaller behaviour change; the comment says so. Happy to drop it if you would rather the failure be loud.

**Caching an empty table.** The class path does not change for the life of the JVM, so retrying the load on every lookup would only fail again. The warning is what explains the missing detection. This is now stated in a comment instead of being whatever the catch happened to do.

**A package private seam.** `loadMimeTypes(ClassLoader)` is package private purely so a test can supply a class loader that hides the resource or fails the read. It never touches `mediaTypeFileExtensions`, so the tests leave the cached table intact for the rest of the suite — the caching is not weakened to make it testable. If you would rather keep it fully private, reflection on the no-arg version is possible, but it costs the two cases this change is actually about.

**Overlap with #TBD.** This builds on the safe publication of the same field (`mediaTypeFileExtensions` is `volatile`, the assignment sits outside the `try`, `forExtension` drops the null check it no longer needs). That work is on `claude/deep-analysis-rebased` and is not merged; this branch carries the `MediaType` part of it so the two merge cleanly rather than reverting each other. Nothing else from that branch is included here.

### Tests

`MediaTypeMimeTypesTest` covers the real class path, a class loader that hides the resource (empty map plus a WARN naming the resource — the case that used to NPE), a class loader whose stream throws (WARN carrying the `IOException`), the `null` bootstrap path, and a check that `forExtension`/`forFilename` still work afterwards, which is what would fail if the seam leaked into the cache. Warnings are captured with a logback `ListAppender` with additivity off, so the expected WARNs stay out of the build output.

`./gradlew :micronaut-http:test` — 1752 tests pass. `checkstyleMain` and `spotlessCheck` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
