### PR TITLE
Prefer an explicit @Head route over the implicit one derived from @Get

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ExplicitHeadRouteTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ExplicitHeadRouteTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Head;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.HttpResponseAssertion;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+/**
+ * A {@code @Get} mapping also registers an implicit {@code HEAD} route, so that a plain {@code GET}
+ * handler answers {@code HEAD} requests too. When a controller additionally declares an explicit
+ * {@code @Head} route for the same URI, both routes match a {@code HEAD} request with identical
+ * specificity, and the request used to be rejected as ambiguous with a {@code 400}.
+ *
+ * <p>The explicit declaration wins that tie. The implicit route is still registered, so a
+ * {@code HEAD} request that earlier stages of resolution - such as content negotiation - can
+ * attribute to the {@code @Get} route keeps reaching it.</p>
+ *
+ * @see <a href="https://github.com/micronaut-projects/micronaut-core/issues/13020">#13020</a>
+ */
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class ExplicitHeadRouteTest {
+    public static final String SPEC_NAME = "ExplicitHeadRouteTest";
+
+    private static final String HANDLER_HEADER = "X-Handler";
+
+    @Test
+    void headRequestPrefersTheExplicitlyDeclaredHeadRoute() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.HEAD("/explicit-head/example.dummy/availability"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .header(HANDLER_HEADER, "head")
+                    .build()));
+    }
+
+    @Test
+    void getRequestOnTheSameUriIsHandledByTheGetRoute() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/explicit-head/example.dummy/availability"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .header(HANDLER_HEADER, "get")
+                    .body("available")
+                    .build()));
+    }
+
+    @Test
+    void headRequestStillReachesTheImplicitRouteOfAGetOnlyUri() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.HEAD("/explicit-head/example.dummy/stock"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .header(HANDLER_HEADER, "get")
+                    .build()));
+    }
+
+    @Test
+    void headRequestAcceptingTheMediaTypeOfTheHeadRouteReachesIt() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.HEAD("/explicit-head-negotiated/example.dummy/availability")
+                .accept(MediaType.TEXT_PLAIN_TYPE),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .header(HANDLER_HEADER, "head")
+                    .build()));
+    }
+
+    @Test
+    void headRequestAcceptingTheMediaTypeOfTheGetRouteReachesTheImplicitRoute() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.HEAD("/explicit-head-negotiated/example.dummy/availability")
+                .accept(MediaType.APPLICATION_JSON_TYPE),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .header(HANDLER_HEADER, "get")
+                    .build()));
+    }
+
+    @Controller("/explicit-head")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class ExplicitHeadController {
+
+        @Head("/{id}/availability")
+        HttpResponse<String> availabilityHead(@PathVariable String id) {
+            return HttpResponse.ok("available").header(HANDLER_HEADER, "head");
+        }
+
+        @Get(uris = {"/{id}/availability", "/{id}/stock"})
+        HttpResponse<String> availabilityGet(@PathVariable String id) {
+            return HttpResponse.ok("available").header(HANDLER_HEADER, "get");
+        }
+    }
+
+    @Controller("/explicit-head-negotiated")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class NegotiatedExplicitHeadController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Head("/{id}/availability")
+        HttpResponse<String> availabilityHead(@PathVariable String id) {
+            return HttpResponse.ok("available").header(HANDLER_HEADER, "head");
+        }
+
+        @Produces(MediaType.APPLICATION_JSON)
+        @Get("/{id}/availability")
+        HttpResponse<String> availabilityGet(@PathVariable String id) {
+            return HttpResponse.ok("available").header(HANDLER_HEADER, "get");
+        }
+    }
+}

--- a/http/src/main/java/io/micronaut/http/annotation/Get.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Get.java
@@ -97,7 +97,9 @@ public @interface Get {
     boolean single() default false;
 
     /**
-     * @return True if a HEAD route should also be registered for the same method
+     * @return True if a HEAD route should also be registered for the same method. The route is
+     * implicit: if the controller also declares an explicit {@link Head} route that matches the
+     * same request, the explicit route takes precedence over this one.
      */
     boolean headRoute() default true;
 }

