### PR TITLE
Preserve map key spelling for indexed keys in the RAW property catalog

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.BeanProperties
 import io.micronaut.context.env.PropertySource
 import io.micronaut.core.util.CollectionUtils
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ConfigurationPropertiesSpec extends Specification {
 
@@ -106,6 +107,31 @@ class ConfigurationPropertiesSpec extends Specification {
         config.defaultPort == 9999
         config.defaultValue == 9999
         config.primitiveDefaultValue == 9999
+    }
+
+    @Unroll
+    void "test configuration properties list binding accepts every spelling of an indexed key inner segment #key"() {
+        given: "the same indexed key written with a differently cased or separated inner segment"
+        ApplicationContext applicationContext = ApplicationContext.builder("test").build()
+        applicationContext.environment.addPropertySource(PropertySource.of(
+            'test',
+            [(key): 123]
+        ))
+        applicationContext.start()
+
+        expect: "every spelling binds to the same property of the object in the List"
+        applicationContext.getBean(MyConfig).innerVals[0].expireUnsignedSeconds == 123
+
+        cleanup:
+        applicationContext.close()
+
+        where:
+        key << [
+            'foo.bar.innerVals[0].expireUnsignedSeconds',
+            'foo.bar.innerVals[0].expire-unsigned-seconds',
+            'foo.bar.innerVals[0].expire_unsigned_seconds',
+            'foo.bar.innerVals[0].EXPIRE_UNSIGNED_SECONDS',
+        ]
     }
 
     void "test configuration inner class properties binding"() {

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -746,16 +746,13 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
                                 property,
                                 properties.getOrigin()
                             ));
-                            expandProperty(
+                            expandIndexedProperty(
+                                entries,
+                                propertyName,
                                 resolvedProperty.substring(i),
-                                val -> entries.put(propertyName, new DefaultPropertyEntry(
-                                    propertyName,
-                                    val,
-                                    property,
-                                    properties.getOrigin()
-                                )),
-                                () -> entries.getOrDefault(propertyName, NULL_ENTRY).value(),
-                                value
+                                value,
+                                property,
+                                properties.getOrigin()
                             );
                         }
                         if (first) {
@@ -800,18 +797,111 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
 
                 final Map<String, DefaultPropertyEntry> rawEntries = resolveEntriesForKey(property, true, PropertyCatalog.RAW);
                 if (rawEntries != null) {
+                    // Copied because the RAW catalog aggregates indexed keys into this structure
+                    // below, mutating it in place. The property source owns this value and the
+                    // GENERATED catalog stores it by reference, so RAW must not share it.
                     rawEntries.put(property, new DefaultPropertyEntry(
                         property,
-                        value,
+                        deepCopyForRawExpansion(value),
                         property,
                         properties.getOrigin()
                     ));
+                }
+
+                // Also expand indexed properties into the RAW catalog, using the verbatim
+                // (non-hyphenated) key, so the spelling of map keys nested under an indexed
+                // segment is preserved as written. Skipped for ENVIRONMENT_VARIABLE, which has no
+                // original spelling left to preserve: EnvironmentPropertySource.getEnv rewrites A_0__B
+                // into the verbatim key A[0]_B, and expanding that verbatim would misinterpret
+                // the trailing "_B" as part of the map key rather than a property delimiter.
+                if (convention != PropertySource.PropertyConvention.ENVIRONMENT_VARIABLE) {
+                    int rawIndex = property.indexOf('[');
+                    if (rawIndex > -1) {
+                        String rawPropertyName = property.substring(0, rawIndex);
+                        Map<String, DefaultPropertyEntry> rawIndexedEntries = resolveEntriesForKey(rawPropertyName, true, PropertyCatalog.RAW);
+                        if (rawIndexedEntries != null) {
+                            // Copied for the same reason, and separately from the copy above:
+                            // expandProperty stores this value into the aggregate by reference, so
+                            // an uncopied container would be reachable from RAW and from GENERATED
+                            // at once, and a later key drilling into the same index would mutate
+                            // both. Copying on the way in keeps RAW's tree entirely its own, which
+                            // is what lets this expansion mutate the aggregate in place instead of
+                            // re-copying it for every indexed key.
+                            expandIndexedProperty(
+                                rawIndexedEntries,
+                                rawPropertyName,
+                                property.substring(rawIndex),
+                                deepCopyForRawExpansion(value),
+                                property,
+                                properties.getOrigin()
+                            );
+                        }
+                    }
                 }
             }
             // A lookup can cache a miss between reset() and catalog reinitialization.
             // Clear those entries after the rebuilt catalog becomes visible.
             resetCaches();
         }
