### PR TITLE
Answer the enclosing method for the outer injection point of a method argument segment

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/kind/InjectionPointKindSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/kind/InjectionPointKindSpec.groovy
@@ -3,6 +3,8 @@ package io.micronaut.inject.injectionpoint.kind
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanResolutionContext
 import io.micronaut.context.BeanResolutionCustomizer
+import io.micronaut.context.DefaultBeanResolutionContext
+import io.micronaut.core.type.Argument
 import io.micronaut.inject.ArgumentInjectionPoint
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ConstructorInjectionPoint
@@ -116,6 +118,48 @@ class InjectionPointKindSpec extends Specification {
         outer.arguments*.name == ['fromMethod']
         !((MethodInjectionPoint) outer).postConstructMethod
         !((MethodInjectionPoint) outer).preDestroyMethod
+    }
+
+    void "a segment pushed with a method injection point answers that injection point as outer"() {
+        given:
+        BeanDefinition<KindConsumer> definition = applicationContext.getBeanDefinition(KindConsumer)
+        MethodInjectionPoint<KindConsumer, ?> setter = definition.injectedMethods.find { it.name == 'setFromMethod' }
+        def resolutionContext = new DefaultBeanResolutionContext(applicationContext, definition)
+
+        when:
+        def path = resolutionContext.path.pushMethodArgumentResolve(definition, setter, setter.arguments[0])
+        def outer = ((ArgumentInjectionPoint) path.currentSegment().get().injectionPoint).outerInjectionPoint
+
+        then:
+        outer.is(setter)
+
+        cleanup:
+        path?.close()
+    }
+
+    void "a method argument segment with no matching method answers itself as outer"() {
+        given:
+        BeanDefinition<KindConsumer> definition = applicationContext.getBeanDefinition(KindConsumer)
+        def resolutionContext = new DefaultBeanResolutionContext(applicationContext, definition)
+        Argument<?> argument = Argument.of(String, 'value')
+
+        when: 'the name matches no injected method'
+        def path = resolutionContext.path.pushMethodArgumentResolve(definition, 'setValue', argument, [argument] as Argument[])
+        def segment = path.currentSegment().get()
+
+        then:
+        ((ArgumentInjectionPoint) segment.injectionPoint).outerInjectionPoint.is(segment)
+
+        when: 'the name matches an injected method but the arguments do not'
+        path = resolutionContext.path.pushMethodArgumentResolve(definition, 'setFromMethod', argument, [argument] as Argument[])
+        segment = path.currentSegment().get()
+
+        then:
+        ((ArgumentInjectionPoint) segment.injectionPoint).outerInjectionPoint.is(segment)
+        segment.name == 'setFromMethod'
+
+        cleanup:
+        path?.close()
     }
 
     void "a factory method argument injection point has the factory method as outer injection point"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/kind/InjectionPointKindSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/kind/InjectionPointKindSpec.groovy
@@ -8,6 +8,7 @@ import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ConstructorInjectionPoint
 import io.micronaut.inject.FieldInjectionPoint
 import io.micronaut.inject.InjectionPoint
