### PR TITLE
Describe the members of a property by the type declaring them

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -117,6 +117,11 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
     private static final java.lang.reflect.Method FIND_PROPERTY_BY_INDEX_METHOD =
         ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanIntrospection.class, "getPropertyByIndex", int.class);
 
+    private static final java.lang.reflect.Method SEPARATES_DECLARATIONS_METHOD = ReflectionUtils.getRequiredMethod(
+        BeanIntrospection.class,
+        "separatesDeclarations"
+    );
+
     private static final java.lang.reflect.Method FIND_INDEXED_PROPERTY_METHOD =
         ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanIntrospection.class, "findIndexedProperty", Class.class, String.class);
 
@@ -226,7 +231,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
     private static final java.lang.reflect.Constructor<?> BEAN_PROPERTY_MEMBER_REF_CONSTRUCTOR = ReflectionUtils.getRequiredInternalConstructor(
         AbstractInitializableBeanIntrospection.BeanPropertyMemberRef.class,
         ElementType.class,
-        Class.class,
+        AnnotationClassValue.class,
         String.class,
         Argument.class,
         int.class
@@ -288,6 +293,11 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
     private final OriginatingElements originatingElements;
 
     private CopyConstructorDispatchTarget copyConstructorDispatchTarget;
+    /**
+     * Whether the members of the properties are described, each by the type declaring it: the introspection
+     * then reports that it separates the declarations.
+     */
+    private boolean membersDescribed;
     private VisitorContext visitorContext;
 
     /**
@@ -492,6 +502,14 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
         ));
     }
 
+    /**
+     * Marks the members of the properties as described: the introspection reports that it
+     * {@link BeanIntrospection#separatesDeclarations() separates the declarations}.
+     */
+    void describeMembers() {
+        this.membersDescribed = true;
+    }
+
     private List<BeanPropertyMemberData> visitPropertyMembers(List<PropertyMemberDef> members,
                                                               @Nullable MemberElement readMember,
                                                               int readDispatchIndex) {
@@ -499,20 +517,32 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
             return List.of();
         }
         List<BeanPropertyMemberData> result = new ArrayList<>(members.size());
+        // the members of a hierarchy are read through one accessor of the bean type: the getter an interface
+        // declares is read by invoking the getter overriding it, which is the same virtual call
+        Map<MemberElement, Integer> dispatchByAccessor = new HashMap<>();
         for (PropertyMemberDef propertyMember : members) {
             MemberElement member = propertyMember.member();
+            MemberElement accessor = propertyMember.accessor();
             this.evaluatedExpressionProcessor.processEvaluatedExpressions(propertyMember.type().getAnnotationMetadata(), beanClassElement);
             int memberReadDispatchIndex;
-            if (member.equals(readMember)) {
+            if (accessor == null) {
+                // a hidden field is read through the class declaring it, where the owning type finds the field
+                // hiding it; the introspection has to be able to name that class
+                memberReadDispatchIndex = dispatchWriter.addGetHiddenField((FieldElement) member);
+            } else if (accessor.equals(readMember)) {
                 // Reuse the accessor that was already generated for reading the property
                 memberReadDispatchIndex = readDispatchIndex;
-            } else if (member instanceof FieldElement fieldElement) {
-                memberReadDispatchIndex = dispatchWriter.addGetField(fieldElement);
-            } else if (member instanceof MethodElement methodElement && methodElement.getParameters().length == 0) {
-                memberReadDispatchIndex = dispatchWriter.addMethod(beanClassElement, methodElement, true);
             } else {
-                // A write method cannot be read
-                memberReadDispatchIndex = -1;
+                memberReadDispatchIndex = dispatchByAccessor.computeIfAbsent(accessor, key -> {
+                    if (key instanceof FieldElement fieldElement) {
+                        return dispatchWriter.addGetField(fieldElement);
+                    } else if (key instanceof MethodElement methodElement && methodElement.getParameters().length == 0) {
+                        return dispatchWriter.addMethod(beanClassElement, methodElement, true);
+                    } else {
+                        // A write method cannot be read
+                        return -1;
+                    }
+                });
             }
             result.add(new BeanPropertyMemberData(
                 member instanceof FieldElement ? ElementType.FIELD : ElementType.METHOD,
@@ -657,7 +687,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
                 // 1: element type
                 ClassTypeDef.of(ElementType.class).getStaticField(member.elementType.name(), TypeDef.of(ElementType.class)),
                 // 2: declaring type
-                ExpressionDef.constant(ClassTypeDef.of(member.declaringType)),
+                loadClassValueExpressionFn.apply(member.declaringType.getName()),
                 // 3: member name
                 ExpressionDef.constant(member.name),
                 // 4: argument
@@ -755,6 +785,14 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
         classDefBuilder.superclass(isEnum ? ClassTypeDef.of(AbstractEnumBeanIntrospectionAndReference.class) : ClassTypeDef.of(AbstractInitializableBeanIntrospectionAndReference.class));
 
         classDefBuilder.addAnnotation(AnnotationDef.builder(Generated.class).addMember("service", introspectionName).build());
+        if (membersDescribed) {
+            classDefBuilder.addMethod(
+                MethodDef.builder(SEPARATES_DECLARATIONS_METHOD.getName())
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(TypeDef.Primitive.BOOLEAN)
+                    .build((aThis, methodParameters) -> ExpressionDef.trueValue().returning())
+            );
+        }
         // init expressions at build time
         evaluatedExpressionProcessor.registerExpressionForBuildTimeInit(classDefBuilder);
 
@@ -1767,10 +1805,14 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
     /**
      * A member of a property to be included in the introspection.
      *
-     * @param member The field, read method or write method
-     * @param type   The type of the member carrying the member's own annotation metadata
+     * @param member   The field, read method or write method, of the bean type or of a super type declaring it
+     * @param accessor The member of the bean type the value of the member is read through: the field, the
+     *                 read method the bean type declares or inherits, which overrides the read method of a
+     *                 super type, or the write method; {@code null} for a field hidden by the field of the
+     *                 property, which is read through the class declaring it
+     * @param type     The type of the member carrying the member's own annotation metadata
      */
-    record PropertyMemberDef(MemberElement member, ClassElement type) {
+    record PropertyMemberDef(MemberElement member, @Nullable MemberElement accessor, ClassElement type) {
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -30,6 +30,7 @@ import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ElementModifier;
 import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.ImportedClass;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
@@ -51,8 +52,11 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -532,6 +536,9 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         List<PropertyElement> beanProperties = ce.getBeanProperties(propertyElementQuery).stream()
             .filter(p -> !p.isExcluded())
             .toList();
+        if (members) {
+            writer.describeMembers();
+        }
         Optional<MethodElement> constructorElement = ce.getPrimaryConstructor();
         constructorElement.ifPresent(constructorEl -> {
             if (ArrayUtils.isNotEmpty(constructorEl.getParameters())) {
@@ -568,7 +575,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 beanProperty.getReadType().map(t -> t.withAnnotationMetadata(annotationMetadata)).orElse(null),
                 beanProperty.getWriteType().map(t -> t.withAnnotationMetadata(annotationMetadata)).orElse(null),
                 beanProperty.isReadOnly(),
-                members ? resolvePropertyMembers(beanProperty) : List.of()
+                members ? resolvePropertyMembers(ce, beanProperty) : List.of()
             );
 
             for (AnnotationValue<?> indexedAnnotation : indexedAnnotations) {
@@ -602,42 +609,173 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
     }
 
     /**
-     * Resolves the individual members (the field, the read method and the write method) a property is composed of,
-     * each with its own type and its own annotation metadata.
+     * Resolves the individual members (the field, the read methods and the write methods) a property is composed
+     * of, each with its own type and its own annotation metadata: the field, and the read and write method of
+     * every type of the hierarchy declaring one, each carrying the annotations of its own declaration and not the
+     * ones of the methods it overrides, so that a member is attributed to the type declaring it.
      *
+     * @param beanType     The introspected type
      * @param beanProperty The property
-     * @return The members, in field, read method, write method order
+     * @return The members, in field, read methods, write methods order, the declaration of the most specific
+     * type first in each group
      */
-    private List<BeanIntrospectionWriter.PropertyMemberDef> resolvePropertyMembers(PropertyElement beanProperty) {
+    private List<BeanIntrospectionWriter.PropertyMemberDef> resolvePropertyMembers(ClassElement beanType, PropertyElement beanProperty) {
         List<BeanIntrospectionWriter.PropertyMemberDef> members = new ArrayList<>(3);
-        beanProperty.getField().ifPresent(field ->
-            members.add(new BeanIntrospectionWriter.PropertyMemberDef(
-                field,
-                field.getGenericType().withAnnotationMetadata(memberAnnotationMetadata(field, field.getType()))
-            ))
-        );
+        beanProperty.getField().ifPresent(field -> {
+            for (FieldElement declaration : fieldDeclarations(beanType, field)) {
+                members.add(new BeanIntrospectionWriter.PropertyMemberDef(
+                    declaration,
+                    // the field of the property is read as the property reads it, a field it hides through
+                    // the class declaring it
+                    declaration == field ? field : null,
+                    declaration.getGenericType().withAnnotationMetadata(memberAnnotationMetadata(declaration, declaration.getType()))
+                ));
+            }
+        });
         beanProperty.getReadMethod()
             .filter(method -> !method.isSynthetic())
-            .ifPresent(method ->
-                members.add(new BeanIntrospectionWriter.PropertyMemberDef(
-                    method,
-                    method.getGenericReturnType().withAnnotationMetadata(
-                        memberAnnotationMetadata(method.getMethodAnnotationMetadata(), method.getReturnType())
-                    )
-                ))
-            );
+            .ifPresent(method -> {
+                for (MethodElement declaration : declarations(beanType, method)) {
+                    members.add(new BeanIntrospectionWriter.PropertyMemberDef(
+                        declaration,
+                        method,
+                        declaration.getGenericReturnType().withAnnotationMetadata(
+                            memberAnnotationMetadata(declaration.getDeclaredMethodAnnotationMetadata(), declaration.getReturnType())
+                        )
+                    ));
+                }
+            });
         beanProperty.getWriteMethod()
             .filter(method -> !method.isSynthetic() && method.getParameters().length == 1)
             .ifPresent(method -> {
-                ParameterElement parameter = method.getParameters()[0];
-                members.add(new BeanIntrospectionWriter.PropertyMemberDef(
-                    method,
-                    parameter.getGenericType().withAnnotationMetadata(
-                        memberAnnotationMetadata(method.getMethodAnnotationMetadata(), parameter.getType())
-                    )
-                ));
+                for (MethodElement declaration : declarations(beanType, method)) {
+                    ParameterElement[] parameters = declaration.getParameters();
+                    if (parameters.length != 1) {
+                        continue;
+                    }
+                    ParameterElement parameter = parameters[0];
+                    members.add(new BeanIntrospectionWriter.PropertyMemberDef(
+                        declaration,
+                        method,
+                        parameter.getGenericType().withAnnotationMetadata(
+                            memberAnnotationMetadata(declaration.getDeclaredMethodAnnotationMetadata(), parameter.getType())
+                        )
+                    ));
+                }
             });
         return members;
+    }
+
+    /**
+     * The declarations of a field: the field itself and the fields of the same name it hides in the super
+     * classes, each a member of the property with the annotations of its own declaration, the bean type first.
+     *
+     * @param beanType The introspected type
+     * @param field    The field of the property
+     * @return The declarations, the most specific first
+     */
+    private static List<FieldElement> fieldDeclarations(ClassElement beanType, FieldElement field) {
+        List<FieldElement> hidden = beanType.getEnclosedElements(
+            ElementQuery.ALL_FIELDS.onlyInstance().includeHiddenElements().named(field.getName())
+        );
+        if (hidden.size() < 2) {
+            return List.of(field);
+        }
+        Set<String> declaringTypes = new HashSet<>();
+        declaringTypes.add(field.getDeclaringType().getName());
+        List<FieldElement> declarations = new ArrayList<>(hidden.size());
+        declarations.add(field);
+        for (FieldElement declaration : hidden) {
+            if (!declaration.isSynthetic() && declaringTypes.add(declaration.getDeclaringType().getName())) {
+                declarations.add(declaration);
+            }
+        }
+        if (declarations.size() > 1) {
+            List<String> hierarchy = hierarchyOf(beanType);
+            declarations.sort(Comparator.comparingInt(declaration -> rankOf(hierarchy, declaration.getDeclaringType().getName())));
+        }
+        return declarations;
+    }
+
+    /**
+     * The declarations of an accessor: the method itself, every method it overrides, and every method of the
+     * same signature the hierarchy declares beside it - an interface inheriting an accessor from two parent
+     * interfaces without redeclaring it overrides neither - one per type declaring it, the bean type first,
+     * then its super classes, then its interfaces.
+     *
+     * @param beanType The introspected type
+     * @param method   The accessor the bean type declares or inherits
+     * @return The declarations, the most specific first
+     */
+    private static List<MethodElement> declarations(ClassElement beanType, MethodElement method) {
+        Set<String> declaringTypes = new HashSet<>();
+        declaringTypes.add(method.getDeclaringType().getName());
+        List<MethodElement> declarations = new ArrayList<>(3);
+        declarations.add(method);
+        List<MethodElement> candidates = new ArrayList<>(method.getOverriddenMethods());
+        candidates.addAll(beanType.getEnclosedElements(
+            ElementQuery.ALL_METHODS.onlyInstance().includeOverriddenMethods().named(method.getName())
+                .filter(candidate -> hasSameParameterTypes(candidate, method))
+        ));
+        for (MethodElement declaration : candidates) {
+            // a type declares an accessor once; an accessor found through more than one path of the hierarchy
+            // is one declaration
+            if (!declaration.isSynthetic() && declaringTypes.add(declaration.getDeclaringType().getName())) {
+                declarations.add(declaration);
+            }
+        }
+        if (declarations.size() > 1) {
+            List<String> hierarchy = hierarchyOf(beanType);
+            declarations.sort(Comparator.comparingInt(declaration -> rankOf(hierarchy, declaration.getDeclaringType().getName())));
+        }
+        return declarations;
+    }
+
+    private static boolean hasSameParameterTypes(MethodElement candidate, MethodElement method) {
+        ParameterElement[] candidateParameters = candidate.getParameters();
+        ParameterElement[] parameters = method.getParameters();
+        if (candidateParameters.length != parameters.length) {
+            return false;
+        }
+        for (int i = 0; i < parameters.length; i++) {
+            if (!candidateParameters[i].getType().getName().equals(parameters[i].getType().getName())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * The names of the types of a hierarchy, the type first, then its super classes, then the interfaces of
+     * each of them, an interface before the ones it extends: the order the declarations of a member are
+     * reported in.
+     */
+    private static List<String> hierarchyOf(ClassElement type) {
+        List<ClassElement> classes = new ArrayList<>();
+        for (ClassElement current = type; current != null && !current.getName().equals(Object.class.getName()); current = current.getSuperType().orElse(null)) {
+            classes.add(current);
+        }
+        Set<String> hierarchy = new LinkedHashSet<>();
+        for (ClassElement aClass : classes) {
+            hierarchy.add(aClass.getName());
+        }
+        for (ClassElement aClass : classes) {
+            collectInterfaces(aClass, hierarchy);
+        }
+        return new ArrayList<>(hierarchy);
+    }
+
+    private static void collectInterfaces(ClassElement type, Set<String> hierarchy) {
+        for (ClassElement anInterface : type.getInterfaces()) {
+            if (hierarchy.add(anInterface.getName())) {
+                collectInterfaces(anInterface, hierarchy);
+            }
+        }
+    }
+
+    private static int rankOf(List<String> hierarchy, String typeName) {
+        int rank = hierarchy.indexOf(typeName);
+        return rank == -1 ? Integer.MAX_VALUE : rank;
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/writer/DispatchWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/DispatchWriter.java
@@ -21,6 +21,7 @@ import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.sourcegen.model.FieldDef;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
@@ -157,7 +158,45 @@ public final class DispatchWriter implements ClassOutputWriter {
         if (beanField.isReflectionRequired(ClassElement.of(thisType))) {
             return addDispatchTarget(new FieldGetReflectionDispatchTarget(beanField));
         }
+
         return addDispatchTarget(new FieldGetDispatchTarget(beanField));
+    }
+
+    /**
+     * Adds a dispatch target reading a field hidden by a field of the same name in a sub class: the field is
+     * read through the class declaring it, where a read through the owning type finds the field hiding it.
+     * The generated code names the declaring class, so the field can only be read when that class is
+     * accessible from the generated type.
+     *
+     * @param beanField The hidden field
+     * @return The dispatch index, or -1 when the declaring class cannot be named
+     * @since 5.2.0
+     */
+    public int addGetHiddenField(FieldElement beanField) {
+        ClassElement declaringType = beanField.getDeclaringType();
+        if (!isAccessibleType(declaringType)) {
+            return -1;
+        }
+        if (beanField.isReflectionRequired(ClassElement.of(thisType))) {
+            return addDispatchTarget(new FieldGetReflectionDispatchTarget(beanField, declaringType));
+        }
+        return addDispatchTarget(new FieldGetDispatchTarget(beanField, declaringType));
+    }
+
+    /**
+     * Whether the generated type can name a type: a public one, its enclosing types included, or one of
+     * the package of the generated type.
+     */
+    private boolean isAccessibleType(ClassElement type) {
+        if (type.getPackageName().equals(NameUtils.getPackageName(thisType))) {
+            return true;
+        }
+        for (ClassElement current = type; current != null; current = current.getEnclosingType().orElse(null)) {
+            if (!current.isPublic()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -878,9 +917,21 @@ public final class DispatchWriter implements ClassOutputWriter {
     @Internal
     public static final class FieldGetDispatchTarget extends AbstractDispatchTarget {
         final FieldElement beanField;
+        private final ClassElement accessType;
 
         public FieldGetDispatchTarget(FieldElement beanField) {
+            this(beanField, beanField.getOwningType());
+        }
+
+        /**
+         * @param beanField  The field
+         * @param accessType The type the field is read through: the owning type, or the declaring type of a
+         *                   field hidden in the owning type
+         * @since 5.2.0
+         */
+        public FieldGetDispatchTarget(FieldElement beanField, ClassElement accessType) {
             this.beanField = beanField;
+            this.accessType = accessType;
         }
 
         @Override
@@ -905,8 +956,11 @@ public final class DispatchWriter implements ClassOutputWriter {
 
         @Override
         public ExpressionDef dispatchExpression(ExpressionDef bean) {
-            return bean.cast(ClassTypeDef.of(beanField.getOwningType()))
-                .field(beanField)
+            // the field is named on the type it is read through, as javac names it on the qualifying type: a
+            // reference naming the declaring class fails to resolve when that class is a package-private super
+            // class of another package, though the field itself is accessible
+            return bean.cast(ClassTypeDef.of(accessType))
+                .field(beanField.getName(), TypeDef.of(beanField.getType()))
                 .cast(TypeDef.of(beanField.getType()));
         }
 
@@ -921,9 +975,21 @@ public final class DispatchWriter implements ClassOutputWriter {
     @Internal
     public static final class FieldGetReflectionDispatchTarget extends AbstractDispatchTarget {
         final FieldElement beanField;
+        private final ClassElement accessType;
 
         public FieldGetReflectionDispatchTarget(FieldElement beanField) {
+            this(beanField, beanField.getOwningType());
+        }
+
+        /**
+         * @param beanField  The field
+         * @param accessType The type the lookup of the field starts from: the owning type, or the declaring
+         *                   type of a field hidden in the owning type
+         * @since 5.2.0
+         */
+        public FieldGetReflectionDispatchTarget(FieldElement beanField, ClassElement accessType) {
             this.beanField = beanField;
+            this.accessType = accessType;
         }
 
         @Override
@@ -950,7 +1016,7 @@ public final class DispatchWriter implements ClassOutputWriter {
         public ExpressionDef dispatchExpression(ExpressionDef bean) {
             return TYPE_REFLECTION_UTILS.invokeStatic(
                 METHOD_GET_FIELD_VALUE,
-                ExpressionDef.constant(ClassTypeDef.of(beanField.getOwningType())), // Target class
+                ExpressionDef.constant(ClassTypeDef.of(accessType)), // Target class, the lookup walks up from it
                 ExpressionDef.constant(beanField.getName()), // Field name,
                 bean // Target instance
             ).cast(TypeDef.of(beanField.getType()));
@@ -994,8 +1060,9 @@ public final class DispatchWriter implements ClassOutputWriter {
 
         @Override
         public StatementDef dispatchOne(int caseValue, ExpressionDef caseExpression, ExpressionDef target, ExpressionDef value) {
+            // named on the owning type, as javac names it on the qualifying type: see FieldGetDispatchTarget
             return target.cast(ClassTypeDef.of(beanField.getOwningType()))
-                .field(beanField)
+                .field(beanField.getName(), TypeDef.of(beanField.getType()))
                 .put(value.cast(TypeDef.of(beanField.getType())))
                 .after(ExpressionDef.nullValue().returning());
         }
@@ -1003,7 +1070,7 @@ public final class DispatchWriter implements ClassOutputWriter {
         @Override
         public StatementDef dispatchOneVoid(int caseValue, ExpressionDef caseExpression, ExpressionDef target, ExpressionDef value) {
             return target.cast(ClassTypeDef.of(beanField.getOwningType()))
-                .field(beanField)
+                .field(beanField.getName(), TypeDef.of(beanField.getType()))
                 .put(value.cast(TypeDef.of(beanField.getType())));
         }
 

--- a/core/src/main/java/io/micronaut/core/annotation/Introspected.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Introspected.java
@@ -154,12 +154,14 @@ public @interface Introspected {
      * Whether the individual members (the field, the read method and the write method) that each property is composed
      * of should be included in the introspection.
      *
-     * <p>A {@link io.micronaut.core.beans.BeanProperty} normally merges its members into a single element with a
-     * single merged {@link AnnotationMetadata}. When this is set to {@code true}
-     * {@link io.micronaut.core.beans.BeanProperty#getMembers()} additionally exposes each member separately, with its
-     * own annotation metadata, its own {@link io.micronaut.core.type.Argument} and its own accessor. This is required
-     * by specifications such as Jakarta Bean Validation that treat a field and a getter as two distinct constrained
-     * elements.</p>
+     * <p>A {@link io.micronaut.core.beans.BeanProperty} normally merges its members, and what the super types
+     * declare on them, into a single element with a single merged {@link AnnotationMetadata}. When this is set to
+     * {@code true} {@link io.micronaut.core.beans.BeanProperty#getMembers()} additionally exposes each member
+     * separately - the field, and the read and write method of every type of the hierarchy declaring one - with
+     * its own annotation metadata, its own {@link io.micronaut.core.type.Argument} and its own accessor, and
+     * {@link io.micronaut.core.beans.BeanIntrospection#separatesDeclarations()} reports it. This is required by
+     * specifications such as Jakarta Bean Validation that treat a field and a getter as two distinct constrained
+     * elements, and attribute a constraint to the type declaring it.</p>
      *
      * <p>Defaults to {@code false} since the additional metadata increases the size of the generated
      * introspection. Has no effect when {@link #annotationMetadata()} is {@code false}, since the members carry

--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
@@ -16,6 +16,7 @@
 package io.micronaut.core.beans;
 
 import io.micronaut.core.annotation.AnnotationMetadataDelegate;
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
@@ -409,6 +410,32 @@ public interface BeanIntrospection<T> extends AnnotationMetadataDelegate, BeanIn
      */
     default List<BeanConstructor<T>> getConstructors() {
         return List.of(getConstructor());
+    }
+
+    /**
+     * Whether this introspection tells the declarations of the bean type apart from the ones it inherits.
+     *
+     * <p>A property merges what its field, its accessors and every super type declaring one of them carry
+     * into one annotation metadata, and a method merges the annotations of the methods it overrides. A
+     * specification attributing an annotation to the element declaring it - Jakarta Validation puts a
+     * constraint an interface declares in the implicit group of that interface, validates a constraint of a
+     * field against the field rather than the getter, and reports the constraints of an element apart from the
+     * inherited ones - needs them apart. An introspection separating them lists in
+     * {@link BeanProperty#getMembers()} the field of a property and the accessor of every type of the
+     * hierarchy declaring one, each carrying the annotations of its own declaration only, and answers what a
+     * method declares itself through {@link BeanMethod#getDeclaredMethodAnnotationMetadata()}.</p>
+     *
+     * <p>A generated introspection separates the declarations when it is compiled with
+     * {@link io.micronaut.core.annotation.Introspected#members()}; by default it does not, and the members of
+     * its properties are empty.</p>
+     *
+     * @return True if the members of a property and the annotations of a method are reported by the type
+     * declaring them
+     * @since 5.2.0
+     */
+    @Experimental
+    default boolean separatesDeclarations() {
+        return false;
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/beans/BeanMethod.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanMethod.java
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package io.micronaut.core.beans;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.type.Executable;
 import io.micronaut.core.type.ReturnType;
@@ -36,7 +38,22 @@ public interface BeanMethod<B, T> extends Executable<B, T>, Named {
     /**
      * @return The return type.
      */
- ReturnType<T> getReturnType();
+    ReturnType<T> getReturnType();
+
+    /**
+     * The annotations this method declares itself: without the ones of the bean type, which
+     * {@link #getAnnotationMetadata()} combines with the ones of the method, and without the ones inherited
+     * from the methods it overrides, which {@link #getDeclaredMetadata()} keeps. The runtime counterpart of
+     * {@code MethodElement.getDeclaredMethodAnnotationMetadata()} of the annotation processors.
+     *
+     * @return The annotation metadata of this method declaration only
+     * @since 5.2.0
+     */
+    default AnnotationMetadata getDeclaredMethodAnnotationMetadata() {
+        // the first call narrows the metadata of the bean type and the method to the one of the method, the
+        // second one narrows the method metadata to what this declaration carries
+        return getAnnotationMetadata().getDeclaredMetadata().getDeclaredMetadata();
+    }
 
     @Override
     default Class<B> getDeclaringType() {

--- a/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
@@ -300,15 +300,23 @@ public interface BeanProperty<B, T> extends BeanReadProperty<B, T>, BeanWritePro
     }
 
     /**
-     * The individual members (the field, the read method and the write method) that this property is composed of.
+     * The individual members (the field, the read methods and the write methods) that this property is composed of.
      *
      * <p>A property merges its members into a single element with a single merged
      * {@link io.micronaut.core.annotation.AnnotationMetadata}. This method exposes each member separately, with its own
      * annotation metadata, its own {@link Argument} and its own accessor, which is required by specifications such as
-     * Jakarta Bean Validation that treat a field and a getter as two distinct constrained elements.</p>
+     * Jakarta Bean Validation that treat a field and a getter as two distinct constrained elements, and a getter an
+     * interface declares apart from the one implementing it.</p>
+     *
+     * <p>The members are the field of the property and the read and write methods of every type of the hierarchy
+     * declaring one: the accessor of the bean type, then the ones it overrides in its super classes, then the ones
+     * of its interfaces, each reported by {@link BeanPropertyMember#getDeclaringType() the type declaring it} and
+     * carrying the annotations of its own declaration only, the fields first, then the read methods, then the
+     * write methods.</p>
      *
      * <p>The members are only computed at compilation time if the introspection was generated with
-     * {@link io.micronaut.core.annotation.Introspected#members()} set to {@code true}. Otherwise, and for any
+     * {@link io.micronaut.core.annotation.Introspected#members()} set to {@code true}, which
+     * {@link BeanIntrospection#separatesDeclarations()} reports. Otherwise, and for any
      * {@link BeanProperty} implementation that doesn't support members, an empty list is returned.</p>
      *
      * @return The members of this property, or an empty list if unavailable

--- a/core/src/main/java/io/micronaut/core/beans/BeanPropertyMember.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanPropertyMember.java
@@ -27,11 +27,14 @@ import java.lang.annotation.ElementType;
 /**
  * A single member (a field, a getter or a setter) that contributed to a {@link BeanProperty}.
  *
- * <p>A {@link BeanProperty} merges the field, the read method and the write method of a property into a single
- * element with a single merged {@link io.micronaut.core.annotation.AnnotationMetadata}. Some specifications, most
- * notably Jakarta Bean Validation, treat those members as distinct elements: a constraint declared on the field is
- * validated against the value the field holds, while a constraint declared on the getter is validated against the
- * value the getter returns, and the two can differ.</p>
+ * <p>A {@link BeanProperty} merges the field, the read method and the write method of a property, and what the
+ * super types declare on them, into a single element with a single merged
+ * {@link io.micronaut.core.annotation.AnnotationMetadata}. Some specifications, most notably Jakarta Bean
+ * Validation, treat those members as distinct elements: a constraint declared on the field is validated against
+ * the value the field holds, while a constraint declared on the getter is validated against the value the getter
+ * returns, and the two can differ; a constraint an interface declares on its getter belongs to the implicit group
+ * of that interface. A member is one declaration: the field, or the read or write method of one type of the
+ * hierarchy, carrying the annotations that declaration carries and not the ones of the methods it overrides.</p>
  *
  * <p>The members of a property are only available if the introspection was generated with
  * {@link io.micronaut.core.annotation.Introspected#members()} set to {@code true}, otherwise

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
@@ -285,8 +285,8 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
             .map(overriddenMethod -> new GroovyMethodElement(
                     owningType,
                     visitorContext,
-                    new GroovyNativeElement.Method(methodNode),
-                    methodNode,
+                    new GroovyNativeElement.Method(overriddenMethod),
+                    overriddenMethod,
                     elementAnnotationMetadataFactory
                 )
             ).collect(Collectors.toList());

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.micronaut.ast.groovy.TypeElementVisitorStart
 import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 import io.micronaut.context.annotation.Executable
+import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.inject.test.IntrospectionMetadataShape
 import io.micronaut.core.beans.BeanIntrospectionReference
 import io.micronaut.core.beans.BeanIntrospector
 import io.micronaut.core.beans.BeanMethod
@@ -2675,6 +2677,66 @@ class Person {
         members[0].read(introspection.instantiate()) == null
     }
 
+    void "the members do not change the metadata the previous API answers"() {
+        given: "the same hierarchy, introspected with and without the members"
+        def source = { boolean members -> """
+package test
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.context.annotation.Executable
+import jakarta.validation.constraints.*
+import java.lang.annotation.*
+
+@Introspected(accessKind = [Introspected.AccessKind.FIELD, Introspected.AccessKind.METHOD], visibility = Introspected.Visibility.ANY${members ? ", members = true" : ""})
+@Marker("type")
+class Child extends Parent implements Holder<String> {
+    @Marker("child-field") @Size(max = 3)
+    private String name = "shadow"
+    @Override @Marker("child-getter") @Positive String getName() { "child" }
+    @Override String getValue() { "value" }
+    @Override @Executable @Marker("child-describe") @Negative String describe(@Min(2L) int level) { "c" }
+    @Executable @NotNull String other() { "o" }
+}
+
+interface Named {
+    @Marker("interface-getter") @NotNull @Size(min = 1) String getName()
+    @Marker("interface-setter") void setName(@Email String name)
+    @Executable @NotNull String describe(@Min(1L) int level)
+}
+
+interface Holder<T> {
+    @NotNull T getValue()
+}
+
+class Parent implements Named {
+    @Marker("field") @NotBlank
+    protected String name = "parent"
+    @Override @Marker("parent-getter") @Size(max = 10) String getName() { name }
+    @Override @Marker("parent-setter") void setName(@Digits(integer = 1, fraction = 1) String name) { this.name = name }
+    @Override @Executable @Size(max = 5) String describe(@Max(9L) int level) { "p" }
+}
+
+@Retention(RetentionPolicy.RUNTIME) @Inherited
+@Target([ElementType.TYPE, ElementType.FIELD, ElementType.METHOD])
+@interface Marker {
+    String value()
+}
+""" }
+        def plain = buildBeanIntrospection('test.Child', source(false))
+        def withMembers = buildBeanIntrospection('test.Child', source(true))
+
+        expect: "the members are there in the one and not in the other"
+        withMembers.separatesDeclarations()
+        !plain.separatesDeclarations()
+        withMembers.getProperty("name").get().members*.declaringType*.simpleName == ["Child", "Parent", "Child", "Parent", "Named", "Parent", "Named"]
+        plain.getProperty("name").get().members.isEmpty()
+
+        and: "the metadata the previous API answers is the same in both"
+        withMembers.propertyNames == plain.propertyNames
+        withMembers.beanMethods*.name.toSorted() == plain.beanMethods*.name.toSorted()
+        IntrospectionMetadataShape.of(withMembers) == IntrospectionMetadataShape.of(plain)
+    }
+
     void "every declared constructor is described"() {
         when:
         def introspection = buildBeanIntrospection('test.Order', '''
@@ -2763,4 +2825,5 @@ class CustomerService {
             introspection.beanType.getDeclaredConstructors()[0].parameterTypes
         introspection.getConstructors()[0].arguments.length == 1
     }
+
 }

--- a/inject-java-test/build.gradle.kts
+++ b/inject-java-test/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     testAnnotationProcessor(projects.micronautInjectJava)
     testCompileOnly(projects.micronautInjectGroovy)
+    testImplementation(projects.micronautInjectTestUtils)
     testImplementation(projects.micronautJacksonDatabind)
     testImplementation(libs.javax.persistence)
     testImplementation(projects.micronautRuntime)

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -6275,6 +6275,49 @@ class Parent implements Named {
         value.members.every { it.read(bean) == "value" }
     }
 
+    void "test a generic accessor of an interface is a declaration of the property that implements it"() {
+        given: "an interface declaring the accessors generically, implemented with a concrete type"
+        def introspection = buildBeanIntrospection('test.Impl', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+interface Holder<T> {
+    @NotNull
+    T getValue();
+
+    @Size(min = 2)
+    void setValue(T value);
+}
+
+interface AlsoHolder<T> {
+    @Size(max = 9)
+    T getValue();
+}
+
+@Introspected(members = true)
+class Impl implements Holder<String>, AlsoHolder<String> {
+    private String value;
+    @Override
+    public String getValue() { return value; }
+    @Override
+    public void setValue(String value) { this.value = value; }
+}
+''')
+        def members = introspection.getRequiredProperty("value", String).members
+
+        expect: "the erasure of the interface accessors does not hide them: every declaration is a member"
+        members*.declaringType*.simpleName == ["Impl", "Impl", "Holder", "AlsoHolder", "Impl", "Holder"]
+        members*.elementType == [ElementType.FIELD, ElementType.METHOD, ElementType.METHOD, ElementType.METHOD, ElementType.METHOD, ElementType.METHOD]
+
+        and: "each carries the annotations of its own declaration, the erased ones included"
+        members.find { it.declaringType.simpleName == "Holder" && it.elementType == ElementType.METHOD && it.readable }.annotationMetadata.hasAnnotation(NotNull)
+        members.find { it.declaringType.simpleName == "AlsoHolder" }.annotationMetadata.hasAnnotation(Size)
+        members.find { it.declaringType.simpleName == "Holder" && !it.readable }.annotationMetadata.hasAnnotation(Size)
+    }
+
     void "test a field of a super class the introspection cannot name is read through the owning type"() {
         given: "an introspection generated in another package than the package-private super class"
         def introspection = BeanIntrospector.SHARED.getIntrospection(HiddenChild)

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -10,15 +10,18 @@ import io.micronaut.annotation.processing.test.JavaParser
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Executable
 import io.micronaut.context.visitor.ConfigurationReaderVisitor
+import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.NextMajorVersion
 import org.jspecify.annotations.NonNull
 import org.jspecify.annotations.Nullable
 import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.inject.test.IntrospectionMetadataShape
 import io.micronaut.core.beans.BeanIntrospectionReference
 import io.micronaut.core.beans.BeanIntrospector
 import io.micronaut.core.beans.BeanMethod
 import io.micronaut.core.beans.BeanProperty
+import io.micronaut.core.beans.BeanPropertyMember
 import io.micronaut.core.beans.EnumBeanIntrospection
 import io.micronaut.core.convert.ConversionContext
 import io.micronaut.core.convert.TypeConverter
@@ -31,6 +34,8 @@ import io.micronaut.inject.ExecutableMethod
 import io.micronaut.inject.annotation.EvaluatedAnnotationMetadata
 import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor
 import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.beans.hidden.HiddenBase
+import io.micronaut.inject.visitor.beans.hidden.HiddenChild
 import io.micronaut.inject.visitor.beans.outer.MuxedEvent2
 import io.micronaut.validation.visitor.ValidationVisitor
 import jakarta.validation.Constraint
@@ -6191,6 +6196,316 @@ class Child extends Parent {
         members*.declaringType.every { it.name == "test.Parent" }
         members*.declaringType != [introspection.beanType] * 3
     }
+
+    void "test property members separate the declarations of the hierarchy"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Child', """
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import java.lang.annotation.*;
+
+@Introspected(members = true)
+class Child extends Parent implements Holder<String> {
+    @Marker("child-field")
+    private String name = "shadow";
+    @Override @Marker("child-getter") public String getName() { return "child"; }
+    @Override public String getValue() { return "value"; }
+}
+
+interface Named {
+    @Marker("interface-getter") String getName();
+    @Marker("interface-setter") void setName(String name);
+}
+
+interface Holder<T> {
+    @Marker("holder-getter") T getValue();
+}
+
+class Parent implements Named {
+    @Marker("field")
+    String name = "parent";
+    @Override @Marker("parent-getter") public String getName() { return name; }
+    @Override @Marker("parent-setter") public void setName(String name) { this.name = name; }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@interface Marker {
+    String value();
+}
+""")
+        def bean = introspection.instantiate()
+        def name = introspection.getProperty("name").get()
+        def value = introspection.getProperty("value").get()
+
+        expect: "the introspection separates the declarations"
+        introspection.separatesDeclarations()
+
+        and: "the field and the fields it hides, then the getter of every type declaring one, the most specific first, then the setters"
+        describe(name.members) == [
+                "FIELD test.Child name",
+                "FIELD test.Parent name",
+                "METHOD test.Child getName",
+                "METHOD test.Parent getName",
+                "METHOD test.Named getName",
+                "METHOD test.Parent setName",
+                "METHOD test.Named setName"
+        ]
+
+        and: "each carries the annotations of its own declaration only"
+        name.members.collect { it.annotationMetadata.stringValue("test.Marker").orElse(null) } ==
+                ["child-field", "field", "child-getter", "parent-getter", "interface-getter", "parent-setter", "interface-setter"]
+        name.members.collect { it.asArgument().annotationMetadata.stringValue("test.Marker").orElse(null) } ==
+                ["child-field", "field", "child-getter", "parent-getter", "interface-getter", "parent-setter", "interface-setter"]
+
+        and: "while the property merges them into one declaration"
+        name.annotationMetadata.stringValue("test.Marker").isPresent()
+
+        and: "a getter of a super type is read as the getter overriding it"
+        name.members.findAll { it.elementType == ElementType.METHOD && it.name == "getName" }.every { it.readable && it.read(bean) == "child" }
+        and: "each field is read as the field it is, the hidden one included"
+        name.members.findAll { it.elementType == ElementType.FIELD }*.read(bean) == ["shadow", "parent"]
+        name.members.findAll { it.name == "setName" }.every { !it.readable }
+
+        and: "the getter a generic interface declares is the type the bean gives it"
+        describe(value.members) == ["METHOD test.Child getValue", "METHOD test.Holder getValue"]
+        value.members*.type == [String, String]
+        value.members.collect { it.annotationMetadata.stringValue("test.Marker").orElse(null) } == [null, "holder-getter"]
+        value.members.every { it.read(bean) == "value" }
+    }
+
+    void "test a field of a super class the introspection cannot name is read through the owning type"() {
+        given: "an introspection generated in another package than the package-private super class"
+        def introspection = BeanIntrospector.SHARED.getIntrospection(HiddenChild)
+        def bean = new HiddenChild()
+
+        expect: "an inherited field is read and written through the accessible owning type"
+        introspection.getRequiredProperty("other", String).get(bean) == "base-other"
+        introspection.getRequiredProperty("other", String).members*.declaringType == [HiddenBase]
+        introspection.getRequiredProperty("other", String).members[0].read(bean) == "base-other"
+        introspection.getRequiredProperty("other", String).set(bean, "written")
+        bean.other == "written"
+
+        and: "the hiding field is read, the hidden one is listed but cannot be read"
+        introspection.getRequiredProperty("name", String).get(bean) == "child"
+        introspection.getRequiredProperty("name", String).members*.declaringType == [HiddenChild, HiddenBase]
+        introspection.getRequiredProperty("name", String).members*.readable == [true, false]
+        introspection.getRequiredProperty("name", String).members[0].read(bean) == "child"
+
+        when:
+        introspection.getRequiredProperty("name", String).members[1].read(bean)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    void "test property members list the declarations of parallel parent interfaces"() {
+        given: "an interface inheriting the same accessor from two parents without redeclaring it"
+        def introspection = buildBeanIntrospection('test.Both', """
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import java.lang.annotation.*;
+
+@Introspected(members = true)
+interface Both extends Left, Right {
+}
+
+interface Left {
+    @Marker("left") String getName();
+}
+
+interface Right {
+    @Marker("right") String getName();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@interface Marker {
+    String value();
+}
+""")
+        def members = introspection.getProperty("name").get().members
+
+        expect: "one member per parent interface, in the order the interfaces are declared"
+        describe(members) == ["METHOD test.Left getName", "METHOD test.Right getName"]
+        members.collect { it.annotationMetadata.stringValue("test.Marker").orElse(null) } == ["left", "right"]
+        members.every { it.readable }
+    }
+
+    void "test a field hidden in a private nested super class of the same package is read"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Outer$Child', """
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+class Outer {
+    private static class Base {
+        String name = "base";
+    }
+
+    @Introspected(accessKind = Introspected.AccessKind.FIELD, visibility = Introspected.Visibility.ANY, members = true)
+    public static class Child extends Base {
+        String name = "child";
+    }
+}
+""")
+        def bean = introspection.instantiate()
+        def members = introspection.getProperty("name").get().members
+
+        expect: "a private nested class is package-private in the class file, so the introspection of its package names it"
+        members*.declaringType*.simpleName == ["Child", "Base"]
+        members*.readable == [true, true]
+        members*.read(bean) == ["child", "base"]
+    }
+
+    void "test an introspection without members does not separate the declarations"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Plain', """
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+class Plain {
+    private String name;
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}
+""")
+
+        expect:
+        !introspection.separatesDeclarations()
+        introspection.getProperty("name").get().members.isEmpty()
+    }
+
+    void "test a bean method answers its own declaration apart from the ones it overrides"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Child', """
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+import java.lang.annotation.*;
+
+@Introspected
+@OnType
+class Child extends Parent {
+    @Override @Executable @OnChild public String describe(int level) { return "child"; }
+    @Executable public String other() { return "other"; }
+}
+
+interface Named {
+    @OnInterface String describe(int level);
+}
+
+class Parent implements Named {
+    @Override @OnParent public String describe(int level) { return "parent"; }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface OnType {}
+
+@Retention(RetentionPolicy.RUNTIME) @Inherited
+@interface OnInterface {}
+
+@Retention(RetentionPolicy.RUNTIME) @Inherited
+@interface OnParent {}
+
+@Retention(RetentionPolicy.RUNTIME) @Inherited
+@interface OnChild {}
+""")
+        def describe = introspection.beanMethods.find { it.name == "describe" }
+        def other = introspection.beanMethods.find { it.name == "other" }
+        def names = { AnnotationMetadata metadata -> metadata.annotationNames.findAll { it.startsWith("test.On") }.sort() }
+
+        expect: "the metadata of the method combines the type, the overridden methods and the declaration"
+        names(describe.annotationMetadata) == ["test.OnChild", "test.OnInterface", "test.OnParent", "test.OnType"]
+
+        and: "the declared metadata narrows it to the method, the overridden ones included"
+        names(describe.declaredMetadata) == ["test.OnChild", "test.OnInterface", "test.OnParent"]
+
+        and: "the declaration is the annotations of the method itself"
+        names(describe.declaredMethodAnnotationMetadata) == ["test.OnChild"]
+        describe.declaredMethodAnnotationMetadata.hasAnnotation(Executable)
+
+        and: "a method overriding nothing declares everything it carries but the type"
+        names(other.annotationMetadata) == ["test.OnType"]
+        names(other.declaredMethodAnnotationMetadata) == []
+        other.declaredMethodAnnotationMetadata.hasAnnotation(Executable)
+    }
+
+    void "test the members do not change the metadata the previous API answers"() {
+        given: "the same hierarchy, introspected with and without the members"
+        def source = { boolean members -> """
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+import jakarta.validation.constraints.*;
+import java.lang.annotation.*;
+import java.util.List;
+
+@Introspected(accessKind = {Introspected.AccessKind.FIELD, Introspected.AccessKind.METHOD}, visibility = Introspected.Visibility.ANY${members ? ", members = true" : ""})
+@Marker("type")
+class Child extends Parent implements Holder<String> {
+    @Marker("child-field") @Size(max = 3)
+    private String name = "shadow";
+    @Override @Marker("child-getter") @Positive public String getName() { return "child"; }
+    @Override public String getValue() { return "value"; }
+    @Override @Executable @Marker("child-describe") @Negative public String describe(@Min(2) int level) { return "c"; }
+    @Executable @NotNull public @Email String other() { return "o"; }
+    public Child() {}
+    public Child(@NotBlank String name) {}
+}
+
+interface Named {
+    @Marker("interface-getter") @NotNull @Size(min = 1) String getName();
+    @Marker("interface-setter") void setName(@Email String name);
+    @Executable @NotNull String describe(@Min(1) int level);
+}
+
+interface Holder<T> {
+    @NotNull T getValue();
+    List<@NotBlank String> getTags();
+}
+
+class Parent implements Named {
+    @Marker("field") @NotBlank
+    String name = "parent";
+    @Override @Marker("parent-getter") @Size(max = 10) public String getName() { return name; }
+    @Override @Marker("parent-setter") public void setName(@Digits(integer = 1, fraction = 1) String name) { this.name = name; }
+    @Override @Executable @Size(max = 5) public String describe(@Max(9) int level) { return "p"; }
+    public List<@Size(max = 2) String> getTags() { return null; }
+}
+
+@Retention(RetentionPolicy.RUNTIME) @Inherited
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+@interface Marker {
+    String value();
+}
+""" }
+        def plain = buildBeanIntrospection('test.Child', source(false))
+        def withMembers = buildBeanIntrospection('test.Child', source(true))
+
+        expect: "the members are there in the one and not in the other"
+        withMembers.separatesDeclarations()
+        !plain.separatesDeclarations()
+        withMembers.getProperty("name").get().members.size() == 7
+        plain.getProperty("name").get().members.isEmpty()
+
+        and: "the metadata the previous API answers is the same in both"
+        withMembers.propertyNames == plain.propertyNames
+        withMembers.beanMethods*.name.toSorted() == plain.beanMethods*.name.toSorted()
+        IntrospectionMetadataShape.of(withMembers) == IntrospectionMetadataShape.of(plain)
+    }
+
+    private static List<String> describe(List<BeanPropertyMember> members) {
+        return members.collect { "$it.elementType $it.declaringType.name $it.name" as String }
+    }
+
 
     void "test a nested type named on classNames is introspected once"() {
         given:

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/hidden/HiddenBase.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/hidden/HiddenBase.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.visitor.beans.hidden;
+
+/**
+ * A package-private super class: an introspection generated in another package cannot name it.
+ */
+class HiddenBase {
+
+    public String name = "base";
+
+    public String other = "base-other";
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/hidden/HiddenChild.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/hidden/HiddenChild.java
@@ -1,0 +1,9 @@
+package io.micronaut.inject.visitor.beans.hidden;
+
+/**
+ * Hides the field of its package-private super class, and inherits the other one.
+ */
+public class HiddenChild extends HiddenBase {
+
+    public String name = "child";
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/outer/HiddenImport.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/outer/HiddenImport.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.visitor.beans.outer;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.inject.visitor.beans.hidden.HiddenChild;
+
+/**
+ * Introspects {@link HiddenChild} from another package: its super class is package-private there.
+ */
+@Introspected(classes = HiddenChild.class, accessKind = Introspected.AccessKind.FIELD, visibility = Introspected.Visibility.ANY, members = true)
+public class HiddenImport {
+}

--- a/inject-kotlin/build.gradle.kts
+++ b/inject-kotlin/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
         exclude(group = "io.micronaut")
     }
 
+    testImplementation(projects.micronautInjectTestUtils)
     testImplementation(libs.managed.kotlin.compiler.embeddable)
     testImplementation(projects.micronautContext)
     testImplementation(projects.micronautJacksonDatabind)

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
 import io.micronaut.context.annotation.Executable
+import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.inject.test.IntrospectionMetadataShape
 import io.micronaut.core.beans.BeanIntrospectionReference
 import io.micronaut.core.beans.BeanIntrospector
 import io.micronaut.core.beans.BeanMethod
@@ -2589,6 +2591,70 @@ class Person {
         members[0].read(introspection.instantiate()) == null
     }
 
+    void "the members do not change the metadata the previous API answers"() {
+        given: "the same hierarchy, introspected with and without the members"
+        def source = { boolean members -> """
+package test
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.context.annotation.Executable
+import jakarta.validation.constraints.*
+
+@Introspected(accessKind = [Introspected.AccessKind.FIELD, Introspected.AccessKind.METHOD], visibility = [Introspected.Visibility.ANY]${members ? ", members = true" : ""})
+@Marker("type")
+open class Child : Parent(), Holder<String> {
+    @field:Marker("child-field") @field:Size(max = 3)
+    private val shadow: String = "shadow"
+    @get:Marker("child-getter") @get:Positive
+    override val name: String get() = "child"
+    override val value: String get() = "value"
+    @Executable @Marker("child-describe") @Negative
+    override fun describe(@Min(2) level: Int): String = "c"
+    @Executable @NotNull
+    fun other(): String = "o"
+}
+
+interface Named {
+    @get:Marker("interface-getter") @get:NotNull @get:Size(min = 1)
+    val name: String
+    @Executable @NotNull
+    fun describe(@Min(1) level: Int): String
+}
+
+interface Holder<T> {
+    @get:NotNull
+    val value: T
+}
+
+open class Parent : Named {
+    @field:Marker("field") @field:NotBlank
+    var tag: String = "parent"
+    @get:Marker("parent-getter") @get:Size(max = 10)
+    override val name: String get() = tag
+    @Executable @Size(max = 5)
+    override fun describe(@Max(9) level: Int): String = "p"
+}
+
+@Retention(AnnotationRetention.RUNTIME)
+@java.lang.annotation.Inherited
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
+annotation class Marker(val value: String)
+""" }
+        def plain = buildBeanIntrospection('test.Child', source(false))
+        def withMembers = buildBeanIntrospection('test.Child', source(true))
+
+        expect: "the members are there in the one and not in the other"
+        withMembers.separatesDeclarations()
+        !plain.separatesDeclarations()
+        !withMembers.getProperty("tag").get().members.isEmpty()
+        plain.getProperty("tag").get().members.isEmpty()
+
+        and: "the metadata the previous API answers is the same in both"
+        withMembers.propertyNames == plain.propertyNames
+        withMembers.beanMethods*.name.toSorted() == plain.beanMethods*.name.toSorted()
+        IntrospectionMetadataShape.of(withMembers) == IntrospectionMetadataShape.of(plain)
+    }
+
     void "constructors = true does not change the constructor beans are built with"() {
         when: 'the same type is built with and without the member'
         def source = '''
@@ -2836,4 +2902,5 @@ class Order(val name: String) {
         introspection.getConstructors().size() == 1
         introspection.getConstructors()[0].arguments.length == introspection.constructor.arguments.length
     }
+
 }

--- a/inject-test-utils/src/main/groovy/io/micronaut/inject/test/IntrospectionMetadataShape.groovy
+++ b/inject-test-utils/src/main/groovy/io/micronaut/inject/test/IntrospectionMetadataShape.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.test
+
+import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.core.beans.BeanMethod
+import io.micronaut.core.beans.BeanProperty
+
+/**
+ * Every answer a {@link BeanIntrospection} gives through the API that predates
+ * {@link io.micronaut.core.annotation.Introspected#members()}, rendered as text so that two introspections can
+ * be compared as a whole rather than assertion by assertion.
+ *
+ * <p>Written for the specs that check {@code members = true} is additive: the same type is compiled with and
+ * without the members, and the two must answer the same.</p>
+ */
+class IntrospectionMetadataShape {
+
+    /**
+     * The metadata an introspection exposes: the introspection itself, the properties with their arguments,
+     * the bean methods with their return types and arguments, and the constructor.
+     *
+     * @param introspection The introspection
+     * @return The rendered metadata
+     */
+    static String of(BeanIntrospection<?> introspection) {
+        List<String> lines = ["introspection:\n" + of(introspection.annotationMetadata)]
+        for (BeanProperty property : introspection.beanProperties) {
+            lines << "property ${property.name}:\n" + of(property.annotationMetadata)
+            lines << "property ${property.name} declared:\n" + of(property.annotationMetadata.declaredMetadata)
+            lines << "property ${property.name} argument:\n" + of(property.asArgument().annotationMetadata)
+            property.asArgument().typeParameters.each {
+                lines << "property ${property.name} type argument ${it.name}:\n" + of(it.annotationMetadata)
+            }
+        }
+        for (BeanMethod method : introspection.beanMethods.toSorted { it.name }) {
+            lines << "method ${method.name}:\n" + of(method.annotationMetadata)
+            lines << "method ${method.name} declared:\n" + of(method.declaredMetadata)
+            lines << "method ${method.name} return:\n" + of(method.returnType.annotationMetadata)
+            lines << "method ${method.name} return argument:\n" + of(method.returnType.asArgument().annotationMetadata)
+            method.arguments.each { lines << "method ${method.name} argument ${it.name}:\n" + of(it.annotationMetadata) }
+        }
+        lines << "constructor:\n" + of(introspection.constructor.annotationMetadata)
+        introspection.constructorArguments.each {
+            lines << "constructor argument ${it.name}:\n" + of(it.annotationMetadata)
+        }
+        return lines.join("\n")
+    }
+
+    /**
+     * Every answer an annotation metadata gives: the names, the declared names, the stereotypes, and for each
+     * annotation its values, its default values and the annotations it is a stereotype of.
+     *
+     * @param metadata The metadata
+     * @return The rendered metadata
+     */
+    static String of(AnnotationMetadata metadata) {
+        List<String> lines = []
+        lines << "names=" + metadata.annotationNames.toSorted()
+        lines << "declared=" + metadata.declaredAnnotationNames.toSorted()
+        lines << "stereotypes=" + metadata.stereotypeAnnotationNames.toSorted()
+        lines << "declaredStereotypes=" + metadata.declaredStereotypeAnnotationNames.toSorted()
+        for (String name : metadata.annotationNames.toSorted()) {
+            lines << name + " values=" + metadata.getAnnotationValuesByName(name)*.toString() +
+                    " defaults=" + canonical(metadata.getDefaultValues(name)) +
+                    " byStereotype=" + metadata.getAnnotationNamesByStereotype(name).toSorted()
+        }
+        return lines.join("\n")
+    }
+
+    private static Object canonical(Object value) {
+        if (value instanceof Map) {
+            return new TreeMap(value.collectEntries { k, v -> [(k.toString()): canonical(v)] })
+        }
+        if (value instanceof Object[]) {
+            return value.toList().collect { canonical(it) }
+        }
+        return value instanceof AnnotationValue ? value.toString() : value
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.beans;
 
+import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
@@ -1667,7 +1668,17 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
 
         @Override
         public Class<?> getDeclaringType() {
-            return ref.declaringType();
+            // the generated code cannot name a package-private super class of another package as a class
+            // constant, so the class value of the declaring type carries its name when the constant fails,
+            // and the class is loaded by that name through the loader of the bean type
+            AnnotationClassValue<?> declaringType = ref.declaringType();
+            Class<?> type = declaringType.getType().orElse(null);
+            if (type != null) {
+                return type;
+            }
+            return ClassUtils.forName(declaringType.getName(), getBeanType().getClassLoader())
+                .orElseThrow(() -> new IllegalStateException("The type declaring the member " + ref.name()
+                    + " of " + getBeanType().getName() + " cannot be loaded: " + declaringType.getName()));
         }
 
         @SuppressWarnings("unchecked")
@@ -2159,7 +2170,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
      * Bean property member compile-time data container.
      *
      * @param elementType    The kind of the member, either {@link ElementType#FIELD} or {@link ElementType#METHOD}
-     * @param declaringType  The type declaring the member
+     * @param declaringType  The type declaring the member, by name when the generated code cannot name it
      * @param name           The name of the member
      * @param argument       The type of the member including its own annotation metadata
      * @param readMethodIndex The dispatch index used to read the member, or {@code -1} if it cannot be read
@@ -2168,10 +2179,29 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
     @Internal
     @UsedByGeneratedCode
     public record BeanPropertyMemberRef(ElementType elementType,
-                                        Class<?> declaringType,
+                                        AnnotationClassValue<?> declaringType,
                                         String name,
                                         Argument<?> argument,
                                         int readMethodIndex) {
+
+        /**
+         * The shape the generated code named the declaring type by before it was carried as a class value;
+         * kept for the introspections compiled against it.
+         *
+         * @param elementType     The kind of the member
+         * @param declaringType   The type declaring the member
+         * @param name            The name of the member
+         * @param argument        The type of the member including its own annotation metadata
+         * @param readMethodIndex The dispatch index used to read the member, or {@code -1} if it cannot be read
+         */
+        @UsedByGeneratedCode
+        public BeanPropertyMemberRef(ElementType elementType,
+                                     Class<?> declaringType,
+                                     String name,
+                                     Argument<?> argument,
+                                     int readMethodIndex) {
+            this(elementType, new AnnotationClassValue<>(declaringType), name, argument, readMethodIndex);
+        }
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -1650,6 +1650,11 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
 
         private final BeanPropertyMemberRef ref;
         private final AnnotationMetadata annotationMetadata;
+        // resolving the declaring type is idempotent and yields the same class, so the field is allowed to be
+        // initialized more than once when getDeclaringType() is called concurrently
+        @SuppressWarnings("java:S3077")
+        @Nullable
+        private volatile Class<?> declaringType;
 
         private BeanPropertyMemberImpl(BeanPropertyMemberRef ref) {
             this.ref = ref;
@@ -1668,17 +1673,29 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
 
         @Override
         public Class<?> getDeclaringType() {
-            // the generated code cannot name a package-private super class of another package as a class
-            // constant, so the class value of the declaring type carries its name when the constant fails,
-            // and the class is loaded by that name through the loader of the bean type
-            AnnotationClassValue<?> declaringType = ref.declaringType();
-            Class<?> type = declaringType.getType().orElse(null);
+            Class<?> resolved = declaringType;
+            if (resolved == null) {
+                resolved = resolveDeclaringType();
+                declaringType = resolved;
+            }
+            return resolved;
+        }
+
+        /**
+         * The generated code cannot name a package-private super class of another package as a class constant,
+         * so the class value of the declaring type carries its name when the constant fails, and the class is
+         * loaded by that name through the loader of the bean type. The lookup runs once per member: it loads a
+         * class and builds a message on the failing path, where a member is described repeatedly.
+         */
+        private Class<?> resolveDeclaringType() {
+            AnnotationClassValue<?> value = ref.declaringType();
+            Class<?> type = value.getType().orElse(null);
             if (type != null) {
                 return type;
             }
-            return ClassUtils.forName(declaringType.getName(), getBeanType().getClassLoader())
+            return ClassUtils.forName(value.getName(), getBeanType().getClassLoader())
                 .orElseThrow(() -> new IllegalStateException("The type declaring the member " + ref.name()
-                    + " of " + getBeanType().getName() + " cannot be loaded: " + declaringType.getName()));
+                    + " of " + getBeanType().getName() + " cannot be loaded: " + value.getName()));
         }
 
         @SuppressWarnings("unchecked")

--- a/reflection/src/main/java/io/micronaut/reflection/AbstractReflectionExecutable.java
+++ b/reflection/src/main/java/io/micronaut/reflection/AbstractReflectionExecutable.java
@@ -177,9 +177,9 @@ abstract class AbstractReflectionExecutable<T, R> implements ExecutableMethod<T,
 
         @Override
         public Argument<R> asArgument() {
-            // the return argument as written - its own type-use annotations, a variable kept a variable - which
-            // is what the return type of a generated executable answers; the metadata of the method is what
-            // getAnnotationMetadata() answers, on both sides
+            // the return argument as built - the annotations of the method with the type-use annotations of the
+            // return type, a variable kept a variable - which is what the return type of a generated executable
+            // method answers; the metadata of the method is what getAnnotationMetadata() answers, on both sides
             return returnArgument;
         }
     }

--- a/reflection/src/main/java/io/micronaut/reflection/ReflectionArguments.java
+++ b/reflection/src/main/java/io/micronaut/reflection/ReflectionArguments.java
@@ -157,16 +157,18 @@ public final class ReflectionArguments {
     }
 
     /**
-     * Converts the return type of a method to an {@link Argument} carrying the type-use annotations of the
-     * return type. An annotation that targets the method alone belongs to the method, not to its return type;
-     * one written before the return type whose target includes {@code TYPE_USE} annotates both (JLS 9.7.4),
-     * and is on both, as the processors record it.
+     * Converts the return type of a method to an {@link Argument} whose metadata holds the annotations of the
+     * method and the type-use annotations of its return type, as {@link #of(Parameter)} builds the argument of
+     * a parameter from the parameter and its type: a generated executable method of a bean definition reports
+     * the return value with the annotations of the method on it, and a constraint declared on a method
+     * constrains the value it returns. An annotation written before the return type whose target includes
+     * {@code TYPE_USE} is on both the method and the type (JLS 9.7.4) and is read once.
      *
      * @param method The method
      * @return The argument
      */
     public static Argument<?> returnOf(Method method) {
-        return toArgument(null, method.getAnnotatedReturnType(), Map.of());
+        return withElementAnnotations(toArgument(null, method.getAnnotatedReturnType(), Map.of()), method);
     }
 
     /**
@@ -218,15 +220,17 @@ public final class ReflectionArguments {
     }
 
     /**
-     * Converts the return type of a method to an {@link Argument} as the type reading it sees it.
+     * Converts the return type of a method to an {@link Argument} as the type invoking it sees it, with the
+     * annotations of the method and the type-use annotations of its return type.
      *
      * @param method  The method
-     * @param context The type the method is read through, an implementation of its declaring type
+     * @param context The type the method is invoked on, an implementation of its declaring type
      * @return The argument
+     * @see #returnOf(Method)
      * @see #of(Field, Class)
      */
     public static Argument<?> returnOf(Method method, Class<?> context) {
-        return returnOf(null, method, context);
+        return withElementAnnotations(returnOf(null, method, context), method);
     }
 
     /**
@@ -264,7 +268,9 @@ public final class ReflectionArguments {
 
     /**
      * Converts the return type of a method to an {@link Argument} under a name of the caller's choosing, as the
-     * reading type sees it.
+     * reading type sees it, carrying the annotations of the return type but not the ones the method declares:
+     * what the processor writes for the return type of a bean method of an introspection, and for the type of
+     * a property read through a getter.
      */
     static Argument<?> returnOf(@Nullable String name, Method method, Class<?> context) {
         return toArgument(name, method.getAnnotatedReturnType(), bindings(context, method.getDeclaringClass()), Set.of());

--- a/reflection/src/main/java/io/micronaut/reflection/ReflectionBeanIntrospection.java
+++ b/reflection/src/main/java/io/micronaut/reflection/ReflectionBeanIntrospection.java
@@ -1758,10 +1758,12 @@ public final class ReflectionBeanIntrospection<T> implements ReflectiveIntrospec
          * the type the bean type gives it rather than the bound of the variable, which is what a generated
          * bean method reports. It carries what the return type itself carries - the annotations of the type
          * and the ones declaring the variable it stands for - and not the metadata of the method, as a
-         * generated bean method reports the argument the processor writes for the return type alone.
+         * generated bean method reports the argument the processor writes for the return type alone, where
+         * {@link ReflectionArguments#returnOf(Method, Class)} folds the annotations of the method in, as a
+         * generated executable method of a bean definition does.
          */
         private static Argument<?> resolvedReturn(ReflectionExecutableMethod<?, ?> executable, Class<?> beanType) {
-            return ReflectionArguments.returnOf(executable.getMethod(), beanType);
+            return ReflectionArguments.returnOf(null, executable.getMethod(), beanType);
         }
 
         /**

--- a/reflection/src/main/java/io/micronaut/reflection/ReflectiveIntrospection.java
+++ b/reflection/src/main/java/io/micronaut/reflection/ReflectiveIntrospection.java
@@ -33,7 +33,9 @@ import java.util.Optional;
  * <p>A specification that describes a type — the constraint metadata of Jakarta Validation, for instance —
  * names constructors by their parameter types and distinguishes the constraints declared on a field from the
  * ones declared on a getter, or in the type from the ones inherited from a super type. A generated
- * introspection merges the members of a property into one metadata; this contract keeps them apart.</p>
+ * introspection merges the members of a property into one metadata unless it is compiled with
+ * {@code @Introspected(members = true)}; this contract always keeps them apart, and
+ * {@link BeanIntrospection#separatesDeclarations()} says so for either.</p>
  *
  * @param <T> The bean type
  * @author Denis Stepanov
@@ -47,6 +49,18 @@ public interface ReflectiveIntrospection<T> extends BeanIntrospection<T> {
      */
     @Override
     List<BeanConstructor<T>> getConstructors();
+
+    /**
+     * A reflective introspection always does: the members of a property are read from the field and the
+     * accessors of every type declaring one, and the annotations of a method from the method itself, which
+     * Java reflection does not inherit.
+     *
+     * @return {@code true}
+     */
+    @Override
+    default boolean separatesDeclarations() {
+        return true;
+    }
 
     /**
      * Finds the method the introspected type itself declares, with the annotations of that declaration only:

--- a/reflection/src/test/groovy/io/micronaut/reflection/MemberParityBase.groovy
+++ b/reflection/src/test/groovy/io/micronaut/reflection/MemberParityBase.groovy
@@ -4,16 +4,18 @@ package io.micronaut.reflection
  * The super class of {@link MemberParityBean}: a property declared away from the introspected type, so that
  * the class a member reports as its declaring type can be compared between the two descriptions.
  */
-class MemberParityBase {
+class MemberParityBase implements MemberParityContract {
 
     @Tag("inherited-field")
     private String note
 
     @Tag("inherited-getter")
+    @Override
     String getNote() {
         return note
     }
 
+    @Override
     void setNote(String note) {
         this.note = note
     }

--- a/reflection/src/test/groovy/io/micronaut/reflection/MemberParityBean.groovy
+++ b/reflection/src/test/groovy/io/micronaut/reflection/MemberParityBean.groovy
@@ -54,4 +54,13 @@ class MemberParityBean extends MemberParityBase {
     String writeOnlyValue() {
         return writeOnly
     }
+
+    @Tag("hiding-field")
+    private String note = "hidden"
+
+    @Tag("overriding-getter")
+    @Override
+    String getNote() {
+        return super.getNote()
+    }
 }

--- a/reflection/src/test/groovy/io/micronaut/reflection/MemberParityContract.groovy
+++ b/reflection/src/test/groovy/io/micronaut/reflection/MemberParityContract.groovy
@@ -1,0 +1,14 @@
+package io.micronaut.reflection
+
+/**
+ * The interface {@link MemberParityBase} implements: a getter and a setter declared away from any class, so
+ * that the member an interface declares can be compared between the two descriptions.
+ */
+interface MemberParityContract {
+
+    @Tag("contract-getter")
+    String getNote()
+
+    @Tag("contract-setter")
+    void setNote(String note)
+}

--- a/reflection/src/test/groovy/io/micronaut/reflection/PropertyMemberParitySpec.groovy
+++ b/reflection/src/test/groovy/io/micronaut/reflection/PropertyMemberParitySpec.groovy
@@ -35,7 +35,7 @@ class PropertyMemberParitySpec extends Specification {
         expect:
         generated.beanProperties.every { property ->
             property.members.every { member ->
-                def other = reflectiveMember(property.name, member.name, member.elementType)
+                def other = reflectiveMember(property.name, member)
                 other != null && tags(other) == tags(member)
             }
         }
@@ -60,17 +60,60 @@ class PropertyMemberParitySpec extends Specification {
                 reflective.getRequiredProperty("value", String).getAnnotationValuesByType(Tag)*.stringValue()*.get().toSet()
     }
 
-    void "a member declared by a super class reports that class in both descriptions"() {
-        expect:
-        generated.getRequiredProperty("note", String).members*.declaringType.every { it == MemberParityBase }
-        members("note")*.declaringType.every { it == MemberParityBase }
+    void "a member is reported by the type declaring it in both descriptions"() {
+        expect: "the field and the field it hides by the class declaring each, the getter by every type of the hierarchy declaring one, the bean type first"
+        describe(generated.getRequiredProperty("note", String).members) == [
+                "FIELD MemberParityBean note",
+                "FIELD MemberParityBase note",
+                "METHOD MemberParityBean getNote",
+                "METHOD MemberParityBase getNote",
+                "METHOD MemberParityContract getNote",
+                "METHOD MemberParityBase setNote",
+                "METHOD MemberParityContract setNote"
+        ]
+
+        and:
+        describe(members("note")) == describe(generated.getRequiredProperty("note", String).members)
+    }
+
+    void "a getter overridden along the hierarchy carries the annotations of its own declaration in both descriptions"() {
+        given:
+        def tagsOf = { List<BeanPropertyMember> members -> members.collect { m -> tags(m) } }
+
+        expect: "the hiding field, the hidden one, the override, the overridden getter and the one of the interface each answer its own tag alone"
+        tagsOf(generated.getRequiredProperty("note", String).members) ==
+                [["hiding-field"], ["inherited-field"], ["overriding-getter"], ["inherited-getter"], ["contract-getter"], [], ["contract-setter"]]
+        tagsOf(members("note")) == tagsOf(generated.getRequiredProperty("note", String).members)
+
+        and: "while the property carries the occurrence of the member it is read through, in both descriptions"
+        generated.getRequiredProperty("note", String).getAnnotationValuesByType(Tag)*.stringValue()*.get() == ["overriding-getter"]
+        reflective.getRequiredProperty("note", String).getAnnotationValuesByType(Tag)*.stringValue()*.get() ==
+                generated.getRequiredProperty("note", String).getAnnotationValuesByType(Tag)*.stringValue()*.get()
+
+        and: "every getter reads the value the override returns, and each field the value it holds"
+        def bean = new MemberParityBean(note: "inherited")
+        generated.getRequiredProperty("note", String).members.findAll { it.readable && it.elementType == ElementType.METHOD }*.read(bean).every { it == "inherited" }
+        generated.getRequiredProperty("note", String).members.findAll { it.elementType == ElementType.FIELD }*.read(bean) == ["hidden", "inherited"]
+        members("note").findAll { it.readable }*.read(bean) == generated.getRequiredProperty("note", String).members.findAll { it.readable }*.read(bean)
+    }
+
+    void "an introspection says whether it separates the declarations"() {
+        expect: "a generated introspection compiled with the members does"
+        generated.separatesDeclarations()
+
+        and: "a reflective one always does"
+        reflective.separatesDeclarations()
+
+        and: "a generated introspection without the members does not, and lists no member"
+        !BeanIntrospection.getIntrospection(ParityBean).separatesDeclarations()
+        BeanIntrospection.getIntrospection(ParityBean).beanProperties.every { it.members.isEmpty() }
     }
 
     void "a member is the type it declares in both descriptions"() {
         expect:
         generated.beanProperties.every { property ->
             property.members.every { member ->
-                def other = reflectiveMember(property.name, member.name, member.elementType)
+                def other = reflectiveMember(property.name, member)
                 other.type == member.type &&
                         other.asArgument().typeParameters*.type == member.asArgument().typeParameters*.type
             }
@@ -84,7 +127,7 @@ class PropertyMemberParitySpec extends Specification {
         expect:
         generated.beanProperties.every { property ->
             property.members.every { member ->
-                def other = reflectiveMember(property.name, member.name, member.elementType)
+                def other = reflectiveMember(property.name, member)
                 other.readable == member.readable &&
                         (!member.readable || other.read(bean) == member.read(bean))
             }
@@ -136,8 +179,10 @@ class PropertyMemberParitySpec extends Specification {
         return reflective.getProperty(property).map { it.members }.orElse([])
     }
 
-    private BeanPropertyMember reflectiveMember(String property, String name, ElementType elementType) {
-        return members(property).find { it.name == name && it.elementType == elementType }
+    private BeanPropertyMember reflectiveMember(String property, BeanPropertyMember member) {
+        return members(property).find {
+            it.name == member.name && it.elementType == member.elementType && it.declaringType == member.declaringType
+        }
     }
 
     private static List<String> describe(List<BeanPropertyMember> members) {

--- a/reflection/src/test/groovy/io/micronaut/reflection/ReflectionArgumentFactoriesSpec.groovy
+++ b/reflection/src/test/groovy/io/micronaut/reflection/ReflectionArgumentFactoriesSpec.groovy
@@ -56,7 +56,7 @@ class ReflectionArgumentFactoriesSpec extends Specification {
         ReflectionArguments.argumentsOf(Factories.getConstructor()).is(io.micronaut.core.type.Argument.ZERO_ARGUMENTS)
     }
 
-    void "the return argument of a method is the annotated return type, not the method"() {
+    void "the return argument of a method carries the annotations of the method and of its return type"() {
         when:
         def argument = ReflectionArguments.returnOf(Factories.getMethod("produce", Map))
 
@@ -64,11 +64,22 @@ class ReflectionArgumentFactoriesSpec extends Specification {
         argument.type == List
         tags(argument.typeParameters[0]) == ["returned"]
 
-        and: "an annotation written before the return type whose target includes TYPE_USE is one of that type too, the way the compiler records it"
+        and: "an annotation written before the return type whose target includes TYPE_USE is on the method and on the type, and is read once"
         tags(argument) == ["method"]
 
         and: "a void method returns a void argument"
         ReflectionArguments.returnOf(Factories.getMethod("consume", String)).type == void
+
+        when: "an annotation targeting the method alone"
+        def labelled = ReflectionArguments.returnOf(Factories.getMethod("label"))
+
+        then: "it is on the return argument, as a generated executable method of a bean definition reports it"
+        labelled.annotationMetadata.stringValue(MethodTag).get() == "method-only"
+        tags(labelled) == ["both"]
+        tags(labelled.typeParameters[0]) == ["element"]
+
+        and: "read through a type the same way"
+        ReflectionArguments.returnOf(Factories.getMethod("label"), Factories).annotationMetadata.stringValue(MethodTag).get() == "method-only"
     }
 
     void "an argument can be named by the caller rather than by the member"() {

--- a/reflection/src/test/java/io/micronaut/reflection/Factories.java
+++ b/reflection/src/test/java/io/micronaut/reflection/Factories.java
@@ -31,4 +31,10 @@ public class Factories {
     public void consume(String value) { // NOSONAR - the parameter is unused on purpose, the signature is what is described
         // empty on purpose - only the declaration is read
     }
+
+    @MethodTag("method-only")
+    @Tag("both")
+    public List<@Tag("element") String> label() {
+        return List.of();
+    }
 }

--- a/reflection/src/test/java/io/micronaut/reflection/MethodTag.java
+++ b/reflection/src/test/java/io/micronaut/reflection/MethodTag.java
@@ -1,0 +1,15 @@
+package io.micronaut.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation targeting a method alone: never a type use, so it is never recorded on the return type.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface MethodTag {
+    String value();
+}


### PR DESCRIPTION
micronaut-validation ([micronaut-projects/micronaut-validation#631](https://github.com/micronaut-projects/micronaut-validation/pull/631)) validates over generated bean introspections and attributes a constraint to the element declaring it: an interface's constraints belong to the implicit group of that interface, `ElementDescriptor.getConstraintDescriptors()` is scoped to the declaring element, the `TraversableResolver` is asked with the member kind, and a field-level constraint is validated against the field's value. A generated introspection reported a property with the annotations of its field, its getter and every super type merged into one metadata, so the validator could read that only from the reflective `ReflectiveIntrospection` of the `micronaut-reflection` module, and the introspection profile of its Jakarta Validation TCK excluded the tests that need it.

### What changes

- **`@Introspected(members = true)` describes every declaration.** `BeanProperty.getMembers()` now lists the field of the property with the fields of the same name it hides in the super classes, and the read and write method of every type of the hierarchy declaring one - the bean type first, then its super classes, then its interfaces - each reported by `getDeclaringType()` and carrying the annotations of its own declaration only (`MethodElement.getDeclaredMethodAnnotationMetadata()`). The declarations of an accessor are the methods it overrides plus the methods of the same signature the hierarchy declares beside it, since an interface inheriting an accessor from two parent interfaces without redeclaring it overrides neither. A getter of a super type is read through the getter overriding it, the same virtual call, so the hierarchy adds no dispatch target; a hidden field is read through the class declaring it. The ordinary field dispatch keeps naming the owning type and names the field on it as javac names a field on its qualifying type, which fixes an `IllegalAccessError` when an introspection generated in another package read a field inherited from a package-private super class; a hidden field whose declaring class the introspection cannot name is listed but not readable, and a member's declaring type is carried as a class value falling back to the name so such an introspection loads (the previous `Class` constructor of the member reference is kept). The members are additive: a spec in the Java, the Groovy and the Kotlin module compiles the same hierarchy with and without the members and finds every metadata the previous API answers - the introspection, the properties and their arguments, the bean methods with their return types and arguments, the constructor - the same. `IntrospectionMetadataShape` of `micronaut-inject-test-utils` renders those answers, so the comparison is written once and no expected metadata is checked in.
- **`BeanIntrospection.separatesDeclarations()`** says whether an introspection tells the declarations apart: a generated one answers true when compiled with the members, a `ReflectiveIntrospection` always does. The validator's `ReflectionSupport.separatesDeclarations` can delegate to it.
- **`BeanMethod.getDeclaredMethodAnnotationMetadata()`** answers what a method declares itself, without the bean type and without the methods it overrides - the runtime counterpart of #12917's `MethodElement.getDeclaredMethodAnnotationMetadata()`; the generated metadata already retained the split.
- **`ReflectionArguments.returnOf(Method)`** folds the annotations of the method into the return argument, as `of(Parameter)` does for a parameter and as a generated executable method of a bean definition reports it; the validator's fold in `ExecutableHierarchy.Declaration` becomes a no-op for reflective declarations. The bean methods of a reflective introspection keep the argument of the return type alone, which is what a generated introspection writes, so the return parity specs hold.
- **`GroovyMethodElement.getOverriddenMethods()`** wrapped the method itself once per overridden method; it now wraps each overridden method, so the Groovy hierarchy of an accessor no longer collapses to one declaration.

`ReflectionExecutables.beanConstructor` already reads `BeanIntrospection.getConstructors()`, which answers for `@Introspected(constructors = true)` too, so nothing changed there.

### Measured on micronaut-validation `spec-compliance`

With `members = true` on the TCK archive types and `separatesDeclarations` delegating to the introspection (plus exact declarations for the bean methods of such an introspection through `getDeclaredMethodAnnotationMetadata()`): `:micronaut-validation:test` 534 tests, 0 failures; `jakartaTck` 1054 run, 0 failed; `jakartaTckIntrospection` with every exclusion removed 1054 run, 34 failed, none outside the former exclusions. 14 of the 44 exclusions pass now:

- `ValidationRequirementTest.testConstraintAppliedOnFieldAndProperty`, `testFieldAccess`
- `GroupTest.testImplicitGrouping`
- `GroupSequenceIsolationTest.testCorrectDefaultSequenceInheritance3`
- `ConstraintInheritanceTest.testValidationConsidersConstraintsFromSuperTypes`
- `ConstraintDescriptorTest.testGetGroupsWithImplicitGroup`
- `ContainerElementTypeDescriptorTest.testGetContainerElementMetaDataForRoles`
- `CrossParameterDescriptorTest.testFindConstraintsForMethodLookingAt` (needs the exact bean method declarations)
- `ElementDescriptorTest.testDeclaredOn`
- `TraversableResolverTest.testCorrectCallsToIsReachableAndIsCascadable`, `...ForParameterValidation`, `...ForReturnValueValidation`
- `ValueAccessStrategyTest.testValueFromFieldIsPassedToValidatorOfFieldLevelConstraint`
- `ValueExtractorDefinitionTest.valuePassedToExtractorRetrievedFromHost`

Of the 30 left, 20 fail with "Bean introspection not found" for nested classes of the TCK test classes - `ExecutableDescriptorTest.testGetParameterDescriptorsForConstructorOfInnerClass` among them: the Java annotation processing round hands the visitors the top-level types only, so the harness's `TestClassVisitor` never annotates `CustomerService.InnerClass`. The TCK expects the enclosing instance among the constructor parameters, as `getConstructors()` reports it, so that one is a harness matter, not the described constructor. The other 10 need the methods an interface or a super class declares that are not bean methods of the introspection.

Reviewed with `codex review` over three passes; every finding is addressed above: the field dispatch naming an inaccessible declaring class, the changed member-reference constructor shape, and the declarations of an accessor inherited from parallel parent interfaces. A fourth, a private nested super class in the same package, is a non-issue that a test now documents: javac compiles such a class as package-private in the class file, so the introspection names it and the hidden field is read. The final pass reported no actionable defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
