### PR TITLE
Register the proxy synthesize() actually creates for DYNAMIC_PROXY annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,11 +75,16 @@ if (System.getenv("SONAR_TOKEN") != null) {
     def pythonCoverageExcludes = pythonProjects.collect {
         "${project(it).projectDir.name}/**/*"
     }
+    // GraalVM Feature code only ever executes during native image generation, so it can never be
+    // covered by the JVM test suite. It is still analysed for issues, just not for coverage.
+    def coverageExcludes = pythonCoverageExcludes + [
+        "**/ServiceLoaderFeature.java"
+    ]
     sonarqube {
         skipProject = project.name.contains("test")
         properties {
             property "sonar.exclusions", analysisExcludes.join(",")
-            property "sonar.coverage.exclusions", pythonCoverageExcludes.join(",")
+            property "sonar.coverage.exclusions", coverageExcludes.join(",")
         }
     }
 }

--- a/core/src/main/java/io/micronaut/core/annotation/TypeHint.java
+++ b/core/src/main/java/io/micronaut/core/annotation/TypeHint.java
@@ -81,6 +81,10 @@ public @interface TypeHint {
         ALL_PUBLIC_FIELDS,
         /**
          * The type is a dynamic proxy.
+         *
+         * <p>For an annotation type this additionally registers the proxy that
+         * {@link AnnotationMetadata#synthesize(Class)} creates, which implements both the annotation
+         * type and {@link AnnotationValueProvider}.</p>
          */
         DYNAMIC_PROXY
     }

--- a/core/src/main/java/io/micronaut/core/graal/GraalReflectionConfigurer.java
+++ b/core/src/main/java/io/micronaut/core/graal/GraalReflectionConfigurer.java
@@ -18,12 +18,14 @@ package io.micronaut.core.graal;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueProvider;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.annotation.ReflectionConfig;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.util.CollectionUtils;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -69,6 +71,12 @@ public interface GraalReflectionConfigurer extends AnnotationMetadataProvider {
                 );
                 if (accessType.contains(TypeHint.AccessType.DYNAMIC_PROXY)) {
                     context.registerDynamicProxy(t);
+                    if (Annotation.class.isAssignableFrom(t)) {
+                        // AnnotationMetadata.synthesize(..) hands out an annotation instance as a
+                        // proxy of the annotation type *and* AnnotationValueProvider, so the pair
+                        // has to be registered as well as the annotation type on its own.
+                        context.registerDynamicProxy(t, AnnotationValueProvider.class);
+                    }
                 }
                 if (accessType.contains(TypeHint.AccessType.ALL_PUBLIC_METHODS)) {
                     final Method[] methods = t.getMethods();
@@ -200,9 +208,14 @@ public interface GraalReflectionConfigurer extends AnnotationMetadataProvider {
         void register(Constructor<?>... constructors);
 
         /**
-         * Register a dynamic proxy.
-         * @param proxyClass The proxy class
+         * Register a dynamic proxy of the given interfaces.
+         *
+         * <p>The interfaces are the complete interface list of a single proxy, in the order they are
+         * passed to {@link java.lang.reflect.Proxy#getProxyClass(ClassLoader, Class[])}. Registering
+         * {@code A} and registering {@code A, B} are two distinct proxies.</p>
+         *
+         * @param interfaces The interfaces implemented by the proxy
          */
-        void registerDynamicProxy(Class<?> proxyClass);
+        void registerDynamicProxy(Class<?>... interfaces);
     }
 }

--- a/core/src/main/java/io/micronaut/core/io/service/ServiceLoaderFeature.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceLoaderFeature.java
@@ -259,8 +259,8 @@ class ServiceLoaderFeature implements Feature {
             }
 
             @Override
