### PR TITLE
Keep the singleton creation lock across a failed creation

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/concurrency/JavaConcurrentFailedSingletonCreationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/concurrency/JavaConcurrentFailedSingletonCreationSpec.groovy
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.concurrency
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanInstantiationException
+import spock.lang.Specification
+
+import java.lang.management.ManagementFactory
+import java.lang.management.ThreadInfo
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+/**
+ * Three threads ask for the same singleton: A is creating it, B is already blocked on the creation lock A holds,
+ * and C arrives only once A is done. The singleton must be constructed by exactly one of B and C whatever
+ * A's creation did.
+ */
+class JavaConcurrentFailedSingletonCreationSpec extends Specification {
+
+    private static final long TIMEOUT_MS = 10_000
+
+    void "a singleton is created once after a concurrent creation of it failed"() {
+        given:
+        SteppedSingleton.reset(true)
+        ApplicationContext context = ApplicationContext.run()
+        Map<String, Object> results = new ConcurrentHashMap<>()
+
+        when: "A starts creating the singleton and stops in its constructor"
+        Thread a = getBeanOn("A", context, results)
+
+        then:
+        SteppedSingleton.started[1].await(TIMEOUT_MS, SECONDS)
+
+        when: "B is blocked on the creation lock that A holds"
+        Thread b = getBeanOn("B", context, results)
+        int lockWaitedOnByB = awaitBlockedOnMonitorOf(b, a)
+
+        and: "A's construction fails"
+        SteppedSingleton.released[1].countDown()
+        a.join(TIMEOUT_MS)
+
+        then:
+        results.A instanceof BeanInstantiationException
+
+        when: "B goes on to construct the singleton and C arrives after the failed creation"
+        SteppedSingleton.started[2].await(TIMEOUT_MS, SECONDS)
+        Thread c = getBeanOn("C", context, results)
+        int lockWaitedOnByC = awaitBlockedOnMonitorOf(c, b, SteppedSingleton.started[3])
+
+        then: "C waits on the same lock as B did rather than constructing a second instance"
+        SteppedSingleton.CONSTRUCTIONS.get() == 2
+        lockWaitedOnByC == lockWaitedOnByB
+
+        when:
+        SteppedSingleton.released[2].countDown()
+        SteppedSingleton.released[3].countDown()
+        b.join(TIMEOUT_MS)
+        c.join(TIMEOUT_MS)
+
+        then:
+        results.B instanceof SteppedSingleton
+        results.C.is(results.B)
+        context.getBean(SteppedSingleton).is(results.B)
+        SteppedSingleton.CONSTRUCTIONS.get() == 2
+
+        cleanup:
+        context.close()
+    }
+
+    void "a singleton is created once when the concurrent creation of it succeeded"() {
+        given:
+        SteppedSingleton.reset(false)
+        ApplicationContext context = ApplicationContext.run()
+        Map<String, Object> results = new ConcurrentHashMap<>()
+
+        when: "A starts creating the singleton and stops in its constructor"
+        Thread a = getBeanOn("A", context, results)
+
+        then:
+        SteppedSingleton.started[1].await(TIMEOUT_MS, SECONDS)
+
+        when: "B is blocked on the creation lock that A holds, then A's construction completes"
+        Thread b = getBeanOn("B", context, results)
+        awaitBlockedOnMonitorOf(b, a)
+        SteppedSingleton.released[1].countDown()
+        a.join(TIMEOUT_MS)
+        b.join(TIMEOUT_MS)
+
+        and: "C arrives after the creation"
+        Thread c = getBeanOn("C", context, results)
+        c.join(TIMEOUT_MS)
+
+        then:
+        results.A instanceof SteppedSingleton
+        results.B.is(results.A)
+        results.C.is(results.A)
+        context.getBean(SteppedSingleton).is(results.A)
+        SteppedSingleton.CONSTRUCTIONS.get() == 1
+
+        cleanup:
+        context.close()
+    }
+
+    private static Thread getBeanOn(String name, ApplicationContext context, Map<String, Object> results) {
+        Thread thread = new Thread({
+            try {
+                results[name] = context.getBean(SteppedSingleton)
+            } catch (Throwable e) {
+                results[name] = e
+            }
+        }, name)
+        thread.start()
+        return thread
+    }
+
+    /**
+     * Waits until the thread is blocked on a plain {@link Object} monitor owned by the owner, or until the given
+     * latch, if any, is counted down.
+     *
+     * @return The identity hash code of the monitor the thread is blocked on, or -1 if the latch was counted down first
+     */
+    private static int awaitBlockedOnMonitorOf(Thread thread, Thread owner, CountDownLatch orUntil = null) {
+        long deadline = System.currentTimeMillis() + TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline) {
+            if (orUntil != null && orUntil.count == 0) {
+                return -1
+            }
+            ThreadInfo info = ManagementFactory.getThreadMXBean().getThreadInfo(thread.id)
+            if (info != null && info.lockOwnerId == owner.id && info.lockInfo?.className == Object.name) {
+                return info.lockInfo.identityHashCode
+            }
+            Thread.sleep(5)
+        }
+        throw new IllegalStateException("$thread.name did not get blocked on a monitor of $owner.name")
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/concurrency/SteppedSingleton.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/concurrency/SteppedSingleton.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.concurrency;
+
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A singleton whose constructions are stepped by the test: the n-th construction reports that it has started,
+ * waits to be released, and then either completes or, for the first one when so configured, throws.
+ */
+@Singleton
+public class SteppedSingleton {
+
+    static final int MAX_CONSTRUCTIONS = 5;
+    static final AtomicInteger CONSTRUCTIONS = new AtomicInteger();
+    static volatile boolean failFirst;
+    static volatile CountDownLatch[] started;
+    static volatile CountDownLatch[] released;
+
+    public SteppedSingleton() {
+        if (started == null) {
+            // Not stepped: constructed by another spec, for example through the eager initialization of singletons
+            return;
+        }
+        int n = CONSTRUCTIONS.incrementAndGet();
+        started[n].countDown();
+        try {
+            released[n].await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+        if (n == 1 && failFirst) {
+            throw new IllegalStateException("The first construction fails");
+        }
+    }
+
+    static void reset(boolean failFirst) {
+        SteppedSingleton.failFirst = failFirst;
+        CONSTRUCTIONS.set(0);
+        started = new CountDownLatch[MAX_CONSTRUCTIONS + 1];
+        released = new CountDownLatch[MAX_CONSTRUCTIONS + 1];
+        for (int i = 0; i <= MAX_CONSTRUCTIONS; i++) {
+            started[i] = new CountDownLatch(1);
+            released[i] = new CountDownLatch(1);
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -40,7 +40,8 @@ import java.util.concurrent.ConcurrentHashMap;
 final class SingletonScope {
 
     /**
-     * The locks used to prevent re-creating of the same singleton.
+     * The locks used to prevent re-creating of the same singleton. A lock stays until the singleton is registered,
+     * across any creation of it that failed.
      */
     private final Map<BeanDefinitionIdentity, Object> singletonsInCreationLocks = new ConcurrentHashMap<>(5, 1);
 
@@ -70,17 +71,18 @@ final class SingletonScope {
         }
         Object lock = singletonsInCreationLocks.computeIfAbsent(identity, beanDefinitionIdentity -> new Object());
         synchronized (lock) {
-            try {
-                existingRegistration = singletonByBeanDefinition.get(identity);
-                if (existingRegistration != null) {
-                    return existingRegistration;
-                }
-                BeanRegistration<T> newRegistration = beanContext.createRegistration(resolutionContext, beanType, qualifier, definition, false);
-                registerSingletonBean(newRegistration, qualifier);
-                return newRegistration;
-            } finally {
-                singletonsInCreationLocks.remove(identity);
+            existingRegistration = singletonByBeanDefinition.get(identity);
+            if (existingRegistration != null) {
+                singletonsInCreationLocks.remove(identity, lock);
+                return existingRegistration;
             }
+            BeanRegistration<T> newRegistration = beanContext.createRegistration(resolutionContext, beanType, qualifier, definition, false);
+            registerSingletonBean(newRegistration, qualifier);
+            // The lock is only let go of once the registration is in the map. A creation that threw keeps it,
+            // so that the threads blocked on it and the ones yet to arrive contend for the same object: were it
+            // removed, a newcomer would get a fresh lock and create the singleton alongside a waiter on the old one.
+            singletonsInCreationLocks.remove(identity, lock);
+            return newRegistration;
         }
     }
 


### PR DESCRIPTION
`SingletonScope.getOrCreate` removed the per-definition creation lock in a `finally`, so a creation that threw removed it too. A thread already blocked on that lock kept the old object, while a thread arriving after the removal got a fresh one from `computeIfAbsent`. Both then found the registration map empty and both created the singleton.

The lock now stays in the map until a registration for the definition is in place. It is removed once the singleton is registered, or once a thread finds it already registered, so a failed creation leaves every contender serialising on the same object. The fast path before the lock is unchanged.

## Reproduction

`JavaConcurrentFailedSingletonCreationSpec` steps three threads through `getBean` of a singleton whose constructor stops on a latch and throws on its first construction:

1. Thread A enters the constructor and stops.
2. Thread B calls `getBean` and is blocked on the monitor A holds (checked through `ThreadMXBean`, so the spec waits for the state rather than sleeping).
3. A's construction is released and fails with `BeanInstantiationException`. B proceeds into the second construction and stops there.
4. Thread C calls `getBean`.

On 5.2.x the spec fails at step 4 with a third construction while the second is still in progress:

```
SteppedSingleton.CONSTRUCTIONS.get() == 2
|                |             |     |
|                3             3     false
```

Letting both constructions complete shows the outcome: B and C receive different instances, `getBean` afterwards returns C's (the last one registered), and B's instance is handed out but is not in the registrations, so its `@PreDestroy` never runs.

With the fix, C blocks on the same monitor B waited on, the singleton is constructed once by B, and A, B, C and a later `getBean` all see that instance.

A second feature in the spec documents the successful case, which was already correct: with A's creation completing, B re-checks the map under the old lock and finds the registration, and C finds it on the fast path. One construction either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
