### PR TITLE
fix(cookie): parse request Cookie header as name/value pairs

### DIFF
--- a/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
@@ -16,11 +16,14 @@
 package io.micronaut.http.cookie;
 
 import io.micronaut.core.annotation.Internal;
-import java.net.HttpCookie;
+
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * {@link ServerCookieDecoder} implementation backed by {@link HttpCookie#parse(String)}.
+ * {@link ServerCookieDecoder} implementation that parses an HTTP {@code Cookie} request header into
+ * its individual name/value pairs, as defined by
+ * <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-4.2.1">RFC 6265, Section 4.2.1</a>.
  *
  * @author Sergio del Amo
  * @since 4.3.0
@@ -29,9 +32,52 @@ import java.util.List;
 public final class DefaultServerCookieDecoder implements ServerCookieDecoder {
     @Override
     public List<Cookie> decode(String header) {
-        return HttpCookie.parse(header)
-                .stream()
-                .map(httpCookie -> (Cookie) new CookieHttpCookieAdapter(httpCookie))
-                .toList();
+        if (header == null || header.isEmpty()) {
+            return List.of();
+        }
+        List<Cookie> cookies = new ArrayList<>();
+        int length = header.length();
+        int pos = 0;
+        while (pos < length) {
+            int semicolon = header.indexOf(';', pos);
+            int end = semicolon == -1 ? length : semicolon;
+            addCookie(header, pos, end, cookies);
+            pos = end + 1;
+        }
+        return cookies;
+    }
+
+    private static void addCookie(String header, int start, int end, List<Cookie> cookies) {
+        while (start < end && header.charAt(start) == ' ') {
+            start++;
+        }
+        while (end > start && header.charAt(end - 1) == ' ') {
+            end--;
+        }
+        if (start == end) {
+            return;
+        }
+        int equals = header.indexOf('=', start);
+        if (equals == -1 || equals >= end) {
+            return;
+        }
+        String name = header.substring(start, equals).trim();
+        if (name.isEmpty()) {
+            return;
+        }
+        String value = unwrapValue(header.substring(equals + 1, end).trim());
+        try {
+            cookies.add(Cookie.of(name, value));
+        } catch (IllegalArgumentException e) {
+            // skip a single malformed pair rather than rejecting the whole header
+        }
+    }
+
+    private static String unwrapValue(String value) {
+        int length = value.length();
+        if (length >= 2 && value.charAt(0) == '"' && value.charAt(length - 1) == '"') {
+            return value.substring(1, length - 1);
+        }
+        return value;
     }
 }

--- a/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.cookie;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,8 +58,14 @@ public final class DefaultServerCookieDecoder implements ServerCookieDecoder {
         if (start == end) {
             return;
         }
-        int equals = header.indexOf('=', start);
-        if (equals == -1 || equals >= end) {
+        int equals = -1;
+        for (int i = start; i < end; i++) {
+            if (header.charAt(i) == '=') {
+                equals = i;
+                break;
+            }
+        }
+        if (equals == -1) {
             return;
         }
         String name = header.substring(start, equals).trim();
@@ -66,17 +73,26 @@ public final class DefaultServerCookieDecoder implements ServerCookieDecoder {
             return;
         }
         String value = unwrapValue(header.substring(equals + 1, end).trim());
+        if (value == null) {
+            return;
+        }
         try {
             cookies.add(Cookie.of(name, value));
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException ignored) {
             // skip a single malformed pair rather than rejecting the whole header
         }
     }
 
+    // Returns null when the value starts with a double quote that is never closed, so the caller
+    // drops the pair, matching Netty's ServerCookieDecoder.LAX.
+    @Nullable
     private static String unwrapValue(String value) {
         int length = value.length();
-        if (length >= 2 && value.charAt(0) == '"' && value.charAt(length - 1) == '"') {
-            return value.substring(1, length - 1);
+        if (length > 0 && value.charAt(0) == '"') {
+            if (length >= 2 && value.charAt(length - 1) == '"') {
+                return value.substring(1, length - 1);
+            }
+            return null;
         }
         return value;
     }

--- a/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
+++ b/http/src/main/java/io/micronaut/http/cookie/DefaultServerCookieDecoder.java
@@ -45,7 +45,7 @@ public final class DefaultServerCookieDecoder implements ServerCookieDecoder {
             addCookie(header, pos, end, cookies);
             pos = end + 1;
         }
-        return cookies;
+        return cookies.isEmpty() ? List.of() : List.copyOf(cookies);
     }
 
     private static void addCookie(String header, int start, int end, List<Cookie> cookies) {

--- a/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
+++ b/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
@@ -63,4 +63,18 @@ class DefaultServerCookieDecoderTest {
         assertEquals("quoted value", cookies.get(0).getValue());
         assertEquals("dark", cookies.get(1).getValue());
     }
+
+    @Test
+    void unbalancedOpeningQuoteDropsThePair() {
+        // Netty's ServerCookieDecoder.LAX drops a value that starts with a double quote but never
+        // closes it; both server decoders must agree on this input.
+        ServerCookieDecoder decoder = new DefaultServerCookieDecoder();
+        List<Cookie> cookies = decoder.decode("a=\"unterminated; b=2");
+        assertEquals(1, cookies.size());
+        assertEquals("b", cookies.get(0).getName());
+        assertEquals("2", cookies.get(0).getValue());
+
+        assertEquals(List.of(), decoder.decode("a=\""));
+        assertEquals("", decoder.decode("a=\"\"").get(0).getValue());
+    }
 }

--- a/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
+++ b/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
@@ -14,32 +14,53 @@ class DefaultServerCookieDecoderTest {
 
     @Test
     void testCookieDecoding() {
-        String header = "SID=31d4d96e407aad42; Path=/; Domain=example.com";
+        // A Cookie request header is a list of name/value pairs; Path/Domain are ordinary cookies
+        // here, not attributes of the preceding cookie (RFC 6265 section 4.2.1).
         ServerCookieDecoder decoder = new DefaultServerCookieDecoder();
-        List<Cookie> cookies = decoder.decode(header);
+        List<Cookie> cookies = decoder.decode("SID=31d4d96e407aad42; Path=/; Domain=example.com");
         assertNotNull(cookies);
-        assertEquals(1, cookies.size());
-        Cookie cookie = cookies.get(0);
-        assertEquals("SID", cookie.getName());
-        assertEquals("31d4d96e407aad42", cookie.getValue());
-        assertEquals("/", cookie.getPath());
-        assertEquals("example.com", cookie.getDomain());
-        assertFalse(cookie.isHttpOnly());
-        assertFalse(cookie.isSecure());
-        assertTrue(cookie.getSameSite().isEmpty());
+        assertEquals(3, cookies.size());
+        assertEquals("SID", cookies.get(0).getName());
+        assertEquals("31d4d96e407aad42", cookies.get(0).getValue());
+        assertNull(cookies.get(0).getPath());
+        assertNull(cookies.get(0).getDomain());
+        assertEquals("Path", cookies.get(1).getName());
+        assertEquals("/", cookies.get(1).getValue());
+        assertEquals("Domain", cookies.get(2).getName());
+        assertEquals("example.com", cookies.get(2).getValue());
 
-        header = "SID=31d4d96e407aad42; Path=/; Secure; HttpOnly";
+        // Attribute-only pairs without a value are not cookie-pairs and are dropped.
+        cookies = decoder.decode("SID=31d4d96e407aad42; Path=/; Secure; HttpOnly");
+        assertEquals(2, cookies.size());
+        assertEquals("SID", cookies.get(0).getName());
+        assertEquals("Path", cookies.get(1).getName());
+    }
 
-        cookies = decoder.decode(header);
-        assertNotNull(cookies);
-        assertEquals(1, cookies.size());
-        cookie = cookies.get(0);
-        assertEquals("SID", cookie.getName());
-        assertEquals("31d4d96e407aad42", cookie.getValue());
-        assertEquals("/", cookie.getPath());
-        assertNull(cookie.getDomain());
-        assertTrue(cookie.isHttpOnly());
-        assertTrue(cookie.isSecure());
-        assertTrue(cookie.getSameSite().isEmpty());
+    @Test
+    void multipleCookiesAreAllDecoded() {
+        List<Cookie> cookies = new DefaultServerCookieDecoder().decode("SID=abc; JSESSIONID=xyz; foo=bar");
+        assertEquals(3, cookies.size());
+        assertEquals("SID", cookies.get(0).getName());
+        assertEquals("abc", cookies.get(0).getValue());
+        assertEquals("JSESSIONID", cookies.get(1).getName());
+        assertEquals("xyz", cookies.get(1).getValue());
+        assertEquals("foo", cookies.get(2).getName());
+        assertEquals("bar", cookies.get(2).getValue());
+    }
+
+    @Test
+    void malformedPairsAreSkippedInsteadOfThrowing() {
+        ServerCookieDecoder decoder = new DefaultServerCookieDecoder();
+        assertEquals(List.of(), decoder.decode("foo"));
+        assertEquals("a", decoder.decode("=noname; a=1").get(0).getName());
+        assertEquals(3, decoder.decode("a=1;;b=2; ;c=3").size());
+    }
+
+    @Test
+    void quotedValuesAreUnwrapped() {
+        List<Cookie> cookies = new DefaultServerCookieDecoder().decode("SID=\"quoted value\"; theme=dark");
+        assertEquals(2, cookies.size());
+        assertEquals("quoted value", cookies.get(0).getValue());
+        assertEquals("dark", cookies.get(1).getValue());
     }
 }

--- a/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
+++ b/http/src/test/java/io/micronaut/http/cookie/DefaultServerCookieDecoderTest.java
@@ -24,6 +24,9 @@ class DefaultServerCookieDecoderTest {
         assertEquals("31d4d96e407aad42", cookies.get(0).getValue());
         assertNull(cookies.get(0).getPath());
         assertNull(cookies.get(0).getDomain());
+        assertFalse(cookies.get(0).isSecure());
+        assertFalse(cookies.get(0).isHttpOnly());
+        assertTrue(cookies.get(0).getSameSite().isEmpty());
         assertEquals("Path", cookies.get(1).getName());
         assertEquals("/", cookies.get(1).getValue());
         assertEquals("Domain", cookies.get(2).getName());
@@ -33,6 +36,10 @@ class DefaultServerCookieDecoderTest {
         cookies = decoder.decode("SID=31d4d96e407aad42; Path=/; Secure; HttpOnly");
         assertEquals(2, cookies.size());
         assertEquals("SID", cookies.get(0).getName());
+        assertNull(cookies.get(0).getPath());
+        assertFalse(cookies.get(0).isSecure());
+        assertFalse(cookies.get(0).isHttpOnly());
+        assertTrue(cookies.get(0).getSameSite().isEmpty());
         assertEquals("Path", cookies.get(1).getName());
     }
 


### PR DESCRIPTION
Rebase of #12871 (by @kali834x) onto the current `5.2.x`. Same two commits, no content changes.

`DefaultServerCookieDecoder.decode` parses an inbound `Cookie` request header on runtimes without http-netty, but delegated to `java.net.HttpCookie.parse`, a `Set-Cookie` *response* parser. On a `Cookie` header with several pairs it returned only the first and dropped the rest (`SID=a; JSESSIONID=b` yielded just `SID`), threw `IllegalArgumentException` on a malformed name so a bad request turned into a 500, and treated `Path`/`Domain`/`Max-Age` as attributes on the inbound cookie, letting a client set `cookie.getPath()` which `NettyCookies` uses to filter which cookies reach the app. The `NettyLaxServerCookieDecoder` sibling backed by Netty's `ServerCookieDecoder.LAX` already parses it as a plain name/value list, so the two SPI implementations disagreed on identical input.

`decode` now splits on `;`, unwraps balanced quotes, and skips empty or unparsable pairs instead of interpreting attributes or throwing. A value that opens with a double quote that is never closed drops the pair, matching `CookieUtil.unwrapValue` in Netty LAX.

Review comments on the original PR are all addressed: the `=` scan is bounded to the current segment (no O(n²) rescan of the rest of the header), the unused catch variable is named `ignored`, and the unbalanced-quote divergence @HDPark95 found is fixed.

Verified against Netty by running both decoders side by side over a set of edge-case headers: `a="unterminated; b=2`, `a="`, `a=""`, `a=1;;b=2; ;c=3`, `=noname; a=1`, `foo`, `a=`, `a=b=c` and `a=1,b=2` all now decode identically. Remaining differences are pre-existing and not touched here: `LAX.decode(String)` returns a `TreeSet`, so the Netty decoder emits cookies sorted by name and deduped while this one keeps header order and duplicates; Netty also skips the RFC 2965 `$Version` pair and does not trim whitespace around a name or value.

`:micronaut-http:test --tests '*Cookie*'` passes, 35 tests.

Closes #12871

🤖 Generated with [Claude Code](https://claude.com/claude-code)