+    }
+
+    /**
+     * Recursively duplicates a {@link List} or {@link Map} so that every value entering the RAW
+     * catalog is one the catalog alone owns, and RAW's aggregated structures can be mutated in
+     * place without corrupting the property source's value or what the GENERATED catalog serves.
+     * Non-container values are returned as-is.
+     *
+     * @param value The value to copy
+     * @return An equivalent, independently mutable copy
+     */
+    private static Object deepCopyForRawExpansion(Object value) {
+        if (value instanceof List<?> list) {
+            List<Object> copy = new ArrayList<>(list.size());
+            for (Object element : list) {
+                copy.add(deepCopyForRawExpansion(element));
+            }
+            return copy;
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<Object, Object> copy = new LinkedHashMap<>(map.size());
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                copy.put(entry.getKey(), deepCopyForRawExpansion(entry.getValue()));
+            }
+            return copy;
+        }
+        return value;
+    }
+
+    /**
+     * Expands an indexed property (e.g. {@code foo[0].bar}) into the given entries map under its
+     * base name, building the container value and writing it back to {@code entries} as it grows.
+     *
+     * @param entries The catalog entries map to read the existing container from and write the
+     *                expanded container to, keyed by {@code baseName}
+     * @param baseName The un-indexed base property name (e.g. {@code foo})
+     * @param indexSuffix The indexed remainder of the property, starting with {@code [} (e.g. {@code [0].bar})
+     * @param value The value to place at the indexed location
+     * @param originalProperty The original, unresolved property key, recorded on the entry
+     * @param origin The origin of the property source, recorded on the entry
+     */
+    private void expandIndexedProperty(
+        Map<String, DefaultPropertyEntry> entries,
+        String baseName,
+        String indexSuffix,
+        Object value,
+        String originalProperty,
+        PropertySource.Origin origin) {
+        expandProperty(
+            indexSuffix,
+            val -> entries.put(baseName, new DefaultPropertyEntry(
+                baseName,
+                val,
+                originalProperty,
+                origin
+            )),
+            () -> entries.getOrDefault(baseName, NULL_ENTRY).value(),
+            value
+        );
     }
 
     private void expandProperty(String property, Consumer<Object> containerSet, Supplier<Object> containerGet, Object actualValue) {

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -725,6 +725,175 @@ class PropertySourcePropertyResolverSpec extends Specification {
         micronaut['security']['intercept-url-map'][0]['access'][1] == '/some-path-x'
     }
 
+    void "test indexed properties expand into the RAW catalog with the map key and base name as written"() {
+        given:
+        def values = new HashMap()
+        values.put('foo.items[0].SOME_KEY', 'x')
+        values.put('foo.myItems[0].K', 'v')
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect:
+        resolver.getProperties("foo", StringConvention.RAW) == [
+                'items[0].SOME_KEY': 'x',
+                'items'             : [['SOME_KEY': 'x']],
+                'myItems[0].K'      : 'v',
+                'myItems'           : [['K': 'v']],
+        ]
+    }
+
+    void "test indexed properties still hyphenate into the GENERATED catalog"() {
+        given:
+        def values = new HashMap()
+        values.put('foo.items[0].SOME_KEY', 'x')
+        values.put('foo.myItems[0].K', 'v')
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect:
+        resolver.getProperties("foo") == [
+                'items[0].some-key': 'x',
+                'items'            : [['some-key': 'x']],
+                'my-items[0].k'    : 'v',
+                'my-items'         : [['k': 'v']],
+        ]
+    }
+
+    void "test indexed property expansion is skipped for the ENVIRONMENT_VARIABLE convention"() {
+        given: "the source key as EnvironmentPropertySource.getEnv would rewrite A_0__B into"
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", ['A[0]_B': 'x'], PropertySource.PropertyConvention.ENVIRONMENT_VARIABLE)
+        )
+
+        expect: "the dotted property still resolves"
+        resolver.getRequiredProperty('a[0].b', String) == 'x'
+
+        and: "no aggregate entry is created in RAW for the rewritten key; checked directly because a top-level key has no dotted prefix for getProperties"
+        resolver.resolveEntriesForKey('A', false, PropertyCatalog.RAW)?.get('A') == null
+    }
+
+    void "test nested and bracketed indexed properties expand into the RAW catalog with map keys as written"() {
+        given: "top-level indexed keys, whose RAW aggregate is fetched from the catalog directly since getProperties only returns entries under a dotted prefix"
+        def values = new HashMap()
+        values.put('custom[0][0][KEY][4]', 'ohh')
+        values.put('custom[0][0][KEY][5]', 'ehh')
+        values.put('foo[1].bar[abx]', 'foo1Bar0')
+        values.put('a[0].b[1].C', 'deep')
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        when:
+        def rawCustom = resolver.resolveEntriesForKey('custom', false, PropertyCatalog.RAW).get('custom').value()
+        def rawFoo = resolver.resolveEntriesForKey('foo', false, PropertyCatalog.RAW).get('foo').value()
+        def rawA = resolver.resolveEntriesForKey('a', false, PropertyCatalog.RAW).get('a').value()
+
+        then: "RAW preserves the spelling as written at every map-key position"
+        rawCustom[0][0]['KEY'][4] == 'ohh'
+        rawCustom[0][0]['KEY'][5] == 'ehh'
+        rawFoo[1]['bar']['abx'] == 'foo1Bar0'
+        rawA[0]['b'][1]['C'] == 'deep'
+
+        and: "GENERATED still holds the hyphenated map keys NameUtils.hyphenate produces"
+        resolver.getProperty("custom", List).get()[0][0]['-key'][4] == 'ohh'
+        resolver.getProperty("foo", List).get()[1]['bar']['abx'] == 'foo1Bar0'
+        resolver.getProperty("a", List).get()[0]['b'][1]['c'] == 'deep'
+    }
+
+    void "test indexed property expansion leaves the NORMALIZED catalog unchanged"() {
+        given:
+        def values = new HashMap()
+        values.put('foo.items[0].SOME_KEY', 'x')
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "NORMALIZED still holds only the scalar under the base name, with no aggregate added"
+        resolver.getPropertyEntries("foo", PropertyCatalog.NORMALIZED) == ['items'] as Set
+
+        and:
+        def normalized = resolver.resolveEntriesForKey('foo', false, PropertyCatalog.NORMALIZED)
+        normalized.size() == 1
+        normalized['foo.items'].value() == 'x'
+    }
+
+    void "test a structured base value plus an indexed key targeting the same base does not corrupt GENERATED"() {
+        given: "a structured value as a YAML source supplies it, plus an indexed key targeting a new index of the same base; LinkedHashMap keeps the structured value first"
+        def values = new LinkedHashMap()
+        values.put('t.env', [[A: 1]])
+        values.put('t.env[1].B', 2)
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "GENERATED is unchanged: the RAW expansion must not mutate the list or map instance GENERATED serves"
+        resolver.getProperties("t")['env'] == [[A: 1], [b: 2]]
+
+        and: "RAW carries the spelling as written for the indexed key"
+        resolver.resolveEntriesForKey('t.env', false, PropertyCatalog.RAW).get('t.env').value()[1]['B'] == 2
+    }
+
+    void "test a structured base value plus an indexed key leaves no hyphenated key in RAW"() {
+        given: "a structured value, then an indexed key adding a new index to it; GENERATED expands into the structured value in place, writing the hyphenated key b"
+        def values = new LinkedHashMap()
+        values.put('t.env', [[A: 1]])
+        values.put('t.env[1].B', 2)
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "RAW shows only what was written; it must not also carry GENERATED's b, which it would if RAW shared the structured value GENERATED expands into"
+        resolver.getProperties("t", StringConvention.RAW)['env'] == [[A: 1], [B: 2]]
+
+        and: "GENERATED still hyphenates"
+        resolver.getProperties("t")['env'] == [[A: 1], [b: 2]]
+    }
+
+    void "test an indexed key, then a bare structured key re-aliasing the base, then another indexed key does not corrupt GENERATED"() {
+        given: "two indexed keys privatize RAW's base value, then the bare structured key re-aliases RAW's base value to the same instance GENERATED serves, then a third indexed key must re-privatize before mutating"
+        def values = new LinkedHashMap()
+        values.put('t.env[0].A', 1)
+        values.put('t.env[1].B', 2)
+        values.put('t.env', [[A: 1], [B: 2]])
+        values.put('t.env[2].C', 3)
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "GENERATED is unchanged: the RAW expansion must not mutate the list or map instance GENERATED serves"
+        resolver.getProperties("t")['env'] == [[A: 1], [B: 2], [c: 3]]
+
+        and: "RAW carries the spelling as written for the third indexed key"
+        resolver.resolveEntriesForKey('t.env', false, PropertyCatalog.RAW).get('t.env').value()[2]['C'] == 3
+    }
+
+    void "test an indexed key, then a bare map re-aliasing an index, then a nested indexed key does not leak into GENERATED"() {
+        given: "an indexed key establishes index 0, a bare map re-aliases index 1 to the source's own instance, then a nested indexed key targets that same index 1"
+        def values = new LinkedHashMap()
+        values.put('t.env[0].A', 1)
+        values.put('t.env[1]', [B: 2])
+        values.put('t.env[1].C', 3)
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "GENERATED is unchanged: the RAW expansion of the nested indexed key must not mutate the map instance GENERATED serves"
+        resolver.getProperties("t")['env'] == [[a: 1], [B: 2, c: 3]]
+
+        and: "RAW carries the nested indexed key's value verbatim"
+        resolver.resolveEntriesForKey('t.env', false, PropertyCatalog.RAW).get('t.env').value()[1]['C'] == 3
+    }
+
     void "test map and list values are collapsed"() {
         given:
         def values = new HashMap()


### PR DESCRIPTION
Micronaut normalizes a property name to kebab case. That is correct for property names, but wrong for a Map key that a user wrote as data. A key supplied as a single flat string, such as foo.items[0].SOME_KEY, is normalized in full before it is split into structure, so the Map key becomes some-key. The same configuration written as a YAML sequence keeps SOME_KEY, because the loader supplies an already-structured List<Map<..>> whose inner keys never pass through normalization. The two authoring forms therefore disagree, and the spelling matters whenever the key is data rather than a property name: environment variable names, HTTP header names, and any Map<String, String> keyed by something outside Micronaut's naming rules.

StringConvention.RAW exists to recover the spelling a user wrote, but it could not help here. The RAW catalog only ever received the verbatim flat entry, never the aggregated structure, so it could return the unexpanded String but never the list carrying the original Map keys.

Run the indexed-property expansion into the RAW catalog as well, built from the verbatim key and stored under the verbatim base name. The GENERATED and NORMALIZED catalogs are untouched, so binding, which depends on the normalized spelling, is unaffected; RAW simply gains the view it was always meant to offer.

Skip the expansion for the ENVIRONMENT_VARIABLE convention. No user spelling survives to that point, and its rewritten keys, such as A[0]_B, would be misread as Map keys rather than as delimiters.

Give RAW a deep copy of any existing container before expanding into it. Catalogs store values by reference, so an aggregate may be the very instance GENERATED serves, or the property source's own value; mutating it in place would corrupt both.

Fixes #13016