--- a/router/src/main/java/io/micronaut/web/router/AnnotatedMethodRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/AnnotatedMethodRouteBuilder.java
@@ -81,11 +81,8 @@ public class AnnotatedMethodRouteBuilder extends DefaultRouteBuilder implements 
             Set<String> uris = this.resolveUrisMapping(Get.class, method);
             for (String uri: uris) {
                 MediaType[] produces = resolveProduces(method);
-                UriRoute route = GET(resolveUri(bean, uri,
-                        method,
-                        uriNamingStrategy),
-                        bean,
-                        method).produces(produces);
+                String resolvedUri = resolveUri(bean, uri, method, uriNamingStrategy);
+                UriRoute route = GET(resolvedUri, bean, method).produces(produces);
 
                 if (definition.port > -1) {
                     route.exposedPort(definition.port);
@@ -94,11 +91,13 @@ public class AnnotatedMethodRouteBuilder extends DefaultRouteBuilder implements 
                     LOG.debug("Created Route: {}", route);
                 }
                 if (method.booleanValue(Get.class, "headRoute").orElse(true)) {
-                    route = HEAD(resolveUri(bean, uri,
-                            method,
-                            uriNamingStrategy),
-                            bean,
-                            method).produces(produces);
+                    route = HEAD(resolvedUri, bean, method).produces(produces);
+                    // Flag the route as implicit so that, should it ever compete with a user-declared
+                    // @Head route for the same request, route resolution can prefer the explicit one
+                    // instead of failing with a DuplicateRouteException. See UriRouteInfo#isImplicitHead().
+                    if (route instanceof DefaultUriRoute defaultUriRoute) {
+                        defaultUriRoute.markImplicitHead();
+                    }
                     if (definition.port > -1) {
                         route.exposedPort(definition.port);
                     }

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
@@ -794,6 +794,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         final UriMatchTemplate uriMatchTemplate;
         final List<DefaultUriRoute> nestedRoutes = new ArrayList<>(2);
         private @Nullable Integer port;
+        private boolean implicitHead;
         private final RouteExecutorSelector executorSelector = new RouteExecutorSelector();
 
         /**
@@ -901,8 +902,18 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
                 port,
                 conversionService,
                 executorSelector,
-                messageBodyHandlerRegistry
+                messageBodyHandlerRegistry,
+                implicitHead
             );
+        }
+
+        /**
+         * Marks this route as an implicit {@code HEAD} route derived from a {@code @Get} mapping.
+         *
+         * @see UriRouteInfo#isImplicitHead()
+         */
+        void markImplicitHead() {
+            this.implicitHead = true;
         }
 
         @Override

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -270,6 +270,9 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
         }
         uriRoutes = resolveAmbiguity(request, uriRoutes);
         if (uriRoutes.size() > 1) {
+            uriRoutes = ImplicitHeadRoutes.preferExplicit(uriRoutes);
+        }
+        if (uriRoutes.size() > 1) {
             throw new DuplicateRouteException(path, (List) uriRoutes);
         } else if (uriRoutes.size() == 1) {
             return uriRoutes.get(0);

--- a/router/src/main/java/io/micronaut/web/router/DefaultUrlRouteInfo.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultUrlRouteInfo.java
@@ -56,6 +56,7 @@ public final class DefaultUrlRouteInfo<T, R> extends DefaultRequestMatcher<T, R>
     private final @Nullable Integer port;
     private final ConversionService conversionService;
     private final ExecutorSelector executorSelector;
+    private final boolean implicitHead;
 
     @Nullable
     private ExecutorService executorService;
@@ -79,7 +80,29 @@ public final class DefaultUrlRouteInfo<T, R> extends DefaultRequestMatcher<T, R>
                                ConversionService conversionService,
                                ExecutorSelector executorSelector,
                                MessageBodyHandlerRegistry messageBodyHandlerRegistry) {
+        this(httpMethod, uriMatchTemplate, defaultCharset, targetMethod, bodyArgumentName, bodyArgument,
+            consumesMediaTypes, producesMediaTypes, predicates, port, conversionService, executorSelector,
+            messageBodyHandlerRegistry, false);
+    }
+
+    @SuppressWarnings("ParameterNumber")
+    public DefaultUrlRouteInfo(HttpMethod httpMethod,
+                               UriMatchTemplate uriMatchTemplate,
+                               Charset defaultCharset,
+                               MethodExecutionHandle<T, R> targetMethod,
+                               @Nullable String bodyArgumentName,
+                               @Nullable Argument<?> bodyArgument,
+                               List<MediaType> consumesMediaTypes,
+                               List<MediaType> producesMediaTypes,
+                               List<Predicate<HttpRequest<?>>> predicates,
+                                @Nullable Integer port,
+
+                               ConversionService conversionService,
+                               ExecutorSelector executorSelector,
+                               MessageBodyHandlerRegistry messageBodyHandlerRegistry,
+                               boolean implicitHead) {
         super(targetMethod, bodyArgument, bodyArgumentName, consumesMediaTypes, producesMediaTypes, httpMethod.permitsRequestBody(), false, predicates, messageBodyHandlerRegistry);
+        this.implicitHead = implicitHead;
         this.httpMethod = httpMethod;
         this.uriMatchTemplate = uriMatchTemplate;
         this.uriTemplateMatcher = new UriTemplateMatcher(uriMatchTemplate.getTemplateString());
@@ -116,6 +139,11 @@ public final class DefaultUrlRouteInfo<T, R> extends DefaultRequestMatcher<T, R>
     @Override
     public @Nullable Integer getPort() {
         return port;
+    }
+
+    @Override
+    public boolean isImplicitHead() {
+        return implicitHead;
     }
 
     @Override

--- a/router/src/main/java/io/micronaut/web/router/DefaultUrlRouteInfo.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultUrlRouteInfo.java
@@ -75,8 +75,7 @@ public final class DefaultUrlRouteInfo<T, R> extends DefaultRequestMatcher<T, R>
                                List<MediaType> consumesMediaTypes,
                                List<MediaType> producesMediaTypes,
                                List<Predicate<HttpRequest<?>>> predicates,
-                                @Nullable Integer port,
-
+                               @Nullable Integer port,
                                ConversionService conversionService,
                                ExecutorSelector executorSelector,
                                MessageBodyHandlerRegistry messageBodyHandlerRegistry) {
@@ -95,8 +94,7 @@ public final class DefaultUrlRouteInfo<T, R> extends DefaultRequestMatcher<T, R>
                                List<MediaType> consumesMediaTypes,
                                List<MediaType> producesMediaTypes,
                                List<Predicate<HttpRequest<?>>> predicates,
-                                @Nullable Integer port,
-
+                               @Nullable Integer port,
                                ConversionService conversionService,
                                ExecutorSelector executorSelector,
                                MessageBodyHandlerRegistry messageBodyHandlerRegistry,

--- a/router/src/main/java/io/micronaut/web/router/ImplicitHeadRoutes.java
+++ b/router/src/main/java/io/micronaut/web/router/ImplicitHeadRoutes.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tie-break used as the very last step of route resolution, once every other discriminator
+ * (media types, versioning, URI specificity, ...) has been applied and more than one route still
+ * matches the request.
+ *
+ * <p>A {@code @Get} mapping also registers an implicit {@code HEAD} route so that a bare {@code GET}
+ * handler answers {@code HEAD} requests too. When the same controller additionally declares an
+ * explicit {@code @Head} route for the same URI, both routes match a {@code HEAD} request with equal
+ * specificity and the request would otherwise be rejected with a
+ * {@link io.micronaut.web.router.exceptions.DuplicateRouteException} (surfaced as a 400 response).
+ * The user's explicit declaration is the more specific intent, so it wins.</p>
+ *
+ * <p>Applying this only at the point of failure — rather than suppressing the implicit route when it
+ * is built — keeps the implicit route available to every earlier discriminator. Two routes for the
+ * same URI that differ by {@code produces} or by {@code @Version} are not ambiguous at all, and both
+ * remain individually reachable.</p>
+ *
+ * @author Graeme Rocher
+ * @since 5.2.0
+ */
+@Internal
+final class ImplicitHeadRoutes {
+
+    private ImplicitHeadRoutes() {
+    }
+
+    /**
+     * Drops implicit {@code HEAD} routes from a set of otherwise indistinguishable matches, provided
+     * at least one explicitly declared route remains.
+     *
+     * @param matches The ambiguous matches, never empty
+     * @param <T>     The target type
+     * @param <R>     The result type
+     * @return The explicitly declared matches, or {@code matches} unchanged if the tie-break does not apply
+     */
+    static <T, R> List<UriRouteMatch<T, R>> preferExplicit(List<UriRouteMatch<T, R>> matches) {
+        int implicitCount = 0;
+        for (UriRouteMatch<T, R> match : matches) {
+            if (match.getRouteInfo().isImplicitHead()) {
+                implicitCount++;
+            }
+        }
+        if (implicitCount == 0 || implicitCount == matches.size()) {
+            // nothing implicit to drop, or every candidate is implicit: leave the ambiguity untouched
+            return matches;
+        }
+        List<UriRouteMatch<T, R>> explicit = new ArrayList<>(matches.size() - implicitCount);
+        for (UriRouteMatch<T, R> match : matches) {
+            if (!match.getRouteInfo().isImplicitHead()) {
+                explicit.add(match);
+            }
+        }
+        return explicit;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/Router.java
+++ b/router/src/main/java/io/micronaut/web/router/Router.java
@@ -145,6 +145,9 @@ public interface Router {
     default <T, R> UriRouteMatch<T, R> findClosest(HttpRequest<?> request) throws DuplicateRouteException {
         List<UriRouteMatch<T, R>> uriRoutes = findAllClosest(request);
         if (uriRoutes.size() > 1) {
+            uriRoutes = ImplicitHeadRoutes.preferExplicit(uriRoutes);
+        }
+        if (uriRoutes.size() > 1) {
             throw new DuplicateRouteException(request.getPath(), (List) uriRoutes);
         } else if (uriRoutes.size() == 1) {
             return uriRoutes.get(0);

--- a/router/src/main/java/io/micronaut/web/router/UriRouteInfo.java
+++ b/router/src/main/java/io/micronaut/web/router/UriRouteInfo.java
@@ -95,4 +95,22 @@ public interface UriRouteInfo<T, R> extends MethodBasedRouteInfo<T, R>, RequestM
     default String getHttpMethodName() {
         return getHttpMethod().name();
     }
+
+    /**
+     * Whether this route is an <em>implicit</em> {@code HEAD} route; that is, a {@code HEAD} route that
+     * was derived automatically from a {@link io.micronaut.http.annotation.Get} mapping rather than
+     * declared by the user with {@link io.micronaut.http.annotation.Head}.
+     *
+     * <p>Implicit routes are fully-fledged routes and participate in matching and content negotiation
+     * exactly like any other route. The distinction is only used as a last-resort tie-break: if a request
+     * cannot be resolved to a single route and the remaining candidates contain both implicit and
+     * explicitly declared routes, the explicitly declared ones win instead of the request being rejected
+     * as ambiguous.</p>
+     *
+     * @return {@code true} if this route was derived from a {@code @Get} mapping rather than declared
+     * @since 5.2.0
+     */
+    default boolean isImplicitHead() {
+        return false;
+    }
 }

--- a/router/src/test/groovy/io/micronaut/context/router/ExplicitHeadRouteSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/context/router/ExplicitHeadRouteSpec.groovy
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.router
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Head
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Produces
+import io.micronaut.web.router.Router
+import io.micronaut.web.router.UriRouteMatch
+import io.micronaut.web.router.exceptions.DuplicateRouteException
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * A {@code @Get} mapping also registers an implicit {@code HEAD} route so that a plain {@code GET}
+ * handler answers {@code HEAD} requests. When a controller additionally declares an explicit
+ * {@code @Head} route for the same URI, both routes match a {@code HEAD} request with identical
+ * specificity, and resolution used to fail with a {@link DuplicateRouteException} (HTTP 400).
+ *
+ * <p>The implicit route is still registered; it simply loses the tie to the user's explicit
+ * declaration. That matters because the two routes are frequently <em>not</em> interchangeable:
+ * they may differ by {@code produces} or by {@code @Version}, in which case earlier stages of route
+ * resolution pick between them and both must remain reachable.</p>
+ */
+@Issue("https://github.com/micronaut-projects/micronaut-core/issues/13020")
+class ExplicitHeadRouteSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.builder("test").build().start()
+
+    @Shared
+    Router router = context.getBean(Router)
+
+    void "an explicit @Head wins over the implicit HEAD route derived from @Get for the same URI"() {
+        when: "resolving a HEAD request the way the HTTP server does"
+        UriRouteMatch<Object, Object> match = router.findClosest(HttpRequest.HEAD("/domainNames/example.dummy/availability"))
+
+        then: "resolution succeeds - it previously threw DuplicateRouteException, surfaced as a 400"
+        noExceptionThrown()
+        match != null
+
+        when:
+        HttpResponse<?> response = match.invoke("example.dummy") as HttpResponse<?>
+
+        then: "the explicitly annotated @Head method handles it"
+        response.header("X-Handler") == "head"
+    }
+
+    void "GET on the shared URI still routes to the @Get method"() {
+        when:
+        UriRouteMatch<Object, Object> match = router.findClosest(HttpRequest.GET("/domainNames/example.dummy/availability"))
+
+        then:
+        match != null
+        (match.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "get"
+    }
+
+    void "the implicit HEAD route is untouched on sibling URIs of a multi-URI @Get"() {
+        when: "the URI shared with the explicit @Head"
+        UriRouteMatch<Object, Object> shared = router.findClosest(HttpRequest.HEAD("/multi/example.dummy/availability"))
+
+        then:
+        shared != null
+        (shared.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "head"
+
+        when: "a sibling URI of the same @Get that has no explicit @Head"
+        UriRouteMatch<Object, Object> sibling = router.findClosest(HttpRequest.HEAD("/multi/example.dummy/stock"))
+
+        then: "the implicit HEAD route still answers"
+        sibling != null
+        (sibling.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "get"
+    }
+
+    void "@Get(headRoute = false) alongside an explicit @Head for the same URI"() {
+        when:
+        UriRouteMatch<Object, Object> head = router.findClosest(HttpRequest.HEAD("/noimplicit/example.dummy/availability"))
+
+        then:
+        head != null
+        (head.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "head"
+
+        when:
+        UriRouteMatch<Object, Object> get = router.findClosest(HttpRequest.GET("/noimplicit/example.dummy/availability"))
+
+        then:
+        get != null
+        (get.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "get"
+    }
+
+    void "the implicit HEAD route stays reachable when it is the only one producing the accepted media type"() {
+        given: "a controller whose @Head produces text/plain and whose @Get produces application/json"
+
+        when: "a HEAD request that accepts JSON - only the @Get route explicitly produces it"
+        UriRouteMatch<Object, Object> json = router.findClosest(
+                HttpRequest.HEAD("/negotiated/example.dummy/availability").accept(MediaType.APPLICATION_JSON_TYPE))
+
+        then: "content negotiation resolves it to the implicit HEAD route, which must therefore still exist"
+        json != null
+        (json.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "get"
+
+        when: "a HEAD request that accepts text/plain"
+        UriRouteMatch<Object, Object> text = router.findClosest(
+                HttpRequest.HEAD("/negotiated/example.dummy/availability").accept(MediaType.TEXT_PLAIN_TYPE))
+
+        then: "the explicit @Head route answers"
+        text != null
+        (text.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "head"
+
+        when: "a HEAD request with no preference - the two are genuinely tied"
+        UriRouteMatch<Object, Object> any = router.findClosest(HttpRequest.HEAD("/negotiated/example.dummy/availability"))
+
+        then: "the explicit declaration wins the tie"
+        noExceptionThrown()
+        any != null
+        (any.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "head"
+    }
+
+    void "genuinely ambiguous routes are still reported as duplicates"() {
+        when: "two controllers declare the same GET URI"
+        router.findClosest(HttpRequest.GET("/ambiguous/example.dummy/availability"))
+
+        then:
+        thrown(DuplicateRouteException)
+
+        when: "and therefore two implicit HEAD routes for it as well"
+        router.findClosest(HttpRequest.HEAD("/ambiguous/example.dummy/availability"))
+
+        then: "the tie-break does not apply - neither candidate is explicit"
+        thrown(DuplicateRouteException)
+    }
+
+    void "only the HEAD route derived from @Get is marked implicit"() {
+        given:
+        Map<String, Boolean> byMethod = router.uriRoutes().toList()
+                .findAll { it.httpMethodName == "HEAD" && it.uriMatchTemplate.toString() == "/domainNames/{id}/availability" }
+                .collectEntries { [(it.targetMethod.methodName): it.implicitHead] }
+
+        expect:
+        byMethod == ["availableSimple": false, "availableAdditional": true]
+    }
+
+    @Controller("/domainNames")
+    static class DomainNameController {
+
+        @Head("/{id}/availability")
+        HttpResponse<?> availableSimple(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "head")
+        }
+
+        @Get("/{id}/availability")
+        HttpResponse<?> availableAdditional(@PathVariable String id) {
+            HttpResponse.ok().header("X-Handler", "get")
+        }
+    }
+
+    @Controller("/multi")
+    static class MultiUriController {
+
+        @Head("/{id}/availability")
+        HttpResponse<?> available(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "head")
+        }
+
+        @Get(uris = ["/{id}/availability", "/{id}/stock"])
+        HttpResponse<?> get(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "get")
+        }
+    }
+
+    @Controller("/noimplicit")
+    static class NoImplicitHeadController {
+
+        @Head("/{id}/availability")
+        HttpResponse<?> available(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "head")
+        }
+
+        @Get(value = "/{id}/availability", headRoute = false)
+        HttpResponse<?> get(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "get")
+        }
+    }
+
+    @Controller("/negotiated")
+    static class NegotiatedController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Head("/{id}/availability")
+        HttpResponse<?> available(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "head")
+        }
+
+        @Produces(MediaType.APPLICATION_JSON)
+        @Get("/{id}/availability")
+        HttpResponse<?> get(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "get")
+        }
+    }
+
+    @Controller("/ambiguous")
+    static class AmbiguousControllerOne {
+
+        @Get("/{id}/availability")
+        HttpResponse<?> get(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "one")
+        }
+    }
+
+    @Controller("/ambiguous")
+    static class AmbiguousControllerTwo {
+
+        @Get("/{id}/availability")
+        HttpResponse<?> get(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "two")
+        }
+    }
+}

--- a/router/src/test/groovy/io/micronaut/context/router/ExplicitHeadRouteVersioningSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/context/router/ExplicitHeadRouteVersioningSpec.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.router
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.version.annotation.Version
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Head
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.web.router.Router
+import io.micronaut.web.router.UriRouteMatch
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * An explicit {@code @Head} and a {@code @Get} can map to the same URI while being scoped to different
+ * API versions. Version filtering runs after route matching, so the implicit HEAD route derived from
+ * the {@code @Get} must survive route registration: it is the only route serving {@code HEAD} for its
+ * own version.
+ */
+@Issue("https://github.com/micronaut-projects/micronaut-core/issues/13020")
+class ExplicitHeadRouteVersioningSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.builder("test")
+            .properties([
+                    'micronaut.router.versioning.enabled'       : true,
+                    'micronaut.router.versioning.header.enabled': true
+            ])
+            .build()
+            .start()
+
+    @Shared
+    Router router = context.getBean(Router)
+
+    void "HEAD resolves to the versioned @Get route for version 1"() {
+        when:
+        UriRouteMatch<Object, Object> match = router.findClosest(
+                HttpRequest.HEAD("/versioned/example.dummy/availability").header("X-API-VERSION", "1"))
+
+        then: "the implicit HEAD route derived from the v1 @Get is the only candidate for that version"
+        noExceptionThrown()
+        match != null
+        (match.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "get-v1"
+    }
+
+    void "HEAD resolves to the explicit @Head route for version 2"() {
+        when:
+        UriRouteMatch<Object, Object> match = router.findClosest(
+                HttpRequest.HEAD("/versioned/example.dummy/availability").header("X-API-VERSION", "2"))
+
+        then:
+        noExceptionThrown()
+        match != null
+        (match.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "head-v2"
+    }
+
+    void "GET still resolves to the versioned @Get route"() {
+        when:
+        UriRouteMatch<Object, Object> match = router.findClosest(
+                HttpRequest.GET("/versioned/example.dummy/availability").header("X-API-VERSION", "1"))
+
+        then:
+        match != null
+        (match.invoke("example.dummy") as HttpResponse<?>).header("X-Handler") == "get-v1"
+    }
+
+    @Controller("/versioned")
+    static class VersionedController {
+
+        @Version("2")
+        @Head("/{id}/availability")
+        HttpResponse<?> availableV2(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "head-v2")
+        }
+
+        @Version("1")
+        @Get("/{id}/availability")
+        HttpResponse<?> availableV1(@PathVariable("id") String id) {
+            HttpResponse.ok().header("X-Handler", "get-v1")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13020. Alternative to #13027.

## Summary

A controller that declares both an explicit `@Head` and a `@Get` for the same URI served `GET`
fine but answered `HEAD` with `400 Bad Request`:

```java
@Head("/{id}/availability") HttpResponse<?> availableSimple(@PathVariable("id") String id) { ... }
@Get ("/{id}/availability") HttpResponse<?> availableAdditional(@PathVariable String id)   { ... }
```

`AnnotatedMethodRouteBuilder` registers an implicit `HEAD` route for every `@Get` method, so that a
bare `GET` handler also answers `HEAD`. Alongside the user's explicit `@Head` route, two `HEAD`
routes match the request with identical path templates and identical specificity. Nothing breaks the
tie, `DefaultRouter.findClosest` throws `DuplicateRouteException`, and the server turns that into the
observed 400.

## The fix

Mark the implicit route as implicit, and let route resolution prefer the explicit one when — and
only when — it is about to give up:

* `UriRouteInfo#isImplicitHead()` (new `default` method, `false`) reports whether a `HEAD` route was
  derived from a `@Get` mapping rather than declared with `@Head`. `AnnotatedMethodRouteBuilder`
  flags the route it synthesises; `DefaultUrlRouteInfo` carries the flag.
* `ImplicitHeadRoutes.preferExplicit(...)` drops implicit candidates from a set of otherwise
  indistinguishable matches, provided at least one explicitly declared route survives.
* It is applied in `DefaultRouter#findClosest` and in the `Router#findClosest` default (used by
  `FilteredRouter`) at the one place that would otherwise throw `DuplicateRouteException`.

`AnnotatedMethodRouteBuilder` also now resolves the URI once per `@Get` iteration instead of twice
with identical inputs.

## Why a tie-break rather than not registering the route

#13027 suppresses the implicit `HEAD` route at build time whenever the bean declares an explicit
`@Head` for the same resolved URI. Copilot flagged that this matches on the URI alone and may remove
implicit routes that differ by other qualifiers. That is not hypothetical — two `HEAD` routes for the
same URI are frequently **not** ambiguous, because earlier stages of resolution already choose
between them, and both must stay individually reachable.

Running this PR's specs against #13027 turns those cases into 404s:

| Controller | Request | main | #13027 | this PR |
|---|---|---|---|---|
| `@Head` produces `text/plain`, `@Get` produces `application/json` | `HEAD` + `Accept: application/json` | → `@Get` | **no route** | → `@Get` |
| same | `HEAD` + `Accept: text/plain` | → `@Head` | → `@Head` | → `@Head` |
| same | `HEAD`, no preference | **400** | → `@Head` | → `@Head` |
| `@Version("2") @Head`, `@Version("1") @Get` | `HEAD` + `X-API-VERSION: 1` | → `@Get` | **no route** | → `@Get` |
| same | `HEAD` + `X-API-VERSION: 2` | → `@Head` | → `@Head` | → `@Head` |

Content negotiation runs in `DefaultRouter.resolveAmbiguity` and version filtering runs in
`FilteredRouter` *after* matching, so neither can compensate for a route that was never registered.
Deferring the decision to the point of failure keeps the implicit route available to every earlier
discriminator, and the ambiguity is only ever broken when the request genuinely cannot be resolved.

Note that placing this *inside* `resolveAmbiguity` would reintroduce the versioning regression, since
`findAllClosest` feeds `FilteredRouter` — hence the two explicit call sites rather than one.

Copilot's second point, the startup-time scan per `@Get` route, does not arise: there is no scan.
The flag is set where the route is already being constructed, and the tie-break allocates nothing
unless a request would otherwise have been rejected as a duplicate.

## Behaviour that is deliberately unchanged

* `@Get(headRoute = false)` still registers no implicit `HEAD` route.
* Two genuinely duplicate routes still raise `DuplicateRouteException`; the tie-break does not apply
  when every remaining candidate is implicit (or none is).
* `findAllClosest` is untouched, so consumers that legitimately want every matching route — CORS
  preflight, `Allow` computation — keep seeing both.

## Tests

`router/src/test/groovy/io/micronaut/context/router/ExplicitHeadRouteSpec.groovy` (7 features) and
`ExplicitHeadRouteVersioningSpec.groovy` (3 features) exercise `Router.findClosest(...)` the way the
HTTP server does, so no embedded server is needed. Each case pins the winning handler with a distinct
`X-Handler` header, so a wrong-route match fails loudly rather than passing silently. Coverage:

* the reported case — explicit `@Head` + `@Get` on the same URI, both directions
* `@Get(uris = ["/a", "/b"])` + `@Head("/a")` — `/b` keeps its implicit `HEAD`
* `@Get(headRoute = false)` beside an explicit `@Head`
* differing `produces`, all three `Accept` outcomes
* differing `@Version`, both versions
* genuinely ambiguous routes still reported as duplicates
* only the `@Get`-derived route is flagged `isImplicitHead()`

Against unpatched `5.2.x` four of these fail; against #13027 the `produces` and version-1 cases fail.

## Verification

JDK 25, `5.2.x` at `3dc8ea0286`:

* `:micronaut-router:test` — 66 tests, 0 failures
* `:micronaut-router:checkstyleMain/checkstyleTest`, `:micronaut-http:checkstyleMain` — clean
* `:micronaut-http-server:test` — green
* `:micronaut-http-server-netty:test` — 1133 tests, 2 failures, both pre-existing and unrelated
  (`BroadcasterSpec` fails identically on a clean tree; `StreamPressureSpec` is timing-flaky)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7GKVDfQZ8vg11dGQhNCJt
