### PR TITLE
Address the Copilot review of the lifecycle interception PR (#13019)

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableInterceptedMethod.java
@@ -20,11 +20,11 @@ import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
-import java.util.List;
 import io.micronaut.inject.ExecutableMethod;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Method;
-import org.jspecify.annotations.Nullable;
+import java.util.List;
 
 /**
  * Executable method that delegates {@link InitializableIntercepted} initialization to the interceptor chain.

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedDisposeMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedDisposeMethod.java
@@ -20,11 +20,11 @@ import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
-import java.util.List;
 import io.micronaut.inject.ExecutableMethod;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Method;
-import org.jspecify.annotations.Nullable;
+import java.util.List;
 
 /**
  * Executable method that delegates {@link DisposableIntercepted} disposal to the interceptor chain.

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/LifecycleCallbacks.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/LifecycleCallbacks.java
@@ -44,7 +44,11 @@ final class LifecycleCallbacks {
      *
      * @param callback  The callback
      * @param bean      The bean
-     * @param arguments The resolved arguments of the callback
+     * @param arguments The resolved arguments of the callback, empty for a callback that takes none. Never
+     *                  {@code null}: the generated code that calls this always supplies an array, and
+     *                  {@link ExecutableMethod#invoke} would reject one that was not there. An individual
+     *                  resolved argument may be {@code null}, which is what the type-use {@code @Nullable}
+     *                  states, matching the signature of {@link ExecutableMethod#invoke} itself.
      * @param <T>       The bean type
      */
     static <T> void invoke(ExecutableMethod<T, ?> callback, T bean, @Nullable Object[] arguments) {

--- a/src/main/docs/guide/aop/lifecycleAdvice.adoc
+++ b/src/main/docs/guide/aop/lifecycleAdvice.adoc
@@ -51,9 +51,13 @@ of that kind declared by the bean, superclass callbacks first, in the same order
 does not call `proceed()` keeps all of them from running, and the bean it returns replaces the instance.
 
 The api:aop.MethodInvocationContext[] passed to the interceptor stands for the event: `getKind()` is
-`POST_CONSTRUCT` or `PRE_DESTROY`, `getTarget()` is the bean, and `getExecutableMethod()` describes the event
-rather than a method of the bean, so it carries the annotation metadata of the bean class and no parameters.
-`proceed()` returns the bean.
+`POST_CONSTRUCT` or `PRE_DESTROY`, `getTarget()` is the bean, and `proceed()` returns the bean.
+`getExecutableMethod()` stands for the whole event, and names it after the last callback the event will run: the
+most derived one, which is the one the bean itself declares where it declares any. Its `getDeclaringType()` and
+`getMethodName()` are that callback's, and `getTargetMethod()` resolves to that callback's `Method`; only when the
+bean declares no callback of that kind does the name fall back to `initialize` or `dispose`. It still describes the
+event rather than that one callback, so it carries the annotation metadata of the bean class and declares no
+parameters, a callback's own arguments being resolved only once the event proceeds.
 
 The callbacks the event is about to run are available from the bean definition of the intercepted bean:
 api:inject.InitializingBeanDefinition[] exposes `getPostConstructExecutableMethods()` and


### PR DESCRIPTION
Follow-up to #13019, which merged before its Copilot review was acted on. Four points, three changes.

### 1. Import ordering

`InitializableInterceptedMethod` and `InterceptedDisposeMethod` had `java.util.List` wedged between two `io.micronaut` imports and `org.jspecify.annotations.Nullable` after `java.lang.reflect.Method`. Both now follow the order the rest of the package uses (see `LifecycleCallbacks`): `io.micronaut.*`, `org.*`, blank line, `java.*`. Mechanical; checkstyle passes.

### 2. Nullability of `LifecycleCallbacks.invoke`

Copilot asked for `arguments` to be normalized from null to an empty array. **Not doing that** — the premise doesn't hold, and the signature is already honest:

- JSpecify's `@Nullable` is `@Target(TYPE_USE)` only. In this `@NullMarked` package, `@Nullable Object[] arguments` annotates the *component* type: an array that is itself non-null, whose elements may be null. Making the array nullable would be written `Object @Nullable []`.
- That reading is accurate — a resolved callback argument really can be null — and it matches `Executable.invoke(T instance, @Nullable Object... arguments)`, which this call delegates to. Dropping the annotation would make the signature *less* true than it is now.
- On what `invoke` does with a null array for a zero-argument method: `AbstractExecutableMethod.invoke` reads `arguments.length` before it consults the argument count, so a null array NPEs there regardless of arity. Normalizing in `LifecycleCallbacks` would only mask a contract the layer below already requires.

So the change is javadoc: `invoke` now states that the array is never null (generated callers always supply one, and `ExecutableMethod#invoke` would reject one that wasn't there) while an individual argument may be. No new branch, so the file's coverage is unchanged and the `throw e` fallback stays the only uncovered line.

### 3. Stale documentation

`lifecycleAdvice.adoc` still said `getExecutableMethod()` "describes the event rather than a method of the bean." The first half stopped being true in #13019: `describedType`/`describedName` resolve to the most-derived callback and `getTargetMethod()` returns that callback's `Method` — `ProxiedFactoryPreDestroySpec` records `PRE_DESTROY:close`, not `dispose`. The sentence now says the executable method stands for the whole event while naming the last callback the event will run, gives the `getDeclaringType()`/`getMethodName()`/`getTargetMethod()` consequences, and notes the `initialize`/`dispose` fallback for a bean that declares no callback. The second half — bean-class annotation metadata, no parameters — was still correct and is kept, as are the surrounding paragraphs.

### Verification

- `./gradlew :micronaut-inject-java:test` — 5145 tests, all pass (8 skipped).
- `./gradlew :micronaut-aop:checkstyleMain :micronaut-aop:javadoc` — pass; the 34 javadoc warnings are pre-existing and none are in the touched files.
- `./gradlew publishGuide` — the section renders with every `api:`/`ann:` macro resolved to a real link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)