### PR TITLE
Normalize Python resource paths on Windows

### DIFF
--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -292,9 +292,10 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
                         .flatMap(tr -> tr.exportedTypes().stream())
                         .collect(Collectors.toSet());
                     for (PythonAstParser.TransformResult transformResult : transformedList) {
-                        for (String srcDir : srcDirs) {
+                        for (String configuredSrcDir : srcDirs) {
                             Source source = transformResult.originalSource();
-                            String path = source.getPath();
+                            String srcDir = normalizeResourcePath(configuredSrcDir);
+                            String path = normalizeResourcePath(source.getPath());
                             int i = path.indexOf(srcDir);
                             if (i == -1) {
                                 continue;
@@ -789,6 +790,10 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
     private static String runtimeFilename(String filePath) {
         String relativePath = filePath.substring(APPLICATION_PATH.length());
         return "/graalpy_vfs/" + relativePath;
+    }
+
+    static String normalizeResourcePath(String path) {
+        return path.replace('\\', '/');
     }
 
     private static String cacheFilePath(String sourcePath, String cachePath) {

--- a/inject-python/src/test/java/io/micronaut/python/processing/PythonAnnotationProcessorTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/processing/PythonAnnotationProcessorTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.processing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PythonAnnotationProcessorTest {
+
+    @Test
+    void normalizesWindowsResourcePathSeparators() {
+        assertEquals(
+            "example/micronaut/forecast_controller.py",
+            PythonAnnotationProcessor.normalizeResourcePath("example\\micronaut\\forecast_controller.py")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Normalize configured Python source directories to forward-slash resource paths.
- Normalize paths returned by `Source.getPath()` before deriving generated resource locations.
- Add a focused test covering Windows path separators.

## Motivation

Windows source paths use backslashes, while generated resource paths and source-directory matching expect forward slashes. This can prevent the Python annotation processor from locating a source beneath its configured source directory and deriving the correct resource path.
