### PR TITLE
Validate constrained @Value fields and setter placeholders at inject time

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -1020,6 +1020,10 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
         applyConfigurationInjectionIfNecessary(methodDefinition.annotationMetadata(), methodDefinition.injectionPoints());
     }
 
+    private void applyConfigurationInjectionIfNecessary(FieldDefinition<ClassElement, FieldElement> fieldDefinition) {
+        applyConfigurationInjectionIfNecessary(fieldDefinition.annotationMetadata(), fieldDefinition.injectionPoints());
+    }
+
     private void applyConfigurationInjectionIfNecessary(AnnotationMetadata annotationMetadata, List<BeanDefinitionInjectionPoint<ClassElement>> injectionPoints) {
         if (annotationMetadata.hasDeclaredAnnotation(RequiresValidation.class)) {
             List<BeanDefinitionInjectionPoint<ClassElement>> validatedPoints = injectionPoints.stream()
@@ -1054,8 +1058,9 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     /**
      * Post-construct {@link ValidatedBeanDefinition#validate} is required when a validated
      * injection point is a (nullable) bean dependency — null can be injected and only full
-     * bean validation rejects it. Pure {@code @Value}/{@code @Property} constraints are
-     * covered by {@code validateBeanArgument} at inject time.
+     * bean validation rejects it. Pure {@code @Value}/{@code @Property} constraints on
+     * constructor parameters, fields and method parameters are covered by
+     * {@code validateBeanArgument} at inject time.
      */
     private boolean needsPostConstructBeanValidation(List<BeanDefinitionInjectionPoint<ClassElement>> validatedPoints) {
         return validatedPoints.stream().anyMatch(ip ->
@@ -1082,6 +1087,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     @Override
     public BeanDefinitionWriter addFieldInjection(FieldDefinition<ClassElement, FieldElement> fieldDefinition) {
+        applyConfigurationInjectionIfNecessary(fieldDefinition);
         injectCommands.add(new InjectField(fieldDefinition));
         if (shouldKeepInjectionPoint(fieldDefinition.annotationMetadata())) {
             allFields.add(fieldDefinition);
@@ -1389,9 +1395,10 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
             ).build((aThis, methodParameters) -> aThis.type().instantiate().returning())
         );
 
-        // Injection-point constraints are validated via validateBeanArgument during construction.
-        // Skip post-construct bean validation so @Singleton beans with constrained @Value
-        // constructor parameters do not require @Introspected (see #12847).
+        // Injection-point constraints are validated via validateBeanArgument while the value is
+        // resolved, for constructor parameters as well as injected fields and method parameters
+        // (AbstractInitializableBeanDefinition). Skip post-construct bean validation so @Singleton
+        // beans with constrained @Value injection points do not require @Introspected (see #12847).
         if (validated && !requiresPostConstructBeanValidation) {
             classDefBuilder.addMethod(
                 MethodDef.override(VALIDATE_BEAN_METHOD)

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/validation/ValidatedValuePropertySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/validation/ValidatedValuePropertySpec.groovy
@@ -1,0 +1,109 @@
+package io.micronaut.inject.validation
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.core.reflect.ClassUtils
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ValidatedBeanDefinition
+
+/**
+ * A Groovy property annotated with {@code @Value} is injected through its setter, a Groovy
+ * field through field injection. Both only carry injection-point constraints, so the bean is
+ * compiled in injection-point-only mode and relies on {@code validateBeanArgument} being
+ * invoked while the value is resolved.
+ */
+class ValidatedValuePropertySpec extends AbstractBeanDefinitionSpec {
+
+    private static final String PROPERTY_BEAN = '''
+package test
+
+import io.micronaut.context.annotation.Value
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.NotNull
+
+@Singleton
+class PropertyBean {
+    @Max(20L)
+    @NotNull
+    @Value('${a.number}')
+    Integer number
+}
+'''
+
+    private static final String FIELD_BEAN = '''
+package test
+
+import io.micronaut.context.annotation.Value
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.NotNull
+
+@Singleton
+class FieldBean {
+    @Max(20L)
+    @NotNull
+    @Value('${a.number}')
+    private Integer number
+
+    Integer getNumber() {
+        return number
+    }
+}
+'''
+
+    void "singleton with validated @Value #description is a ValidatedBeanDefinition without introspection"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition(className, source)
+
+        then:
+        beanDefinition instanceof ValidatedBeanDefinition
+        ClassUtils.forName(className.replace('test.', 'test.$') + '$Introspection', beanDefinition.beanType.classLoader).isEmpty()
+
+        where:
+        description | className          | source
+        'property'  | 'test.PropertyBean' | PROPERTY_BEAN
+        'field'     | 'test.FieldBean'    | FIELD_BEAN
+    }
+
+    void "singleton with validated @Value #description accepts a valid value"() {
+        given:
+        ApplicationContext context = buildContext(source, true, ['a.number': 10])
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass(className))
+
+        then:
+        bean.getNumber() == 10
+
+        cleanup:
+        context.close()
+
+        where:
+        description | className          | source
+        'property'  | 'test.PropertyBean' | PROPERTY_BEAN
+        'field'     | 'test.FieldBean'    | FIELD_BEAN
+    }
+
+    void "singleton with validated @Value #description rejects an invalid value"() {
+        given:
+        ApplicationContext context = buildContext(source, true, ['a.number': 40])
+
+        when:
+        context.getBean(context.classLoader.loadClass(className))
+
+        then:
+        BeanInstantiationException e = thrown()
+        e.message.contains('must be less than or equal to 20')
+        !e.message.toLowerCase().contains('no bean introspection present')
+
+        cleanup:
+        context.close()
+
+        where:
+        description | className          | source
+        'property'  | 'test.PropertyBean' | PROPERTY_BEAN
+        'field'     | 'test.FieldBean'    | FIELD_BEAN
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/ValidatedValueFieldSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/ValidatedValueFieldSpec.groovy
@@ -1,0 +1,228 @@
+package io.micronaut.aop.compile
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanResolutionContext
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.context.exceptions.DependencyInjectionException
+import io.micronaut.core.reflect.ClassUtils
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.ArgumentInjectionPoint
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.CallableInjectionPoint
+import io.micronaut.inject.ConstructorInjectionPoint
+import io.micronaut.inject.FieldInjectionPoint
+import io.micronaut.inject.InjectionPoint
+import io.micronaut.inject.ValidatedBeanDefinition
+import io.micronaut.inject.validation.BeanDefinitionValidator
+
+/**
+ * Regression for the field-injection gap left by https://github.com/micronaut-projects/micronaut-core/pull/12859.
+ *
+ * A plain {@code @Singleton} whose only constraints sit on {@code @Value}/{@code @Property}
+ * <em>field</em> (or setter) injection points is compiled in injection-point-only mode: the generated
+ * {@code validate} does nothing and the bean relies on {@code validateBeanArgument} being invoked
+ * while each value is resolved. The runtime field paths used to skip that call, so such beans were
+ * never validated at all.
+ */
+class ValidatedValueFieldSpec extends AbstractTypeElementSpec {
+
+    private static final String FIELD_BEAN = '''
+package test;
+
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Singleton;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+
+@Singleton
+class FieldBean {
+    @Max(20)
+    @NotNull
+    @Value("${a.number}")
+    Integer number;
+
+    Integer getNumber() {
+        return number;
+    }
+}
+'''
+
+    private static final String PROPERTY_FIELD_BEAN = '''
+package test;
+
+import io.micronaut.context.annotation.Property;
+import jakarta.inject.Singleton;
+import jakarta.validation.constraints.Max;
+
+@Singleton
+class PropertyFieldBean {
+    @Max(20)
+    @Property(name = "a.number")
+    Integer number;
+
+    Integer getNumber() {
+        return number;
+    }
+}
+'''
+
+    private static final String SETTER_BEAN = '''
+package test;
+
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.validation.constraints.Max;
+
+@Singleton
+class SetterBean {
+    private Integer number;
+
+    @Inject
+    void setNumber(@Max(20) @Value("${a.number}") Integer number) {
+        this.number = number;
+    }
+
+    Integer getNumber() {
+        return number;
+    }
+}
+'''
+
+    private static final String CONSTRUCTOR_BEAN = '''
+package test;
+
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Singleton;
+import jakarta.validation.constraints.Max;
+
+@Singleton
+class ConstructorBean {
+    private final Integer number;
+
+    ConstructorBean(@Max(20) @Value("${a.number}") Integer number) {
+        this.number = number;
+    }
+
+    Integer getNumber() {
+        return number;
+    }
+}
+'''
+
+    void "singleton with validated @Value field is a ValidatedBeanDefinition without introspection"() {
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.FieldBean', FIELD_BEAN)
+
+        then:
+        beanDefinition instanceof ValidatedBeanDefinition
+        ClassUtils.forName('test.$FieldBean$Introspection', beanDefinition.beanType.classLoader).isEmpty()
+    }
+
+    void "singleton with validated @Value field starts with a valid value"() {
+        given:
+        ApplicationContext context = buildContext('test.FieldBean', FIELD_BEAN, true, ['a.number': 10])
+
+        when:
+        def bean = getBean(context, 'test.FieldBean')
+
+        then:
+        bean.getNumber() == 10
+
+        cleanup:
+        context.close()
+    }
+
+    void "singleton with validated #description rejects an invalid value"() {
+        given:
+        ApplicationContext context = buildContext(className, source, true, ['a.number': 40])
+
+        when:
+        getBean(context, className)
+
+        then:
+        BeanInstantiationException e = thrown()
+        e.message.contains('must be less than or equal to 20')
+        !e.message.toLowerCase().contains('no bean introspection present')
+
+        cleanup:
+        context.close()
+
+        where:
+        description        | className                | source
+        '@Value field'     | 'test.FieldBean'         | FIELD_BEAN
+        '@Property field'  | 'test.PropertyFieldBean' | PROPERTY_FIELD_BEAN
+        '@Value setter'    | 'test.SetterBean'        | SETTER_BEAN
+    }
+
+    void "singleton with validated @Value constructor parameter rejects an invalid value"() {
+        given:
+        ApplicationContext context = buildContext('test.ConstructorBean', CONSTRUCTOR_BEAN, true, ['a.number': 40])
+
+        when:
+        getBean(context, 'test.ConstructorBean')
+
+        then:
+        DependencyInjectionException e = thrown()
+        e.cause instanceof BeanInstantiationException
+        e.cause.message.contains('must be less than or equal to 20')
+
+        cleanup:
+        context.close()
+    }
+
+    void "validateBeanArgument receives the #expectedInjectionPoint for a constrained #description"() {
+        given:
+        ApplicationContext context = buildContext(className, source, false, ['a.number': 40])
+        RecordingValidator validator = new RecordingValidator()
+        context.registerSingleton(BeanDefinitionValidator, validator)
+
+        when:
+        def bean = getBean(context, className)
+
+        then:
+        bean.getNumber() == 40
+        validator.validatedBeans.isEmpty()
+        validator.arguments.size() == 1
+        isExpectedInjectionPoint(validator.arguments[0].injectionPoint)
+        validator.arguments[0].argument.name == 'number'
+        validator.arguments[0].value == 40
+
+        cleanup:
+        context.close()
+
+        where:
+        description                    | className              | source           | expectedInjectionPoint      | isExpectedInjectionPoint
+        '@Value field'                 | 'test.FieldBean'       | FIELD_BEAN       | 'FieldInjectionPoint'       | { it instanceof FieldInjectionPoint }
+        '@Value setter parameter'      | 'test.SetterBean'      | SETTER_BEAN      | 'setter ArgumentInjectionPoint' | { it instanceof ArgumentInjectionPoint && it instanceof CallableInjectionPoint && it.name == 'setNumber' }
+        '@Value constructor parameter' | 'test.ConstructorBean' | CONSTRUCTOR_BEAN | 'ConstructorInjectionPoint' | { it instanceof ConstructorInjectionPoint }
+    }
+
+    static class RecordingValidator implements BeanDefinitionValidator {
+        final List<ValidatedArgument> arguments = []
+        final List<Object> validatedBeans = []
+
+        @Override
+        <T> void validateBeanArgument(BeanResolutionContext resolutionContext, InjectionPoint injectionPoint, Argument<T> argument, int index, T value) throws BeanInstantiationException {
+            arguments << new ValidatedArgument(injectionPoint, argument, value)
+        }
+
+        @Override
+        <T> void validateBean(BeanResolutionContext resolutionContext, BeanDefinition<T> definition, T bean) throws BeanInstantiationException {
+            validatedBeans << bean
+        }
+    }
+
+    static class ValidatedArgument {
+        final InjectionPoint injectionPoint
+        final Argument<?> argument
+        final Object value
+
+        ValidatedArgument(InjectionPoint injectionPoint, Argument<?> argument, Object value) {
+            this.injectionPoint = injectionPoint
+            this.argument = argument
+            this.value = value
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/ValidatedValueFieldSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/ValidatedValueFieldSpec.groovy
@@ -90,6 +90,31 @@ class SetterBean {
 }
 '''
 
+    /**
+     * Configuration properties are validated post-construct as well, which needs an introspection the
+     * in-memory test class loader cannot provide, so only the invalid value is asserted for this bean.
+     */
+    private static final String CONFIGURATION_SETTER_BEAN = '''
+package test;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Value;
+import jakarta.validation.constraints.Max;
+
+@ConfigurationProperties("a")
+class ConfigurationSetterBean {
+    private Integer number;
+
+    void setNumber(@Max(20) @Value("${a.number}") Integer number) {
+        this.number = number;
+    }
+
+    Integer getNumber() {
+        return number;
+    }
+}
+'''
+
     private static final String CONSTRUCTOR_BEAN = '''
 package test;
 
@@ -120,21 +145,27 @@ class ConstructorBean {
         ClassUtils.forName('test.$FieldBean$Introspection', beanDefinition.beanType.classLoader).isEmpty()
     }
 
-    void "singleton with validated @Value field starts with a valid value"() {
+    void "bean with validated #description starts with a valid value"() {
         given:
-        ApplicationContext context = buildContext('test.FieldBean', FIELD_BEAN, true, ['a.number': 10])
+        ApplicationContext context = buildContext(className, source, true, ['a.number': 10])
 
         when:
-        def bean = getBean(context, 'test.FieldBean')
+        def bean = getBean(context, className)
 
         then:
         bean.getNumber() == 10
 
         cleanup:
         context.close()
+
+        where:
+        description       | className                | source
+        '@Value field'    | 'test.FieldBean'         | FIELD_BEAN
+        '@Property field' | 'test.PropertyFieldBean' | PROPERTY_FIELD_BEAN
+        '@Value setter'   | 'test.SetterBean'        | SETTER_BEAN
     }
 
-    void "singleton with validated #description rejects an invalid value"() {
+    void "bean with validated #description rejects an invalid value"() {
         given:
         ApplicationContext context = buildContext(className, source, true, ['a.number': 40])
 
@@ -150,10 +181,11 @@ class ConstructorBean {
         context.close()
 
         where:
-        description        | className                | source
-        '@Value field'     | 'test.FieldBean'         | FIELD_BEAN
-        '@Property field'  | 'test.PropertyFieldBean' | PROPERTY_FIELD_BEAN
-        '@Value setter'    | 'test.SetterBean'        | SETTER_BEAN
+        description                              | className                      | source
+        '@Value field'                           | 'test.FieldBean'               | FIELD_BEAN
+        '@Property field'                        | 'test.PropertyFieldBean'       | PROPERTY_FIELD_BEAN
+        '@Value setter'                          | 'test.SetterBean'              | SETTER_BEAN
+        '@Value configuration properties setter' | 'test.ConfigurationSetterBean' | CONFIGURATION_SETTER_BEAN
     }
 
     void "singleton with validated @Value constructor parameter rejects an invalid value"() {

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -1052,11 +1052,9 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
     protected final Object getValueForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Qualifier qualifier) {
         MethodReference methodRef = Objects.requireNonNull(methodInjection)[methodIndex];
         Argument<?> argument = methodRef.arguments[argIndex];
-        try (BeanResolutionContext.Path path = resolutionContext.getPath()
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments)) {
-            Object val = resolveValue(resolutionContext, context, methodRef.annotationMetadata, argument, qualifier);
-            validateBeanArgument(resolutionContext, path, argument, argIndex, val);
-            return val;
+            return resolveValue(resolutionContext, context, methodRef.annotationMetadata, argument, qualifier);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -1052,9 +1052,11 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
     protected final Object getValueForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Qualifier qualifier) {
         MethodReference methodRef = Objects.requireNonNull(methodInjection)[methodIndex];
         Argument<?> argument = methodRef.arguments[argIndex];
-        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+        try (BeanResolutionContext.Path path = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments)) {
-            return resolveValue(resolutionContext, context, methodRef.annotationMetadata, argument, qualifier);
+            Object val = resolveValue(resolutionContext, context, methodRef.annotationMetadata, argument, qualifier);
+            validateBeanArgument(resolutionContext, path, argument, argIndex, val);
+            return val;
         }
     }
 
@@ -1116,9 +1118,11 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
                                                                         String value) {
         MethodReference methodRef = Objects.requireNonNull(methodInjection)[methodIndex];
         Argument<?> argument = methodRef.arguments[argIndex];
-        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+        try (BeanResolutionContext.Path path = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments)) {
-            return resolutionContext.resolvePropertyValue(argument, value, null, true);
+            Object val = resolutionContext.resolvePropertyValue(argument, value, null, true);
+            validateBeanArgument(resolutionContext, path, argument, argIndex, val);
+            return val;
         }
     }
 
@@ -1186,9 +1190,11 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
                                                                 String setterName,
                                                                 Argument<?> argument,
                                                                 String value) {
-        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+        try (BeanResolutionContext.Path path = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, setterName, argument, new Argument[]{argument})) {
-            return resolutionContext.resolvePropertyValue(argument, value, null, true);
+            Object val = resolutionContext.resolvePropertyValue(argument, value, null, true);
+            validateBeanArgument(resolutionContext, path, argument, 0, val);
+            return val;
         }
     }
 
@@ -1906,8 +1912,10 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
     @Nullable
     protected final Object getValueForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Qualifier qualifier) {
         FieldReference fieldRef = Objects.requireNonNull(fieldInjection)[fieldIndex];
-        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushFieldResolve(this, fieldRef.argument)) {
-            return resolveValue(resolutionContext, context, fieldRef.argument.getAnnotationMetadata(), fieldRef.argument, qualifier);
+        try (BeanResolutionContext.Path path = resolutionContext.getPath().pushFieldResolve(this, fieldRef.argument)) {
+            Object val = resolveValue(resolutionContext, context, fieldRef.argument.getAnnotationMetadata(), fieldRef.argument, qualifier);
+            validateBeanArgument(resolutionContext, path, fieldRef.argument, 0, val);
+            return val;
         }
     }
 
@@ -1928,8 +1936,10 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
     @Deprecated
     @Nullable
     protected final Object getPropertyValueForField(BeanResolutionContext resolutionContext, BeanContext context, Argument argument, String propertyValue, String cliProperty) {
-        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushFieldResolve(this, argument)) {
-            return resolutionContext.resolvePropertyValue(argument, propertyValue, cliProperty, false);
+        try (BeanResolutionContext.Path path = resolutionContext.getPath().pushFieldResolve(this, argument)) {
+            Object val = resolutionContext.resolvePropertyValue(argument, propertyValue, cliProperty, false);
+            validateBeanArgument(resolutionContext, path, argument, 0, val);
+            return val;
         }
     }
 
@@ -1949,8 +1959,40 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
     @Deprecated
     @Nullable
     protected final Object getPropertyPlaceholderValueForField(BeanResolutionContext resolutionContext, BeanContext context, Argument argument, String placeholder) {
-        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushFieldResolve(this, argument)) {
-            return resolutionContext.resolvePropertyValue(argument, placeholder, null, true);
+        try (BeanResolutionContext.Path path = resolutionContext.getPath().pushFieldResolve(this, argument)) {
+            Object val = resolutionContext.resolvePropertyValue(argument, placeholder, null, true);
+            validateBeanArgument(resolutionContext, path, argument, 0, val);
+            return val;
+        }
+    }
+
+    /**
+     * Validates an injected value against the constraints declared on its injection point when this
+     * definition is a {@link ValidatedBeanDefinition}. The injection point is the segment on top of
+     * the given path, so this covers fields (a {@link FieldInjectionPoint}) as well as method
+     * arguments. Beans that only carry constraints on {@code @Value}/{@code @Property} injection
+     * points rely on this call because the generated {@code validate} does not run full bean
+     * validation for them.
+     *
+     * @param resolutionContext The resolution context
+     * @param path              The resolution path whose top segment is the injection point
+     * @param argument          The argument being injected
+     * @param index             The argument index
+     * @param value             The resolved value
+     */
+    private void validateBeanArgument(BeanResolutionContext resolutionContext,
+                                      BeanResolutionContext.Path path,
+                                      Argument<?> argument,
+                                      int index,
+                                      @Nullable Object value) {
+        if (this instanceof ValidatedBeanDefinition validatedBeanDefinition) {
+            validatedBeanDefinition.validateBeanArgument(
+                resolutionContext,
+                Objects.requireNonNull(path.peek()).getInjectionPoint(),
+                argument,
+                index,
+                value
+            );
         }
     }
 


### PR DESCRIPTION
## What changed

Since #12859 a bean whose validated injection points are all `@Value`/`@Property` values is compiled in "injection-point-only" mode: it is a `ValidatedBeanDefinition`, but the generated `validate(BeanResolutionContext, Object)` returns the instance untouched and the bean relies on `validateBeanArgument` being invoked while each value is resolved. Only the constructor-argument paths and the property-value method/setter paths in `AbstractInitializableBeanDefinition` did that.

- `getValueForField`, `getPropertyValueForField`, `getPropertyPlaceholderValueForField`, `getPropertyPlaceholderValueForMethodArgument`, `getPropertyPlaceholderValueForSetter` and `getValueForMethodArgument` now route through a single private helper that calls `validateBeanArgument` with the segment on top of the resolution path as the injection point (a `FieldInjectionPoint` for fields since #12970).
- `BeanDefinitionWriter` now applies the same `applyConfigurationInjectionIfNecessary` rule to field injection points as to constructor and method ones. A plain Java field with a constraint previously never made the bean a `ValidatedBeanDefinition` at all (also on 5.1.x).
- Bean injection paths such as `getBeanForField` are left alone, matching the constructor/method bean paths which do not validate either.

## Why

A `@Singleton` such as

```groovy
@Singleton
class A {
    @Max(20L) @NotNull @Value('${a.number}') Integer number
}
```

was created with `a.number=40` and nothing threw. In Groovy `number` is a property injected through its setter, which takes the placeholder setter path; a Java field takes the field path. Both skipped `validateBeanArgument`, so the injection-point-only mode of #12859 covered constructor parameters only. This is what breaks `ValidatorSpec."test @Introspected is required to validate the bean"` (and the bean `B` variant) in micronaut-validation when pinned to core 5.2.x.

## Reviewer notes

- The micronaut-validation spec for bean `A` asserts the old "No bean introspection present. Please add @Introspected." message. With this change `A` now fails with the actual constraint violation, which is the behaviour #12859 intended, so that assertion needs updating on the validation side to match the bean `B` variant.
- Tests: `ValidatedValueFieldSpec` (inject-java) covers `@Value` field, `@Property` field, `@Value` setter and `@Value` constructor variants with the real validator, plus a recording `BeanDefinitionValidator` asserting the injection point kind and that post-construct `validate` stays a no-op. `ValidatedValuePropertySpec` (inject-groovy) mirrors the failing validation spec with a Groovy property and a Groovy private field.
- Verified: inject-java `*Validat*` + `RecordBeansSpec`, inject-groovy `ValidatedValueProperty*` + `ValidationAdviceSpec`, the full `:micronaut-inject:test`, and checkstyle for inject, core-processor and both test source sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
