### PR TITLE
Fix the endless destruction of a per-bean-locked scope holding a bean it cannot take out

### DIFF
--- a/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
@@ -534,16 +534,42 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
                 return;
             }
             for (CreatedBean<?> closedBean : closedInThisPass) {
-                // under the identifier's lock, so that a creation racing this take-out is not taken out unclosed,
-                // and by identity, so that a bean the racing creation published is not taken for the closed one
+                final boolean stillHeld;
+                // under the identifier's lock, so that a creation racing this take-out is not taken out unclosed
                 synchronized (creationLocks.computeIfAbsent(closedBean.id(), key -> new Object())) {
-                    if (scopeMap.get(closedBean.id()) == closedBean) {
-                        scopeMap.remove(closedBean.id());
+                    // taken out by identity rather than by identifier, so that a scope keying its map by
+                    // something of its own - anything other than the identifier the bean carries - has its entry
+                    // taken out all the same, and so that a bean a racing creation published is left alone
+                    for (Map.Entry<BeanIdentifier, CreatedBean<?>> entry : scopeMap.entrySet()) {
+                        if (entry.getValue() == closedBean) {
+                            scopeMap.remove(entry.getKey(), closedBean);
+                        }
                     }
+                    stillHeld = holds(scopeMap, closedBean);
                 }
-                closing.remove(new IdentityKey(closedBean));
+                if (!stillHeld) {
+                    closing.remove(new IdentityKey(closedBean));
+                }
+                // the mark of an instance the map holds even after the take-out - one a creation racing this
+                // destruction has just put back - is kept, so that no later pass closes that instance a second time
             }
         }
+    }
+
+    /**
+     * Whether the given map holds the given instance, by identity, under any key.
+     *
+     * @param scopeMap    The scope map
+     * @param createdBean The created bean
+     * @return Whether it is held
+     */
+    private static boolean holds(Map<BeanIdentifier, CreatedBean<?>> scopeMap, CreatedBean<?> createdBean) {
+        for (CreatedBean<?> held : scopeMap.values()) {
+            if (held == createdBean) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void closeQuietly(CreatedBean<?> createdBean) {

--- a/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/scope/AbstractConcurrentCustomScopeSpec.groovy
@@ -338,6 +338,25 @@ class AbstractConcurrentCustomScopeSpec extends Specification {
         other.isEmpty()
     }
 
+    void "under a lock per bean a bean held under a key of the scope's own is closed once and taken out"() {
+        given: "a map keying a bean by something other than the identifier the bean carries"
+        def scope = new TestScope(true)
+        def closings = new java.util.concurrent.atomic.AtomicInteger()
+        def held = new TestCreatedBean(id: BeanIdentifier.of("its own name"), bean: new Object(), onClose: { closings.incrementAndGet() })
+        scope.scopeMap.put(BeanIdentifier.of("the scope's key"), held)
+
+        when: "on a daemon thread, since a destruction that spins closing it again could not be interrupted"
+        def destruction = new Thread({ scope.destroyScope(scope.scopeMap) } as Runnable, "destruction")
+        destruction.daemon = true
+        destruction.start()
+        destruction.join(TimeUnit.SECONDS.toMillis(10))
+
+        then: "the destruction ends, having closed the bean once and taken it out"
+        !destruction.alive
+        closings.get() == 1
+        scope.scopeMap.isEmpty()
+    }
+
     void "under a lock per bean the scope map must be a concurrent map"() {
         given:
         def scope = new TestScope(true, new HashMap<BeanIdentifier, CreatedBean<?>>())


### PR DESCRIPTION
Fixes #13043

### Cause

In `AbstractConcurrentCustomScope.destroyScopeLockingPerBean`, each pass closes the beans the map holds and only then takes them out — but the take-out looked the bean up by `scopeMap.get(bean.id())`, while the `closing` mark was dropped unconditionally:

```java
if (scopeMap.get(closedBean.id()) == closedBean) {
    scopeMap.remove(closedBean.id());
}
closing.remove(new IdentityKey(closedBean));   // also when the entry above did not match
```

Whenever the map does not hold the bean under the identifier the bean carries — a scope keying its map by something of its own, or an entry replaced by a creation racing the destruction — the bean stayed in the map, un-marked, so the next pass closed the same instance again. `destroyScope` never returned, spinning at 100% CPU, and nothing could interrupt it (the loop never blocks, so a `@Timeout` on the caller cannot save it).

### Change

Both parts the issue suggests, in `destroyScopeLockingPerBean`:

- the take-out is now by identity over the map's entries, so an entry held under a key of the scope's own is removed too. It stays a `scopeMap.remove(key, bean)` rather than a `values().removeIf(...)`, so a scope map that overrides `remove` still sees the call;
- the `closing` mark of an instance the map still holds after the take-out is kept, so no later pass closes one instance twice.

Either alone ends the loop; together they also keep the "closed exactly once" property the mode documents.

### Test

`AbstractConcurrentCustomScopeSpec` gains "under a lock per bean a bean held under a key of the scope's own is closed once and taken out": a bean put into the map under a different key, destroyed on a daemon thread with a 10s join, asserting the destruction ends, the bean is closed exactly once, and the map is empty. It hangs on `5.2.x` and passes here.

`:micronaut-inject:test` (362 tests) and `:micronaut-inject:checkstyleMain` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CbQLgo2NpkeF2jDtckHjA

---
_Generated by [Claude Code](https://claude.ai/code/session_018CbQLgo2NpkeF2jDtckHjA)_