-            public void registerDynamicProxy(Class<?> proxyClass) {
-                RuntimeProxyCreation.register(proxyClass);
+            public void registerDynamicProxy(Class<?>... interfaces) {
+                RuntimeProxyCreation.register(interfaces);
             }
         };
         for (GraalReflectionConfigurer configurer : configurers) {

--- a/graal/src/test/groovy/io/micronaut/graal/reflect/DynamicProxyReflectionConfigSpec.groovy
+++ b/graal/src/test/groovy/io/micronaut/graal/reflect/DynamicProxyReflectionConfigSpec.groovy
@@ -1,0 +1,165 @@
+package io.micronaut.graal.reflect
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.AnnotationValueProvider
+import io.micronaut.core.graal.GraalReflectionConfigurer
+
+import java.lang.reflect.Constructor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+class DynamicProxyReflectionConfigSpec extends AbstractTypeElementSpec {
+
+    void "an annotation with DYNAMIC_PROXY registers the pair synthesize() actually creates"() {
+        given:
+        GraalReflectionConfigurer configurer = buildReflectionConfigurer('test.Test', '''
+package test;
+
+import io.micronaut.core.annotation.*;
+import java.lang.annotation.*;
+
+@ReflectionConfig(type = Guarded.class, accessType = TypeHint.AccessType.DYNAMIC_PROXY)
+class Test {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Guarded {
+    String value() default "";
+    int max() default 1;
+}
+''')
+        def context = new RecordingContext(configurer.getClass().classLoader)
+
+        when:
+        configurer.configure(context)
+        def guarded = context.findClassByName('test.Guarded')
+
+        then:
+        context.proxies == [
+                [guarded],
+                [guarded, AnnotationValueProvider]
+        ]
+    }
+
+    void "a repeatable annotation and its container both register the pair"() {
+        given:
+        GraalReflectionConfigurer configurer = buildReflectionConfigurer('test.Test', '''
+package test;
+
+import io.micronaut.core.annotation.*;
+import java.lang.annotation.*;
+
+@ReflectionConfig(type = Role.class, accessType = TypeHint.AccessType.DYNAMIC_PROXY)
+@ReflectionConfig(type = Roles.class, accessType = TypeHint.AccessType.DYNAMIC_PROXY)
+class Test {
+}
+
+@Repeatable(Roles.class)
+@Retention(RetentionPolicy.RUNTIME)
+@interface Role {
+    String value();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Roles {
+    Role[] value();
+}
+''')
+        def context = new RecordingContext(configurer.getClass().classLoader)
+
+        when:
+        configurer.configure(context)
+        def role = context.findClassByName('test.Role')
+        def roles = context.findClassByName('test.Roles')
+
+        then:
+        context.proxies.contains([role, AnnotationValueProvider])
+        context.proxies.contains([roles, AnnotationValueProvider])
+    }
+
+    void "a non-annotation type with DYNAMIC_PROXY registers only itself"() {
+        given:
+        GraalReflectionConfigurer configurer = buildReflectionConfigurer('test.Test', '''
+package test;
+
+import io.micronaut.core.annotation.*;
+
+@ReflectionConfig(type = Bar.class, accessType = TypeHint.AccessType.DYNAMIC_PROXY)
+class Test {
+}
+
+interface Bar {}
+''')
+        def context = new RecordingContext(configurer.getClass().classLoader)
+
+        when:
+        configurer.configure(context)
+
+        then:
+        context.proxies == [[context.findClassByName('test.Bar')]]
+    }
+
+    void "an annotation without DYNAMIC_PROXY registers no proxy"() {
+        given:
+        GraalReflectionConfigurer configurer = buildReflectionConfigurer('test.Test', '''
+package test;
+
+import io.micronaut.core.annotation.*;
+import java.lang.annotation.*;
+
+@ReflectionConfig(type = Guarded.class, accessType = TypeHint.AccessType.ALL_DECLARED_METHODS)
+class Test {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Guarded {
+}
+''')
+        def context = new RecordingContext(configurer.getClass().classLoader)
+
+        when:
+        configurer.configure(context)
+
+        then:
+        context.proxies.isEmpty()
+    }
+
+    private static class RecordingContext implements GraalReflectionConfigurer.ReflectionConfigurationContext {
+        final List<List<Class<?>>> proxies = []
+        private final ClassLoader classLoader
+
+        RecordingContext(ClassLoader classLoader) {
+            this.classLoader = classLoader
+        }
+
+        @Override
+        Class<?> findClassByName(String name) {
+            try {
+                return classLoader.loadClass(name)
+            } catch (ClassNotFoundException e) {
+                return null
+            }
+        }
+
+        @Override
+        void register(Class<?>... types) {
+        }
+
+        @Override
+        void register(Method... methods) {
+        }
+
+        @Override
+        void register(Field... fields) {
+        }
+
+        @Override
+        void register(Constructor<?>... constructors) {
+        }
+
+        @Override
+        void registerDynamicProxy(Class<?>... interfaces) {
+            proxies.add(interfaces.toList())
+        }
+    }
+}

--- a/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/Guarded.java
+++ b/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/Guarded.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.synthesis;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * An annotation with members, synthesized back into a real instance by the test.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Guarded {
+    String value() default "";
+
+    int max() default 1;
+}

--- a/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/Protected.java
+++ b/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/Protected.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.synthesis;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.ReflectionConfig;
+import io.micronaut.core.annotation.TypeHint;
+
+/**
+ * The type whose annotation metadata the test synthesizes annotations from.
+ *
+ * <p>The {@link ReflectionConfig} hints declare the annotation types as dynamic proxies, which is the
+ * only mechanism Micronaut offers for making {@code synthesize(..)} work in a native image.</p>
+ */
+@Guarded(value = "secret", max = 3)
+@Role("admin")
+@Role("auditor")
+@Introspected
+@ReflectionConfig(type = Guarded.class, accessType = TypeHint.AccessType.DYNAMIC_PROXY)
+@ReflectionConfig(type = Role.class, accessType = TypeHint.AccessType.DYNAMIC_PROXY)
+@ReflectionConfig(type = Roles.class, accessType = TypeHint.AccessType.DYNAMIC_PROXY)
+public class Protected {
+}

--- a/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/Role.java
+++ b/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/Role.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.synthesis;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * A repeatable annotation, synthesized through its container by the test.
+ */
+@Repeatable(Roles.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Role {
+    String value();
+}

--- a/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/Roles.java
+++ b/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/Roles.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.synthesis;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * The container of {@link Role}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Roles {
+    Role[] value();
+}

--- a/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/SynthesizeInNativeImageTest.java
+++ b/test-suite-annotation-remapper/src/test/java/example/micronaut/synthesis/SynthesizeInNativeImageTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.synthesis;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValueProvider;
+import io.micronaut.core.beans.BeanIntrospection;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies that {@link AnnotationMetadata#synthesize(Class)} can hand out real annotation instances in
+ * a native image when the annotation type carries a {@code DYNAMIC_PROXY} reflection hint.
+ *
+ * <p>{@code synthesize(..)} builds the instance as a JDK dynamic proxy of the annotation type
+ * <em>and</em> {@link AnnotationValueProvider}. Before the fix, the hint registered a proxy of the
+ * annotation type alone, so every test here failed in a native image with
+ * {@code MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting
+ * ['example.micronaut.synthesis.Guarded','io.micronaut.core.annotation.AnnotationValueProvider']}.
+ * They all pass on the JVM either way, so only the {@code nativeTest} run is a regression test.</p>
+ */
+class SynthesizeInNativeImageTest {
+
+    private static AnnotationMetadata metadata() {
+        return BeanIntrospection.getIntrospection(Protected.class).getAnnotationMetadata();
+    }
+
+    @Test
+    void synthesizesAnAnnotationWithItsMembers() {
+        Guarded guarded = metadata().synthesize(Guarded.class);
+
+        assertNotNull(guarded);
+        assertEquals("secret", guarded.value());
+        assertEquals(3, guarded.max());
+        assertEquals(Guarded.class, guarded.annotationType());
+    }
+
+    @Test
+    void theSynthesizedInstanceIsAlsoAnAnnotationValueProvider() {
+        // this is the second interface of the proxy, and the reason registering the annotation type on
+        // its own is not enough
+        Guarded guarded = metadata().synthesize(Guarded.class);
+
+        AnnotationValueProvider<?> provider = assertInstanceOf(AnnotationValueProvider.class, guarded);
+        assertEquals("secret", provider.annotationValue().stringValue().orElse(null));
+    }
+
+    @Test
+    void synthesizesARepeatableAnnotationThroughItsContainer() {
+        Role[] roles = metadata().synthesizeAnnotationsByType(Role.class);
+
+        assertEquals(2, roles.length);
+        assertArrayEquals(new String[]{"admin", "auditor"}, new String[]{roles[0].value(), roles[1].value()});
+    }
+
+    @Test
+    void synthesizesTheRepeatableContainerItself() {
+        Roles roles = metadata().synthesize(Roles.class);
+
+        assertNotNull(roles);
+        assertEquals(2, roles.value().length);
+    }
+}


### PR DESCRIPTION
## The problem

`AnnotationMetadata.synthesize(Class)` builds an annotation instance as a JDK dynamic proxy of **two** interfaces — see [`AnnotationMetadataSupport.getProxyClass`](https://github.com/micronaut-projects/micronaut-core/blob/5.2.x/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java#L489):

```java
Class proxyClass = Proxy.getProxyClass(proxyLoader, annotation, AnnotationValueProvider.class);
```

In a native image that pair has to be registered, and `@ReflectionConfig(accessType = DYNAMIC_PROXY)` could not express it. `ReflectionConfigurationContext.registerDynamicProxy` took a single `Class`, so the hint registered a proxy of `[t]` alone and synthesis still failed:

```
org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy
class inheriting ['com.acme.Guarded','io.micronaut.core.annotation.AnnotationValueProvider'].
```

Applying the hint produced *the same error verbatim* — it is applied, it just registers the wrong proxy — leaving a hand-written `reachability-metadata.json` as the only way out. That makes `DYNAMIC_PROXY` unusable for any annotation Micronaut will synthesize, which is every annotation reachable through `synthesize()` or through `getAnnotationValuesByType(..)` turned into an instance.

This matters for any implementation that must hand out real annotation instances. Jakarta Interceptors requires it — `InvocationContext.getInterceptorBindings()` returns `Set<Annotation>` — so today every native image whose interceptors read their bindings needs hand-written metadata.

## What changed

**`registerDynamicProxy` is now varargs** — `GraalReflectionConfigurer.ReflectionConfigurationContext` and its one implementation in `ServiceLoaderFeature`. `RuntimeProxyCreation.register` was already varargs over one proxy's interface list, so this just stops the hook from throwing that expressiveness away. The interface is `@Internal` with a single implementation in tree and the call site is source-compatible.

**Annotation types register the pair** — the hint now registers `[t]` and, when `t` is an annotation, also `[t, AnnotationValueProvider]`, matching what `getProxyClass` actually builds. Non-annotation types are unchanged.

Platform- and bootstrap-loaded annotations (the fallback loader branch in `getProxyClass`) need nothing extra: GraalVM keys the proxy registry on the interface list, not the loader.

## Note for reviewers

I considered the wider option of auto-registering every annotation reachable through `synthesize()`, which would remove the hint from user code, and **did not** do it. `synthesize(Class)` takes its argument from arbitrary caller code, so "reachable" isn't decidable at build time; the only safe over-approximation is every runtime-retained annotation in the image, a large unconditional cost paid by every application for a feature most don't use. Hanging it on `@ReflectiveAccess` is narrower but a semantic stretch — that annotation means "reflect on this type's members", not "proxy it". Modules that know they will hand out annotation instances should emit the hint themselves, now that it works.

## Tests

`SynthesizeInNativeImageTest` goes in `test-suite-annotation-remapper`, which already runs `nativeTest` with the graal processor on the test processor path — no new module or build change. It covers an annotation with members read back, the synthesized instance really being an `AnnotationValueProvider` (the second proxy interface, i.e. the root cause), and a repeatable annotation both through `synthesizeAnnotationsByType` and via its container.

Verified on GraalVM CE 25.0.2, three real `nativeTest` runs:

| | result |
|---|---|
| fix in place | 6/6 successful (2 pre-existing + 4 new) |
| annotation-pair block reverted | the 4 new FAILED with the reported error for `Guarded`, `Role` and `Roles`; the 2 pre-existing still passed |
| fix restored | 6/6 successful |

These pass on the JVM either way, so `nativeTest` is the only meaningful regression guard — the test's javadoc says so.

`DynamicProxyReflectionConfigSpec` covers, without a native build, the two cases the native test can't reach cheaply: a non-annotation type still registering only `[t]`, and an annotation without the hint registering nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)