### PR TITLE
Make error body buffering for streaming clients configurable

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -131,6 +131,11 @@ public abstract class HttpClientConfiguration {
     /**
      * The default value.
      */
+    public static final boolean DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING = false;
+
+    /**
+     * The default value.
+     */
     @SuppressWarnings("WeakerAccess")
     public static final boolean DEFAULT_ALLOW_BLOCK_EVENT_LOOP = false;
 
@@ -221,6 +226,7 @@ public abstract class HttpClientConfiguration {
     private int maxRedirects = DEFAULT_MAX_REDIRECTS;
 
     private boolean exceptionOnErrorStatus = DEFAULT_EXCEPTION_ON_ERROR_STATUS;
+    private boolean bufferErrorBodyForStreaming = DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING;
     private boolean decompressionEnabled = true;
 
     private SslConfiguration sslConfiguration = new ClientSslConfiguration();
@@ -280,6 +286,7 @@ public abstract class HttpClientConfiguration {
             this.numOfThreads = copy.numOfThreads;
             this.connectTimeout = copy.connectTimeout;
             this.connectTtl = copy.connectTtl;
+            this.bufferErrorBodyForStreaming = copy.bufferErrorBodyForStreaming;
             this.defaultCharset = copy.defaultCharset;
             this.exceptionOnErrorStatus = copy.exceptionOnErrorStatus;
             this.eventLoopGroup = copy.eventLoopGroup;
@@ -404,6 +411,23 @@ public abstract class HttpClientConfiguration {
     @Nullable
     public WebSocketCompressionConfiguration getWebSocketCompressionConfiguration() {
         return null;
+    }
+
+    /**
+     * @return Whether the error response body should be buffered and parsed for streaming clients.
+     */
+    public boolean isBufferErrorBodyForStreaming() {
+        return bufferErrorBodyForStreaming;
+    }
+
+    /**
+     * Sets whether the error response body should be buffered and parsed for streaming clients, so that
+     * {@code getResponse().getBody(..)} is populated on error. Default value ({@link io.micronaut.http.client.HttpClientConfiguration#DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING})
+     *
+     * @param bufferErrorBodyForStreaming Whether
+     */
+    public void setBufferErrorBodyForStreaming(boolean bufferErrorBodyForStreaming) {
+        this.bufferErrorBodyForStreaming = bufferErrorBodyForStreaming;
     }
 
     /**

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -414,6 +414,9 @@ public abstract class HttpClientConfiguration {
     }
 
     /**
+     * Whether the error response body should be buffered for streaming clients when no error type is set,
+     * configured by {@code micronaut.http.client.buffer-error-body-for-streaming}.
+     *
      * @return Whether the error response body should be buffered for streaming clients when no error type is set
      * @since 5.2.0
      */
@@ -423,8 +426,11 @@ public abstract class HttpClientConfiguration {
 
     /**
      * Sets whether the error response body should be buffered for streaming clients when no error type is set, so
-     * that {@code getResponse().getBody(..)} is populated on error. Default value
-     * ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING}).
+     * that {@code getResponse().getBody(..)} is populated on error. Configured by
+     * {@code micronaut.http.client.buffer-error-body-for-streaming}. Default value
+     * ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING}), because
+     * the error body has no size limit of its own: enabling this holds the whole of it in memory for every
+     * streaming request that fails.
      *
      * @param bufferErrorBodyForStreaming Whether the error response body should be buffered for streaming clients
      * @since 5.2.0

--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -129,7 +129,7 @@ public abstract class HttpClientConfiguration {
     public static final boolean DEFAULT_EXCEPTION_ON_ERROR_STATUS = true;
 
     /**
-     * The default value.
+     * The default buffer error body for streaming value.
      */
     public static final boolean DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING = false;
 
@@ -414,17 +414,20 @@ public abstract class HttpClientConfiguration {
     }
 
     /**
-     * @return Whether the error response body should be buffered and parsed for streaming clients.
+     * @return Whether the error response body should be buffered for streaming clients when no error type is set
+     * @since 5.2.0
      */
     public boolean isBufferErrorBodyForStreaming() {
         return bufferErrorBodyForStreaming;
     }
 
     /**
-     * Sets whether the error response body should be buffered and parsed for streaming clients, so that
-     * {@code getResponse().getBody(..)} is populated on error. Default value ({@link io.micronaut.http.client.HttpClientConfiguration#DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING})
+     * Sets whether the error response body should be buffered for streaming clients when no error type is set, so
+     * that {@code getResponse().getBody(..)} is populated on error. Default value
+     * ({@value io.micronaut.http.client.HttpClientConfiguration#DEFAULT_BUFFER_ERROR_BODY_FOR_STREAMING}).
      *
-     * @param bufferErrorBodyForStreaming Whether
+     * @param bufferErrorBodyForStreaming Whether the error response body should be buffered for streaming clients
+     * @since 5.2.0
      */
     public void setBufferErrorBodyForStreaming(boolean bufferErrorBodyForStreaming) {
         this.bufferErrorBodyForStreaming = bufferErrorBodyForStreaming;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
@@ -1247,7 +1247,7 @@ final class NettyHttpClient implements
     }
 
     private ExecutionFlow<HttpResponse<?>> readBodyOnError(@Nullable Argument<?> errorType, ExecutionFlow<HttpResponse<?>> publisher) {
-        if (errorType != null && errorType != HttpClient.DEFAULT_ERROR_TYPE) {
+        if (errorType != null && (errorType != HttpClient.DEFAULT_ERROR_TYPE || configuration.isBufferErrorBodyForStreaming())) {
             return publisher.onErrorResume(clientException -> {
                 if (clientException instanceof HttpClientResponseException exception) {
                     final HttpResponse<?> response = exception.getResponse();

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
@@ -1281,17 +1281,18 @@ final class NettyHttpClient implements
                             public void onComplete() {
                                 try {
                                     FullHttpResponse fullHttpResponse = new DefaultFullHttpResponse(nettyResponse.protocolVersion(), nettyResponse.status(), buffer, nettyResponse.headers(), new DefaultHttpHeaders(true));
-                                    final FullNettyClientHttpResponse<Object> fullNettyClientHttpResponse = new FullNettyClientHttpResponse<>(fullHttpResponse, handlerRegistry, (Argument<Object>) errorType, true, conversionService);
+                                    boolean hasErrorType = errorType != HttpClient.DEFAULT_ERROR_TYPE;
+                                    final FullNettyClientHttpResponse<Object> fullNettyClientHttpResponse = new FullNettyClientHttpResponse<>(fullHttpResponse, handlerRegistry, hasErrorType ? (Argument<Object>) errorType : null, hasErrorType, conversionService);
                                     completeExceptionallySafe(delayed, decorate(new HttpClientResponseException(
                                         fullHttpResponse.status().reasonPhrase(),
                                         null,
                                         fullNettyClientHttpResponse,
-                                        new HttpClientErrorDecoder() {
+                                        hasErrorType ? new HttpClientErrorDecoder() {
                                             @Override
                                             public Argument<?> getErrorType(MediaType mediaType) {
                                                 return errorType;
                                             }
-                                        }
+                                        } : HttpClientErrorDecoder.DEFAULT
                                     )));
                                 } finally {
                                     buffer.release();

--- a/http-client/src/test/groovy/io/micronaut/http/client/stream/ClientStreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/stream/ClientStreamSpec.groovy
@@ -74,6 +74,25 @@ class ClientStreamSpec extends Specification {
         !ex.response.getBody(Map).isPresent()
     }
 
+    void "test a stream error body is buffered when buffer-error-body-for-streaming is enabled"() {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.http.client.buffer-error-body-for-streaming': true
+        ])
+        def client = server.applicationContext.getBean(BookClientNoErrorType)
+
+        when:
+        Flux.from(client.errorStream()).blockFirst()
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.response.getBody(Map).isPresent()
+        ex.response.getBody(Map).get().get("error") == "from server"
+
+        cleanup:
+        server.close()
+    }
+
     void "test a stream that returns an error response"() {
         when:
         Flux.from(bookClient.errorStream2()).blockFirst()

--- a/http-client/src/test/groovy/io/micronaut/http/client/stream/ClientStreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/stream/ClientStreamSpec.groovy
@@ -105,6 +105,7 @@ class ClientStreamSpec extends Specification {
 
         then:
         def ex = thrown(HttpClientResponseException)
+        ex.response.getBody(String).isPresent()
         ex.response.getBody(String).get() == "from server"
         ex.message == "from server"
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/stream/ClientStreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/stream/ClientStreamSpec.groovy
@@ -93,6 +93,25 @@ class ClientStreamSpec extends Specification {
         server.close()
     }
 
+    void "test a buffered stream error body with a non-json content type is not forced into JsonError"() {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.http.client.buffer-error-body-for-streaming': true
+        ])
+        def client = server.applicationContext.getBean(BookClientNoErrorType)
+
+        when:
+        Flux.from(client.errorStreamText()).blockFirst()
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.response.getBody(String).get() == "from server"
+        ex.message == "from server"
+
+        cleanup:
+        server.close()
+    }
+
     void "test a stream that returns an error response"() {
         when:
         Flux.from(bookClient.errorStream2()).blockFirst()
@@ -116,6 +135,9 @@ class ClientStreamSpec extends Specification {
 
         @Get("/error")
         Publisher<Book> errorStream()
+
+        @Get("/error-text")
+        Publisher<Book> errorStreamText()
     }
 
     @Controller("/rxjava/stream")
@@ -146,6 +168,12 @@ class ClientStreamSpec extends Specification {
         HttpResponse<Map> errorStream2() {
             return HttpResponse.serverError()
                     .contentLength(0)
+        }
+
+        @Get("/error-text")
+        HttpResponse<String> errorStreamText() {
+            return HttpResponse.serverError("from server")
+                    .contentType(MediaType.TEXT_PLAIN_TYPE)
         }
     }
 


### PR DESCRIPTION
Fixes #12771. Supersedes #12841 — rebased onto `5.2.x`, with a follow-up fix; original commit and authorship by @adityaanikam preserved.

Streaming clients (`SseClient`, `ReactorSseClient`, `dataStream`, `jsonStream`) drop the error response body when no explicit `errorType` is given, so `getResponse().getBody(..)` is empty on an HTTP error. `readBodyOnError` in `NettyHttpClient` only buffers the body when `errorType != DEFAULT_ERROR_TYPE`, which is never true for the default overloads — they all pass `DEFAULT_ERROR_TYPE` explicitly.

Adds `micronaut.http.client.buffer-error-body-for-streaming` on `HttpClientConfiguration` to control this, per @graemerocher's comment that the default should be configurable.

The default is `false`, preserving current behaviour: buffering an arbitrarily large error body for every streaming client is a memory tradeoff worth opting into, and the existing behaviour is asserted by `ClientStreamSpec` ("test a stream that produces an error without an error type"). Happy to flip the default to `true` if you would prefer the bug fixed out of the box.

### Follow-up commit

Once the flag routes the *default* error type through `readBodyOnError`, the rest of that method was still written for the explicit-error-type case: it built the response with `errorType` as its body type (eagerly converted) and installed a decoder returning that type for **every** media type. A `text/plain` or `application/vnd.error` error body was therefore forced through `JsonError`, and `HttpClientResponseException.getMessage()` fell back to the reason phrase instead of the body text — a behaviour change beyond "buffer the body".

The second commit uses a null body type and `HttpClientErrorDecoder.DEFAULT` when no error type was given, so a buffered streaming error decodes exactly as a full response does.

### Tests

`ClientStreamSpec` gains two cases: the error body is present with the flag on, and a `text/plain` error body is not forced into `JsonError` (this one fails without the second commit). All 7 cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
