### PR TITLE
Retain the interceptor registrations on every AOP proxy

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/Intercepted.java
+++ b/aop/src/main/java/io/micronaut/aop/Intercepted.java
@@ -33,7 +33,11 @@ public interface Intercepted extends InterceptedBean {
     /**
      * The interceptor registrations that were resolved for this proxy.
      *
-     * <p>The scenario this exists for is an advised bean that also declares lifecycle advice:</p>
+     * <p>Every generated proxy retains the registrations its constructor was given, so a proxy can always report the
+     * interceptors bound to it. For an around- or introduction-only proxy that is the set matching its around
+     * bindings; a proxy whose target also declares lifecycle advice is given a wider set, described below.</p>
+     *
+     * <p>The scenario the retention was introduced for is an advised bean that also declares lifecycle advice:</p>
      *
      * <pre>{@code
      * @Retention(RUNTIME)
@@ -52,8 +56,8 @@ public interface Intercepted extends InterceptedBean {
      * particular has no other route to them: it runs with a fresh resolution context, and the proxy instance is the
      * only thing that survives from creation to destruction.</p>
      *
-     * <p>Proxies whose target declares no lifecycle binding, and proxies generated before this existed, keep the
-     * empty default; the runtime then resolves interceptors by binding as it always did.</p>
+     * <p>Proxies generated before this existed keep the empty default; the runtime then resolves interceptors by
+     * binding as it always did.</p>
      *
      * <p>The context reads the same list through {@link InterceptedBean#$interceptorRegistrations()} when
      * {@code destroyBean(Object)} is handed a proxy it tracks no registration for, so the non-singleton interceptors

--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -505,26 +505,28 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
 
         proxyBuilder.addField(interceptorsField);
 
-        FieldDef interceptorRegistrationsField;
-        if (proxyBeanDefinitionWriter.hasInterceptedLifecycle()) {
-            interceptorRegistrationsField = FieldDef.builder(FIELD_INTERCEPTOR_REGISTRATIONS, List.class)
-                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .build();
-            proxyBuilder.addField(interceptorRegistrationsField);
-            proxyBuilder.addMethod(MethodDef.override(GET_INTERCEPTOR_REGISTRATIONS_METHOD)
-                .build((aThis, methodParameters) -> aThis.field(interceptorRegistrationsField).returning()));
+        // Every proxy retains the registrations its constructor was given, so a proxy can always report the
+        // interceptors bound to it. For an around-only proxy that is exactly the around/introduction set it already
+        // receives; only a proxy with intercepted lifecycle widens the constructor qualifier below.
+        FieldDef interceptorRegistrationsField = FieldDef.builder(FIELD_INTERCEPTOR_REGISTRATIONS, List.class)
+            .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+            .build();
+        proxyBuilder.addField(interceptorRegistrationsField);
+        proxyBuilder.addMethod(MethodDef.override(GET_INTERCEPTOR_REGISTRATIONS_METHOD)
+            .build((aThis, methodParameters) -> aThis.field(interceptorRegistrationsField).returning()));
 
+        if (proxyBeanDefinitionWriter.hasInterceptedLifecycle()) {
             // The constructor argument is qualified by the accumulated around/introduction bindings only. Widen it
             // with the lifecycle bindings so the retained list is a superset of what lifecycle interception needs,
             // otherwise a lifecycle interceptor bound by a different annotation would be dropped.
             // This is the compile-time half of the same rule InterceptedBeanDefinition#resolveInterceptors applies at
             // runtime for beans that get no proxy: whatever a bean binds for construction, post-construct and
             // pre-destroy is resolved as one set. Keep the two in step.
+            // Only widen here: doing it for every proxy would change which interceptors are injected into every
+            // proxied bean in every application.
             AnnotationMetadata targetAnnotationMetadata = targetType.getAnnotationMetadata();
             visitInterceptorBinding(InterceptedMethodUtil.resolveInterceptorBinding(targetAnnotationMetadata, InterceptorKind.POST_CONSTRUCT));
             visitInterceptorBinding(InterceptedMethodUtil.resolveInterceptorBinding(targetAnnotationMetadata, InterceptorKind.PRE_DESTROY));
-        } else {
-            interceptorRegistrationsField = null;
         }
 
         FieldDef proxyMethodsField = FieldDef.builder(FIELD_PROXY_METHODS, ExecutableMethod[].class)
@@ -626,16 +628,14 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                                 ClassTypeDef targetType,
                                 @Nullable FieldDef targetField,
                                 FieldDef interceptorsField,
-                                @Nullable FieldDef interceptorRegistrationsField,
+                                FieldDef interceptorRegistrationsField,
                                 FieldDef proxyMethodsField,
                                 List<MethodElement> interceptedMethods) {
 
         List<MethodDef.MethodBodyBuilder> bodyBuilders = new ArrayList<>();
-        if (interceptorRegistrationsField != null) {
-            bodyBuilders.add((aThis, methodParameters) -> aThis.field(interceptorRegistrationsField).assign(
-                methodParameters.get(constructor.findParameterIndex(INTERCEPTORS_PARAMETER))
-            ));
-        }
+        bodyBuilders.add((aThis, methodParameters) -> aThis.field(interceptorRegistrationsField).assign(
+            methodParameters.get(constructor.findParameterIndex(INTERCEPTORS_PARAMETER))
+        ));
 
         if (isProxyTarget) {
 

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
@@ -33,7 +33,7 @@ class MyRepoIntroductionSpec extends Specification {
             def bean = applicationContext.getBean(MyRepo)
             def interceptorDeclaredMethods = Arrays.stream(bean.getClass().getMethods())
                     .filter(m -> m.getDeclaringClass() == bean.getClass())
-                    .filter(m -> m.name != "interceptedMethods")
+                    .filter(m -> m.name != "interceptedMethods" && !m.name.startsWith('$'))
                     .collect(Collectors.toList())
             def repoDeclaredMethods = Arrays.stream(MyRepo.class.getMethods()).filter(m -> m.getDeclaringClass() == MyRepo.class).collect(Collectors.toList())
         then:

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
@@ -33,7 +33,8 @@ class MyRepoIntroductionSpec extends Specification {
             def bean = applicationContext.getBean(MyRepo)
             def interceptorDeclaredMethods = Arrays.stream(bean.getClass().getMethods())
                     .filter(m -> m.getDeclaringClass() == bean.getClass())
-                    .filter(m -> m.name != "interceptedMethods")
+                    // Generated proxy infrastructure, not part of the introduced interface
+                    .filter(m -> m.name != "interceptedMethods" && !m.name.startsWith('$'))
                     .collect(Collectors.toList())
             def repoDeclaredMethods = Arrays.stream(MyRepo.class.getMethods()).filter(m -> m.getDeclaringClass() == MyRepo.class).collect(Collectors.toList())
         then:

--- a/inject-java/src/test/groovy/io/micronaut/aop/proxy/InterceptorRegistrationRetentionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxy/InterceptorRegistrationRetentionSpec.groovy
@@ -1,0 +1,450 @@
+package io.micronaut.aop.proxy
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.Intercepted
+import io.micronaut.context.ApplicationContext
+
+/**
+ * Every generated proxy retains the interceptor registrations its constructor was given, not only a proxy whose
+ * bean has intercepted lifecycle callbacks.
+ */
+class InterceptorRegistrationRetentionSpec extends AbstractTypeElementSpec {
+
+    private static List<String> interceptorNames(Object bean) {
+        assert bean instanceof Intercepted
+        ((Intercepted) bean).$interceptorRegistrations()*.bean*.getClass()*.simpleName
+    }
+
+    void 'test an around only proxy retains the around interceptors bound to it'() {
+        given:
+        ApplicationContext context = buildContext('''
+package retention.around;
+
+import io.micronaut.aop.*;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@interface Aro {
+}
+
+@Singleton
+@InterceptorBinding(value = Aro.class, kind = InterceptorKind.AROUND)
+class AroundInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Aro
+class MyBean {
+    String work() { return "done"; }
+}
+''')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('retention.around.MyBean'))
+
+        then: 'the proxy reports the interceptor it was built with'
+        bean.work() == 'done'
+        interceptorNames(bean) == ['AroundInterceptor']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test an introduction only proxy retains the introduction interceptors bound to it'() {
+        given:
+        ApplicationContext context = buildContext('''
+package retention.introduction;
+
+import io.micronaut.aop.*;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Introduction
+@interface Stub {
+}
+
+@Singleton
+@InterceptorBinding(value = Stub.class, kind = InterceptorKind.INTRODUCTION)
+class StubInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return "stubbed";
+    }
+}
+
+@Stub
+interface MyItfce {
+    String work();
+}
+''')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('retention.introduction.MyItfce'))
+
+        then:
+        bean.work() == 'stubbed'
+        interceptorNames(bean) == ['StubInterceptor']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a proxy with lifecycle advice still retains the superset covering the lifecycle bindings'() {
+        given:
+        ApplicationContext context = buildContext('''
+package retention.lifecycle;
+
+import io.micronaut.aop.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@interface Aro {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Life {
+}
+
+@Singleton
+@InterceptorBinding(value = Aro.class, kind = InterceptorKind.AROUND)
+class AroundInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Singleton
+@InterceptorBinding(value = Life.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Life.class, kind = InterceptorKind.PRE_DESTROY)
+class LifecycleInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Aro
+@Life
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('retention.lifecycle.MyBean'))
+
+        then: 'the constructor qualifier is still widened, so the list covers the lifecycle binding too'
+        interceptorNames(bean).toSorted() == ['AroundInterceptor', 'LifecycleInterceptor']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a proxy with both around and lifecycle advice under one annotation reports one list'() {
+        given:
+        ApplicationContext context = buildContext('''
+package retention.both;
+
+import io.micronaut.aop.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('retention.both.MyBean'))
+
+        then:
+        bean.work() == 'done'
+        interceptorNames(bean) == ['TrackingInterceptor']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test two beans advised by a prototype interceptor report different interceptor instances'() {
+        given:
+        ApplicationContext context = buildContext('''
+package retention.prototype;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@interface Aro {
+}
+
+@Prototype
+@InterceptorBinding(value = Aro.class, kind = InterceptorKind.AROUND)
+class AroundInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Prototype
+@Aro
+class MyBean {
+    String work() { return "done"; }
+}
+''')
+
+        when:
+        Class<?> beanType = context.classLoader.loadClass('retention.prototype.MyBean')
+        def first = context.getBean(beanType)
+        def second = context.getBean(beanType)
+
+        then:
+        !first.is(second)
+        interceptorNames(first) == ['AroundInterceptor']
+        interceptorNames(second) == ['AroundInterceptor']
+
+        and: 'each proxy holds its own interceptor instance'
+        !((Intercepted) first).$interceptorRegistrations()[0].bean
+                .is(((Intercepted) second).$interceptorRegistrations()[0].bean)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a bean with around and lifecycle advice bound by different annotations still selects the right interceptors'() {
+        given:
+        ApplicationContext context = buildContext('''
+package retention.mixed;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@interface Aro {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Life {
+}
+
+@Prototype
+@InterceptorBinding(value = Aro.class, kind = InterceptorKind.AROUND)
+class AroundInterceptor implements Interceptor<Object, Object> {
+    static final List<String> events = new ArrayList<>();
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        events.add(((MethodInvocationContext<?, ?>) context).getKind().name());
+        return context.proceed();
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Life.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Life.class, kind = InterceptorKind.PRE_DESTROY)
+class LifecycleInterceptor implements Interceptor<Object, Object> {
+    static final List<String> events = new ArrayList<>();
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        events.add(((MethodInvocationContext<?, ?>) context).getKind().name());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Aro
+@Life
+class MyBean {
+    @PostConstruct void init() {}
+    String work() { return "done"; }
+    @PreDestroy void close() {}
+}
+''')
+        Class<?> around = context.classLoader.loadClass('retention.mixed.AroundInterceptor')
+        Class<?> lifecycle = context.classLoader.loadClass('retention.mixed.LifecycleInterceptor')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('retention.mixed.MyBean'))
+        bean.work()
+
+        then: 'the around interceptor sees only the method call and the lifecycle one only post construct'
+        around.events == ['AROUND']
+        lifecycle.events == ['POST_CONSTRUCT']
+
+        when:
+        context.stop()
+
+        then: 'and pre destroy still goes to the lifecycle interceptor alone'
+        around.events == ['AROUND']
+        lifecycle.events == ['POST_CONSTRUCT', 'PRE_DESTROY']
+
+        cleanup:
+        context.close()
+    }
+
+    // MethodInterceptorChain#doIntercept selects intercepted.$interceptorRegistrations() whenever the list is
+    // non-empty. Retaining a list on every proxy makes that branch reachable for an around-only proxy, so pin down
+    // that such a proxy still has no lifecycle interception at all: the definition only generates the post-construct
+    // and pre-destroy entry points when the bean carries lifecycle bindings, which is the same condition that widens
+    // the constructor qualifier.
+    void 'test an around only proxy with lifecycle callbacks does not gain lifecycle interception'() {
+        given:
+        ApplicationContext context = buildContext('''
+package retention.aroundlifecycle;
+
+import io.micronaut.aop.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around
+@interface Aro {
+}
+
+@Singleton
+@InterceptorBinding(value = Aro.class, kind = InterceptorKind.AROUND)
+class AroundInterceptor implements Interceptor<Object, Object> {
+    static final List<String> events = new ArrayList<>();
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        events.add(((MethodInvocationContext<?, ?>) context).getKind().name());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Aro
+class MyBean {
+    static final List<String> callbacks = new ArrayList<>();
+    @PostConstruct void init() { callbacks.add("init"); }
+    String work() { return "done"; }
+    @PreDestroy void close() { callbacks.add("close"); }
+}
+''')
+        Class<?> around = context.classLoader.loadClass('retention.aroundlifecycle.AroundInterceptor')
+        Class<?> beanType = context.classLoader.loadClass('retention.aroundlifecycle.MyBean')
+
+        when:
+        def bean = context.getBean(beanType)
+        bean.work()
+
+        then: 'the retained list is non-empty, but post construct was not routed through the chain'
+        interceptorNames(bean) == ['AroundInterceptor']
+        beanType.callbacks == ['init']
+        around.events == ['AROUND']
+
+        when:
+        context.stop()
+
+        then: 'and neither was pre destroy'
+        beanType.callbacks == ['init', 'close']
+        around.events == ['AROUND']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a proxy target proxy retains the around interceptors bound to it'() {
+        given:
+        ApplicationContext context = buildContext('''
+package retention.proxytarget;
+
+import io.micronaut.aop.*;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around(proxyTarget = true)
+@interface Aro {
+}
+
+@Singleton
+@InterceptorBinding(value = Aro.class, kind = InterceptorKind.AROUND)
+class AroundInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Aro
+class MyBean {
+    String work() { return "done"; }
+}
+''')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('retention.proxytarget.MyBean'))
+
+        then:
+        bean.work() == 'done'
+        interceptorNames(bean) == ['AroundInterceptor']
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/RequestBeanScope.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/RequestBeanScope.groovy
@@ -36,7 +36,7 @@ open class RequestScopeClass (
                 .sort()
 
         then:
-        methods == ["\$withBeanQualifier", "getList", "getText", "interceptedTarget", "setText"] as List
+        methods == ["\$interceptorRegistrations", "\$withBeanQualifier", "getList", "getText", "interceptedTarget", "setText"] as List
 
         cleanup:
         applicationContext.close()

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MyRepoIntroductionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/introduction/MyRepoIntroductionSpec.groovy
@@ -15,7 +15,7 @@ class MyRepoIntroductionSpec extends Specification {
         def bean = applicationContext.getBean(MyRepo)
         def interceptorDeclaredMethods = Arrays.stream(bean.getClass().getMethods())
                 .filter(m -> m.getDeclaringClass() == bean.getClass())
-                .filter(m -> m.name != "interceptedMethods")
+                .filter(m -> m.name != "interceptedMethods" && !m.name.startsWith('$'))
                 .collect(Collectors.toList())
         def repoDeclaredMethods = Arrays.stream(MyRepo.class.getMethods()).filter(m -> m.getDeclaringClass() == MyRepo.class).collect(Collectors.toList())
         def myRepoIntroducer = applicationContext.getBean(MyRepoIntroducer)


### PR DESCRIPTION
## What

`AopProxyWriter` generated the `$interceptorRegistrations` field and the `Intercepted#$interceptorRegistrations()` override only when `proxyBeanDefinitionWriter.hasInterceptedLifecycle()`. A bean with only `@Around` or `@Introduction` advice fell back to the interface default (an empty list), so nothing could read back the interceptors bound to it — even though they were already resolved and injected into the private `$interceptors` field.

This makes the field and the accessor unconditional, so any proxy can report the interceptors bound to it.

## What stays conditional

The two `visitInterceptorBinding(...)` calls that widen the proxy constructor's qualifier with the POST_CONSTRUCT and PRE_DESTROY bindings remain gated on `hasInterceptedLifecycle()`. Widening for every proxy would change which interceptors are injected into every proxied bean in every application, and cost startup time. An around-only proxy therefore retains exactly the around/introduction registrations it already receives.

## The `MethodInterceptorChain` interaction

`MethodInterceptorChain#doIntercept` selects `intercepted.$interceptorRegistrations()` whenever the list is non-empty. Retaining a list on every proxy makes that branch reachable for an around-only proxy for the first time — the concern being that a POST_CONSTRUCT or PRE_DESTROY interception on such a bean would then select from the around set instead of resolving by lifecycle binding.

It cannot happen, and no narrower gate is needed. `BeanDefinitionWriter` adds the `InitializableIntercepted` / `DisposableIntercepted` entry points only when `isPostConstructIntercepted()` / `isPreDestroyIntercepted()` — exactly the two predicates behind `hasInterceptedLifecycle()`, which is the same condition that widens the qualifier here. So a proxy whose retained list is around-only is never handed to a lifecycle interception point at all; whenever the branch *is* reached, the list is the widened superset it was before this change.

That is pinned down by a spec rather than left to reasoning: `test an around only proxy with lifecycle callbacks does not gain lifecycle interception` gives an around-only advised bean real `@PostConstruct` / `@PreDestroy` methods and asserts the callbacks run while the around interceptor only ever sees `AROUND`.

## Spec coverage

New `inject-java/src/test/groovy/io/micronaut/aop/proxy/InterceptorRegistrationRetentionSpec.groovy`, 8 cases: `@Around`-only, `@Introduction`-only, lifecycle advice (still the widened superset), around and lifecycle under one annotation, a `@Prototype` interceptor giving two beans distinct interceptor instances, around and lifecycle bound by *different* annotations still selecting correctly per event, the interaction probe above, and a `proxyTarget = true` variant.

The generated class was also checked directly — `javap` on `$SimpleClass$Definition$Intercepted` (an around-only bean) now shows both `private final java.util.List $interceptorRegistrations;` and `public java.util.List $interceptorRegistrations();`.

## Existing specs touched

Three specs assert the complete method inventory of a generated proxy and saw the extra accessor. `MyRepoIntroductionSpec` (java, groovy, kotlin) already filtered out `interceptedMethods` as generated infrastructure, so the filter now also drops `$`-prefixed names; `RequestBeanScope` (kotlin) lists infrastructure explicitly, so `$interceptorRegistrations` was added to its expected list. No behavioural assertion changed.

## Verification

| Task | Result |
| --- | --- |
| `:micronaut-aop:test :micronaut-inject-java:test --rerun-tasks` | 5178 tests, 0 failures, 9 skipped |
| `:micronaut-inject-groovy:test` | 1090 tests, 0 failures, 17 skipped |
| `:micronaut-inject-kotlin:test` | 830 tests, 0 failures, 12 skipped |
| `:micronaut-inject:test :micronaut-runtime:test :micronaut-context-propagation:test` | 493 tests, 0 failures |

## Motivation

micronaut-jakarta-interceptors needs, at bean-creation time, the advice bound to the object being created, to satisfy Jakarta Interceptors 2.2 §2.3 ba) — an interceptor instance per interceptor class when the target instance is created, whether or not anything is invoked on it. `$interceptorRegistrations()` is exactly that, and was previously empty for the case under test (a bean with a method-level binding and no lifecycle advice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)