### PR TITLE
Make the Python compile tasks cacheable and relocatable

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/python/PythonCompile.java
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/python/PythonCompile.java
@@ -19,9 +19,11 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -37,15 +39,23 @@ import org.gradle.workers.WorkerExecutor;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-//@CacheableTask
-// Currently NOT cacheable because generated Python code
-// contains absolute paths
+/**
+ * Compiles Python sources with the Pyronaut compiler.
+ * <p>
+ * The compiler is given each source directory relative to the project directory, so that the
+ * {@code @PythonApplication(src = ...)} value it compiles into the output carries no absolute path.
+ * The project directory itself reaches the annotation processor as a compiler option, because a
+ * worker daemon does not run in the project directory. That keeps the outputs relocatable and
+ * therefore cacheable.
+ */
+@CacheableTask
 public abstract class PythonCompile extends DefaultTask {
 
     private static final String PYRONAUT_COMPILER_MAIN_CLASS =
@@ -93,6 +103,9 @@ public abstract class PythonCompile extends DefaultTask {
     @Inject
     protected abstract FileSystemOperations getFileSystemOperations();
 
+    @Inject
+    protected abstract ProjectLayout getLayout();
+
     private Map<String, String> getMergedSystemProperties() {
         var systemProperties = new LinkedHashMap<>(getSystemProperties().getOrElse(Map.of()));
         systemProperties.putAll(Map.of(
@@ -113,6 +126,7 @@ public abstract class PythonCompile extends DefaultTask {
     @TaskAction
     void compile() throws IOException {
         var outputDir = getDestinationDir().getAsFile().get().toPath();
+        var projectDir = getLayout().getProjectDirectory().getAsFile().toPath().toAbsolutePath().normalize();
         getFileSystemOperations().delete(spec -> spec.delete(outputDir));
         Files.createDirectories(outputDir);
         // A process-isolated worker is reused for matching fork options within one build, so several
@@ -132,7 +146,7 @@ public abstract class PythonCompile extends DefaultTask {
             // Compiler currently accepts a single directory, but maybe it should
             // accept a list of .py files instead
             if (location.getAsFile().isDirectory()) {
-                sourceDirs.add(location.getAsFile().getAbsolutePath());
+                sourceDirs.add(relocatableSourcePath(projectDir, location.getAsFile().toPath()));
             }
         }
         if (sourceDirs.isEmpty()) {
@@ -141,11 +155,22 @@ public abstract class PythonCompile extends DefaultTask {
         // one work item: the roots share the destination, so they must not compile concurrently
         queue.submit(PythonCompileWorkAction.class, parameters -> {
             parameters.getSourceDirs().set(sourceDirs);
+            parameters.getSourceRoot().set(projectDir.toString());
             parameters.getDestinationDir().set(destDir);
             parameters.getClasspath().from(getCompilerClasspath(), getClasspath());
         });
         queue.await();
     }
 
-
+    /**
+     * Returns the source directory relative to the project directory when it is located inside it,
+     * otherwise its absolute path. The annotation processor resolves relative paths against the project directory.
+     */
+    private static String relocatableSourcePath(Path projectDir, Path sourceDir) {
+        var absoluteSource = sourceDir.toAbsolutePath().normalize();
+        if (absoluteSource.startsWith(projectDir)) {
+            return projectDir.relativize(absoluteSource).toString();
+        }
+        return absoluteSource.toString();
+    }
 }

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/python/PythonCompileParameters.java
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/python/PythonCompileParameters.java
@@ -28,6 +28,13 @@ public interface PythonCompileParameters extends WorkParameters {
 
     ListProperty<String> getSourceDirs();
 
+    /**
+     * The absolute directory against which relative source directories are resolved. It is handed to the
+     * annotation processor as a compiler option rather than compiled into the output, so the output
+     * stays free of absolute paths.
+     */
+    Property<String> getSourceRoot();
+
     Property<String> getDestinationDir();
 
     /**

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/python/PythonCompileWorkAction.java
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/python/PythonCompileWorkAction.java
@@ -34,6 +34,11 @@ import java.util.List;
 public abstract class PythonCompileWorkAction implements WorkAction<PythonCompileParameters> {
 
     private static final String PYRONAUT_COMPILER_MAIN_CLASS = "io.micronaut.python.compiler.PyronautCompiler";
+    /**
+     * The processor option naming the directory relative source directories are resolved against.
+     * Mirrors {@code PythonAnnotationProcessor.SOURCE_ROOT_OPTION}, which buildSrc cannot reference.
+     */
+    private static final String SOURCE_ROOT_OPTION = "micronaut.python.source.root";
 
     @Override
     public void execute() {
@@ -42,10 +47,10 @@ public abstract class PythonCompileWorkAction implements WorkAction<PythonCompil
         // one compiler run over every root: each run writes the launcher, the VFS file list and the
         // package initialisers for the whole output, so a run per root would keep only the last
         // root's files and drop the others
-        compile(String.join(",", getParameters().getSourceDirs().get()), destinationDir, classpath);
+        compile(String.join(",", getParameters().getSourceDirs().get()), getParameters().getSourceRoot().get(), destinationDir, classpath);
     }
 
-    private void compile(String sourceDirs, String destinationDir, List<File> classpath) {
+    private void compile(String sourceDirs, String sourceRoot, String destinationDir, List<File> classpath) {
         try {
             Class<?> compiler = Class.forName(PYRONAUT_COMPILER_MAIN_CLASS, true, getClass().getClassLoader());
             Object builder = compiler.getMethod("builder").invoke(null);
@@ -54,6 +59,7 @@ public abstract class PythonCompileWorkAction implements WorkAction<PythonCompil
             builderType.getMethod("targetDir", File.class).invoke(builder, new File(destinationDir));
             builderType.getMethod("classpath", List.class).invoke(builder, classpath);
             builderType.getMethod("annotationProcessorPath", List.class).invoke(builder, classpath);
+            builderType.getMethod("options", List.class).invoke(builder, List.of("-A" + SOURCE_ROOT_OPTION + "=" + sourceRoot));
             Object instance = builderType.getMethod("build").invoke(builder);
             instance.getClass().getMethod("compile").invoke(instance);
         } catch (InvocationTargetException e) {

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/python/PythonVfsBytecodeCompile.java
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/python/PythonVfsBytecodeCompile.java
@@ -20,10 +20,13 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 
@@ -32,11 +35,13 @@ import javax.inject.Inject;
 /**
  * Copies a GraalPy VFS resource tree and adds checked-hash Python bytecode caches to its file list.
  */
+@CacheableTask
 public abstract class PythonVfsBytecodeCompile extends DefaultTask {
     private static final String PYTHON_BYTECODE_COMPILER_MAIN_CLASS =
         "io.micronaut.python.compiler.PythonBytecodeCompiler";
 
     @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract DirectoryProperty getSourceDirectory();
 
     @OutputDirectory

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationProcessor.java
@@ -72,6 +72,11 @@ import java.util.stream.Collectors;
 public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor implements AutoCloseable {
     public static final String APPLICATION_PATH = "GRAALPY-VFS/micronaut-application/";
     public static final String APPLICATION_SRC_PATH = "GRAALPY-VFS/micronaut-application/src/";
+    /**
+     * The compiler option naming the directory that relative {@code @PythonApplication(src = ...)}
+     * directories are resolved against. Without it they resolve against the working directory.
+     */
+    public static final String SOURCE_ROOT_OPTION = "micronaut.python.source.root";
     public static final String APPLICATION_LAUNCHER_PATH = APPLICATION_SRC_PATH + "__main__.py";
     static final String PYTHON_APPLICATION_ANNOTATION = "io.micronaut.context.python.annotation.PythonApplication";
     private static final String PYTHON_LANGUAGE = "python";
@@ -628,8 +633,33 @@ public class PythonAnnotationProcessor extends AbstractInjectAnnotationProcessor
         }
 
         String code = getString(values.get("code"));
-        String[] src = getStringArray(values.get("src"));
+        String[] src = resolveSourceDirectories(getStringArray(values.get("src")));
         return Optional.of(new PythonApplicationValues(code, src));
+    }
+
+    /**
+     * Resolves the configured source directories against the {@link #SOURCE_ROOT_OPTION} directory, or the
+     * working directory when the option is absent. A build tool can then compile a relative directory into
+     * the {@code @PythonApplication} annotation, which keeps the compiled output free of absolute paths,
+     * while the processor keeps matching the absolute paths of the parsed sources against absolute roots.
+     *
+     * @param src The configured source directories
+     * @return The absolute source directories
+     */
+    private String[] resolveSourceDirectories(String[] src) {
+        if (src == null) {
+            return null;
+        }
+        String root = processingEnv.getOptions().get(SOURCE_ROOT_OPTION);
+        Path base = root == null || root.isBlank() ? Paths.get("") : Paths.get(root);
+        String[] resolved = new String[src.length];
+        for (int i = 0; i < src.length; i++) {
+            String directory = src[i];
+            resolved[i] = directory == null || directory.isBlank()
+                ? directory
+                : base.resolve(directory).toAbsolutePath().normalize().toString();
+        }
+        return resolved;
     }
 
     private static AnnotationMirror getAnnotationMirror(Element element, String annotationFqcn) {


### PR DESCRIPTION
The Pyronaut compiler embeds the source directory it is given into the generated `@PythonApplication(src = ...)` annotation, so `PythonCompile` produced exactly one output file with an absolute path (the compiled main class) and was left with `@CacheableTask` commented out. Every other output, including the VFS file lists and the checked-hash `.pyc` files, was already relocatable.

### Changes

- `PythonCompile` is `@CacheableTask`. It hands the compiler each source directory relative to the project directory and passes the project directory to the annotation processor as the `micronaut.python.source.root` compiler option. A worker daemon does not run in the project directory, which is why the root travels as an option rather than as the working directory, and the option is not a task input, so it stays out of the cache key.
- `PythonAnnotationProcessor` resolves relative `src` entries against that option, or the working directory when it is absent. This is required: the parser matches the absolute paths of parsed sources against the raw `src` value by string prefix, so a relative value would otherwise silently generate no bean classes.
- `PythonVfsBytecodeCompile` is `@CacheableTask` with `@PathSensitive(RELATIVE)` on its input directory.

### Verification

Local build cache redirected to a scratch directory, JDK 25:

| Step | Result |
|---|---|
| Modified build vs unmodified baseline | 4,481 output files identical except the main class, now `src=["src/test/python"]` |
| Absolute paths in outputs | none |
| Clean, then rebuild | `compileTestPython` and both `compileVfsPythonBytecode` tasks FROM-CACHE |
| Checkout at a different absolute path | all three FROM-CACHE, outputs byte-identical |
| `check` of the five Python modules on the restored outputs | 1,133 tests, 0 failures |
| `validatePlugins` for buildSrc | passes |

### Expected effect on CI

Modest on its own: the compile is off the critical path of the Python job (the `inject-python-test` tests are), and a PR only hits the cache when nothing upstream of the Python modules changed, since the application classpath is a content-hashed `@Classpath`. The change mainly removes the one non-relocatable output so the tasks can benefit once the remote cache is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
