### PR TITLE
Do not lose a bean created while a per-bean-locked scope shuts down

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanLockingScopeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanLockingScopeSpec.groovy
@@ -104,6 +104,46 @@ class PerBeanLockingScopeSpec extends Specification {
         !second.destroyed
     }
 
+    void "under a lock per bean remove by definition destroys the bean and the next resolution creates a new one"() {
+        given:
+        def scope = context.getBean(PerBeanScopeImpl)
+        def definition = context.getBeanDefinition(PerBeanRemoved)
+        def first = context.getBean(PerBeanRemoved)
+
+        expect:
+        scope.findBeanRegistration(definition).get().bean.is(first)
+
+        when:
+        def removed = scope.remove(definition)
+
+        then:
+        removed.present
+        removed.get().is(first)
+        first.destroyed
+        !scope.findBeanRegistration(definition).present
+
+        when:
+        def second = context.getBean(PerBeanRemoved)
+
+        then:
+        !second.is(first)
+        !second.destroyed
+    }
+
+    void "under a lock per bean remove by an unknown definition is empty and leaves the scope untouched"() {
+        given:
+        def scope = context.getBean(PerBeanScopeImpl)
+        def bean = context.getBean(PerBeanOther)
+
+        when:
+        def removed = scope.remove(context.getBeanDefinition(PerBeanFaulty))
+
+        then:
+        !removed.present
+        context.getBean(PerBeanOther).is(bean)
+        !bean.destroyed
+    }
+
     void "under a lock per bean the scope answers the registration of a bean it holds"() {
         given:
         def bean = context.getBean(PerBeanOther)

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanRemoved.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanRemoved.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.scope.custom.perbean;
+
+import jakarta.annotation.PreDestroy;
+
+/**
+ * A bean removed from the scope by its definition rather than by its identifier.
+ */
+@PerBeanScope
+public class PerBeanRemoved {
+
+    private boolean destroyed;
+
+    @PreDestroy
+    void destroy() {
+        destroyed = true;
+    }
+
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
@@ -28,10 +28,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
@@ -58,6 +60,13 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
     private final Lock r = rwl.readLock();
     private final Lock w = rwl.writeLock();
     private final ConcurrentMap<BeanIdentifier, Object> creationLocks = new ConcurrentHashMap<>();
+    /**
+     * The identifier of every creation in flight in the {@code lockPerBean} mode, against the scope map it creates
+     * into, published before the creation begins and removed once it has published its bean or failed. It is what
+     * makes a creation that is not yet in the scope map visible to a destruction of that map, which would otherwise
+     * see an empty map, finish, and leave the bean that the creation then publishes to be never destroyed.
+     */
+    private final ConcurrentMap<BeanIdentifier, Map<BeanIdentifier, CreatedBean<?>>> creationsInFlight = new ConcurrentHashMap<>();
 
     /**
      * A custom scope annotation.
@@ -75,8 +84,11 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
      * to its {@link BeanIdentifier} alone, so that beans of different identifiers are created in parallel, a creation
      * may wait for another thread that creates a bean of the same scope, and the fast path of a bean already held
      * is a plain lookup. {@link #remove(BeanIdentifier)} takes the same lock, so it still waits for a creation of that
-     * identifier in flight and then destroys what was created. {@link #destroyScope(Map)} and
-     * {@link #findBeanRegistration(Object)} work on the scope map without any lock, which is why the map returned by
+     * identifier in flight and then destroys what was created, and so do {@link #remove(BeanDefinition)} and
+     * {@link #destroyScope(Map)}, which wait for the creations in flight of the map they work on. Nothing else holds
+     * creation off: a creation that has not begun when a destruction of the scope map ends publishes its bean into
+     * that map afterwards, exactly as one that arrives after the scope-wide write lock is released does.
+     * {@link #findBeanRegistration(Object)} works on the scope map without any lock, which is why the map returned by
      * {@link #getScopeMap(boolean)} must then be a {@link ConcurrentMap}: {@link #getOrCreate(BeanCreationContext)}
      * rejects any other map with an {@link IllegalStateException}. The lock objects live as long as the scope, one
      * per identifier ever created or removed through it.</p>
@@ -255,9 +267,11 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
      * Remove and destroy the bean held for the given definition. The definition may be the
      * {@link ProxyBeanDefinition} of a scoped proxy, in which case the target it stands for is removed.
      *
-     * <p>The bean is taken out of the scope under the write lock and closed after the lock is released, so a
-     * {@code @PreDestroy} hook may reach into the scope from another thread without deadlocking on it. Unlike
-     * {@link #remove(BeanIdentifier)} a destruction failure is not routed through
+     * <p>The bean is taken out of the scope under the write lock, or, where creation is locked per bean, under the
+     * lock of the identifier it is held under, having first waited for the creations into the scope map that are in
+     * flight so that a bean of the definition one of them is about to publish is not missed. It is closed after the
+     * lock is released, so a {@code @PreDestroy} hook may reach into the scope from another thread without
+     * deadlocking on it. Unlike {@link #remove(BeanIdentifier)} a destruction failure is not routed through
      * {@link #handleDestructionException(BeanDestructionException)} but propagated to the caller.</p>
      *
      * @param beanDefinition The bean definition
@@ -268,6 +282,9 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
      */
     @SuppressWarnings("unchecked")
     public <T> Optional<T> remove(BeanDefinition<T> beanDefinition) {
+        if (lockPerBean) {
+            return removeLockingPerBean(beanDefinition);
+        }
         final CreatedBean<?> createdBean;
         w.lock();
         try {
@@ -345,8 +362,16 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
             // re-check
             createdBean = scopeMap.get(id);
             if (createdBean == null) {
-                createdBean = doCreate(creationContext);
-                scopeMap.put(id, createdBean);
+                // announced before the bean is created, and while this thread holds the identifier's lock, so that a
+                // destruction of this map sees the creation and waits on that lock for what is published here,
+                // instead of observing an empty map and leaving the bean behind undestroyed
+                creationsInFlight.put(id, scopeMap);
+                try {
+                    createdBean = doCreate(creationContext);
+                    scopeMap.put(id, createdBean);
+                } finally {
+                    creationsInFlight.remove(id);
+                }
             }
             return (T) createdBean.bean();
         }
@@ -382,6 +407,87 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
     }
 
     /**
+     * Remove and destroy the bean held for the given definition, waiting for the creations of this scope map that are
+     * in flight rather than missing a bean of the definition that one of them is about to publish.
+     *
+     * <p>The identifier is only known once the entry is found, so the entry is located, then its identifier is
+     * locked against a creation or a removal of it, and only then is the entry removed, and only if it is still the
+     * one that was located.</p>
+     *
+     * @param beanDefinition The bean definition
+     * @param <T>            The generic type
+     * @return An {@link Optional} of the instance that was destroyed if it exists
+     */
+    @SuppressWarnings("unchecked")
+    private <T> Optional<T> removeLockingPerBean(BeanDefinition<T> beanDefinition) {
+        final Map<BeanIdentifier, CreatedBean<?>> scopeMap;
+        try {
+            scopeMap = getScopeMap(false);
+        } catch (IllegalStateException e) {
+            return Optional.empty();
+        }
+        if (scopeMap == null) {
+            return Optional.empty();
+        }
+        // the creations already waited for: once one is done it has published its bean or failed, so waiting for it
+        // again would not make a bean of the definition appear, and the search ends rather than following creations
+        // that keep arriving
+        final Set<BeanIdentifier> awaited = new HashSet<>();
+        while (true) {
+            final CreatedBean<?> createdBean = findCreatedBean(scopeMap, beanDefinition);
+            if (createdBean == null) {
+                final BeanIdentifier inFlight = identifierInFlightFor(scopeMap, awaited);
+                if (inFlight == null) {
+                    return Optional.empty();
+                }
+                awaited.add(inFlight);
+                awaitCreation(inFlight);
+                continue;
+            }
+            final boolean removed;
+            synchronized (creationLocks.computeIfAbsent(createdBean.id(), key -> new Object())) {
+                // only the entry that was located, another thread may have removed or replaced it since
+                removed = scopeMap.remove(createdBean.id(), createdBean);
+            }
+            if (!removed) {
+                continue;
+            }
+            // closed outside the lock, so that a @PreDestroy hook may reach into the scope from another thread
+            createdBean.close();
+            return (Optional<T>) Optional.ofNullable(createdBean.bean());
+        }
+    }
+
+    /**
+     * Waits for a creation of the given identifier to have published its bean or to have failed. A creation holds
+     * the identifier's lock from before it begins until after it publishes, so having taken that lock is the wait.
+     *
+     * @param identifier The identifier
+     */
+    private void awaitCreation(BeanIdentifier identifier) {
+        synchronized (creationLocks.computeIfAbsent(identifier, key -> new Object())) {
+            LOG.trace("Waited for the creation of {} of scope @{}", identifier, annotationType.getSimpleName());
+        }
+    }
+
+    /**
+     * The identifier of any one creation in flight into the given scope map, or {@code null} where there is none.
+     *
+     * @param scopeMap The scope map
+     * @param exclude  Identifiers not to answer
+     * @return An identifier, or {@code null}
+     */
+    @Nullable
+    private BeanIdentifier identifierInFlightFor(Map<BeanIdentifier, CreatedBean<?>> scopeMap, Set<BeanIdentifier> exclude) {
+        for (Map.Entry<BeanIdentifier, Map<BeanIdentifier, CreatedBean<?>>> creation : creationsInFlight.entrySet()) {
+            if (creation.getValue() == scopeMap && !exclude.contains(creation.getKey())) {
+                return creation.getKey();
+            }
+        }
+        return null;
+    }
+
+    /**
      * The identifier of any one entry of the map, or {@code null} where it holds none.
      *
      * @param scopeMap The scope map
@@ -393,15 +499,30 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
         return identifiers.hasNext() ? identifiers.next() : null;
     }
 
+    /**
+     * The identifier of the next bean a destruction of the given scope map has to take out: one the map holds, or
+     * failing that one whose creation into the map is in flight, or {@code null} where there is neither.
+     *
+     * @param scopeMap The scope map
+     * @return An identifier, or {@code null}
+     */
+    @Nullable
+    private BeanIdentifier nextIdentifierToDestroy(Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
+        final BeanIdentifier held = firstIdentifierOf(scopeMap);
+        return held != null ? held : identifierInFlightFor(scopeMap, Set.of());
+    }
+
     private void destroyScopeLockingPerBean(@Nullable Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
-        if (CollectionUtils.isEmpty(scopeMap)) {
+        if (scopeMap == null) {
             return;
         }
         // the map is drained rather than cleared: each entry is taken out before it is closed, so that two
         // destructions of one map close each bean once, and a bean that another thread put there while the
         // destruction runs is closed by the pass that finds it instead of being dropped by a clear(). Nothing
-        // holds creation off in this mode, so the drain repeats until the map stays empty
-        for (BeanIdentifier id = firstIdentifierOf(scopeMap); id != null; id = firstIdentifierOf(scopeMap)) {
+        // holds creation off in this mode, so the drain repeats until the map stays empty and no creation into
+        // it is in flight; a creation that is in flight is waited for on its identifier's lock and the bean it
+        // publishes is then taken out, rather than being left behind by a drain that saw an empty map
+        for (BeanIdentifier id = nextIdentifierToDestroy(scopeMap); id != null; id = nextIdentifierToDestroy(scopeMap)) {
             final CreatedBean<?> createdBean;
             // under the identifier's lock, so that a creation of it in flight is waited for and then taken out
             synchronized (creationLocks.computeIfAbsent(id, key -> new Object())) {

--- a/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.context.scope
 
+import io.micronaut.context.exceptions.BeanDestructionException
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanIdentifier
 import jakarta.inject.Singleton
@@ -297,6 +298,175 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         lockPerBean << [false, true]
     }
 
+    void "under a lock per bean a creation in flight when the scope is destroyed is destroyed too"() {
+        given:
+        def scope = new TestScope(true)
+        def creating = new CountDownLatch(1)
+        def release = new CountDownLatch(1)
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"), {
+            creating.countDown()
+            release.await(5, TimeUnit.SECONDS)
+        })
+
+        when: "the scope is stopped while a creation is inside its doCreate, holding nothing the destruction sees"
+        def creator = Thread.start { scope.getOrCreate(creationContext) }
+        creating.await(5, TimeUnit.SECONDS)
+        assert scope.scopeMap.isEmpty(): "the creation has not published its bean yet"
+        def stopper = Thread.start { scope.stop() }
+        stopper.join(300)
+
+        then: "the destruction waits for the creation rather than finishing on an empty map"
+        stopper.alive
+        !scope.closed
+
+        when:
+        release.countDown()
+        creator.join(5000)
+        stopper.join(5000)
+
+        then: "the bean the creation published is closed, not left behind in a scope that is already shut down"
+        !creator.alive
+        !stopper.alive
+        creationContext.created.size() == 1
+        creationContext.created[0].closed
+        scope.scopeMap.isEmpty()
+        scope.closed
+    }
+
+    void "under a lock per bean a creation in flight that fails does not hold the destruction up"() {
+        given:
+        def scope = new TestScope(true)
+        def creating = new CountDownLatch(1)
+        def release = new CountDownLatch(1)
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"), {
+            creating.countDown()
+            release.await(5, TimeUnit.SECONDS)
+            throw new IllegalStateException("Bad things")
+        })
+
+        when:
+        def creator = Thread.start { try { scope.getOrCreate(creationContext) } catch (IllegalStateException ignored) { } }
+        creating.await(5, TimeUnit.SECONDS)
+        def stopper = Thread.start { scope.stop() }
+        stopper.join(300)
+
+        then:
+        stopper.alive
+
+        when:
+        release.countDown()
+        creator.join(5000)
+        stopper.join(5000)
+
+        then: "the failed creation leaves nothing behind and the destruction ends"
+        !stopper.alive
+        creationContext.created.isEmpty()
+        scope.scopeMap.isEmpty()
+        scope.closed
+    }
+
+    void "under a lock per bean a creation of another scope map does not hold a destruction up"() {
+        given: "two maps standing for two contexts of one scope, as a request scope holds one map per request"
+        def other = new ConcurrentHashMap<BeanIdentifier, CreatedBean<?>>()
+        def scope = new TestScope(true)
+        def creating = new CountDownLatch(1)
+        def release = new CountDownLatch(1)
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"), {
+            creating.countDown()
+            release.await(5, TimeUnit.SECONDS)
+        })
+
+        when: "a creation into the other map is in flight"
+        def creator = Thread.start { scope.withScopeMap(other) { scope.getOrCreate(creationContext) } }
+        creating.await(5, TimeUnit.SECONDS)
+        def destroyer = Thread.start { scope.destroyScope(scope.scopeMap) }
+        destroyer.join(5000)
+
+        then: "the destruction of this map is not made to wait for it"
+        !destroyer.alive
+
+        cleanup:
+        release.countDown()
+        creator.join(5000)
+    }
+
+    void "under a lock per bean remove by definition waits for a creation of the definition in flight"() {
+        given:
+        def definition = Stub(BeanDefinition)
+        def scope = new TestScope(true)
+        def creating = new CountDownLatch(1)
+        def release = new CountDownLatch(1)
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"), {
+            creating.countDown()
+            release.await(5, TimeUnit.SECONDS)
+        }, definition)
+        def removed = new AtomicReference<Optional<Object>>()
+
+        when:
+        def creator = Thread.start { scope.getOrCreate(creationContext) }
+        creating.await(5, TimeUnit.SECONDS)
+        def remover = Thread.start { removed.set(scope.remove(definition)) }
+        remover.join(300)
+
+        then: "the removal waits for the creation instead of missing the bean it is about to publish"
+        remover.alive
+        removed.get() == null
+
+        when:
+        release.countDown()
+        creator.join(5000)
+        remover.join(5000)
+
+        then:
+        !creator.alive
+        !remover.alive
+        removed.get().present
+        removed.get().get().is(creationContext.created[0].bean)
+        creationContext.created[0].closed
+        scope.scopeMap.isEmpty()
+    }
+
+    void "under a lock per bean remove by definition destroys the bean and an unknown definition is empty"() {
+        given:
+        def definition = Stub(BeanDefinition)
+        def scope = new TestScope(true)
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"), {}, definition)
+        def bean = scope.getOrCreate(creationContext)
+
+        when:
+        def removed = scope.remove(definition)
+
+        then:
+        removed.present
+        removed.get().is(bean)
+        creationContext.created[0].closed
+        scope.scopeMap.isEmpty()
+
+        when:
+        def none = scope.remove(Stub(BeanDefinition))
+
+        then:
+        !none.present
+    }
+
+    void "under a lock per bean a destruction failure of remove by definition is propagated to the caller"() {
+        given: "the bean type is answered, the destruction exception names it"
+        def definition = Stub(BeanDefinition) {
+            getBeanType() >> Object
+        }
+        def scope = new TestScope(true)
+        def creationContext = new TestCreationContext(BeanIdentifier.of("myBean"), {}, definition)
+        creationContext.failToClose = true
+        scope.getOrCreate(creationContext)
+
+        when:
+        scope.remove(definition)
+
+        then: "unlike remove by identifier it is not routed through handleDestructionException"
+        thrown(BeanDestructionException)
+        scope.scopeMap.isEmpty()
+    }
+
     /**
      * A scope map that puts one more entry in the first time its keys are read, standing for a bean created by
      * another thread while the scope is being destroyed.
@@ -356,8 +526,27 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
             return true
         }
 
+        /**
+         * The map creations of the current thread go to, standing for a scope whose map belongs to a context
+         * rather than to the scope itself, as the request scope's does.
+         */
+        final ThreadLocal<Map<BeanIdentifier, CreatedBean<?>>> currentMap = new ThreadLocal<>()
+
+        def withScopeMap(Map<BeanIdentifier, CreatedBean<?>> map, Closure<?> work) {
+            currentMap.set(map)
+            try {
+                return work.call()
+            } finally {
+                currentMap.remove()
+            }
+        }
+
         @Override
         protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+            def current = currentMap.get()
