### PR TITLE
Preserve map key spelling for indexed keys in the RAW property catalog

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.BeanProperties
 import io.micronaut.context.env.PropertySource
 import io.micronaut.core.util.CollectionUtils
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ConfigurationPropertiesSpec extends Specification {
 
@@ -106,6 +107,31 @@ class ConfigurationPropertiesSpec extends Specification {
         config.defaultPort == 9999
         config.defaultValue == 9999
         config.primitiveDefaultValue == 9999
+    }
+
+    @Unroll
+    void "test configuration properties list binding accepts every spelling of an indexed key inner segment #key"() {
+        given: "the same indexed key written with a differently cased or separated inner segment"
+        ApplicationContext applicationContext = ApplicationContext.builder("test").build()
+        applicationContext.environment.addPropertySource(PropertySource.of(
+            'test',
+            [(key): 123]
+        ))
+        applicationContext.start()
+
+        expect: "every spelling binds to the same property of the object in the List"
+        applicationContext.getBean(MyConfig).innerVals[0].expireUnsignedSeconds == 123
+
+        cleanup:
+        applicationContext.close()
+
+        where:
+        key << [
+            'foo.bar.innerVals[0].expireUnsignedSeconds',
+            'foo.bar.innerVals[0].expire-unsigned-seconds',
+            'foo.bar.innerVals[0].expire_unsigned_seconds',
+            'foo.bar.innerVals[0].EXPIRE_UNSIGNED_SECONDS',
+        ]
     }
 
     void "test configuration inner class properties binding"() {

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -85,6 +86,10 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
     private final @Nullable Map<String, DefaultPropertyEntry>[] catalog = new Map[58];
     private final @Nullable Map<String, DefaultPropertyEntry>[] rawCatalog = new Map[58];
     private final @Nullable Map<String, DefaultPropertyEntry>[] nonGenerated = new Map[58];
+    // Base names whose RAW aggregate the RAW catalog owns outright and may therefore expand in
+    // place. A bare key stores its value by reference and clears the name; the next indexed key
+    // targeting that base copies the value once and records it here. Guarded by `catalog`.
+    private final Set<String> rawOwnedBases = new HashSet<>();
 
     private final Logger log;
 
@@ -158,6 +163,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
             Arrays.fill(nonGenerated, null);
             Arrays.fill(rawCatalog, null);
             Arrays.fill(catalog, null);
+            rawOwnedBases.clear();
             resetCaches();
         }
     }
@@ -732,6 +738,8 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
 
                 Object value = properties.get(property);
 
+                populateRawCatalog(property, value, convention, properties.getOrigin());
+
                 List<String> resolvedProperties = resolvePropertiesForConvention(property, convention);
                 boolean first = true;
                 for (String resolvedProperty : resolvedProperties) {
@@ -746,16 +754,13 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
                                 property,
                                 properties.getOrigin()
                             ));
-                            expandProperty(
+                            expandIndexedProperty(
+                                entries,
+                                propertyName,
                                 resolvedProperty.substring(i),
-                                val -> entries.put(propertyName, new DefaultPropertyEntry(
-                                    propertyName,
-                                    val,
-                                    property,
-                                    properties.getOrigin()
-                                )),
-                                () -> entries.getOrDefault(propertyName, NULL_ENTRY).value(),
-                                value
+                                value,
+                                property,
+                                properties.getOrigin()
                             );
                         }
                         if (first) {
@@ -798,20 +803,155 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
                     }
                 }
 
-                final Map<String, DefaultPropertyEntry> rawEntries = resolveEntriesForKey(property, true, PropertyCatalog.RAW);
-                if (rawEntries != null) {
-                    rawEntries.put(property, new DefaultPropertyEntry(
-                        property,
-                        value,
-                        property,
-                        properties.getOrigin()
-                    ));
-                }
             }
             // A lookup can cache a miss between reset() and catalog reinitialization.
             // Clear those entries after the rebuilt catalog becomes visible.
             resetCaches();
         }
