### PR TITLE
Close every bean of a per-bean-locked scope before taking any out

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanLockingScopeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanLockingScopeSpec.groovy
@@ -152,4 +152,20 @@ class PerBeanLockingScopeSpec extends Specification {
         context.getBean(PerBeanScopeImpl).findBeanRegistration(bean).get().bean.is(bean)
         context.findBeanRegistration(bean).present
     }
+
+    void "under a lock per bean a destruction that resolves another bean of the scope reaches the instance held"() {
+        given: "two beans of the scope, each resolving the other as it is destroyed"
+        def referrer = context.getBean(PerBeanReferrer)
+        def referent = context.getBean(PerBeanReferent)
+        def constructions = PerBeanReferent.CONSTRUCTIONS.get()
+
+        when: "the scope is destroyed"
+        context.getBean(PerBeanScopeImpl).close()
+
+        then: "whichever was destroyed first, the other reached the instance the scope held, not a fresh one"
+        referrer.resolvedOnDestroy.is(referent)
+        referent.resolvedOnDestroy.is(referrer)
+        PerBeanReferent.CONSTRUCTIONS.get() == constructions
+        context.getBean(PerBeanScopeImpl).beans.isEmpty()
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanReferent.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanReferent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.scope.custom.perbean;
+
+import io.micronaut.context.BeanContext;
+import jakarta.annotation.PreDestroy;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The bean {@link PerBeanReferrer} resolves as it is destroyed, which resolves the referrer back as it is destroyed
+ * itself, so that whichever the scope destroys first reaches the other.
+ */
+@PerBeanScope
+public class PerBeanReferent {
+
+    public static final AtomicInteger CONSTRUCTIONS = new AtomicInteger();
+
+    private final BeanContext beanContext;
+    private PerBeanReferrer resolvedOnDestroy;
+
+    public PerBeanReferent(BeanContext beanContext) {
+        this.beanContext = beanContext;
+        CONSTRUCTIONS.incrementAndGet();
+    }
+
+    @PreDestroy
+    void destroy() {
+        resolvedOnDestroy = beanContext.getBean(PerBeanReferrer.class);
+    }
+
+    public PerBeanReferrer getResolvedOnDestroy() {
+        return resolvedOnDestroy;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanReferrer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/perbean/PerBeanReferrer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.scope.custom.perbean;
+
+import io.micronaut.context.BeanContext;
+import jakarta.annotation.PreDestroy;
+
+/**
+ * A bean of the per-bean-locked scope whose destruction resolves another bean of the scope.
+ */
+@PerBeanScope
+public class PerBeanReferrer {
+
+    private final BeanContext beanContext;
+    private PerBeanReferent resolvedOnDestroy;
+
+    public PerBeanReferrer(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @PreDestroy
+    void destroy() {
+        resolvedOnDestroy = beanContext.getBean(PerBeanReferent.class);
+    }
+
+    public PerBeanReferent getResolvedOnDestroy() {
+        return resolvedOnDestroy;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
@@ -28,8 +28,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -67,6 +68,13 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
      * see an empty map, finish, and leave the bean that the creation then publishes to be never destroyed.
      */
     private final ConcurrentMap<BeanIdentifier, Map<BeanIdentifier, CreatedBean<?>>> creationsInFlight = new ConcurrentHashMap<>();
+
+    /**
+     * The beans a destruction in the {@code lockPerBean} mode is closing, while they are still held: a bean is
+     * closed while the scope holds all of them and taken out afterwards, so a second destruction running at the
+     * same time must not close it again.
+     */
+    private final Set<CreatedBean<?>> closing = ConcurrentHashMap.newKeySet();
 
     /**
      * A custom scope annotation.
@@ -487,54 +495,57 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
         return null;
     }
 
-    /**
-     * The identifier of any one entry of the map, or {@code null} where it holds none.
-     *
-     * @param scopeMap The scope map
-     * @return An identifier, or {@code null}
-     */
-    @Nullable
-    private static BeanIdentifier firstIdentifierOf(Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
-        final Iterator<BeanIdentifier> identifiers = scopeMap.keySet().iterator();
-        return identifiers.hasNext() ? identifiers.next() : null;
-    }
-
-    /**
-     * The identifier of the next bean a destruction of the given scope map has to take out: one the map holds, or
-     * failing that one whose creation into the map is in flight, or {@code null} where there is neither.
-     *
-     * @param scopeMap The scope map
-     * @return An identifier, or {@code null}
-     */
-    @Nullable
-    private BeanIdentifier nextIdentifierToDestroy(Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
-        final BeanIdentifier held = firstIdentifierOf(scopeMap);
-        return held != null ? held : identifierInFlightFor(scopeMap, Set.of());
-    }
-
     private void destroyScopeLockingPerBean(@Nullable Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
         if (scopeMap == null) {
             return;
         }
-        // the map is drained rather than cleared: each entry is taken out before it is closed, so that two
-        // destructions of one map close each bean once, and a bean that another thread put there while the
-        // destruction runs is closed by the pass that finds it instead of being dropped by a clear(). Nothing
-        // holds creation off in this mode, so the drain repeats until the map stays empty and no creation into
-        // it is in flight; a creation that is in flight is waited for on its identifier's lock and the bean it
-        // publishes is then taken out, rather than being left behind by a drain that saw an empty map
-        for (BeanIdentifier id = nextIdentifierToDestroy(scopeMap); id != null; id = nextIdentifierToDestroy(scopeMap)) {
-            final CreatedBean<?> createdBean;
-            // under the identifier's lock, so that a creation of it in flight is waited for and then taken out
-            synchronized (creationLocks.computeIfAbsent(id, key -> new Object())) {
-                createdBean = scopeMap.remove(id);
-            }
-            if (createdBean != null) {
-                try {
-                    createdBean.close();
-                } catch (BeanDestructionException e) {
-                    handleDestructionException(e);
+        // every bean of a pass is closed while the map still holds all of them, and only then taken out: a
+        // destruction that resolves another bean of the scope - a @PreDestroy reaching a collaborator, a
+        // pre-destroy listener asking for one - then reaches the instance the scope holds, as it does under the
+        // scope-wide lock, rather than a fresh one created into a scope on its way out. Nothing holds creation
+        // off in this mode, so the pass repeats until the map stays empty and no creation into it is in
+        // flight: a bean another thread put there meanwhile is closed by the pass that finds it, and a creation
+        // in flight is waited for on its identifier's lock and the bean it publishes is closed then. Two
+        // destructions of one map running at once close each bean once: the one that marks it as closing
+        // closes it, the other leaves it alone and finds it gone
+        while (true) {
+            final List<CreatedBean<?>> closedInThisPass = new ArrayList<>();
+            for (CreatedBean<?> createdBean : new ArrayList<>(scopeMap.values())) {
+                if (closing.add(createdBean)) {
+                    closeQuietly(createdBean);
+                    closedInThisPass.add(createdBean);
                 }
             }
+            for (BeanIdentifier id = identifierInFlightFor(scopeMap, Set.of()); id != null; id = identifierInFlightFor(scopeMap, Set.of())) {
+                final CreatedBean<?> published;
+                // under the identifier's lock, so that the creation in flight is waited for and what it published is seen
+                synchronized (creationLocks.computeIfAbsent(id, key -> new Object())) {
+                    published = scopeMap.get(id);
+                }
+                if (published != null && closing.add(published)) {
+                    closeQuietly(published);
+                    closedInThisPass.add(published);
+                }
+            }
+            if (closedInThisPass.isEmpty()) {
+                // nothing held, nothing in flight, and nothing another destruction is not already closing
+                return;
+            }
+            for (CreatedBean<?> closedBean : closedInThisPass) {
+                // under the identifier's lock, so that a creation racing this take-out is not taken out unclosed
+                synchronized (creationLocks.computeIfAbsent(closedBean.id(), key -> new Object())) {
+                    scopeMap.remove(closedBean.id(), closedBean);
+                }
+                closing.remove(closedBean);
+            }
+        }
+    }
+
+    private void closeQuietly(CreatedBean<?> createdBean) {
+        try {
+            createdBean.close();
+        } catch (BeanDestructionException e) {
+            handleDestructionException(e);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
@@ -72,9 +72,11 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
     /**
      * The beans a destruction in the {@code lockPerBean} mode is closing, while they are still held: a bean is
      * closed while the scope holds all of them and taken out afterwards, so a second destruction running at the
-     * same time must not close it again.
+     * same time must not close it again. Held by identity, since one scope has a map per context - a request
+     * scope has one per request - and {@link BeanRegistration} equals another of the same identifier and
+     * definition, so beans of two maps destroyed at once would otherwise be taken for one.
      */
-    private final Set<CreatedBean<?>> closing = ConcurrentHashMap.newKeySet();
+    private final Set<IdentityKey> closing = ConcurrentHashMap.newKeySet();
 
     /**
      * A custom scope annotation.
@@ -511,7 +513,7 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
         while (true) {
             final List<CreatedBean<?>> closedInThisPass = new ArrayList<>();
             for (CreatedBean<?> createdBean : new ArrayList<>(scopeMap.values())) {
-                if (closing.add(createdBean)) {
+                if (closing.add(new IdentityKey(createdBean))) {
                     closeQuietly(createdBean);
                     closedInThisPass.add(createdBean);
                 }
@@ -522,7 +524,7 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
                 synchronized (creationLocks.computeIfAbsent(id, key -> new Object())) {
                     published = scopeMap.get(id);
                 }
-                if (published != null && closing.add(published)) {
+                if (published != null && closing.add(new IdentityKey(published))) {
                     closeQuietly(published);
                     closedInThisPass.add(published);
                 }
@@ -532,11 +534,14 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
                 return;
             }
             for (CreatedBean<?> closedBean : closedInThisPass) {
-                // under the identifier's lock, so that a creation racing this take-out is not taken out unclosed
+                // under the identifier's lock, so that a creation racing this take-out is not taken out unclosed,
+                // and by identity, so that a bean the racing creation published is not taken for the closed one
                 synchronized (creationLocks.computeIfAbsent(closedBean.id(), key -> new Object())) {
-                    scopeMap.remove(closedBean.id(), closedBean);
+                    if (scopeMap.get(closedBean.id()) == closedBean) {
+                        scopeMap.remove(closedBean.id());
+                    }
                 }
-                closing.remove(closedBean);
+                closing.remove(new IdentityKey(closedBean));
             }
         }
     }
@@ -610,6 +615,26 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
             return unwrap(delegatingBeanDefinition.getTarget());
         }
         return beanDefinition;
+    }
+
+    /**
+     * A key that holds a bean by identity, so that two distinct beans that are equal - two
+     * {@link BeanRegistration} of one identifier and definition, held by the maps of two contexts of one scope -
+     * are two keys.
+     *
+     * @param createdBean The bean
+     */
+    private record IdentityKey(CreatedBean<?> createdBean) {
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof IdentityKey other && other.createdBean == createdBean;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(createdBean);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
@@ -313,6 +313,31 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         scope.scopeMap.isEmpty()
     }
 
+    void "under a lock per bean two maps destroyed at once each close their own bean"() {
+        given: "two maps of one scope, each holding a bean that equals the other, as two BeanRegistration of one identifier and definition do"
+        def scope = new TestScope(true)
+        def other = new ConcurrentHashMap<BeanIdentifier, CreatedBean<?>>()
+        def id = BeanIdentifier.of("shared")
+        def first = new EqualByIdentifierCreatedBean(id: id, bean: new Object())
+        def second = new EqualByIdentifierCreatedBean(id: id, bean: new Object())
+        scope.scopeMap.put(id, first)
+        other.put(id, second)
+        def otherDestroyed = new CountDownLatch(1)
+        first.onClose = {
+            Thread.start { scope.destroyScope(other); otherDestroyed.countDown() }
+            assert otherDestroyed.await(5, TimeUnit.SECONDS): "the destruction of the other map should not wait for this one"
+        }
+
+        when: "the other map is destroyed while this one is closing its own bean"
+        scope.destroyScope(scope.scopeMap)
+
+        then: "the bean of the other map is closed and taken out, not taken for the one already being closed"
+        first.closed
+        second.closed
+        scope.scopeMap.isEmpty()
+        other.isEmpty()
+    }
+
     void "under a lock per bean the scope map must be a concurrent map"() {
         given:
         def scope = new TestScope(true, new HashMap<BeanIdentifier, CreatedBean<?>>())
@@ -647,6 +672,23 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
             def createdBean = new TestCreatedBean(id: id, bean: new Object(), definition: definition, failToClose: failToClose)
             created << createdBean
             return createdBean
+        }
+    }
+
+    /**
+     * A created bean that equals another of the same identifier, as {@link io.micronaut.context.BeanRegistration}
+     * equals another of the same identifier and definition, however distinct the instances they hold are.
+     */
+    static class EqualByIdentifierCreatedBean extends TestCreatedBean {
+
+        @Override
+        boolean equals(Object o) {
+            return o instanceof EqualByIdentifierCreatedBean && ((EqualByIdentifierCreatedBean) o).id == id
+        }
+
+        @Override
+        int hashCode() {
+            return id.hashCode()
         }
     }
 

--- a/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
@@ -267,6 +267,52 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         latecomer.isEmpty()
     }
 
+    void "under a lock per bean a destruction that resolves another bean of the scope reaches the instance held"() {
+        given: "two beans, each of which resolves the other as it is destroyed"
+        def scope = new TestScope(true)
+        def firstContext = new TestCreationContext(BeanIdentifier.of("first"))
+        def secondContext = new TestCreationContext(BeanIdentifier.of("second"))
+        def first = scope.getOrCreate(firstContext)
+        def second = scope.getOrCreate(secondContext)
+        def resolvedByFirst = null
+        def resolvedBySecond = null
+        firstContext.created[0].onClose = { resolvedByFirst = scope.getOrCreate(secondContext) }
+        secondContext.created[0].onClose = { resolvedBySecond = scope.getOrCreate(firstContext) }
+
+        when:
+        scope.destroyScope(scope.scopeMap)
+
+        then: "whichever is destroyed first, the other reaches the instance the scope held, not a fresh one"
+        resolvedByFirst.is(second)
+        resolvedBySecond.is(first)
+        firstContext.created.size() == 1
+        secondContext.created.size() == 1
+        firstContext.created[0].closed
+        secondContext.created[0].closed
+        scope.scopeMap.isEmpty()
+    }
+
+    void "under a lock per bean two destructions of one map close each bean once"() {
+        given: "a bean whose destruction lets a second destruction of the map run to the end"
+        def scope = new TestScope(true)
+        def secondDestructionDone = new CountDownLatch(1)
+        def context = new TestCreationContext(BeanIdentifier.of("slow"))
+        scope.getOrCreate(context)
+        def closings = new java.util.concurrent.atomic.AtomicInteger()
+        context.created[0].onClose = {
+            closings.incrementAndGet()
+            Thread.start { scope.destroyScope(scope.scopeMap); secondDestructionDone.countDown() }
+            assert secondDestructionDone.await(5, TimeUnit.SECONDS): "the second destruction should not wait for the first"
+        }
+
+        when:
+        scope.destroyScope(scope.scopeMap)
+
+        then:
+        closings.get() == 1
+        scope.scopeMap.isEmpty()
+    }
+
     void "under a lock per bean the scope map must be a concurrent map"() {
         given:
         def scope = new TestScope(true, new HashMap<BeanIdentifier, CreatedBean<?>>())
@@ -495,11 +541,22 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         @Override
         CreatedBean<?> remove(Object key) {
             def removed = delegate.remove(key)
+            arrive()
+            return removed
+        }
+
+        @Override
+        boolean remove(Object key, Object value) {
+            def removed = delegate.remove(key, value)
+            arrive()
+            return removed
+        }
+
+        private void arrive() {
             if (!arrived) {
                 arrived = true
                 delegate.put(late.id(), late)
             }
-            return removed
         }
     }
 
@@ -600,6 +657,7 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         BeanDefinition<Object> definition
         boolean closed
         boolean failToClose
+        Runnable onClose = {}
 
         @Override
         BeanDefinition<Object> definition() {
@@ -619,6 +677,7 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         @Override
         void close() {
             closed = true
+            onClose.run()
             if (failToClose) {
                 throw new BeanDestructionException(definition, new IllegalStateException("destroy failed on purpose"))
             }


### PR DESCRIPTION
## What

`AbstractConcurrentCustomScope` in the `lockPerBean` mode (#12973, #13008) destroyed a scope by taking each bean out of the map and then closing it, one at a time. The scope-wide mode closes every bean while the map still holds all of them and clears afterwards. The two orders disagree, and the per-bean order breaks a destruction that resolves another bean of the same scope.

## Why it matters

A `@PreDestroy` reaching a collaborator of the same scope, or a `BeanPreDestroyEventListener` asking for one (a CDI disposer method does exactly this), resolves it through `getOrCreate`. In the per-bean order the collaborator has already been taken out, so the resolution creates a **fresh instance into a scope that is being destroyed** instead of handing back the one the scope held. When two beans resolve each other on destruction, the drain re-creates and destroys them in turn and **never terminates**: the added `PerBeanLockingScopeSpec` case runs for as long as the build lets it on the current code (a thread dump shows `destroyScopeLockingPerBean` → `close` → `getBean` → `getOrCreateLockingPerBean` → `doCreate`, round and round).

Found from micronaut-cdi, whose `StaticDisposerTest` audits into a fresh application-scoped bean once its scopes opt into `lockPerBean`.

## The change

`destroyScopeLockingPerBean` now runs in passes:

1. close every bean the map holds, while all of them are still held;
2. wait, under its identifier's lock, for each creation in flight into this map and close what it published (the #13008 guarantee, kept);
3. take out what was closed, each under its identifier's lock so a creation racing the take-out is not removed unclosed;
4. repeat until a pass closes nothing — nothing held, nothing in flight.

Two destructions of one map running at once close each bean once: a `closing` set marks a bean while it is closed-but-held, and the other destruction leaves it alone and finds it gone. `nextIdentifierToDestroy`/`firstIdentifierOf` are no longer needed.

## Tests

- `AbstractConcurrentCustomScopeSpec`: "a destruction that resolves another bean of the scope reaches the instance held" (fails on 5.2.x: the second bean destroyed reaches a fresh first one), and "two destructions of one map close each bean once". The latecomer fixture now reacts to the two-argument `remove` as well, so "a bean put there while the scope is destroyed is closed, not dropped" still exercises the in-flight path.
- `PerBeanLockingScopeSpec`: "a destruction that resolves another bean of the scope reaches the instance held", with two `@PerBeanScope` beans whose `@PreDestroy` resolve each other; does not terminate on 5.2.x.
- `:micronaut-inject:test --tests 'io.micronaut.context.scope.*'` (26) and `:micronaut-inject-java:test --tests 'io.micronaut.inject.scope.*' --tests 'io.micronaut.inject.lifecycle.*'` (97) pass; `:micronaut-inject:checkstyleMain` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