+            if (current != null) {
+                return current
+            }
             if (scopeMap == null) {
                 throw new IllegalStateException("No scope map")
             }
@@ -375,16 +564,19 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
 
         final BeanIdentifier id
         final List<TestCreatedBean> created = []
+        final BeanDefinition<Object> definition
         Runnable onCreate
+        boolean failToClose
 
-        TestCreationContext(BeanIdentifier id, Runnable onCreate = {}) {
+        TestCreationContext(BeanIdentifier id, Runnable onCreate = {}, BeanDefinition<Object> definition = null) {
             this.id = id
             this.onCreate = onCreate
+            this.definition = definition
         }
 
         @Override
         BeanDefinition<Object> definition() {
-            return null
+            return definition
         }
 
         @Override
@@ -395,7 +587,7 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         @Override
         CreatedBean<Object> create() {
             onCreate.run()
-            def createdBean = new TestCreatedBean(id: id, bean: new Object())
+            def createdBean = new TestCreatedBean(id: id, bean: new Object(), definition: definition, failToClose: failToClose)
             created << createdBean
             return createdBean
         }
@@ -405,11 +597,13 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
 
         BeanIdentifier id
         Object bean
+        BeanDefinition<Object> definition
         boolean closed
+        boolean failToClose
 
         @Override
         BeanDefinition<Object> definition() {
-            return null
+            return definition
         }
 
         @Override
@@ -425,6 +619,9 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         @Override
         void close() {
             closed = true
+            if (failToClose) {
+                throw new BeanDestructionException(definition, new IllegalStateException("destroy failed on purpose"))
+            }
         }
     }
 }


