### PR TITLE
Honour the route's executor for Kotlin suspend functions

### DIFF
--- a/http-server/build.gradle.kts
+++ b/http-server/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     annotationProcessor(projects.micronautInjectJava)
 
     testImplementation(libs.managed.netty.codec.http)
+    testImplementation(libs.managed.kotlinx.coroutines.core)
+    testImplementation(projects.micronautContextPropagation)
 
     testAnnotationProcessor(projects.micronautInjectJava)
     testAnnotationProcessor(platform(libs.test.boms.micronaut.validation))

--- a/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
+++ b/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
@@ -76,7 +76,14 @@ public final class CoroutineHelper {
         ContinuationArgumentBinder.setupCoroutineContext(httpRequest, contextView, propagatedContext, coroutineContextFactories, dispatcher);
     }
 
-    private CoroutineContext dispatcherFor(ExecutorService executorService) {
+    /**
+     * Resolves, and caches, the dispatcher for an executor. Package private so that the caching and unwrapping
+     * can be asserted directly.
+     *
+     * @param executorService The executor the route runs on
+     * @return The dispatcher for that executor
+     */
+    CoroutineContext dispatcherFor(ExecutorService executorService) {
         // the coroutine's own propagation is handled by KotlinCoroutinePropagation, so dispatch on the raw
         // executor rather than the instrumented wrapper, which would otherwise capture the propagated context
         // of whichever thread happened to resume the continuation

--- a/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
+++ b/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
@@ -16,7 +16,9 @@
 package io.micronaut.http.server;
 
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.propagation.instrument.execution.ContextPropagatingExecutorService;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.bind.binders.ContinuationArgumentBinder;
@@ -25,6 +27,10 @@ import jakarta.inject.Singleton;
 import reactor.util.context.ContextView;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import kotlin.coroutines.CoroutineContext;
 
 /**
  * Coroutines helper.
@@ -38,12 +44,43 @@ import java.util.List;
 public final class CoroutineHelper {
 
     private final List<HttpCoroutineContextFactory<?>> coroutineContextFactories;
+    /**
+     * Dispatchers are resolved once per executor rather than per request: a coroutine dispatcher is compared by
+     * identity, so a new instance for every request would allocate on the request path and stop {@code withContext}
+     * from recognising the route's own dispatcher. The map is bound to this singleton, and therefore to the
+     * application context that owns the executors, so it does not outlive them.
+     */
+    private final Map<ExecutorService, CoroutineContext> dispatchers = new ConcurrentHashMap<>();
 
     CoroutineHelper(List<HttpCoroutineContextFactory<?>> coroutineContextFactories) {
         this.coroutineContextFactories = coroutineContextFactories;
     }
 
     public void setupCoroutineContext(HttpRequest<?> httpRequest, ContextView contextView, PropagatedContext propagatedContext) {
-        ContinuationArgumentBinder.setupCoroutineContext(httpRequest, contextView, propagatedContext, coroutineContextFactories);
+        setupCoroutineContext(httpRequest, contextView, propagatedContext, null);
+    }
+
+    /**
+     * Sets up the coroutine context for a suspended route, dispatching it onto the given executor.
+     *
+     * @param httpRequest       The request
+     * @param contextView       The reactor context
+     * @param propagatedContext The propagated context
+     * @param executorService   The executor the route runs on, or {@code null} to use {@code Dispatchers.Default}
+     */
+    public void setupCoroutineContext(HttpRequest<?> httpRequest,
+                                      ContextView contextView,
+                                      PropagatedContext propagatedContext,
+                                      @Nullable ExecutorService executorService) {
+        CoroutineContext dispatcher = executorService == null ? null : dispatcherFor(executorService);
+        ContinuationArgumentBinder.setupCoroutineContext(httpRequest, contextView, propagatedContext, coroutineContextFactories, dispatcher);
+    }
+
+    private CoroutineContext dispatcherFor(ExecutorService executorService) {
+        // the coroutine's own propagation is handled by KotlinCoroutinePropagation, so dispatch on the raw
+        // executor rather than the instrumented wrapper, which would otherwise capture the propagated context
+        // of whichever thread happened to resume the continuation
+        ExecutorService target = ContextPropagatingExecutorService.unwrap(executorService).orElse(executorService);
+        return dispatchers.computeIfAbsent(target, ContinuationArgumentBinder::dispatcherFor);
     }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -434,27 +434,34 @@ public final class RouteExecutor {
         ExecutionFlow<HttpResponse<?>> executeMethodResponseFlow;
         if (executorService != null) {
             if (routeInfo.isSuspended()) {
-                executeMethodResponseFlow = ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(contextView -> {
-                        return Mono.from(
-                            ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request, true, contextView)).toPublisher()
-                        );
-                    }));
+                // a suspend function runs synchronously on the caller until its first suspension point, and its
+                // coroutine context decides where it resumes, so honouring the executor needs both: applying it to
+                // the publisher moves the body off the event loop, and passing it on to the coroutine context keeps
+                // the continuation there. publishOn is deliberate - it holds the same "the response is assembled off
+                // the event loop" invariant the blocking branch below gets from ExecutionFlow.async
+                executeMethodResponseFlow = ReactiveExecutionFlow.fromPublisher(
+                    applyExecutorToPublisher(
+                        Mono.deferContextual(contextView -> Mono.from(
+                            ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request, true, contextView, executorService)).toPublisher()
+                        )),
+                        executorService,
+                        propagatedContext
+                    )
+                );
             } else if (routeInfo.isReactive()) {
-                executeMethodResponseFlow = ReactiveExecutionFlow.async(executorService, () -> executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null));
+                executeMethodResponseFlow = ReactiveExecutionFlow.async(executorService, () -> executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null, null));
             } else {
-                executeMethodResponseFlow = ExecutionFlow.async(executorService, () -> executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null));
+                executeMethodResponseFlow = ExecutionFlow.async(executorService, () -> executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null, null));
             }
         } else {
             if (routeInfo.isSuspended()) {
-                executeMethodResponseFlow = ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(contextView -> {
-                        return Mono.from(
-                            ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request, true, contextView)).toPublisher()
-                        );
-                    }));
+                executeMethodResponseFlow = ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(contextView -> Mono.from(
+                    ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request, true, contextView, null)).toPublisher()
+                )));
             } else if (routeInfo.isReactive()) {
-                executeMethodResponseFlow = ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null));
+                executeMethodResponseFlow = ReactiveExecutionFlow.fromFlow(executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null, null));
             } else {
-                executeMethodResponseFlow = executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null);
+                executeMethodResponseFlow = executeRouteAndConvertBody(propagatedContext, routeMatch, request, false, null, null);
             }
         }
         return executeMethodResponseFlow;
