### PR TITLE
Document the jakarta.annotation.Priority to @Order mapping and its sign

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/JakartaPriorityAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/JakartaPriorityAnnotationMapper.java
@@ -25,7 +25,25 @@ import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
 
-/** Maps Jakarta's priority annotation to Micronaut's order annotation. */
+/**
+ * Maps Jakarta's priority annotation to Micronaut's order annotation.
+ *
+ * <p>The value is mapped across unchanged: {@code @Priority(10)} becomes {@code @Order(10)}. Both
+ * annotations sort the lowest value first, which is the convention Jakarta Interceptors and Jakarta
+ * RESTful Web Services use for the priorities they define, so the mapped order means the same thing
+ * as the source annotation for those. {@code jakarta.annotation.Priority} itself leaves the
+ * direction to the specification that consumes it, and a consumer following one that prefers the
+ * highest value instead (the selection of a CDI alternative, for example) has to negate the
+ * value it reads.</p>
+ *
+ * <p>An annotation mapper adds to what it reads rather than replacing it, so
+ * {@code jakarta.annotation.Priority} is still present in the metadata after mapping and
+ * {@code metadata.intValue("jakarta.annotation.Priority")} still returns the value as written. Code
+ * that needs the priority exactly as the author declared it can read the source annotation directly
+ * instead of going through {@link Order}.</p>
+ *
+ * @see Order
+ */
 @Internal
 public final class JakartaPriorityAnnotationMapper implements NamedAnnotationMapper {
 

--- a/core/src/main/java/io/micronaut/core/annotation/Order.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Order.java
@@ -36,6 +36,18 @@ import java.lang.annotation.Target;
  * <p>This annotation can be used to control the order by specifying a numerical value
  * that sorts components in the desired order</p>
  *
+ * <p>The lowest value takes precedence: a component annotated {@code @Order(1)} comes before one
+ * annotated {@code @Order(100)}, and {@link io.micronaut.core.order.Ordered#HIGHEST_PRECEDENCE} is
+ * the most negative value rather than the largest one.</p>
+ *
+ * <p>{@code jakarta.annotation.Priority} is mapped to this annotation at compile time with its
+ * value unchanged, so a bean annotated {@code @Priority(10)} orders as {@code @Order(10)} and the
+ * lowest priority value wins. That is the direction Jakarta Interceptors and Jakarta RESTful Web
+ * Services give the priorities they define; a specification that prefers the highest value instead,
+ * such as the selection of a CDI alternative, needs the value negated by whoever reads it. The
+ * mapping adds to the metadata rather than replacing it, so {@code jakarta.annotation.Priority} is
+ * still readable as written alongside the mapped order.</p>
+ *
  * @author Sean Carroll
  * @since 2.0
  * @see io.micronaut.core.order.Ordered

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/PriorityAnnotationMapperSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/PriorityAnnotationMapperSpec.groovy
@@ -5,6 +5,8 @@ import io.micronaut.core.annotation.Order
 
 class PriorityAnnotationMapperSpec extends AbstractTypeElementSpec {
 
+    private static final String PRIORITY = 'jakarta.annotation.Priority'
+
     void 'maps jakarta.annotation.Priority to Order preserving positive value'() {
         given:
         def definition = buildBeanDefinition('test.Test', '''
@@ -39,5 +41,26 @@ class Test {
 
         expect:
         definition.intValue(Order).orElseThrow() == -3
+    }
+
+    void 'keeps jakarta.annotation.Priority alongside the mapped Order'() {
+        given:
+        def definition = buildBeanDefinition('test.Test', '''
+package test;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Priority(10)
+class Test {
+}
+''')
+
+        expect: 'the mapper adds @Order without consuming the annotation it read'
+        definition.getAnnotationNames().containsAll([PRIORITY, Order.name])
+
+        and: 'so the priority is still readable exactly as it was written'
+        definition.intValue(PRIORITY, 'value').orElseThrow() == 10
     }
 }


### PR DESCRIPTION
Closes #13044.

`JakartaPriorityAnnotationMapper` maps the priority value across unchanged, and nothing said which way the resulting order sorts or what happened to the annotation it read. Anything reading priorities out of compiled metadata had to rediscover both. The issue proposed three fixes: negate the value, keep `@Priority` alongside `@Order`, or document the mapping. Checking each against the code, only the third is left to do.

### `@Priority` is already kept alongside `@Order`

`AbstractAnnotationMetadataBuilder.processAnnotationMappers` concatenates the mapped values onto the annotation it read:

```java
return Stream.concat(
        Stream.of(processedAnnotation), // Mapper retains the original value
        mappedAnnotationsStream
);
```

A probe over the compiled metadata confirms it — a bean written `@Singleton @Priority(10)` carries `[jakarta.inject.Singleton, jakarta.annotation.Priority, io.micronaut.core.annotation.Order]`, and `intValue("jakarta.annotation.Priority", "value")` returns `10`. So there is no need to check both forms and guess which one survived; a consumer that wants the priority exactly as the author declared it can read the source annotation directly.

### The sign is faithful for the priorities Jakarta actually defines

`@Order` and `@Priority` both sort the lowest value first. That is the direction Jakarta Interceptors gives its own priorities (`Interceptor.Priority.LIBRARY_BEFORE` = 1000 runs before `APPLICATION` = 2000) and the direction Jakarta RESTful Web Services gives provider priorities, so the pass-through means the same thing as the source annotation for those. `jakarta.annotation.Priority` itself leaves the direction to the specification that consumes it.

"Highest wins" is the rule for the selection of a CDI alternative specifically. Negating in the mapper would make that case work by inverting the interceptor case, and `inject-java/src/test/groovy/io/micronaut/inject/ordered/PriorityOrderingSpec.groovy` already pins the current direction (`@Priority(-10)` beats `@Priority(10)`). So the negation belongs to the consumer following that rule, not to the mapper.

### What this changes

- **`JakartaPriorityAnnotationMapper`** — javadoc explaining the sign, that the source annotation is retained and readable as written, and when a consumer has to negate.
- **`Order`** — javadoc now states that the lowest value takes precedence (`HIGHEST_PRECEDENCE` being the most negative value, not the largest), and documents how `@Priority` maps onto it and in which direction.
- **`PriorityAnnotationMapperSpec`** — a third test pinning the retention the javadoc promises, so the written priority stays readable alongside the mapped order.

No behaviour change; javadoc and one added test.

### Verification

- `PriorityAnnotationMapperSpec`, `PriorityOrderingSpec`, `PickHighestPriorityBeanSpec` — 17 tests pass.
- `:micronaut-core:checkstyleMain` and `:micronaut-core-processor:checkstyleMain` clean (only pre-existing `TodoComment` warnings).
- `:micronaut-core:javadoc` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9j7AuhVLt8ZmcYHBwQRV3