### PR DESCRIPTION
Two concurrency bugs in the `lockPerBean` mode of `AbstractConcurrentCustomScope` added by #12973.

## Shutdown missed a creation in flight

`getOrCreateLockingPerBean` held the identifier's lock but put the bean into the scope map only *after* `doCreate()` returned. A creation inside `doCreate()` was therefore invisible to `destroyScopeLockingPerBean`, which drains the map and stops as soon as it observes it empty: the drain finished, `close()` ran, and the creation then published a live bean into a scope that was already shut down. That bean was never closed, so its `@PreDestroy` never ran.

Every creation is now announced in a `creationsInFlight` map — identifier against the scope map it creates into — before it begins, and while it already holds the identifier's lock; the entry is cleared in a `finally`, so a failed creation leaves nothing behind. The drain takes an identifier the map holds or, where it holds none, one whose creation into *that same map* is in flight; it then blocks on that identifier's lock (which the creator holds across `doCreate` + `put`), removes what was published and closes it. It ends only once the map is empty and nothing is in flight for it.

Keying the in-flight entry by scope map matters because the map may be context-scoped — `RequestCustomScope` keeps one per `HttpRequest` — so a creation into another request's map does not hold this map's destruction up. That is also why this is tracked per creation rather than with a `closing`/`stopped` flag on the scope: such a flag would wrongly mark every later request's map as dead.