@@ -464,12 +471,13 @@ public final class RouteExecutor {
                                                                       RouteMatch<?> routeMatch,
                                                                       HttpRequest<?> httpRequest,
                                                                       boolean isKotlinCoroutine,
-                                                                      @Nullable ContextView contextView) {
+                                                                      @Nullable ContextView contextView,
+                                                                      @Nullable ExecutorService executorService) {
         PropagatedContext routePropagatedContext = propagatedContext.plus(new ServerHttpRequestContext(httpRequest));
         return routePropagatedContext.propagate(() -> {
             try {
                 if (isKotlinCoroutine && contextView != null) {
-                    coroutineHelper.ifPresent(helper -> helper.setupCoroutineContext(httpRequest, contextView, routePropagatedContext));
+                    coroutineHelper.ifPresent(helper -> helper.setupCoroutineContext(httpRequest, contextView, routePropagatedContext, executorService));
                 }
                 requestArgumentSatisfier.fulfillArgumentRequirementsAfterFilters(routeMatch, httpRequest);
                 Object body = routeMatch.execute();

--- a/http-server/src/test/java/io/micronaut/http/server/CoroutineHelperTest.java
+++ b/http-server/src/test/java/io/micronaut/http/server/CoroutineHelperTest.java
@@ -16,8 +16,12 @@
 package io.micronaut.http.server;
 
 import io.micronaut.context.propagation.instrument.execution.ContextPropagatingExecutorService;
+import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.bind.binders.ContinuationArgumentBinder;
+import kotlin.coroutines.Continuation;
+import kotlin.coroutines.CoroutineContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import reactor.util.context.Context;
@@ -27,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -66,6 +71,38 @@ class CoroutineHelperTest {
     void anInstrumentedExecutorResolvesToItsTargetsDispatcher() {
         ExecutorService instrumented = new ContextPropagatingExecutorService(executor);
         assertSame(helper.dispatcherFor(executor), helper.dispatcherFor(instrumented));
+    }
+
+    /**
+     * The point of the change: the executor a route was assigned to becomes the dispatcher its coroutine runs and
+     * resumes on, rather than {@code Dispatchers.Default}.
+     */
+    @Test
+    void theExecutorBecomesTheCoroutinesDispatcher() {
+        HttpRequest<?> request = HttpRequest.GET("/");
+        Continuation<?> continuation = bindContinuation(request);
+
+        helper.setupCoroutineContext(request, Context.empty(), PropagatedContext.empty(), executor);
+
+        CoroutineContext.Element dispatcher = (CoroutineContext.Element) helper.dispatcherFor(executor);
+        assertSame(dispatcher, continuation.getContext().get(dispatcher.getKey()));
+    }
+
+    @Test
+    void withNoExecutorTheCoroutineKeepsTheDefaultDispatcher() {
+        HttpRequest<?> request = HttpRequest.GET("/");
+        Continuation<?> continuation = bindContinuation(request);
+
+        helper.setupCoroutineContext(request, Context.empty(), PropagatedContext.empty());
+
+        CoroutineContext.Element dispatcher = (CoroutineContext.Element) helper.dispatcherFor(executor);
+        assertNotNull(continuation.getContext().get(dispatcher.getKey()));
+        assertNotSame(dispatcher, continuation.getContext().get(dispatcher.getKey()));
+    }
+
+    private static Continuation<?> bindContinuation(HttpRequest<?> request) {
+        ContinuationArgumentBinder binder = new ContinuationArgumentBinder();
+        return binder.bind(ConversionContext.of(binder.argumentType()), request).getValue().orElseThrow();
     }
 
     @Test

--- a/http-server/src/test/java/io/micronaut/http/server/CoroutineHelperTest.java
+++ b/http-server/src/test/java/io/micronaut/http/server/CoroutineHelperTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server;
+
+import io.micronaut.context.propagation.instrument.execution.ContextPropagatingExecutorService;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.http.HttpRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import reactor.util.context.Context;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class CoroutineHelperTest {
+
+    private final CoroutineHelper helper = new CoroutineHelper(List.of());
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final ExecutorService otherExecutor = Executors.newSingleThreadExecutor();
+
+    @AfterEach
+    void shutdown() {
+        executor.shutdownNow();
+        otherExecutor.shutdownNow();
+    }
+
+    /**
+     * A coroutine dispatcher is compared by identity, so building one per request would allocate on the request
+     * path and stop {@code withContext} from recognising the route's own dispatcher as the one already in effect.
+     */
+    @Test
+    void theDispatcherIsResolvedOncePerExecutor() {
+        assertSame(helper.dispatcherFor(executor), helper.dispatcherFor(executor));
+    }
+
+    @Test
+    void differentExecutorsGetDifferentDispatchers() {
+        assertNotSame(helper.dispatcherFor(executor), helper.dispatcherFor(otherExecutor));
+    }
+
+    /**
+     * Every {@link ExecutorService} bean is instrumented, so the executor a route is assigned to is normally a
+     * {@link ContextPropagatingExecutorService}. Coroutine propagation is handled by {@code KotlinCoroutinePropagation},
+     * so the dispatcher must be built from the target rather than the wrapper - otherwise every resumption would
+     * also capture the propagated context of whichever thread happened to dispatch it.
+     */
+    @Test
+    void anInstrumentedExecutorResolvesToItsTargetsDispatcher() {
+        ExecutorService instrumented = new ContextPropagatingExecutorService(executor);
+        assertSame(helper.dispatcherFor(executor), helper.dispatcherFor(instrumented));
+    }
+
+    @Test
+    void aRequestWithNoContinuationIsLeftAlone() {
+        HttpRequest<?> request = HttpRequest.GET("/");
+        assertDoesNotThrow(() -> helper.setupCoroutineContext(request, Context.empty(), PropagatedContext.empty()));
+        assertDoesNotThrow(() -> helper.setupCoroutineContext(request, Context.empty(), PropagatedContext.empty(), executor));
+    }
+}

--- a/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
+++ b/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
@@ -72,14 +72,6 @@ class ContinuationArgumentBinder : TypedRequestArgumentBinder<Continuation<*>> {
         fun setupCoroutineContext(source: HttpRequest<*>,
                                   contextView: ContextView,
                                   propagatedContext: PropagatedContext,
-                                  continuationArgumentBinderCoroutineContextFactories: Collection<HttpCoroutineContextFactory<*>>) {
-            setupCoroutineContext(source, contextView, propagatedContext, continuationArgumentBinderCoroutineContextFactories, null)
-        }
-
-        @JvmStatic
-        fun setupCoroutineContext(source: HttpRequest<*>,
-                                  contextView: ContextView,
-                                  propagatedContext: PropagatedContext,
                                   continuationArgumentBinderCoroutineContextFactories: Collection<HttpCoroutineContextFactory<*>>,
                                   dispatcher: CoroutineContext?) {
             val customContinuation = source.getAttribute(CONTINUATION_ARGUMENT_ATTRIBUTE_KEY, CustomContinuation::class.java).orElse(null)

--- a/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
+++ b/http/src/main/kotlin/io/micronaut/http/bind/binders/ContinuationArgumentBinder.kt
@@ -24,10 +24,12 @@ import io.micronaut.core.reflect.ClassUtils
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.reactor.ReactorContext
 import reactor.util.context.ContextView
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
 import java.util.function.Supplier
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
@@ -51,14 +53,38 @@ class ContinuationArgumentBinder : TypedRequestArgumentBinder<Continuation<*>> {
 
         private val reactorContextPresent: Boolean = ClassUtils.isPresent("kotlinx.coroutines.reactor.ReactorContext", null);
 
+        /**
+         * Builds the dispatcher a route's coroutine should run and resume on.
+         *
+         * The returned dispatcher holds a reference to [executorService] and is meant to be resolved once per
+         * executor and reused; [kotlinx.coroutines.CoroutineDispatcher] equality is identity based, so a fresh
+         * instance per request would defeat `withContext` short circuiting and allocate on the request path.
+         *
+         * Note the returned dispatcher must never be closed: closing it shuts down the underlying executor.
+         *
+         * @param executorService The executor the route was assigned to
+         * @return The dispatcher for that executor
+         */
+        @JvmStatic
+        fun dispatcherFor(executorService: ExecutorService): CoroutineContext = executorService.asCoroutineDispatcher()
+
         @JvmStatic
         fun setupCoroutineContext(source: HttpRequest<*>,
                                   contextView: ContextView,
                                   propagatedContext: PropagatedContext,
                                   continuationArgumentBinderCoroutineContextFactories: Collection<HttpCoroutineContextFactory<*>>) {
+            setupCoroutineContext(source, contextView, propagatedContext, continuationArgumentBinderCoroutineContextFactories, null)
+        }
+
+        @JvmStatic
+        fun setupCoroutineContext(source: HttpRequest<*>,
+                                  contextView: ContextView,
+                                  propagatedContext: PropagatedContext,
+                                  continuationArgumentBinderCoroutineContextFactories: Collection<HttpCoroutineContextFactory<*>>,
+                                  dispatcher: CoroutineContext?) {
             val customContinuation = source.getAttribute(CONTINUATION_ARGUMENT_ATTRIBUTE_KEY, CustomContinuation::class.java).orElse(null)
             if (customContinuation != null) {
-                var coroutineContext: CoroutineContext = Dispatchers.Default
+                var coroutineContext: CoroutineContext = dispatcher ?: Dispatchers.Default
                 if (reactorContextPresent) {
                     coroutineContext += propagateReactorContext(contextView)
                 }

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -471,3 +471,9 @@ If the previous behavior is desired, configure the retryable annotation explicit
 ----
 @Retryable(includes = RuntimeException.class)
 ----
+
+==== Kotlin `suspend` routes honour the selected executor
+
+In Micronaut Framework 4, a Kotlin `suspend` route ignored ann:scheduling.annotation.ExecuteOn[] and the `micronaut.server.thread-selection` setting: the route ran on the event loop and resumed on `Dispatchers.Default`. In Micronaut 5 the selected executor is applied, and it is also the dispatcher the coroutine resumes on.
+
+This changes which thread a `suspend` route runs on for applications that annotate one with ann:scheduling.annotation.ExecuteOn[], or that set `micronaut.server.thread-selection` to `AUTO`, `IO` or `BLOCKING` (the default is `MANUAL`, which selects no executor and is unaffected). To keep a `suspend` route on the event loop under `AUTO`, annotate it with ann:core.annotation.NonBlocking[].

--- a/src/main/docs/guide/httpServer/reactiveServer.adoc
+++ b/src/main/docs/guide/httpServer/reactiveServer.adoc
@@ -24,6 +24,10 @@ The value of the ann:scheduling.annotation.ExecuteOn[] annotation can be any nam
 
 TIP: Generally speaking for database operations you want a thread pool configured that matches the maximum number of connections specified in the database connection pool.
 
+For a Kotlin `suspend` function, the selected executor is also the dispatcher the coroutine resumes on, so work after a suspension point stays on that executor rather than falling back to `Dispatchers.Default`. Child coroutines inherit it, and an explicit `withContext` still wins for the duration of its block.
+
+NOTE: An explicit ann:scheduling.annotation.ExecuteOn[] and the `micronaut.server.thread-selection` setting both resolve through the same executor selection, so a `suspend` route is offloaded under `AUTO`, `IO` and `BLOCKING` thread selection just as a blocking route is. To keep a `suspend` route on the event loop under `AUTO`, annotate it with ann:core.annotation.NonBlocking[].
+
 An alternative to the ann:scheduling.annotation.ExecuteOn[] annotation is to use the facility provided by the reactive library you have chosen. Reactive implementations such as https://projectreactor.io[Project Reactor] or https://github.com/ReactiveX/RxJava[RxJava] feature a `subscribeOn` method which lets you alter which thread executes user code. For example:
 
 snippet::io.micronaut.docs.http.server.reactive.PersonController[tags="imports,class", indent=0,title="Reactive subscribeOn Example"]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/executeon/SuspendExecuteOnTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/executeon/SuspendExecuteOnTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.executeon
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Test
+
+/**
+ * A `suspend` route annotated with [ExecuteOn] used to ignore the annotation and run on the event loop.
+ * See https://github.com/micronaut-projects/micronaut-core/issues/12326.
+ */
+@MicronautTest
+@Property(name = "spec.name", value = "SuspendExecuteOnTest")
+class SuspendExecuteOnTest {
+    @Inject
+    lateinit var server: EmbeddedServer
+
+    @Test
+    fun `a suspend route honours ExecuteOn`() {
+        assertOnIoExecutor(threadFor("/suspending"), "a suspend route with @ExecuteOn(IO)")
+    }
+
+    @Test
+    fun `a blocking route honours ExecuteOn`() {
+        assertOnIoExecutor(threadFor("/blocking"), "a blocking route with @ExecuteOn(IO)")
+    }
+
+    @Test
+    fun `a route without ExecuteOn is left on the event loop`() {
+        assertOnEventLoop(threadFor("/without-execute-on"), "a suspend route with no executor")
+    }
+
+    private fun threadFor(path: String): String =
+        server.applicationContext.createBean(HttpClient::class.java, server.uri).use {
+            it.toBlocking().retrieve("/suspend-execute-on$path")
+        }
+
+    @Requires(property = "spec.name", value = "SuspendExecuteOnTest")
+    @Controller("/suspend-execute-on")
+    class MyController {
+        @Get("/suspending")
+        @ExecuteOn(TaskExecutors.IO)
+        suspend fun suspending(): String = Thread.currentThread().name
+
+        @Get("/blocking")
+        @ExecuteOn(TaskExecutors.IO)
+        fun blocking(): String = Thread.currentThread().name
+
+        @Get("/without-execute-on")
+        suspend fun withoutExecuteOn(): String = Thread.currentThread().name
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/executeon/SuspendResumptionTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/executeon/SuspendResumptionTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.executeon
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.context.ServerRequestContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * The route's executor must also be the dispatcher the coroutine resumes on, otherwise work after a suspension
+ * point runs on `Dispatchers.Default` regardless of [ExecuteOn].
+ * See https://github.com/micronaut-projects/micronaut-core/issues/12326.
+ */
+@MicronautTest
+@Property(name = "spec.name", value = "SuspendResumptionTest")
+class SuspendResumptionTest {
+    @Inject
+    lateinit var server: EmbeddedServer
+
+    @Test
+    fun `a suspend route with ExecuteOn stays on that executor across a suspension point`() {
+        val (before, after) = threadsFor("/executeOn")
+        assertOnIoExecutor(before, "a suspend route with @ExecuteOn(IO)")
+        assertOnIoExecutor(after, "a suspend route with @ExecuteOn(IO), after resuming")
+    }
+
+    @Test
+    fun `a route without ExecuteOn is not diverted onto the executor`() {
+        val (before, after) = threadsFor("/plain")
+        assertOnEventLoop(before, "a suspend route with no executor")
+        assertNotOnIoExecutor(after, "a suspend route with no executor, after resuming")
+    }
+
+    @Test
+    fun `child coroutines of a route with ExecuteOn inherit that executor`() {
+        val (first, second) = threadsFor("/nested-executeOn")
+        assertOnIoExecutor(first, "the first child coroutine of a route with @ExecuteOn(IO)")
+        assertOnIoExecutor(second, "the second child coroutine of a route with @ExecuteOn(IO)")
+    }
+
+    @Test
+    fun `child coroutines of a route without ExecuteOn are not diverted onto the executor`() {
+        val (first, second) = threadsFor("/nested-plain")
+        assertNotOnIoExecutor(first, "the first child coroutine of a route with no executor")
+        assertNotOnIoExecutor(second, "the second child coroutine of a route with no executor")
+    }
+
+    @Test
+    fun `an explicit dispatcher wins over the route's executor, which is restored afterwards`() {
+        val (inside, after) = threadsFor("/explicit-dispatcher")
+        assertNotOnIoExecutor(inside, "a withContext(Dispatchers.Default) block")
+        assertOnIoExecutor(after, "a route with @ExecuteOn(IO), after a withContext block returns")
+    }
+
+    /**
+     * The dispatcher is resolved once per executor rather than per request. A coroutine dispatcher is compared by
+     * identity, so a fresh one each time would allocate on the request path and stop `withContext` from recognising
+     * the route's own dispatcher as the one already in effect.
+     */
+    @Test
+    fun `the route's dispatcher is the same instance across requests`() {
+        val (first, _) = threadsFor("/dispatcher-identity")
+        val (second, _) = threadsFor("/dispatcher-identity")
+        Assertions.assertEquals(first, second, "the route's dispatcher was rebuilt for the second request")
+    }
+
+    /**
+     * The dispatcher is built from the raw executor rather than the context propagating wrapper, so the propagated
+     * context has to survive a suspension point on the strength of KotlinCoroutinePropagation alone.
+     */
+    @Test
+    fun `the request is still propagated after resuming on the executor`() {
+        val (before, after) = threadsFor("/propagation")
+        Assertions.assertEquals("/suspend-resumption/propagation", before, "the request was missing before suspending")
+        Assertions.assertEquals("/suspend-resumption/propagation", after, "the request was missing after resuming")
+    }
+
+    private fun threadsFor(path: String): Pair<String, String> =
+        server.applicationContext.createBean(HttpClient::class.java, server.uri).use {
+            val (before, after) = it.toBlocking().retrieve("/suspend-resumption$path").split("|")
+            before to after
+        }
+
+    @Requires(property = "spec.name", value = "SuspendResumptionTest")
+    @Controller("/suspend-resumption")
+    class MyController {
+        @Get("/executeOn")
+        @ExecuteOn(TaskExecutors.IO)
+        suspend fun withExecuteOn(): String = beforeAndAfterSuspension()
+
+        @Get("/plain")
+        suspend fun plain(): String = beforeAndAfterSuspension()
+
+        @Get("/nested-executeOn")
+        @ExecuteOn(TaskExecutors.IO)
+        suspend fun nestedWithExecuteOn(): String = threadsOfChildCoroutines()
+
+        @Get("/nested-plain")
+        suspend fun nestedPlain(): String = threadsOfChildCoroutines()
+
+        @Get("/dispatcher-identity")
+        @ExecuteOn(TaskExecutors.IO)
+        suspend fun dispatcherIdentity(): String {
+            val before = dispatcherId()
+            delay(5.milliseconds)
+            return "$before|${dispatcherId()}"
+        }
+
+        @Get("/propagation")
+        @ExecuteOn(TaskExecutors.IO)
+        suspend fun propagation(): String {
+            val before = currentPath()
+            delay(5.milliseconds)
+            return "$before|${currentPath()}"
+        }
+
+        @Get("/explicit-dispatcher")
+        @ExecuteOn(TaskExecutors.IO)
+        suspend fun explicitDispatcher(): String {
+            val inside = withContext(Dispatchers.Default) { Thread.currentThread().name }
+            return "$inside|${Thread.currentThread().name}"
+        }
+
+        private suspend fun dispatcherId(): String =
+            System.identityHashCode(coroutineContext[ContinuationInterceptor]).toString()
+
+        private fun currentPath(): String =
+            ServerRequestContext.currentRequest<Any>().map { it.path }.orElse("<no request>")
+
+        private suspend fun beforeAndAfterSuspension(): String {
+            val before = Thread.currentThread().name
+            delay(5.milliseconds)
+            return "$before|${Thread.currentThread().name}"
+        }
+
+        // children inherit the dispatcher from the route's coroutine context, so @ExecuteOn reaches them too
+        private suspend fun threadsOfChildCoroutines(): String = coroutineScope {
+            val first = async { Thread.currentThread().name }
+            val second = async { Thread.currentThread().name }
+            "${first.await()}|${second.await()}"
+        }
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/executeon/SuspendThreadSelectionTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/executeon/SuspendThreadSelectionTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.executeon
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.executor.ThreadSelection
+import org.junit.jupiter.api.Test
+
+/**
+ * `@ExecuteOn` and `micronaut.server.thread-selection` both resolve through `RouteInfo.getExecutor`, so a suspend
+ * route ignored every offloading thread-selection mode as well.
+ * See https://github.com/micronaut-projects/micronaut-core/issues/12326.
+ */
+class SuspendThreadSelectionTest {
+
+    @Test
+    fun `thread-selection AUTO offloads both route shapes`() = assertOffloadsBothShapes(ThreadSelection.AUTO)
+
+    @Test
+    fun `thread-selection IO offloads both route shapes`() = assertOffloadsBothShapes(ThreadSelection.IO)
+
+    @Test
+    fun `thread-selection BLOCKING offloads both route shapes`() = assertOffloadsBothShapes(ThreadSelection.BLOCKING)
+
+    @Test
+    fun `thread-selection MANUAL selects no executor, so both shapes stay on the event loop`() {
+        val (suspending, blocking) = threadsFor(ThreadSelection.MANUAL)
+        assertOnEventLoop(suspending, "thread-selection=MANUAL: a suspend route")
+        assertOnEventLoop(blocking, "thread-selection=MANUAL: a blocking route")
+    }
+
+    private fun assertOffloadsBothShapes(mode: ThreadSelection) {
+        val (suspending, blocking) = threadsFor(mode)
+        assertOffloaded(suspending, "thread-selection=$mode: a suspend route")
+        assertOffloaded(blocking, "thread-selection=$mode: a blocking route")
+    }
+
+    private fun threadsFor(mode: ThreadSelection): Pair<String, String> {
+        val configuration = mapOf(
+            "spec.name" to "SuspendThreadSelectionTest",
+            "micronaut.server.thread-selection" to mode,
+        )
+        ApplicationContext.run(EmbeddedServer::class.java, configuration).use { server ->
+            server.applicationContext.createBean(HttpClient::class.java, server.uri).use {
+                val client = it.toBlocking()
+                return client.retrieve("/suspend-thread-selection/suspending") to
+                    client.retrieve("/suspend-thread-selection/blocking")
+            }
+        }
+    }
+
+    @Requires(property = "spec.name", value = "SuspendThreadSelectionTest")
+    @Controller("/suspend-thread-selection")
+    class MyController {
+        @Get("/suspending")
+        suspend fun suspending(): String = Thread.currentThread().name
+
+        @Get("/blocking")
+        fun blocking(): String = Thread.currentThread().name
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/executeon/ThreadAssertions.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/executeon/ThreadAssertions.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.executeon
+
+import org.junit.jupiter.api.Assertions
+
+internal const val IO = "io-executor-thread-"
+internal const val LOOP = "default-eventLoopGroup"
+
+internal fun assertOnIoExecutor(thread: String, what: String) =
+    Assertions.assertTrue(thread.startsWith(IO), "$what did not run on the IO executor: '$thread'")
+
+internal fun assertNotOnIoExecutor(thread: String, what: String) =
+    Assertions.assertFalse(thread.startsWith(IO), "$what unexpectedly ran on the IO executor: '$thread'")
+
+// AUTO and BLOCKING pick virtual threads on JDK 21+ and the IO executor on 17, so only "not the event loop" holds
+internal fun assertOffloaded(thread: String, what: String) =
+    Assertions.assertFalse(thread.startsWith(LOOP), "$what ran on the event loop: '$thread'")
+
+internal fun assertOnEventLoop(thread: String, what: String) =
+    Assertions.assertTrue(thread.startsWith(LOOP), "$what did not run on the event loop: '$thread'")


### PR DESCRIPTION
Supersedes #12869 and #12594, rebased onto `5.2.x` and extended. Fixes #12326.

Thanks to @rawilder and @jpbempel — the diagnosis and the core of the fix are theirs, and they are credited as co-authors on the commit.

## The bug

A Kotlin `suspend` route ignored `@ExecuteOn` and `micronaut.server.thread-selection`. `RouteInfo.getExecutor` picked an executor, `RouteExecutor.callRoute` then dropped it on the floor for the suspended branch, and the route ran on the event loop and resumed on `Dispatchers.Default`.

## The fix

Two changes are needed, and a partial fix looks plausible but doesn't work. A suspend function runs **synchronously on its caller** until the first suspension point, and its coroutine context governs only where it *resumes*:

- **`applyExecutorToPublisher`** around the deferred `Mono` moves the body off the event loop up to the first suspension point. Changing only the dispatcher would leave that part on the event loop.
- **The executor becomes the coroutine's dispatcher**, so the continuation — and the child coroutines that inherit it — stay there afterwards. `subscribeOn` alone would run the body on IO and then resume on `Dispatchers.Default`.

The no-executor path is unchanged: `dispatcher ?: Dispatchers.Default`, and the WebSocket caller keeps the 3-arg overload.

## Differences from #12869

- **The dispatcher is resolved once per executor, not per request.** `Executor.asCoroutineDispatcher()` returns a fresh `ExecutorCoroutineDispatcherImpl` on every call. Per request that allocates on the request path, re-runs the `ScheduledThreadPoolExecutor` reflection probe in its `init`, and — because dispatcher equality is identity — stops `withContext` from recognising the route's own dispatcher as the one already in effect. The cache lives on the `CoroutineHelper` singleton, so it is bound to the application context that owns the executors and cannot outlive them.
- **The dispatcher is built from the raw executor, not the instrumented wrapper.** `ExecutorServiceInstrumenter` wraps every `ExecutorService` bean, so what `getExecutor()` returns is a `ContextPropagatingExecutorService`. Coroutine propagation is already handled by `MicronautPropagatedContext` (a `ThreadContextElement`); dispatching through the wrapper would *additionally* capture the propagated context of whichever thread happened to resume the continuation and push it as an outer scope. `CoroutineHelper` now unwraps first, matching what `applyExecutorToPublisher` already does a few lines up.
- **`publishOn` is kept, and the reason is now in a comment.** It holds the same "the response is assembled off the event loop" invariant that the blocking branch gets from `ExecutionFlow.async`.
- **The `thread-selection` behaviour change is documented**, in the guide and in the breaking-changes appendix.
- License headers on the new test files, plus two new tests (below).

## Behaviour change

`@ExecuteOn` and `micronaut.server.thread-selection` resolve through the same `RouteInfo.getExecutor`, so this also makes a `suspend` route obey `AUTO`, `IO` and `BLOCKING` selection.

The alternative was to special-case suspend inside `DefaultExecutorSelector` and treat it as non-blocking under `AUTO`. I went the other way: the selector also feeds `@ExecuteOn` and the AOP `ExecuteOnInterceptor`, so Kotlin-specific knowledge doesn't belong in it, and it would leave `AUTO` offloading `fun foo(): String` but not `suspend fun foo(): String` — `suspend` is no compile-time promise the body doesn't block. `@NonBlocking` already exists for opting a route back onto the event loop, and the selector honours it.

The default is `MANUAL`, which selects no executor, so applications on the default are unaffected. Documented in `breaks.adoc`.

## Tests

`test-suite-kotlin/.../http/server/executeon/` — 14 tests:

- `SuspendExecuteOnTest` — `@ExecuteOn` on suspend and blocking routes, and that a route without it stays on the event loop.
- `SuspendResumptionTest` — thread identity *across* a suspension point, child coroutine inheritance, `withContext` winning and then restoring the route's dispatcher, that the dispatcher is the **same instance across two requests** (the caching fix), and that the request is **still propagated after resuming** on the executor (the unwrapping fix).
- `SuspendThreadSelectionTest` — `AUTO`/`IO`/`BLOCKING` offload both route shapes; `MANUAL` leaves both on the event loop.

Every thread-name constant is pinned by at least one *positive* assertion, so the negative assertions can't pass vacuously from a typo'd prefix.

Verified locally: 14/14 new tests pass, and a regression sweep over the existing suspend, coroutine and `ThreadSelectionSpec` tests is 85 tests / 0 failures.

## Note on 4.10.x

#12869 targeted `4.10.x`; this targets `5.2.x`. If the fix is wanted in a 4.10 patch, that needs a separate back-port — but note the `thread-selection` behaviour change above, which is easier to justify on a minor line than in a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
