### PR TITLE
Record on a bean introspection the type arguments a type binds in a super type

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -109,6 +109,7 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
     private static final String FIELD_BEAN_METHODS_REFERENCES = "$METHODS_REFERENCES";
     private static final String FIELD_BEAN_CONSTRUCTORS_REFERENCES = "$CONSTRUCTORS_REFERENCES";
     private static final String FIELD_ENUM_CONSTANTS_REFERENCES = "$ENUM_CONSTANTS_REFERENCES";
+    private static final String FIELD_TYPE_ARGUMENTS = "$TYPE_ARGUMENTS";
     private static final String METADATA_METHOD_SUFFIX = "$metadata";
     /**
      * The name the JDK gives the synthetic enclosing instance parameter of an inner class constructor.
@@ -122,6 +123,9 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
 
     private static final java.lang.reflect.Method GET_INDEXED_PROPERTIES =
         ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanIntrospection.class, "getIndexedProperties", Class.class);
+
+    private static final java.lang.reflect.Method GET_TYPE_ARGUMENTS_MAP_METHOD =
+        ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanIntrospection.class, "getTypeArgumentsMap");
 
     private static final java.lang.reflect.Method GET_BP_INDEXED_SUBSET_METHOD =
         ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanIntrospection.class, "getBeanPropertiesIndexedSubset", int[].class);
@@ -922,6 +926,11 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
             enumsField = null;
         }
 
+        FieldDef typeArgumentsField = buildTypeArgumentsField(thisType, loadClassValueExpressionFn);
+        if (typeArgumentsField != null) {
+            classDefBuilder.addField(typeArgumentsField);
+        }
+
         int indexesIndex = 0;
         for (String annotationName : indexByAnnotations.keySet()) {
             int[] indexes = indexByAnnotations.get(annotationName)
@@ -1078,9 +1087,53 @@ final class BeanIntrospectionWriter implements OriginatingElements, Buildable<Li
             getBooleanMethod(HAS_BUILDER_METHOD, hasBuilder)
         );
 
+        if (typeArgumentsField != null) {
+            classDefBuilder.addMethod(
+                MethodDef.override(GET_TYPE_ARGUMENTS_MAP_METHOD)
+                    .build((aThis, methodParameters) -> thisType.getStaticField(typeArgumentsField).returning())
+            );
+        }
+
         loadTypeMethods.values().forEach(classDefBuilder::addMethod);
 
         return classDefBuilder.build();
+    }
+
+    /**
+     * Builds the field holding the type arguments the bean binds in each of its super types, mirroring what
+     * {@code BeanDefinitionWriter} writes for a bean definition. Super types that bind nothing are left out; the
+     * accessor answers an empty list for a name it does not hold, so the result is the same and the metadata smaller.
+     *
+     * @param thisType                   The introspection type
+     * @param loadClassValueExpressionFn The load type expression fn
+     * @return The field, or {@code null} if the bean binds no type argument anywhere in its hierarchy
+     */
+    @Nullable
+    private FieldDef buildTypeArgumentsField(ClassTypeDef thisType, Function<String, ExpressionDef> loadClassValueExpressionFn) {
+        Map<String, Map<String, ClassElement>> allTypeArguments = beanClassElement.getAllTypeArguments();
+        Map<String, Map<String, ClassElement>> typeArguments = new LinkedHashMap<>(allTypeArguments.size());
+        for (Map.Entry<String, Map<String, ClassElement>> entry : allTypeArguments.entrySet()) {
+            if (!entry.getValue().isEmpty()) {
+                typeArguments.put(entry.getKey(), entry.getValue());
+            }
+        }
+        if (typeArguments.isEmpty()) {
+            return null;
+        }
+        return FieldDef.builder(FIELD_TYPE_ARGUMENTS, Map.class)
+            .addModifiers(Modifier.PRIVATE, Modifier.FINAL, Modifier.STATIC)
+            .initializer(
+                GenUtils.stringMapOf(
+                    typeArguments, true, null, types -> ArgumentExpUtils.pushTypeArgumentElements(
+                        annotationMetadata,
+                        thisType,
+                        ClassElement.of(introspectionName),
+                        types,
+                        loadClassValueExpressionFn
+                    )
+                )
+            )
+            .build();
     }
 
     private void addPrimitiveDispatchMethods(ClassDef.ClassDefBuilder classDefBuilder) {

--- a/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
@@ -375,7 +375,7 @@ public final class ArgumentExpUtils {
      * @param loadClassValueExpressionFn     The load type expression fn
      * @return The expression
      */
-    static ExpressionDef pushTypeArgumentElements(
+    public static ExpressionDef pushTypeArgumentElements(
         AnnotationMetadata annotationMetadataWithDefaults,
         ClassTypeDef owningType,
         ClassElement declaringType,

--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
@@ -192,6 +192,48 @@ public interface BeanIntrospection<T> extends AnnotationMetadataDelegate, BeanIn
     }
 
     /**
+     * If the bean itself declares any type arguments this method will return the arguments that represent those
+     * types.
+     *
+     * <p>Note this returns the type arguments the bean type <em>declares</em>, not the arguments it binds in a
+     * super type. Use {@link #getTypeArguments(Class)} for the latter.</p>
+     *
+     * @return The type arguments
+     * @since 5.2.0
+     */
+    default List<Argument<?>> getTypeArguments() {
+        return getTypeArguments(getBeanType());
+    }
+
+    /**
+     * Return the type arguments this bean binds in the given interface or super type.
+     *
+     * <p>For example a type declared as {@code class Foo implements Function<String, Integer>} answers
+     * {@code [String T, Integer R]} for {@code Function.class}.</p>
+     *
+     * @param type The super class or interface type
+     * @return The type arguments, never {@code null}
+     * @since 5.2.0
+     */
+    default List<Argument<?>> getTypeArguments(@Nullable Class<?> type) {
+        if (type == null) {
+            return Collections.emptyList();
+        }
+        return getTypeArguments(type.getName());
+    }
+
+    /**
+     * Return the type arguments this bean binds in the given interface or super type.
+     *
+     * @param type The super class or interface type name
+     * @return The type arguments, never {@code null}
+     * @since 5.2.0
+     */
+    default List<Argument<?>> getTypeArguments(@Nullable String type) {
+        return Collections.emptyList();
+    }
+
+    /**
      * Obtain a property by name.
      *
      * @param name The name of the property

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/IntrospectionTypeArgumentsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/IntrospectionTypeArgumentsSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.generics
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+
+class IntrospectionTypeArgumentsSpec extends AbstractBeanDefinitionSpec {
+
+    private static final String SOURCE = '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+import jakarta.inject.Singleton
+
+interface Validator<A, T> {
+    boolean isValid(T value)
+}
+
+interface StringIterable extends Iterable<String> {
+}
+
+@Introspected
+@Singleton
+class Bound implements Validator<CharSequence, Number> {
+    boolean isValid(Number value) { true }
+}
+
+@Introspected
+@Singleton
+class Indirect implements StringIterable {
+    Iterator<String> iterator() { null }
+}
+
+@Introspected
+@Singleton
+class Plain {
+}
+'''
+
+    void "an introspected type reports the arguments it binds in an interface"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Bound', SOURCE)
+        def definition = buildBeanDefinition('test.Bound', SOURCE)
+
+        expect:
+        introspection.getTypeArguments('test.Validator')*.type == [CharSequence, Number]
+        introspection.getTypeArguments('test.Validator') == definition.getTypeArguments('test.Validator')
+    }
+
+    void "arguments bound through an intermediate interface are reported"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Indirect', SOURCE)
+
+        expect:
+        introspection.getTypeArguments(Iterable)*.type == [String]
+    }
+
+    void "an introspected type that binds nothing reports an empty list"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Plain', SOURCE)
+
+        expect:
+        introspection.getTypeArguments() == []
+        introspection.getTypeArguments('test.Validator') == []
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/IntrospectionTypeArgumentsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/IntrospectionTypeArgumentsSpec.groovy
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.generics
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import java.util.function.Function
+
+class IntrospectionTypeArgumentsSpec extends AbstractTypeElementSpec {
+
+    private static final String SOURCE = '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.inject.Singleton;
+import java.util.Iterator;
+
+interface Validator<A, T> {
+    boolean isValid(T value);
+}
+
+interface StringIterable extends Iterable<String> {
+}
+
+@Introspected
+@Singleton
+class Bound implements Validator<CharSequence, Number> {
+    public boolean isValid(Number value) { return true; }
+}
+
+@Introspected
+@Singleton
+class Indirect implements StringIterable {
+    public Iterator<String> iterator() { return null; }
+}
+
+@Introspected
+@Singleton
+class Open<T> implements Validator<CharSequence, T> {
+    public boolean isValid(T value) { return true; }
+}
+
+@Introspected
+@Singleton
+class Plain {
+}
+'''
+
+    void "an introspected type reports the arguments it binds in an interface"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Bound', SOURCE)
+
+        expect:
+        introspection.getTypeArguments('test.Validator')*.type == [CharSequence, Number]
+        introspection.getTypeArguments('test.Validator')*.name == ['A', 'T']
+    }
+
+    void "an introspection reports the same arguments as the bean definition for the same class"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Bound', SOURCE)
+        def definition = buildBeanDefinition('test.Bound', SOURCE)
+
+        expect:
+        introspection.getTypeArguments('test.Validator') == definition.getTypeArguments('test.Validator')
+        introspection.getTypeArguments() == definition.getTypeArguments()
+    }
+
+    void "arguments bound through an intermediate interface are reported"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Indirect', SOURCE)
+
+        expect:
+        introspection.getTypeArguments(Iterable)*.type == [String]
+        introspection.getTypeArguments(Iterable) == buildBeanDefinition('test.Indirect', SOURCE).getTypeArguments(Iterable)
+    }
+
+    void "an argument left open is reported as the type variable"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Open', SOURCE)
+        def definition = buildBeanDefinition('test.Open', SOURCE)
+        def arguments = introspection.getTypeArguments('test.Validator')
+
+        expect:
+        arguments*.type == [CharSequence, Object]
+        arguments[1].isTypeVariable()
+        arguments == definition.getTypeArguments('test.Validator')
+
+        and: "the no-argument overload reports what the type itself declares"
+        introspection.getTypeArguments()*.name == ['T']
+        introspection.getTypeArguments() == definition.getTypeArguments()
+    }
+
+    void "an introspected type that binds nothing reports an empty list"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Plain', SOURCE)
+
+        expect:
+        introspection.getTypeArguments() == []
+        introspection.getTypeArguments('test.Validator') == []
+        introspection.getTypeArguments(Iterable) == []
+        introspection.getTypeArguments((Class) null) == []
+        introspection.getTypeArguments((String) null) == []
+    }
+
+    void "an introspection generated for a type that is not itself annotated reports its bindings"() {
+        given:
+        def introspection = buildBeanIntrospection('test.$test_Outer$Inner', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import java.util.function.Function;
+
+@Introspected(classes = Outer.Inner.class)
+class Outer {
+    static class Inner implements Function<String, Integer> {
+        public Integer apply(String s) { return 1; }
+    }
+}
+''')
+
+        expect:
+        introspection.getTypeArguments(Function)*.type == [String, Integer]
+    }
+
+    void "a type that binds nothing anywhere still answers for a type it does not implement"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Bound', SOURCE)
+
+        expect:
+        introspection.getTypeArguments(Comparable) == []
+        introspection.getTypeArguments('does.not.Exist') == []
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/IntrospectionTypeArgumentsSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/IntrospectionTypeArgumentsSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.processing.inject.generics
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+
+class IntrospectionTypeArgumentsSpec extends AbstractKotlinCompilerSpec {
+
+    private static final String SOURCE = '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+import jakarta.inject.Singleton
+
+interface Validator<A, T> {
+    fun isValid(value: T): Boolean
+}
+
+interface StringIterable : Iterable<String>
+
+@Introspected
+@Singleton
+class Bound : Validator<CharSequence, Number> {
+    override fun isValid(value: Number): Boolean = true
+}
+
+@Introspected
+@Singleton
+class Indirect : StringIterable {
+    override fun iterator(): Iterator<String> = emptyList<String>().iterator()
+}
+
+@Introspected
+@Singleton
+class Plain
+'''
+
+    void "an introspected type reports the arguments it binds in an interface"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Bound', SOURCE)
+        def definition = buildBeanDefinition('test.Bound', SOURCE)
+
+        expect:
+        introspection.getTypeArguments('test.Validator')*.type == [CharSequence, Number]
+        introspection.getTypeArguments('test.Validator') == definition.getTypeArguments('test.Validator')
+    }
+
+    void "arguments bound through an intermediate interface are reported"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Indirect', SOURCE)
+
+        expect:
+        introspection.getTypeArguments(Iterable)*.type == [String]
+    }
+
+    void "an introspected type that binds nothing reports an empty list"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Plain', SOURCE)
+
+        expect:
+        introspection.getTypeArguments() == []
+        introspection.getTypeArguments('test.Validator') == []
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -981,6 +981,35 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements Unsaf
         return beanType;
     }
 
+    /**
+     * The type arguments this bean binds in each of its super types, keyed by the super type name. The generated
+     * subclass overrides this when the bean binds at least one type argument somewhere in its hierarchy.
+     *
+     * @return The map of super type name to bound arguments, or {@code null} if the bean binds none
+     * @since 5.2.0
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected @Nullable Map<String, Argument<?>[]> getTypeArgumentsMap() {
+        return null;
+    }
+
+    @Override
+    public final List<Argument<?>> getTypeArguments(@Nullable String type) {
+        if (type == null) {
+            return Collections.emptyList();
+        }
+        Map<String, Argument<?>[]> typeArgumentsMap = getTypeArgumentsMap();
+        if (typeArgumentsMap == null) {
+            return Collections.emptyList();
+        }
+        Argument<?>[] arguments = typeArgumentsMap.get(type);
+        if (arguments == null) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(arguments);
+    }
+
     @Override
     public Collection<BeanMethod<B, Object>> getBeanMethods() {
         return beanMethodsList;

--- a/src/main/docs/guide/ioc/introspection/introspectionTypeArguments.adoc
+++ b/src/main/docs/guide/ioc/introspection/introspectionTypeArguments.adoc
@@ -1,0 +1,32 @@
+A api:core.beans.BeanIntrospection[] records the type arguments the introspected type binds in each of its super types, the same way api:inject.BeanDefinition[] does for a bean. This answers what a type binds without reading the class reflectively, and without the type having to be a bean.
+
+Given a type that binds both arguments of a generic interface:
+
+[source,java]
+----
+@Introspected
+class PhoneValidator implements Validator<Phone> { // <1>
+    // ...
+}
+----
+
+<1> `Validator` is a generic interface, `interface Validator<T>`
+
+the bound arguments are read back from the introspection by super type:
+
+[source,java]
+----
+BeanIntrospection<PhoneValidator> introspection = BeanIntrospection.getIntrospection(PhoneValidator.class);
+
+List<Argument<?>> arguments = introspection.getTypeArguments(Validator.class); // <1>
+assert arguments.get(0).getType() == Phone.class;
+
+assert introspection.getTypeArguments(Comparable.class).isEmpty(); // <2>
+----
+
+<1> Arguments are looked up by the super class or interface that declares them, either as a `Class` or by name
+<2> A super type the introspected type does not bind, or does not have, answers an empty list
+
+Arguments bound through an intermediate super type are resolved too, and an argument the type leaves open is reported as the type variable rather than as a resolved type.
+
+NOTE: The no-argument `getTypeArguments()` reports the arguments the introspected type itself *declares*, not what it binds in a super type. For `class PhoneValidator implements Validator<Phone>` it is empty; for `class AnyValidator<T> implements Validator<T>` it is `[T]`.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -57,6 +57,7 @@ ioc:
     introspectionConstructors: Describing Constructors
     introspectionBuilders: Builders
     introspectionEnums: Introspect Enums
+    introspectionTypeArguments: Type Arguments
     introspectedAnnotationOnAConfigurationClass: Use the @Introspected Annotation on a Configuration Class
     introspectExistingAnnotations: Write an AnnotationMapper to Introspect Existing Annotations
     beanWrapperApi: The BeanWrapper API


### PR DESCRIPTION
A `BeanDefinition` answers what a bean binds in a super type through `getTypeArguments(String)`. A `BeanIntrospection` for the same class, written by the same processor run from the same resolution, answered nothing of the kind — so a lookup keyed by a bare `Class` could learn what a type binds only when that type happened to be a container bean.

For one class compiled with both annotations:

```java
@Introspected
@Singleton
class Test implements ConstraintValidator<NotNull, CharSequence> { ... }
```

| Call | Before | After |
| --- | --- | --- |
| `definition.getTypeArguments("…ConstraintValidator")` | `[NotNull A, CharSequence T]` | unchanged |
| `introspection.getTypeArguments("…ConstraintValidator")` | *no such method* | `[NotNull A, CharSequence T]` |

## The change

- `BeanIntrospection` gains `getTypeArguments()`, `getTypeArguments(Class)` and `getTypeArguments(String)`, defaulting to empty and mirroring the `BeanDefinition` accessors.
- `AbstractInitializableBeanIntrospection` gains a `getTypeArgumentsMap()` hook the generated subclass overrides, and a `final` `getTypeArguments(String)` over it. A hook rather than a constructor parameter because the introspection has three super constructors (plain, with-constructors, enum) and a parameter would double all three.
- `BeanIntrospectionWriter` writes the `$TYPE_ARGUMENTS` field from `ClassElement.getAllTypeArguments()` — the same map `BeanDefinitionWriter` already takes — plus the override.

One deliberate difference from the bean definition: super types that bind nothing are dropped from the map. The accessor answers an empty list for a name it does not hold, so the answers are identical and the metadata smaller. A type that binds nothing anywhere — the ordinary POJO, which is most `@Introspected` classes — gets no field and no method at all, so it pays nothing. An enum pays two entries (`Enum<E>`, `Comparable<E>`).

The no-argument `getTypeArguments()` keeps the meaning it has on `BeanDefinition`: the arguments the type itself *declares*, not what it binds in a super type. For `Test` above that is empty; for `Open<T> implements Validator<CharSequence, T>` it is `[T]`. That was already what the `BeanDefinition` javadoc said, and it is now stated explicitly on the introspection and in the guide.

`getGenericBeanType()` / `asArgument()` are left alone: making them carry the declared parameters would change an `Argument` identity that conversion and serialization caches key on, which is a wider blast radius than this needs.

## Why

Jakarta Validation picks a `ConstraintValidator` for a value by the second type argument of `ConstraintValidator<A, T>`, and micronaut-validation has to answer that from a bare `Class` in three places where no `BeanDefinition` is at hand — resolving among the classes a constraint's `@Constraint(validatedBy)` names, checking a class returned by a user-supplied `ConstraintValidatorFactory`, and describing a validator the container does not build. Each falls back to reading the class's generic interfaces. This is the metadata that lets an introspected-but-not-a-bean type be answered without that read.

## Tests

`IntrospectionTypeArgumentsSpec` for the Java processor (7 cases) with parity specs for Groovy and Kotlin: both arguments bound and equal to what the bean definition reports for the same class; binding through an intermediate interface; an argument left open reported as the type variable; a type binding nothing reporting an empty list rather than throwing; nulls; a super type the class does not implement; and a type introspected through `@Introspected(classes = …)` that is not itself annotated.

Regression: `core`, `inject`, `inject-java`, `inject-groovy`, `inject-kotlin` — 831 test classes, zero failures — plus `jackson-databind` and the `*-test` modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)