Nothing was added to the creation path that beans of other identifiers contend on — the point of #12973 — and beans are still closed outside every lock, so a `@PreDestroy` hook may reach back into the scope from another thread.

The remaining limit is documented on the constructor: a creation that has not begun when the destruction ends publishes afterwards, exactly as one arriving after the scope-wide write lock is released does. The two modes now agree.

## `remove(BeanDefinition)` had the same mismatch

It took the scope-wide write lock `w`, which creation in this mode never acquires, so it neither waited for nor excluded an in-flight creation of the matching identifier, and could race a concurrent publish of the entry it had just removed.

It now mirrors `removeLockingPerBean(BeanIdentifier)`. The identifier is only known once `findCreatedBean` locates the entry — the definition may be a `ProxyBeanDefinition` — so the entry is located, its identifier is locked, and the entry is removed only if it is still the one that was located; otherwise the search restarts. Where nothing matches, it waits on the lock of each creation into this map that is in flight (each at most once, so creations that keep arriving cannot spin it) and looks again. The documented difference is preserved: a destruction failure propagates to the caller rather than going through `handleDestructionException`.

## Tests

`AbstractConcurrentCustomScopeSpec` gains six specs, including the race itself: a creation blocks in `doCreate`, `stop()` runs on another thread and is asserted to still be blocked, the latch releases, and the published bean is asserted closed with the map empty. Also: a failing in-flight creation does not hang the drain; a creation into another scope map does not hold this map's destruction up; `remove(definition)` waits for a matching creation in flight; remove-by-definition happy path, unknown definition, and propagated destruction failure.

`PerBeanLockingScopeSpec` gains remove-by-definition against real bean definitions and a real `@PreDestroy` (new `PerBeanRemoved` bean), and remove by an unknown definition.

`:micronaut-inject:test --tests "io.micronaut.context.scope.*"`, `:micronaut-inject-java:test --tests "io.micronaut.inject.scope.custom.*"` and `:micronaut-inject:checkstyleMain` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)