+    }
+
+    /**
+     * Populates the RAW catalog for a single property: the verbatim entry under its own key, plus,
+     * for an indexed key, the expanded aggregate under the verbatim base name. Aggregating in RAW
+     * as well as in GENERATED is what preserves the spelling of a map key nested under an indexed
+     * segment, since GENERATED sees only the hyphenated key.
+     *
+     * <p>Skipped for {@link PropertySource.PropertyConvention#ENVIRONMENT_VARIABLE}, which has no
+     * original spelling left to preserve: {@code EnvironmentPropertySource.getEnv} rewrites
+     * {@code A_0__B} into the verbatim key {@code A[0]_B}, and expanding that verbatim would
+     * misread the trailing {@code _B} as part of the map key rather than as a property
+     * delimiter.</p>
+     *
+     * @param property The verbatim property key
+     * @param value The property value
+     * @param convention The property convention
+     * @param origin The origin of the property source
+     */
+    private void populateRawCatalog(
+        String property,
+        Object value,
+        PropertySource.PropertyConvention convention,
+        PropertySource.Origin origin) {
+
+        int bracket = property.indexOf('[');
+
+        Map<String, DefaultPropertyEntry> rawEntries = resolveEntriesForKey(property, true, PropertyCatalog.RAW);
+        if (rawEntries != null) {
+            if (bracket < 0) {
+                // Only a key without an index can be an aggregate base. The value goes in by
+                // reference, so RAW no longer owns whatever it held under this name; the next
+                // indexed key targeting it takes its own copy below.
+                rawOwnedBases.remove(property);
+            }
+            rawEntries.put(property, new DefaultPropertyEntry(
+                property,
+                value,
+                property,
+                origin
+            ));
+        }
+
+        if (bracket <= 0 || convention == PropertySource.PropertyConvention.ENVIRONMENT_VARIABLE) {
+            return;
+        }
+        String baseName = property.substring(0, bracket);
+        Map<String, DefaultPropertyEntry> baseEntries = resolveEntriesForKey(baseName, true, PropertyCatalog.RAW);
+        if (baseEntries == null) {
+            return;
+        }
+
+        // The expansion below mutates the aggregate in place, so RAW has to own it. It does not
+        // yet if a bare key last stored it by reference, so take a copy on the first indexed key
+        // to target this base since then. This must happen before the GENERATED expansion for the
+        // same key, which mutates its own aggregate in place and may share that very instance:
+        // copied afterwards, RAW would inherit GENERATED's hyphenated spelling.
+        if (rawOwnedBases.add(baseName)) {
+            DefaultPropertyEntry existing = baseEntries.get(baseName);
+            if (existing != null) {
+                baseEntries.put(baseName, new DefaultPropertyEntry(
+                    baseName,
+                    deepCopyForRawExpansion(existing.value()),
+                    existing.raw(),
+                    existing.origin()
+                ));
+            }
+        }
+
+        // expandProperty stores this value into the aggregate by reference, so a container that
+        // GENERATED can reach too would be mutated by a later key drilling into the same index.
+        // Scalars, which are the overwhelming majority, pass through untouched.
+        expandIndexedProperty(
+            baseEntries,
+            baseName,
+            property.substring(bracket),
+            deepCopyForRawExpansion(value),
+            property,
+            origin
+        );
+    }
+
+    /**
+     * Recursively duplicates the {@link List} and {@link Map} spine of a value, so that RAW can
+     * expand into its own copy without mutating the property source's value or the instance the
+     * GENERATED catalog serves.
+     *
+     * <p>Every other value is shared rather than copied, which is safe because expansion only ever
+     * mutates a {@code List} by index or a {@code Map} by key: an array, a {@code Set} or a leaf
+     * is never written through. Note that a copied {@code Map} becomes a {@link LinkedHashMap}, so
+     * a source supplying a sorted or case-insensitive map keeps its iteration order at the point
+     * of copying but not its behaviour for keys added afterwards.</p>
+     *
+     * @param value The value to copy
+     * @return An equivalent value whose containers are independently mutable
+     */
+    private static Object deepCopyForRawExpansion(Object value) {
+        if (value instanceof List<?> list) {
+            List<Object> copy = new ArrayList<>(list.size());
+            for (Object element : list) {
+                copy.add(deepCopyForRawExpansion(element));
+            }
+            return copy;
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<Object, Object> copy = new LinkedHashMap<>(map.size());
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                copy.put(entry.getKey(), deepCopyForRawExpansion(entry.getValue()));
+            }
+            return copy;
+        }
+        return value;
+    }
+
+    /**
+     * Expands an indexed property (e.g. {@code foo[0].bar}) into the given entries map under its
+     * base name, building the container value and writing it back to {@code entries} as it grows.
+     *
+     * @param entries The catalog entries map to read the existing container from and write the
+     *                expanded container to, keyed by {@code baseName}
+     * @param baseName The un-indexed base property name (e.g. {@code foo})
+     * @param indexSuffix The indexed remainder of the property, starting with {@code [} (e.g. {@code [0].bar})
+     * @param value The value to place at the indexed location
+     * @param originalProperty The original, unresolved property key, recorded on the entry
+     * @param origin The origin of the property source, recorded on the entry
+     */
+    private void expandIndexedProperty(
+        Map<String, DefaultPropertyEntry> entries,
+        String baseName,
+        String indexSuffix,
+        Object value,
+        String originalProperty,
+        PropertySource.Origin origin) {
+        expandProperty(
+            indexSuffix,
+            val -> entries.put(baseName, new DefaultPropertyEntry(
+                baseName,
+                val,
+                originalProperty,
+                origin
+            )),
+            () -> entries.getOrDefault(baseName, NULL_ENTRY).value(),
+            value
+        );
     }
 
     private void expandProperty(String property, Consumer<Object> containerSet, Supplier<Object> containerGet, Object actualValue) {

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -725,6 +725,209 @@ class PropertySourcePropertyResolverSpec extends Specification {
         micronaut['security']['intercept-url-map'][0]['access'][1] == '/some-path-x'
     }
 
+    void "test indexed properties expand into the RAW catalog with the map key and base name as written"() {
+        given:
+        def values = new HashMap()
+        values.put('foo.items[0].SOME_KEY', 'x')
+        values.put('foo.myItems[0].K', 'v')
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect:
+        resolver.getProperties("foo", StringConvention.RAW) == [
+                'items[0].SOME_KEY': 'x',
+                'items'             : [['SOME_KEY': 'x']],
+                'myItems[0].K'      : 'v',
+                'myItems'           : [['K': 'v']],
+        ]
+    }
+
+    void "test indexed properties still hyphenate into the GENERATED catalog"() {
+        given:
+        def values = new HashMap()
+        values.put('foo.items[0].SOME_KEY', 'x')
+        values.put('foo.myItems[0].K', 'v')
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect:
+        resolver.getProperties("foo") == [
+                'items[0].some-key': 'x',
+                'items'            : [['some-key': 'x']],
+                'my-items[0].k'    : 'v',
+                'my-items'         : [['k': 'v']],
+        ]
+    }
+
+    void "test indexed property expansion is skipped for the ENVIRONMENT_VARIABLE convention"() {
+        given: "the source key as EnvironmentPropertySource.getEnv would rewrite A_0__B into"
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", ['A[0]_B': 'x'], PropertySource.PropertyConvention.ENVIRONMENT_VARIABLE)
+        )
+
+        expect: "the dotted property still resolves"
+        resolver.getRequiredProperty('a[0].b', String) == 'x'
+
+        and: "no aggregate entry is created in RAW for the rewritten key; checked directly because a top-level key has no dotted prefix for getProperties"
+        resolver.resolveEntriesForKey('A', false, PropertyCatalog.RAW)?.get('A') == null
+    }
+
+    void "test nested and bracketed indexed properties expand into the RAW catalog with map keys as written"() {
+        given: "top-level indexed keys, whose RAW aggregate is fetched from the catalog directly since getProperties only returns entries under a dotted prefix"
+        def values = new HashMap()
+        values.put('custom[0][0][KEY][4]', 'ohh')
+        values.put('custom[0][0][KEY][5]', 'ehh')
+        values.put('foo[1].bar[abx]', 'foo1Bar0')
+        values.put('a[0].b[1].C', 'deep')
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        when:
+        def rawCustom = resolver.resolveEntriesForKey('custom', false, PropertyCatalog.RAW).get('custom').value()
+        def rawFoo = resolver.resolveEntriesForKey('foo', false, PropertyCatalog.RAW).get('foo').value()
+        def rawA = resolver.resolveEntriesForKey('a', false, PropertyCatalog.RAW).get('a').value()
+
+        then: "RAW preserves the spelling as written at every map-key position"
+        rawCustom[0][0]['KEY'][4] == 'ohh'
+        rawCustom[0][0]['KEY'][5] == 'ehh'
+        rawFoo[1]['bar']['abx'] == 'foo1Bar0'
+        rawA[0]['b'][1]['C'] == 'deep'
+
+        and: "GENERATED still holds the hyphenated map keys NameUtils.hyphenate produces"
+        resolver.getProperty("custom", List).get()[0][0]['-key'][4] == 'ohh'
+        resolver.getProperty("foo", List).get()[1]['bar']['abx'] == 'foo1Bar0'
+        resolver.getProperty("a", List).get()[0]['b'][1]['c'] == 'deep'
+    }
+
+    void "test indexed property expansion leaves the NORMALIZED catalog unchanged"() {
+        given:
+        def values = new HashMap()
+        values.put('foo.items[0].SOME_KEY', 'x')
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "NORMALIZED still holds only the scalar under the base name, with no aggregate added"
+        resolver.getPropertyEntries("foo", PropertyCatalog.NORMALIZED) == ['items'] as Set
+
+        and:
+        def normalized = resolver.resolveEntriesForKey('foo', false, PropertyCatalog.NORMALIZED)
+        normalized.size() == 1
+        normalized['foo.items'].value() == 'x'
+    }
+
+    void "test a structured base value plus an indexed key targeting the same base does not corrupt GENERATED"() {
+        given: "a structured value as a YAML source supplies it, plus an indexed key targeting a new index of the same base; LinkedHashMap keeps the structured value first"
+        def values = new LinkedHashMap()
+        values.put('t.env', [[A: 1]])
+        values.put('t.env[1].B', 2)
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "GENERATED is unchanged: the RAW expansion must not mutate the list or map instance GENERATED serves"
+        resolver.getProperties("t")['env'] == [[A: 1], [b: 2]]
+
+        and: "RAW carries the spelling as written for the indexed key"
+        resolver.resolveEntriesForKey('t.env', false, PropertyCatalog.RAW).get('t.env').value()[1]['B'] == 2
+    }
+
+    void "test a structured base value plus an indexed key leaves no hyphenated key in RAW"() {
+        given: "a structured value, then an indexed key adding a new index to it; GENERATED expands into the structured value in place, writing the hyphenated key b"
+        def values = new LinkedHashMap()
+        values.put('t.env', [[A: 1]])
+        values.put('t.env[1].B', 2)
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "RAW shows only what was written; it must not also carry GENERATED's b, which it would if RAW shared the structured value GENERATED expands into"
+        resolver.getProperties("t", StringConvention.RAW)['env'] == [[A: 1], [B: 2]]
+
+        and: "GENERATED still hyphenates"
+        resolver.getProperties("t")['env'] == [[A: 1], [b: 2]]
+    }
+
+    void "test an indexed key, then a bare structured key re-aliasing the base, then another indexed key does not corrupt GENERATED"() {
+        given: "two indexed keys privatize RAW's base value, then the bare structured key re-aliases RAW's base value to the same instance GENERATED serves, then a third indexed key must re-privatize before mutating"
+        def values = new LinkedHashMap()
+        values.put('t.env[0].A', 1)
+        values.put('t.env[1].B', 2)
+        values.put('t.env', [[A: 1], [B: 2]])
+        values.put('t.env[2].C', 3)
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "GENERATED is unchanged: the RAW expansion must not mutate the list or map instance GENERATED serves"
+        resolver.getProperties("t")['env'] == [[A: 1], [B: 2], [c: 3]]
+
+        and: "RAW carries the spelling as written for the third indexed key"
+        resolver.resolveEntriesForKey('t.env', false, PropertyCatalog.RAW).get('t.env').value()[2]['C'] == 3
+    }
+
+    void "test an indexed key, then a bare map re-aliasing an index, then a nested indexed key does not leak into GENERATED"() {
+        given: "an indexed key establishes index 0, a bare map re-aliases index 1 to the source's own instance, then a nested indexed key targets that same index 1"
+        def values = new LinkedHashMap()
+        values.put('t.env[0].A', 1)
+        values.put('t.env[1]', [B: 2])
+        values.put('t.env[1].C', 3)
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "GENERATED is unchanged: the RAW expansion of the nested indexed key must not mutate the map instance GENERATED serves"
+        resolver.getProperties("t")['env'] == [[a: 1], [B: 2, c: 3]]
+
+        and: "RAW carries the nested indexed key's value verbatim"
+        resolver.resolveEntriesForKey('t.env', false, PropertyCatalog.RAW).get('t.env').value()[1]['C'] == 3
+    }
+
+    void "test the RAW catalog shares the property source value when no indexed key targets it"() {
+        given: "a structured value and no indexed key anywhere, as in a plain YAML config"
+        def sourceList = [[A: 1], [B: 2]]
+        def sourceMap = [C: 3]
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", ['t.env': sourceList, 't.other': sourceMap])
+        )
+
+        expect: "RAW stores them by reference; nothing may expand into them, so nothing is copied"
+        resolver.resolveEntriesForKey('t.env', false, PropertyCatalog.RAW).get('t.env').value().is(sourceList)
+        resolver.resolveEntriesForKey('t.other', false, PropertyCatalog.RAW).get('t.other').value().is(sourceMap)
+    }
+
+    void "test the RAW catalog copies a base only once however many indexed keys target it"() {
+        given: "a structured base re-aliased by a bare key, then several indexed keys targeting it"
+        def values = new LinkedHashMap()
+        values.put('t.env', [[A: 1]])
+        values.put('t.env[1].B', 2)
+        values.put('t.env[2].C', 3)
+        values.put('t.env[3].D', 4)
+
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect: "the first indexed key privatizes the base; the rest expand into the copy in place"
+        resolver.resolveEntriesForKey('t.env', false, PropertyCatalog.RAW).get('t.env').value() ==
+                [[A: 1], [B: 2], [C: 3], [D: 4]]
+
+        and: "GENERATED keeps its own hyphenated expansion, and the source value is untouched by RAW"
+        resolver.getProperties("t")['env'] == [[A: 1], [b: 2], [c: 3], [d: 4]]
+    }
+
     void "test map and list values are collapsed"() {
         given:
         def values = new HashMap()


### PR DESCRIPTION
Supersedes #13018 by @MariusVolkhart, rebased onto current `5.2.x` with the review feedback applied. The analysis, the fix and the ordering tests are all theirs; this branch changes when the defensive copy is taken and corrects two comments.

### The problem

Micronaut normalizes a property name to kebab case. That is correct for property names, but wrong for a Map key that a user wrote as data. A key supplied as a single flat string, such as `foo.items[0].SOME_KEY`, is normalized in full before it is split into structure, so the Map key becomes `some-key`. The same configuration written as a YAML sequence keeps `SOME_KEY`, because the loader supplies an already-structured `List<Map<..>>` whose inner keys never pass through normalization. The spelling matters whenever the key is data rather than a property name: environment variable names, HTTP header names, and any `Map<String, String>` keyed by something outside Micronaut's naming rules.

`StringConvention.RAW` exists to recover the spelling a user wrote, but it could not help here. The RAW catalog only ever received the verbatim flat entry, never the aggregated structure, so it could return the unexpanded String but never the list carrying the original Map keys.

### The fix

Run the indexed-property expansion into the RAW catalog as well, built from the verbatim key and stored under the verbatim base name. The GENERATED and NORMALIZED catalogs are untouched, so binding, which depends on the normalized spelling, is unaffected; RAW simply gains the view it was always meant to offer.

Skipped for the `ENVIRONMENT_VARIABLE` convention. No user spelling survives to that point, and its rewritten keys, such as `A[0]_B`, would be misread as Map keys rather than as delimiters.

### What changed from #13018

RAW aggregates are expanded in place, so RAW must own them rather than share the property source's value or the instance GENERATED serves. #13018 guaranteed that by deep-copying **every** container value on its way into RAW. That is correct, but every application pays it — including those with no indexed key anywhere — and the copy is retained for the life of the catalog.

This branch takes the copy lazily instead: a bare key stores its value by reference as before, and the first indexed key targeting that base privatizes it once, recording the base in `rawOwnedBases`.

The subtle part, and the reason the obvious version of this is wrong: the copy has to be taken **before** the GENERATED expansion for the same key. GENERATED expands into its own aggregate in place and may hold the very instance RAW points at, so a copy taken afterwards would already carry GENERATED's hyphenated spelling. #13018's `test a structured base value plus an indexed key leaves no hyphenated key in RAW` catches exactly that, which is why the whole RAW block now runs at the top of the property iteration.

Measured on a synthetic config of 200 list-valued properties of 50 maps each, min-of-100 builds, three interleaved runs:

| | #13018 | this branch |
|---|---|---|
| Retained heap, one resolver | 11.02 / 11.03 / 11.01 MB | **7.99 / 8.04 / 8.03 MB** |
| Build, structured config | 5.27 / 5.22 / 5.64 ms | **4.63 / 4.78 / 4.93 ms** |
| Build, indexed scalar keys | 1.12 / 1.12 / 1.39 ms | 1.21 / 1.17 / 1.08 ms |

A config that uses no indexed keys now copies nothing at all, which two added tests pin down: one asserts RAW holds the source instance itself, the other that a base is copied once however many indexed keys extend it.

`deepCopyForRawExpansion`'s javadoc also claimed RAW owned every value entering it, which was never true of arrays or `Set`s. That is safe — expansion only ever writes through a `List` index or a `Map` key — so the doc now says what the method actually guarantees, and notes that a copied `Map` becomes a `LinkedHashMap`.

### Scope

Related to #13016. This preserves the spelling in the RAW catalog only. The GENERATED catalog still hyphenates, so `env.getProperty("foo.items", Argument.listOf(Map.class))` — the call in that issue's Expected Behavior — still returns `[{some-key=x}]`, and the two authoring forms still disagree by default. Changing that would change binding, so the issue stays open for a separate decision.

Note that RAW submaps now carry the aggregate alongside the flat keys, exactly mirroring GENERATED, so `getPropertyEntries(name, RAW)`, `@MapFormat(keyFormat = RAW)` bindings and the `/info` endpoint gain entries for indexed keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
