### PR TITLE
Resolve member-level @AnnotationExpressionContext in Kotlin

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/context/DefaultExpressionCompilationContextFactory.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/DefaultExpressionCompilationContextFactory.java
@@ -21,14 +21,18 @@ import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.visitor.VisitorContext;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 /**
  * Factory for producing expression evaluation context.
@@ -106,18 +110,25 @@ public final class DefaultExpressionCompilationContextFactory implements Express
         ClassElement annotation,
         String annotationMember) {
 
-        ElementQuery<MethodElement> memberQuery =
-            ElementQuery.ALL_METHODS
-                .onlyDeclared()
-                .annotated(am -> am.hasAnnotation(AnnotationExpressionContext.class))
-                .named(annotationMember);
-
-        return annotation.getEnclosedElements(memberQuery).stream()
+        return findAnnotationMembers(annotation, annotationMember)
                    .flatMap(element -> Optional.ofNullable(element.getDeclaredAnnotation(AnnotationExpressionContext.class)).stream())
                    .flatMap(av -> av.annotationClassValue(AnnotationMetadata.VALUE_MEMBER).stream())
                    .map(AnnotationClassValue::getName)
                    .flatMap(className -> visitorContext.getClassElement(className).stream())
                    .reduce(currentEvaluationContext, ExtensibleExpressionEvaluationContext::extendWith, (a, b) -> a);
+    }
+
+    private Stream<? extends Element> findAnnotationMembers(ClassElement annotation, String annotationMember) {
+        List<MethodElement> methods = annotation.getEnclosedElements(ElementQuery.ALL_METHODS.onlyDeclared());
+        if (!methods.isEmpty()) {
+            return methods.stream().filter(method -> method.getName().equals(annotationMember));
+        }
+        // Kotlin models the members of an annotation class as properties instead of methods
+        ElementQuery<PropertyElement> propertyQuery =
+            ElementQuery.of(PropertyElement.class)
+                .onlyDeclared()
+                .named(annotationMember);
+        return annotation.getEnclosedElements(propertyQuery).stream();
     }
 
     /**

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/expressions/AnnotationLevelContextExpressionsSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/expressions/AnnotationLevelContextExpressionsSpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.kotlin.processing.expressions
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+import static io.micronaut.annotation.processing.test.KotlinCompiler.buildContext
+
+class AnnotationLevelContextExpressionsSpec extends Specification {
+
+    void "test annotation level context"() {
+        given:
+        ApplicationContext ctx = buildContext("""
+            package test
+
+            import io.micronaut.context.annotation.AnnotationExpressionContext
+            import jakarta.inject.Singleton
+
+            @Singleton
+            @CustomAnnotation("#{ #getAnnotationLevelValue() }")
+            class Expr
+
+            @Singleton
+            class CustomContext {
+                fun getAnnotationLevelValue(): String = "annotationLevelValue"
+            }
+
+            @AnnotationExpressionContext(CustomContext::class)
+            annotation class CustomAnnotation(val value: String)
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+        def annType = ctx.classLoader.loadClass('test.CustomAnnotation')
+
+        expect:
+        ctx.getBeanDefinition(type).stringValue(annType).get() == 'annotationLevelValue'
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "test annotation member level context"() {
+        given:
+        ApplicationContext ctx = buildContext("""
+            package test
+
+            import io.micronaut.context.annotation.AnnotationExpressionContext
+            import jakarta.inject.Singleton
+
+            @Singleton
+            @CustomAnnotation(customValue = "#{ #getAnnotationLevelValue() }")
+            class Expr
+
+            @Singleton
+            class CustomContext {
+                fun getAnnotationLevelValue(): String = "annotationLevelValue"
+            }
+
+            annotation class CustomAnnotation(
+                @get:AnnotationExpressionContext(CustomContext::class)
+                val customValue: String
+            )
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+        def annType = ctx.classLoader.loadClass('test.CustomAnnotation')
+
+        expect:
+        ctx.getBeanDefinition(type).stringValue(annType, "customValue").get() == 'annotationLevelValue'
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/expressions/AnnotationContextExample.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/expressions/AnnotationContextExample.kt
@@ -1,0 +1,24 @@
+package io.micronaut.docs.expressions
+
+import io.micronaut.context.annotation.AnnotationExpressionContext
+import jakarta.inject.Singleton
+
+@Singleton
+@CustomAnnotation("#{firstValue() + secondValue()}") // <1>
+class Example
+
+@Singleton
+class AnnotationContext { // <2>
+    fun firstValue(): String = "first value"
+}
+
+@Singleton
+class AnnotationMemberContext { // <3>
+    fun secondValue(): String = "second value"
+}
+
+@AnnotationExpressionContext(AnnotationContext::class) // <4>
+annotation class CustomAnnotation(
+    @get:AnnotationExpressionContext(AnnotationMemberContext::class) // <5>
+    val value: String
+)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/expressions/AnnotationContextExampleSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/expressions/AnnotationContextExampleSpec.kt
@@ -1,0 +1,17 @@
+package io.micronaut.docs.expressions
+
+import io.micronaut.context.ApplicationContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AnnotationContextExampleSpec {
+
+    @Test
+    fun testAnnotationContextEvaluation() {
+        ApplicationContext.run().use { beanContext ->
+            val beanDefinition = beanContext.getBeanDefinition(Example::class.java)
+            val value = beanDefinition.stringValue(CustomAnnotation::class.java).orElse(null)
+            assertEquals("first valuesecond value", value)
+        }
+    }
+}


### PR DESCRIPTION
## What

`@AnnotationExpressionContext` worked at annotation *type* level in Kotlin but was silently ignored at annotation *member* level, so an evaluated expression could not resolve methods from a member-scoped context. The Kotlin equivalent of the `AnnotationContextExample` docs snippet failed at KSP time, which is why the `evaluatedExpressions` guide page had Java and Groovy tabs but no Kotlin one.

Reproduction (before this change):

```
e: [ksp] Failed to compile evaluated expression [#{firstValue() + secondValue()}].
   Cause: No method [ secondValue() ] available in evaluation context
```

The type-level context (`firstValue()`) resolved; only the member-level one did not.

## Why

`DefaultExpressionCompilationContextFactory` looked up the annotation member with `ElementQuery.ALL_METHODS`. Java and Groovy model annotation members as methods, so that works there. Kotlin models the members of an `annotation class` as properties (constructor `val`s), and `KotlinClassElement`'s method query only returns `getDeclaredFunctions()` — empty for an annotation class. The member's `@AnnotationExpressionContext` was therefore never found.

## How

`findAnnotationMembers` queries declared methods first and falls back to a `PropertyElement` query only when the annotation type declares no methods at all.

The guard is load-bearing: `JavaClassElement` and `GroovyClassElement` both throw `IllegalStateException: Unknown result type` on a `PropertyElement` query, so an unguarded fallback breaks the Java and Groovy paths (an earlier attempt failed 42 Groovy expression specs this way). Keying on an empty method list rather than on the language also keeps a *Java* annotation seen through KSP on the method path, since KSP reports its members as functions.

## Reviewer notes

**Base branch is 5.2.x, not 5.1.x.** The branch is cut from `origin/5.2.x` (`49b15cf`), and 5.1.x is not an ancestor of 5.2.x — against 5.1.x this PR would show 1448 files / ~143k lines instead of 4 files / 132 lines.

**The bare annotation form cannot work on a Kotlin member, so the docs example uses `@get:`.** `@Target({ANNOTATION_TYPE, METHOD})` maps to the Kotlin targets `ANNOTATION_CLASS, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER, EXPRESSION`, none of which apply to a value parameter, so kotlinc rejects both the bare form and `@property:` before KSP ever runs. `@get:` targets the getter — i.e. the JVM annotation member method — and is what the metadata builder already reads. Widening the Java `@Target` to `PARAMETER` would make the bare form compile but would also permit the annotation on ordinary method parameters, so I left it alone. Flagging in case you'd rather take that trade.

## Tests

New `AnnotationLevelContextExpressionsSpec` in `inject-kotlin` mirrors the existing Java and Groovy specs, covering both type-level and member-level context. New `AnnotationContextExample.kt` / `AnnotationContextExampleSpec.kt` in `test-suite-kotlin` give the guide page its Kotlin tab (the `snippet::` macro picks it up by path, so no `.adoc` change was needed).

Verified green:

```
:micronaut-inject-kotlin:test --tests io.micronaut.kotlin.processing.expressions.*
:micronaut-inject-java:test   --tests io.micronaut.expressions.*
:micronaut-inject-groovy:test --tests io.micronaut.expressions.*
:test-suite-kotlin / :test-suite / :test-suite-groovy --tests io.micronaut.docs.expressions.*
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)