### PR TITLE
Inherit the active environment in GraalPy contexts

### DIFF
--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyContextFactory.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyContextFactory.java
@@ -29,6 +29,7 @@ import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.EnvironmentAccess;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.PolyglotAccess;
 import org.graalvm.polyglot.PolyglotException;
@@ -214,6 +215,7 @@ public class GraalPyContextFactory implements BeanDestroyedEventListener<org.gra
             .logHandler(new GraalPySlf4jLogHandler())
             .allowExperimentalOptions(true)
             .allowCreateProcess(true)
+            .allowEnvironmentAccess(EnvironmentAccess.INHERIT)
             .allowValueSharing(true)
             .allowPolyglotAccess(PolyglotAccess.ALL)
             // Allow access to host classes

--- a/context-python/src/test/java/io/micronaut/context/python/GraalPyContextFactoryTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/GraalPyContextFactoryTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static io.micronaut.context.python.GraalPyRuntimeUtil.PYTHON;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -56,6 +57,21 @@ final class GraalPyContextFactoryTest {
     @Test
     void ignoresBlankVirtualEnv() {
         assertTrue(GraalPyContextFactory.resolveVirtualEnvExecutable(Map.of("VIRTUAL_ENV", " ")).isEmpty());
+    }
+
+    @Test
+    void inheritsVirtualEnvIntoGuestPython() throws IOException {
+        String virtualEnv = System.getenv("VIRTUAL_ENV");
+        assumeTrue(virtualEnv != null && !virtualEnv.isBlank());
+
+        PythonContextRuntime.setReuseContext(false);
+        PythonContextRuntime.resetContext();
+        try (Context context = GraalPyContextFactory.bootstrapReusableContext(getClass().getClassLoader())) {
+            assertEquals(virtualEnv, context.eval(PYTHON, "import os; os.environ.get('VIRTUAL_ENV')").asString());
+        } finally {
+            PythonContextRuntime.setReuseContext(false);
+            PythonContextRuntime.resetContext();
+        }
     }
 
     @Test


### PR DESCRIPTION
GraalPy contexts configured with python.Executable must inherit the host environment so the active virtualenv metadata is visible to embedded Python.

This enables EnvironmentAccess.INHERIT and adds a regression test for VIRTUAL_ENV propagation. It keeps the existing executable discovery and does not add native-image preserves.

Validation: -Ppython-ci :micronaut-context-python:test --tests io.micronaut.context.python.GraalPyContextFactoryTest (6/6 passed).