+import io.micronaut.inject.MethodInjectionPoint
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -23,6 +24,9 @@ class InjectionPointKindSpec extends Specification {
     List<BeanResolutionContext.Segment<?, ?>> kindBeanSegments = []
 
     @Shared
+    List<BeanResolutionContext.Segment<?, ?>> dependencySegments = []
+
+    @Shared
     ApplicationContext applicationContext
 
     @Shared
@@ -36,6 +40,8 @@ class InjectionPointKindSpec extends Specification {
                 boolean shouldDestroyDependentBeanAfterResolution(BeanResolutionContext resolutionContext, BeanDefinition<?> beanDefinition) {
                     if (beanDefinition.beanType == KindBean) {
                         resolutionContext.path.currentSegment().ifPresent(kindBeanSegments::add)
+                    } else if (beanDefinition.beanType == KindDependency) {
+                        resolutionContext.path.currentSegment().ifPresent(dependencySegments::add)
                     }
                     return false
                 }
@@ -87,6 +93,44 @@ class InjectionPointKindSpec extends Specification {
         ((ArgumentInjectionPoint) method).argument.name == 'fromMethod'
     }
 
+    void "a constructor argument injection point has the constructor as outer injection point"() {
+        given:
+        def outer = ((ArgumentInjectionPoint) consumer.fromConstructor.injectionPoint).outerInjectionPoint
+
+        expect:
+        outer instanceof ConstructorInjectionPoint
+        !(outer instanceof MethodInjectionPoint)
+        outer.declaringBean.beanType == KindConsumer
+        outer.arguments*.name == ['fromConstructor']
+    }
+
+    void "a method argument injection point has its method as outer injection point"() {
+        given:
+        def outer = ((ArgumentInjectionPoint) consumer.fromMethod.injectionPoint).outerInjectionPoint
+
+        expect:
+        outer instanceof MethodInjectionPoint
+        !(outer instanceof ConstructorInjectionPoint)
+        outer.name == 'setFromMethod'
+        outer.declaringBean.beanType == KindConsumer
+        outer.arguments*.name == ['fromMethod']
+        !((MethodInjectionPoint) outer).postConstructMethod
+        !((MethodInjectionPoint) outer).preDestroyMethod
+    }
+
+    void "a factory method argument injection point has the factory method as outer injection point"() {
+        given:
+        def outers = dependencySegments*.injectionPoint*.outerInjectionPoint
+
+        expect:
+        // KindBean is a prototype created once per injection into KindConsumer
+        outers.size() == 3
+        outers.every { it instanceof ConstructorInjectionPoint }
+        outers.every { it instanceof MethodInjectionPoint }
+        outers*.name.unique() == ['kindBean']
+        outers.every { it.declaringBean.beanType == KindBean }
+    }
+
     void "a resolution customizer can tell the kind of the current segment without internal classes"() {
         given:
         def injectionPoints = kindBeanSegments*.injectionPoint
@@ -100,5 +144,27 @@ class InjectionPointKindSpec extends Specification {
         def field = injectionPoints.find { it instanceof FieldInjectionPoint }
         field.name == 'fromField'
         ((ArgumentInjectionPoint) field).outerInjectionPoint == null
+    }
+
+    void "a resolution customizer can tell a constructor argument from a method argument by the outer injection point"() {
+        given:
+        def outers = kindBeanSegments*.injectionPoint
+            .findAll { !(it instanceof FieldInjectionPoint) }
+            .collect { ((ArgumentInjectionPoint) it).outerInjectionPoint }
+
+        expect:
+        outers.size() == 2
+        outers.every { it != null }
+
+        and:
+        def constructor = outers.find { it instanceof ConstructorInjectionPoint }
+        constructor != null
+        constructor.arguments*.name == ['fromConstructor']
+
+        and:
+        def method = outers.find { !(it instanceof ConstructorInjectionPoint) }
+        method instanceof MethodInjectionPoint
+        method.name == 'setFromMethod'
+        method.arguments*.name == ['fromMethod']
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/kind/KindDependency.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/kind/KindDependency.java
@@ -15,17 +15,14 @@
  */
 package io.micronaut.inject.injectionpoint.kind;
 
-import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.inject.InjectionPoint;
 
-@Factory
+/**
+ * Injected into the factory method that creates {@link KindBean}, so the resolution of a
+ * factory method argument is observable.
+ */
 @Requires(property = "spec.name", value = "InjectionPointKindSpec")
-public class KindFactory {
-
-    @Prototype
-    KindBean kindBean(InjectionPoint<KindBean> injectionPoint, KindDependency dependency) {
-        return new KindBean(injectionPoint);
-    }
+@Prototype
+public class KindDependency {
 }

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -731,8 +731,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
                     ConstructorSegment constructorSegment = new ConstructorArgumentSegment(declaringType, (Qualifier<Object>) getCurrentQualifier(), methodName, argument, arguments);
                     detectCircularDependency(declaringType, argument, constructorSegment);
                 } else {
-                    Segment<?, ?> previous = peek();
-                    MethodSegment<?, ?> methodSegment = new MethodArgumentSegment(declaringType, (Qualifier<Object>) getCurrentQualifier(), methodName, argument, arguments, previous instanceof MethodSegment ms ? ms : null);
+                    MethodSegment<?, ?> methodSegment = new MethodArgumentSegment(declaringType, (Qualifier<Object>) getCurrentQualifier(), methodName, argument, arguments, null);
                     if (contains(methodSegment)) {
                         push(methodSegment);
                         throw new CircularDependencyException(AbstractBeanResolutionContext.this, argument, CIRCULAR_ERROR_MSG);
@@ -770,9 +769,8 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         @Override
         public Path pushMethodArgumentResolve(BeanDefinition declaringType, MethodInjectionPoint methodInjectionPoint, Argument argument) {
             try {
-                Segment<?, ?> previous = peek();
                 MethodSegment<?, ?> methodSegment = new MethodArgumentSegment(declaringType, (Qualifier<Object>) getCurrentQualifier(), methodInjectionPoint.getName(), argument,
-                    methodInjectionPoint.getArguments(), previous instanceof MethodSegment ms ? ms : null);
+                    methodInjectionPoint.getArguments(), (CallableInjectionPoint<Object>) methodInjectionPoint);
                 if (contains(methodSegment)) {
                     push(methodSegment);
                     throw new CircularDependencyException(AbstractBeanResolutionContext.this, methodInjectionPoint, argument, CIRCULAR_ERROR_MSG);
@@ -789,8 +787,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         @Override
         public Path pushMethodArgumentResolve(BeanDefinition declaringType, String methodName, Argument argument, Argument[] arguments) {
             try {
-                Segment<?, ?> previous = peek();
-                MethodSegment<?, ?> methodSegment = new MethodArgumentSegment(declaringType, (Qualifier<Object>) getCurrentQualifier(), methodName, argument, arguments, previous instanceof MethodSegment ms ? ms : null);
+                MethodSegment<?, ?> methodSegment = new MethodArgumentSegment(declaringType, (Qualifier<Object>) getCurrentQualifier(), methodName, argument, arguments, null);
                 if (contains(methodSegment)) {
                     push(methodSegment);
                     throw new CircularDependencyException(AbstractBeanResolutionContext.this, declaringType, methodName, argument, CIRCULAR_ERROR_MSG);
@@ -1050,28 +1047,72 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     }
 
     /**
-     * A segment that represents a method argument.
+     * A segment that represents a method argument. Its {@link #getOuterInjectionPoint()} is
+     * the method the argument belongs to: for an injected method that is the bean's
+     * {@link MethodInjectionPoint}, and for a factory method argument it is the bean's
+     * {@link ConstructorInjectionPoint}, as for a constructor argument.
      */
     public static final class MethodArgumentSegment extends MethodSegment<Object, Object> implements ArgumentInjectionPoint<Object, Object> {
         @Nullable
-        private final MethodSegment<Object, Object> outer;
+        private CallableInjectionPoint<Object> outer;
 
+        /**
+         * @param declaringType The declaring type
+         * @param qualifier     The qualifier
+         * @param methodName    The method name
+         * @param argument      The argument
+         * @param arguments     The arguments
+         * @param outer         The method the argument belongs to, or {@code null} to find it
+         *                      among the declaring type's methods on demand
+         */
         public MethodArgumentSegment(BeanDefinition<Object> declaringType,
                                      @Nullable Qualifier<Object> qualifier,
                                      String methodName,
                                      Argument<Object> argument,
                                      Argument<Object>[] arguments,
-                                     @Nullable MethodSegment<Object, Object> outer) {
+                                     @Nullable CallableInjectionPoint<Object> outer) {
             super(declaringType, qualifier, methodName, argument, arguments);
             this.outer = outer;
         }
 
+        /**
+         * The method this argument belongs to. When the segment was pushed without a
+         * {@link MethodInjectionPoint}, the declaring type's factory method and injected
+         * methods are searched for the method by name and arguments; when none matches (a
+         * setter that is not an injected method, for example) this segment, which is itself
+         * the {@link CallableInjectionPoint} of the method, is answered.
+         *
+         * @return The method the argument belongs to, never {@code null}
+         */
         @Override
         public CallableInjectionPoint<Object> getOuterInjectionPoint() {
+            CallableInjectionPoint<Object> outer = this.outer;
             if (outer == null) {
-                throw new IllegalStateException("Outer argument inaccessible");
+                outer = findMethod();
+                this.outer = outer;
             }
             return outer;
+        }
+
+        private CallableInjectionPoint<Object> findMethod() {
+            BeanDefinition<Object> declaringType = getDeclaringType();
+            ConstructorInjectionPoint<Object> constructor = declaringType.getConstructor();
+            if (isThisMethod(constructor)) {
+                // a factory method
+                return constructor;
+            }
+            for (MethodInjectionPoint<Object, ?> methodInjectionPoint : declaringType.getInjectedMethods()) {
+                if (isThisMethod(methodInjectionPoint)) {
+                    return methodInjectionPoint;
+                }
+            }
+            return this;
+        }
+
+        private boolean isThisMethod(@Nullable CallableInjectionPoint<Object> callable) {
+            return callable instanceof MethodInjectionPoint<?, ?> method
+                && getName().equals(method.getName())
+                && Arrays.equals(getArguments(), callable.getArguments());
         }
 
         @Override


### PR DESCRIPTION
`AbstractBeanResolutionContext.MethodArgumentSegment.getOuterInjectionPoint()` threw `IllegalStateException("Outer argument inaccessible")` for a plain `@Inject` method argument. Its `outer` was only set when the previous segment on the path happened to be a `MethodSegment`, and every production caller pushes method arguments through the `(BeanDefinition, String, Argument, Argument[])` overload with no `MethodInjectionPoint` at hand, so it was almost never set. When it was, it was the segment that led to resolving the bean, not the method the argument belongs to.

### Who needs it

Follow-up to #12970. A `BeanResolutionCustomizer` that reads `BeanResolutionContext.getPath()` can tell a field since then, because `FieldSegment` is a `FieldInjectionPoint` whose outer injection point is `null`. It still could not tell a constructor argument from a method argument without referring to the `@Internal` `ConstructorSegment` class: asking `getOuterInjectionPoint()` on an arbitrary segment blew up on a method argument, and `ConstructorSegment.getName()` is the bean type's name rather than `<init>`, so the name is no help either. The CDI integration in micronaut-cdi (`CdiInjectionPoint.of(Bean, Segment)`) is the caller that needs this: it maps each segment to a CDI `InjectionPoint` and has to know whether the member is a field, a constructor or a method.

### What changes

A `MethodArgumentSegment` now answers the method its argument belongs to, and never throws or returns `null`:

- The overload that receives a `MethodInjectionPoint` stores it as the outer.
- The name-and-arguments overloads store nothing; the segment finds the method on demand, so nothing is computed at push time and generated code is untouched. For an injected method that is the bean definition's `MethodInjectionPoint`, matched by name and arguments (the same array the generated code passes, so the comparison short-circuits on identity).
- For a factory method argument, which goes through `pushConstructorResolve`, it is the bean's `ConstructorInjectionPoint`, as `ConstructorSegment` already answers for a constructor argument.
- When nothing matches, such as a setter resolved through `getPropertyValueForSetter`, the segment answers itself, since it is already the `CallableInjectionPoint` of the method.

So a customizer can now do `outer == null` for a field, `outer instanceof ConstructorInjectionPoint` for a constructor (or factory method) argument, and `outer instanceof MethodInjectionPoint` for an injected method argument, from the public injection point hierarchy alone.

### Tests

`InjectionPointKindSpec` gains features that check the outer injection point of a constructor argument, an injected method argument and a factory method argument, both from the `InjectionPoint` a bean receives and from the segments a `BeanResolutionCustomizer` sees. The three new features fail with the `IllegalStateException` without the change.

`:micronaut-inject:test` (353 tests) and `:micronaut-inject-java:test` (5121 tests) pass. Checkstyle is disabled for `inject` in its build file; run by force with an init script, it reports nothing in the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
