### PR TITLE
Destroy singletons created during context shutdown

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/close/shutdowncreated/CreatedDuringShutdownSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/close/shutdowncreated/CreatedDuringShutdownSpec.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.close.shutdowncreated
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class CreatedDuringShutdownSpec extends Specification {
+
+    static List<Class<?>> destroyed = []
+
+    void "test a singleton created from a @PreDestroy hook is destroyed before stop() returns"() {
+        given:
+        destroyed.clear()
+        ApplicationContext ctx = ApplicationContext.run(["spec.name": getClass().simpleName])
+        ctx.getBean(ShutdownCreator)
+
+        expect: "nothing has been destroyed yet"
+        destroyed.isEmpty()
+
+        when:
+        ctx.stop()
+
+        then: "both the original bean and the one created during shutdown were destroyed"
+        destroyed == [ShutdownCreator, LateSingleton]
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/close/shutdowncreated/LateSingleton.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/close/shutdowncreated/LateSingleton.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.close.shutdowncreated;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+/**
+ * A singleton that is only created from within {@link ShutdownCreator}'s {@code @PreDestroy} hook,
+ * i.e. after the context has already snapshotted its singletons for destruction.
+ */
+@Requires(property = "spec.name", value = "CreatedDuringShutdownSpec")
+@Singleton
+public class LateSingleton {
+
+    @PreDestroy
+    void close() {
+        CreatedDuringShutdownSpec.getDestroyed().add(LateSingleton.class);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/close/shutdowncreated/ShutdownCreator.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/close/shutdowncreated/ShutdownCreator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.close.shutdowncreated;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Requires;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+/**
+ * Resolves a brand-new singleton from its {@code @PreDestroy} hook.
+ */
+@Requires(property = "spec.name", value = "CreatedDuringShutdownSpec")
+@Singleton
+public class ShutdownCreator {
+
+    private final BeanContext beanContext;
+
+    public ShutdownCreator(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @PreDestroy
+    void close() {
+        CreatedDuringShutdownSpec.getDestroyed().add(ShutdownCreator.class);
+        // creates a singleton that was not part of the destruction snapshot
+        beanContext.getBean(LateSingleton.class);
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -159,6 +159,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     protected static final Logger LOG_LIFECYCLE = LoggerFactory.getLogger(DefaultBeanContext.class.getPackage().getName() + ".lifecycle");
     private static final String SCOPED_PROXY_ANN = "io.micronaut.runtime.context.scope.ScopedProxy";
     private static final String INTRODUCTION_TYPE = "io.micronaut.aop.Introduction";
+    /**
+     * The maximum number of additional destruction passes performed during {@link #stop()} to destroy
+     * singletons created by {@code @PreDestroy} hooks, bounding a hook that always creates a new bean.
+     */
+    private static final int MAX_SHUTDOWN_PASSES = 10;
 
     private static final Predicate<BeanDefinition<?>> FILTER_OUT_ANY_PROVIDERS = new Predicate<BeanDefinition<?>>() { // Keep anonymous for hot path
         @Override
@@ -407,40 +412,29 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             publishEvent(new ShutdownEvent(this));
             attributes.clear();
 
-            // need to sort registered singletons so that beans with that require other beans appear first
-            List<BeanRegistration> objects = topologicalSort(singletonScope.getBeanRegistrations());
+            // dedup by identity: identity hash codes are not unique across live objects
+            Set<Object> processed = Collections.newSetFromMap(new IdentityHashMap<>());
+            destroySingletons(singletonScope.getBeanRegistrations(), processed);
 
-            Map<Boolean, List<BeanRegistration>> result = objects.stream().collect(Collectors.groupingBy(br -> br.bean != null
-                && (br.bean instanceof BeanPreDestroyEventListener || br.bean instanceof BeanDestroyedEventListener)));
-
-            List<BeanRegistration> listeners = result.get(true);
-            if (listeners != null) {
-                // destroy all bean destroy listeners at the end
-                objects.clear();
-                objects.addAll(result.get(false));
-                objects.addAll(listeners);
-            }
-
-            Set<Integer> processed = new HashSet<>();
-            for (BeanRegistration beanRegistration : objects) {
-                Object bean = beanRegistration.bean;
-                int sysId = System.identityHashCode(bean);
-                if (processed.contains(sysId)) {
-                    continue;
+            // a @PreDestroy hook is free to resolve beans, which may create brand-new singletons
+            // registered after the snapshot above was taken. Destroy those stragglers too, with a
+            // bound so a pathological hook that always creates a bean cannot spin forever
+            for (int pass = 0; ; pass++) {
+                List<BeanRegistration> stragglers = singletonScope.getBeanRegistrations()
+                    .stream()
+                    .filter(br -> !processed.contains(br.bean))
+                    .toList();
+                if (stragglers.isEmpty()) {
+                    break;
                 }
-
-                if (LOG_LIFECYCLE.isDebugEnabled()) {
-                    LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", bean, beanRegistration.identifier);
-                }
-
-                processed.add(sysId);
-                try {
-                    destroyBean(beanRegistration);
-                } catch (BeanDestructionException e) {
-                    if (LOG.isErrorEnabled()) {
-                        LOG.error(e.getMessage(), e);
+                if (pass == MAX_SHUTDOWN_PASSES) {
+                    if (LOG.isWarnEnabled()) {
+                        LOG.warn("Singletons are still being created during shutdown after {} destruction passes. "
+                            + "Giving up, {} bean(s) will not be destroyed.", MAX_SHUTDOWN_PASSES, stragglers.size());
                     }
+                    break;
                 }
+                destroySingletons(stragglers, processed);
             }
 
             if (checkEnabledBeans != null) {
@@ -3507,6 +3501,47 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
      * @param beans The registrations
      * @return The registrations in destruction order
      */
+    /**
+     * Destroys the given singleton registrations, skipping any bean already present in {@code processed}.
+     *
+     * @param registrations The registrations to destroy
+     * @param processed     The identity set of already destroyed beans, added to as beans are destroyed
+     */
+    private void destroySingletons(Collection<BeanRegistration> registrations, Set<Object> processed) {
+        // need to sort registered singletons so that beans with that require other beans appear first
+        List<BeanRegistration> objects = topologicalSort(registrations);
+
+        Map<Boolean, List<BeanRegistration>> result = objects.stream().collect(Collectors.groupingBy(br -> br.bean != null
+            && (br.bean instanceof BeanPreDestroyEventListener || br.bean instanceof BeanDestroyedEventListener)));
+
+        List<BeanRegistration> listeners = result.get(true);
+        if (listeners != null) {
+            // destroy all bean destroy listeners at the end
+            objects.clear();
+            objects.addAll(result.getOrDefault(false, Collections.emptyList()));
+            objects.addAll(listeners);
+        }
+
+        for (BeanRegistration beanRegistration : objects) {
+            Object bean = beanRegistration.bean;
+            if (!processed.add(bean)) {
+                continue;
+            }
+
+            if (LOG_LIFECYCLE.isDebugEnabled()) {
+                LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", bean, beanRegistration.identifier);
+            }
+
+            try {
+                destroyBean(beanRegistration);
+            } catch (BeanDestructionException e) {
+                if (LOG.isErrorEnabled()) {
+                    LOG.error(e.getMessage(), e);
+                }
+            }
+        }
+    }
+
     private List<BeanRegistration> topologicalSort(Collection<BeanRegistration> beans) {
         final int size = beans.size();
         // Nodes are indexed in bean name order so that the destruction sequence is deterministic


### PR DESCRIPTION
Two related shutdown bugs in `DefaultBeanContext.stop()`.

## A singleton created during shutdown was never destroyed

`stop()` snapshots the singleton registrations once, and bean resolution stays permitted for the whole method — `assertContextState()` only checks `running` and `initializing`, and `running` is not cleared until the end. So a `@PreDestroy` hook that resolves a not-yet-created singleton registered it in `singletonScope` *after* the snapshot: it never had its own `@PreDestroy` run, and was then silently dropped by `singletonScope.clear()`.

The destruction loop moves into a private `destroySingletons(Collection<BeanRegistration>, Set<Object>)`. `stop()` calls it on the initial snapshot, then re-reads `singletonScope.getBeanRegistrations()` and destroys anything not already processed, repeating until no new registrations appear — bounded by `MAX_SHUTDOWN_PASSES` (10) so a pathological hook that always creates a bean cannot spin forever; on exhaustion it logs a warning naming how many beans were left undestroyed. The `processed` set is shared across passes, so nothing is destroyed twice.

Resolution during shutdown is deliberately left allowed. Refusing new singleton creation once `terminating` is set would also break hooks that legitimately resolve *existing* beans, which is a behaviour change; destroying the stragglers is not.

## Identity-hash dedup could skip a distinct singleton

The loop deduplicated with `Set<Integer>` keyed on `System.identityHashCode`, which is not unique across live objects — two distinct singletons whose identity hash codes collide meant one bean's destruction was skipped entirely. It now uses `Collections.newSetFromMap(new IdentityHashMap<>())` holding the beans themselves. Null beans keep the previous behaviour: `IdentityHashMap` permits a null key, so the first null-bean registration is destroyed and further ones skipped, exactly as `identityHashCode(null) == 0` did.

## Also

The listener partition used `result.get(false)`, which NPEs if a batch consists entirely of destroy listeners — reachable now that later passes operate on small batches. Changed to `getOrDefault(false, Collections.emptyList())`.

## Testing

New `io.micronaut.inject.close.shutdowncreated.CreatedDuringShutdownSpec`, alongside the existing `BeanCloseOrderSpec`: `ShutdownCreator` resolves `LateSingleton` from its own `@PreDestroy`, and the spec asserts both were destroyed before `stop()` returned. Verified it fails on the unpatched code and passes with the fix.

The identity-collision fix has no direct test — identity hash collisions cannot be forced.

Green locally: the new spec plus `*lifecycle*` / `*close*` / `*Destroy*` / `*Context*` in `:micronaut-inject-java:test` (174 tests), and full `:micronaut-inject:test` and `:micronaut-inject-groovy:test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)