### PR TITLE
Do not register an implicit HEAD route when an explicit @Head maps to the same URI

### DIFF
--- a/http/src/main/java/io/micronaut/http/annotation/Get.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Get.java
@@ -97,7 +97,9 @@ public @interface Get {
     boolean single() default false;
 
     /**
-     * @return True if a HEAD route should also be registered for the same method
+     * @return True if a HEAD route should also be registered for the same method. If the
+     * controller declares an explicit {@link Head} route for the same URI, the implicit
+     * HEAD route is not registered for that URI and the explicit one takes precedence.
      */
     boolean headRoute() default true;
 }

--- a/router/src/main/java/io/micronaut/web/router/AnnotatedMethodRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/AnnotatedMethodRouteBuilder.java
@@ -81,9 +81,8 @@ public class AnnotatedMethodRouteBuilder extends DefaultRouteBuilder implements 
             Set<String> uris = this.resolveUrisMapping(Get.class, method);
             for (String uri: uris) {
                 MediaType[] produces = resolveProduces(method);
-                UriRoute route = GET(resolveUri(bean, uri,
-                        method,
-                        uriNamingStrategy),
+                String resolvedUri = resolveUri(bean, uri, method, uriNamingStrategy);
+                UriRoute route = GET(resolvedUri,
                         bean,
                         method).produces(produces);
 
@@ -93,10 +92,15 @@ public class AnnotatedMethodRouteBuilder extends DefaultRouteBuilder implements 
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Created Route: {}", route);
                 }
-                if (method.booleanValue(Get.class, "headRoute").orElse(true)) {
-                    route = HEAD(resolveUri(bean, uri,
-                            method,
-                            uriNamingStrategy),
+                // Only auto-create an implicit HEAD route for this GET method if the
+                // controller does not already declare an explicit @Head method for the
+                // exact same URI. Otherwise, two HEAD routes would match the same request
+                // (this implicit one and the explicit one), and since neither is more specific
+                // than the other, the router cannot resolve the ambiguity and rejects the
+                // request as a duplicate route (see DuplicateRouteException / HTTP 400).
+                if (method.booleanValue(Get.class, "headRoute").orElse(true)
+                        && !hasExplicitHeadMapping(bean, resolvedUri)) {
+                    route = HEAD(resolvedUri,
                             bean,
                             method).produces(produces);
                     if (definition.port > -1) {
@@ -349,6 +353,31 @@ public class AnnotatedMethodRouteBuilder extends DefaultRouteBuilder implements 
                 }
             }
         );
+    }
+
+    /**
+     * Determines whether the given bean declares an explicit {@link Head}-mapped method
+     * for the given, already-resolved URI. Used to prevent registering an implicit HEAD
+     * route (auto-derived from a {@code @Get} method) that would otherwise collide with a
+     * user-defined {@code @Head} route mapped to the exact same URI.
+     *
+     * @param bean The bean definition being processed
+     * @param resolvedUri The fully resolved URI of the candidate implicit HEAD route
+     * @return {@code true} if an explicit {@code @Head} route already exists for {@code resolvedUri}
+     */
+    private boolean hasExplicitHeadMapping(BeanDefinition<?> bean, String resolvedUri) {
+        for (ExecutableMethod<?, ?> candidate : bean.getExecutableMethods()) {
+            if (candidate.getAnnotationTypeByStereotype(HttpMethodMapping.class)
+                    .filter(Head.class::equals)
+                    .isPresent()) {
+                for (String headUri : resolveUrisMapping(Head.class, candidate)) {
+                    if (resolveUri(bean, headUri, candidate, uriNamingStrategy).equals(resolvedUri)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private Set<String> resolveUrisMapping(Class<? extends Annotation> httpMethod, ExecutableMethod method) {

--- a/router/src/test/groovy/io/micronaut/context/router/HeadGetSameUriRouteBuilderSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/context/router/HeadGetSameUriRouteBuilderSpec.groovy
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.router
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Head
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.web.router.Router
+import io.micronaut.web.router.UriRouteMatch
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * A controller that declares an explicit {@code @Head} method AND a {@code @Get} method for
+ * the exact same URI used to be broken: the router auto-registers an implicit HEAD route for
+ * every {@code @Get} method (so that a bare GET handler also answers HEAD requests). When an
+ * explicit {@code @Head} route existed for the identical URI, that gave the router two HEAD
+ * routes matching the same request with nothing to break the tie (same path template,
+ * same specificity), so route resolution failed with a {@code DuplicateRouteException},
+ * which the server translates into an HTTP 400 response.
+ */
+@Issue("https://github.com/micronaut-projects/micronaut-core/issues/13020")
+class HeadGetSameUriRouteBuilderSpec extends Specification {
+
+    void "an explicit @Head route is used - not the implicit HEAD route generated for @Get - when both map to the same URI"() {
+        given:
+        Router router = ApplicationContext.builder("test").build().start().getBean(Router)
+
+        when: "resolving a HEAD request the same way the HTTP server does"
+        UriRouteMatch<Object, Object> match = router.findClosest(HttpRequest.HEAD("/domainNames/example.dummy/availability"))
+
+        then: "the route is resolved unambiguously (previously threw DuplicateRouteException -> HTTP 400)"
+        noExceptionThrown()
+        match != null
+
+        when:
+        HttpResponse<?> result = match.invoke("example.dummy") as HttpResponse<?>
+
+        then: "the explicitly annotated @Head method handles the request, not the @Get method"
+        result.status().code == 200
+        result.header("X-Handler") == "head"
+    }
+
+    void "GET requests for the same URI still route to the @Get method"() {
+        given:
+        Router router = ApplicationContext.builder("test").build().start().getBean(Router)
+
+        when:
+        UriRouteMatch<Object, Object> match = router.findClosest(HttpRequest.GET("/domainNames/example.dummy/availability"))
+        HttpResponse<?> result = match.invoke("example.dummy") as HttpResponse<?>
+
+        then:
+        match != null
+        result.status().code == 200
+        result.header("X-Handler") == "get"
+    }
+
+    void "an explicit @Head on one of multiple @Get uris only suppresses the implicit HEAD for that URI"() {
+        given:
+        Router router = ApplicationContext.builder("test").build().start().getBean(Router)
+
+        when: "HEAD on the URI shared with @Head"
+        UriRouteMatch<Object, Object> headMatch = router.findClosest(HttpRequest.HEAD("/multi/example.dummy/availability"))
+
+        then:
+        noExceptionThrown()
+        headMatch != null
+        HttpResponse<?> headResult = headMatch.invoke("example.dummy") as HttpResponse<?>
+        headResult.status().code == 200
+        headResult.header("X-Handler") == "head"
+
+        when: "HEAD on a sibling URI from @Get(uris=[...]) without an explicit @Head"
+        UriRouteMatch<Object, Object> implicitMatch = router.findClosest(HttpRequest.HEAD("/multi/example.dummy/stock"))
+
+        then: "the implicit HEAD route is still registered and routes to the @Get method"
+        noExceptionThrown()
+        implicitMatch != null
+        HttpResponse<?> implicitResult = implicitMatch.invoke("example.dummy") as HttpResponse<?>
+        implicitResult.status().code == 200
+        implicitResult.header("X-Handler") == "get"
+    }
+
+    void "@Get(headRoute = false) with a sibling @Head on the same URI registers only the explicit @Head"() {
+        given:
+        Router router = ApplicationContext.builder("test").build().start().getBean(Router)
+
+        when:
+        UriRouteMatch<Object, Object> headMatch = router.findClosest(HttpRequest.HEAD("/noimplicit/example.dummy/availability"))
+        HttpResponse<?> headResult = headMatch.invoke("example.dummy") as HttpResponse<?>
+
+        then:
+        noExceptionThrown()
+        headMatch != null
+        headResult.status().code == 200
+        headResult.header("X-Handler") == "head"
+
+        when: "GET still routes to the @Get method"
+        UriRouteMatch<Object, Object> getMatch = router.findClosest(HttpRequest.GET("/noimplicit/example.dummy/availability"))
+        HttpResponse<?> getResult = getMatch.invoke("example.dummy") as HttpResponse<?>
+
+        then:
+        getMatch != null
+        getResult.status().code == 200
+        getResult.header("X-Handler") == "get"
+    }
+
+    @Controller("/domainNames")
+    static class DomainNameController {
+
+        @Head("/{id}/availability")
+        HttpResponse<?> availableSimple(@PathVariable("id") String id) {
+            return HttpResponse.ok().header("X-Handler", "head")
+        }
+
+        @Get("/{id}/availability")
+        HttpResponse<?> availableAdditional(@PathVariable String id) {
+            return HttpResponse.ok().header("X-Handler", "get")
+        }
+    }
+
+    @Controller("/multi")
+    static class MultiUriController {
+
+        @Head("/{id}/availability")
+        HttpResponse<?> available(@PathVariable("id") String id) {
+            return HttpResponse.ok().header("X-Handler", "head")
+        }
+
+        @Get(uris = ["/{id}/availability", "/{id}/stock"])
+        HttpResponse<?> getOrHead(@PathVariable("id") String id) {
+            return HttpResponse.ok().header("X-Handler", "get")
+        }
+    }
+
+    @Controller("/noimplicit")
+    static class NoImplicitHeadController {
+
+        @Head("/{id}/availability")
+        HttpResponse<?> available(@PathVariable("id") String id) {
+            return HttpResponse.ok().header("X-Handler", "head")
+        }
+
+        @Get(value = "/{id}/availability", headRoute = false)
+        HttpResponse<?> get(@PathVariable("id") String id) {
+            return HttpResponse.ok().header("X-Handler", "get")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13020

## Summary

A controller that declares both an explicit `@Head` and a `@Get` for the **same URI** served `GET`
requests fine but answered `HEAD` with **400 Bad Request**:

```java
@Head("/{id}/availability")  HttpResponse<?> availableSimple(...) { ... }
@Get ("/{id}/availability")  HttpResponse<?> availableAdditional(...) { ... }
```

This PR stops the duplicate `HEAD` route from being registered in the first place. The fix is at
route-build time in `AnnotatedMethodRouteBuilder`; no runtime resolution logic changes.

## Root cause

`AnnotatedMethodRouteBuilder` auto-registers an **implicit `HEAD` route** for every `@Get` method
(so a bare GET handler also answers HEAD), in addition to the developer's explicit `@Head` route.
When both target the identical resolved URI, the route table ends up with **two `HEAD` routes whose
path templates are literally identical**. At request time `DefaultRouter.findClosest()` filters by
method and content negotiation, then reaches `resolveAmbiguity()` to break the tie — but equal
templates have equal specificity, nothing breaks the tie, and resolution throws
`DuplicateRouteException`, which the server translates into the observed 400.

## The fix

`router/.../AnnotatedMethodRouteBuilder.java`:

1. **Resolve the URI once** per `@Get` iteration (it was resolved twice with identical inputs) and
   reuse it for the GET route and the implicit-HEAD decision.
2. **Guard the implicit HEAD route** so it is only registered when the controller does not already
   declare an explicit `@Head` for that exact URI:

```java
if (method.booleanValue(Get.class, "headRoute").orElse(true)
        && !hasExplicitHeadMapping(bean, resolvedUri)) {
    route = HEAD(resolvedUri, bean, method).produces(produces);
    ...
}
```

3. **`hasExplicitHeadMapping(bean, resolvedUri)`** scans the bean's executable methods for an
   `@Head`-stereotyped method whose *resolved* URI equals the candidate's, honouring the
   `uris = [...]` multi-URI form on both annotations.

Why this is the right place:

- **Build time, not request time.** The duplicate is synthetic and should never exist. Suppressing
  it at registration keeps the route table honest; a runtime ambiguity tie-break would paper over
  ill-formed state and add heuristics to every ambiguous match.
- **Order-independent.** It inspects the bean's complete statically-computed method list, so the
  result does not depend on whether `process()` visits the `@Get` or `@Head` method first.
- **Per-URI.** The check sits *inside* the `uris` loop, so `@Get(uris = ["/a", "/b"])` with
  `@Head("/a")` suppresses the implicit HEAD only for `/a`; `/b` keeps its implicit HEAD.
- **`@Get(headRoute = false)` is unchanged** — it short-circuits before this check.
- **Scoped to one controller.** Two *different* controllers claiming the same URI is a separate,
  pre-existing ambiguity and is deliberately out of scope here.
- No content-negotiation change was needed: removing the duplicate is sufficient; the suspected
  `produces` mismatch between the two routes was a red herring.

A note on the helper signature: it takes `BeanDefinition<?>`, not the raw `BeanDefinition` used
elsewhere in the file. This is a **compile requirement**: calling the generic `getExecutableMethods()`
on a raw type erases its return to a raw `List`, so the enhanced-for element types as `Object` and
the loop over `ExecutableMethod<?, ?>` does not compile.

## Tests

`router/src/test/groovy/io/micronaut/context/router/HeadGetSameUriRouteBuilderSpec.groovy` — new
spec exercising the router the way the HTTP server does (`Router.findClosest(...)`), so the failure
mode is precise and no embedded server is needed. Four features:

| Scenario | Asserts |
|---|---|
| Explicit `@Head` + `@Get`, same URI | HEAD resolves (previously threw `DuplicateRouteException`) and invokes the **explicit `@Head`** method |
| Same controller, `GET` to the shared URI | `GET` still routes to the `@Get` method |
| `@Get(uris = ["/a", "/b"])` + `@Head("/a")` | `/a` → explicit `@Head`; `/b` → implicit HEAD **still registered** and routes to `@Get` (suppression is per-URI) |
| `@Get(headRoute = false)` + sibling `@Head`, same URI | Only the explicit `@Head` answers HEAD; `GET` still hits `@Get` |

Each case pins the winning handler via a distinct `X-Handler` response header, so a wrong-route
match fails loudly instead of silently passing.

## Documentation

- `Get.java`: the `headRoute()` javadoc now states that when the controller declares an explicit
  `@Head` route for the same URI, the implicit HEAD route is not registered for that URI.

## Verification

- `./gradlew :micronaut-router:test` — **60 tests, 0 failures** (full router module).
- New spec: 4/4 green (`JAVA_HOME` pointing at a JDK 25; the build requires JVM 25+).
- Pre-fix behaviour confirmed: without the guard the new spec's first feature throws
  `DuplicateRouteException`.
