### PR TITLE
Recompute the closure of an annotation a visitor added to an annotation type

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -1790,7 +1790,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         }
         return Stream.concat(
                 modifiedStereotypes.getStereotypeAnnotationNames().stream().flatMap(stereotypeName -> {
-                    final AnnotationValue<Annotation> a = modifiedStereotypes.getAnnotation(stereotypeName);
+                    final AnnotationValue<Annotation> a = withoutRetainedStereotypes(modifiedStereotypes.getAnnotation(stereotypeName));
                     if (a == null) {
                         return Stream.of();
                     }
@@ -1818,7 +1818,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
 
                 }),
                 modifiedStereotypes.getAnnotationNames().stream().flatMap(annotationName -> {
-                    AnnotationValue<Annotation> a = modifiedStereotypes.getAnnotation(annotationName);
+                    AnnotationValue<Annotation> a = withoutRetainedStereotypes(modifiedStereotypes.getAnnotation(annotationName));
                     if (a == null) {
                         return Stream.empty();
                     }
@@ -1828,6 +1828,31 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                     );
                 })
         ).toList();
+    }
+
+    /**
+     * The annotation without the occurrences retained in the reserved {@link AnnotationUtil#STEREOTYPES_MEMBER}
+     * member. An annotation read back out of stored metadata to be processed again carries the retained tree,
+     * which is only the {@link Retainable} part of the closure; leaving it in place would present that part as
+     * the whole set of stereotypes the annotation was written with, and everything else it composes would be
+     * dropped from the metadata it is being added to. The closure is computed again, and retained again, from
+     * the annotation type.
+     *
+     * @param annotationValue The annotation value, or {@code null}
+     * @return The annotation value with no stereotypes, or {@code null} when none was given
+     */
+    @Nullable
+    private AnnotationValue<Annotation> withoutRetainedStereotypes(@Nullable AnnotationValue<Annotation> annotationValue) {
+        if (annotationValue == null || annotationValue.getStereotypes() == null) {
+            return annotationValue;
+        }
+        return new AnnotationValue<>(
+            annotationValue.getAnnotationName(),
+            annotationValue.getValues(),
+            annotationValue.getDefaultValues(),
+            annotationValue.getRetentionPolicy(),
+            null
+        );
     }
 
     private <K> List<K> eliminateProcessed(ProcessingContext context, @Nullable List<K> visitors) {

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AddedAnnotationStereotypeIndexSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AddedAnnotationStereotypeIndexSpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.InterceptorBinding
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+
+/**
+ * An annotation a visitor adds to an annotation type reaches the classes declaring that annotation together with
+ * the annotations it is itself meta-annotated with. A {@code @Retainable} annotation additionally keeps the
+ * occurrences composing it in a reserved member; that member holds the retainable part of the closure only, so
+ * reading it back as the stereotypes the annotation was written with would drop everything else it composes.
+ */
+class AddedAnnotationStereotypeIndexSpec extends AbstractTypeElementSpec {
+
+    void "an annotation added to an annotation type keeps its own stereotypes in the index"() {
+        given:
+        def definition = buildBeanDefinition('addedstereotype.Test', '''
+package addedstereotype;
+
+import io.micronaut.inject.annotation.MyDeclaredStereotype;
+import jakarta.inject.Singleton;
+
+@Singleton
+@MyDeclaredStereotype
+class Test {}
+''')
+
+        expect: "the added annotation is there"
+        definition.hasStereotype(MyAddedScope.name)
+
+        and: "so are the annotations it is meta-annotated with, the retainable one and the one that is not"
+        definition.getAnnotationNamesByStereotype(MyScopeMarker.name) == [MyAddedScope.name]
+        definition.getAnnotationNamesByStereotype(MyOtherMarker.name) == [MyAddedScope.name]
+
+        and: "the retainable occurrence is still retained by the annotation composing it"
+        definition.getAnnotation(MyAddedScope.name).stereotypes*.annotationName == [MyScopeMarker.name]
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        return [new ScopeAddingVisitor()]
+    }
+
+    static class ScopeAddingVisitor implements TypeElementVisitor<Object, MyDeclaredStereotype> {
+        @Override
+        void start(VisitorContext visitorContext) {
+            visitorContext.getClassElement(MyDeclaredStereotype).ifPresent({ ClassElement ce ->
+                ce.annotate(MyAddedScope)
+            })
+        }
+    }
+}
+
+// The one core annotation carrying the marker, which makes everything composing it retainable
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@interface MyScopeMarker {}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface MyOtherMarker {}
+
+@MyScopeMarker
+@MyOtherMarker
+@Retention(RetentionPolicy.RUNTIME)
+@interface MyAddedScope {}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface MyDeclaredStereotype {}


### PR DESCRIPTION
Fixes #13038, a regression from #12968.

## The mechanism

When a `TypeElementVisitor` calls `element.annotate(...)` on an annotation type, the addition is recorded in
`MUTATED_ANNOTATION_METADATA` for that type. `AbstractAnnotationMetadataBuilder#getAddedStereotypes` reads those
annotations back out of the stored metadata and feeds them through `processAnnotation` again, so that every class
declaring the annotation type gains them — together with the annotations they are themselves meta-annotated with.

#12968 gave a `@Retainable` annotation a reserved `$stereotypes` member holding the occurrences composing it, read
through `AnnotationValue#getStereotypes()`. That member is deliberately partial: it holds the retainable part of
the closure only. So an annotation read back out of stored metadata now arrives at `processAnnotation` with
`getStereotypes() != null`, which is how an annotation whose stereotypes were given explicitly — by a mapper or a
transformer — announces itself. `stereotypesProvided` came out `true`, `extractStereotypes` was skipped, and the
partial view was taken for the whole closure. Everything the added annotation composes that is not itself
retainable was dropped, so a class declaring the annotation type had the added annotation in its metadata but not
the level below it: `hasStereotype(Added)` true, `getAnnotationNamesByStereotype(Meta)` empty.

The chain reaches this at all because `@InterceptorBinding` is the one core annotation carrying `@Retainable`, so
anything composing Micronaut AOP advice is retainable — a CDI normal scope, for one.

## The fix

`getAddedStereotypes` drops the reserved member from the values it reads back, so the closure is computed again —
and retained again — from the annotation type. The stored form stays a storage form; it is not read as a
declaration of what the annotation composes.

## Tests

New `inject-java` spec `AddedAnnotationStereotypeIndexSpec`: a visitor annotates an annotation type with an
annotation meta-annotated both with a retainable annotation and with one that is not, and a class declaring the
annotation type must find both in its stereotype index, with the retained occurrence still retained. It fails on
5.2.x and passes here.

Run green: `:micronaut-inject:test` (361), `:micronaut-inject-java:test` (5171), `:micronaut-inject-kotlin:test`
(1090), `:micronaut-inject-groovy:test` (830), `:micronaut-core:test --tests '*AnnotationValueSpec*'`,
`:test-suite:test --tests '*retainable*'` — which covers the specs #12968 added (`StereotypeOriginSpec`,
`RetainableSpec`, `ValidationRetainedStereotypesSpec`, `ComposedBindingMembersSpec`,
`BindingOccurrenceResolutionSpec`, `AnnotationValueSpec`).

End to end, the CDI Lite TCK reproduction in [micronaut-cdi](https://github.com/dstepanov/micronaut-cdi) —
`org.jboss.cdi.tck.tests.build.compatible.extensions.customStereotype.CustomStereotypeTest` — passes with this
build published to mavenLocal, and the full 807-test suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)