### PR TITLE
test: add regression tests for DefaultBeanContext

### DIFF
--- a/test-suite/src/test/java/io/micronaut/context/DefaultBeanContextTest.java
+++ b/test-suite/src/test/java/io/micronaut/context/DefaultBeanContextTest.java
@@ -2,10 +2,21 @@ package io.micronaut.context;
 
 import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.exceptions.NonUniqueBeanException;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import spock.lang.Specification;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DefaultBeanContextTest extends Specification {
     @Test
@@ -31,4 +42,89 @@ class DefaultBeanContextTest extends Specification {
     @Singleton
     @Secondary
     static class Foo2 implements Foo {}
+    static class BeanFromDefinition {}
+    interface AdoptedService {}
+    record FirstAdoptedService() implements AdoptedService {}
+    record SecondAdoptedService() implements AdoptedService {}
+
+    @Test
+    void beanKeyEqualityIncludesQualifierAndTypeArguments() {
+        Qualifier<BeanFromDefinition> definitionQualifier = Qualifiers.byName("definitionBean");
+        RuntimeBeanDefinition<BeanFromDefinition> definition = RuntimeBeanDefinition.of(BeanFromDefinition.class, BeanFromDefinition::new);
+
+        DefaultBeanContext.BeanKey<BeanFromDefinition> fromDefinition = new DefaultBeanContext.BeanKey<>(definition, definitionQualifier);
+        assertEquals(new DefaultBeanContext.BeanKey<>(definition.asArgument(), definitionQualifier), fromDefinition);
+        assertEquals(definitionQualifier + " " + definition.asArgument().getName(), fromDefinition.toString());
+
+        Argument<CharSequence> beanType = Argument.of(CharSequence.class);
+        DefaultBeanContext.BeanKey<CharSequence> unqualified = new DefaultBeanContext.BeanKey<>(beanType, null);
+        DefaultBeanContext.BeanKey<CharSequence> sameUnqualified = new DefaultBeanContext.BeanKey<>(Argument.of(CharSequence.class), null);
+
+        assertTrue(unqualified.equals(unqualified));
+        assertFalse(unqualified.equals(null));
+        assertEquals(unqualified, sameUnqualified);
+        assertEquals(unqualified.hashCode(), sameUnqualified.hashCode());
+        assertNotEquals(unqualified, new DefaultBeanContext.BeanKey<>(beanType, Qualifiers.byName("primaryString")));
+
+        Qualifier<List> listQualifier = Qualifiers.byName("strings");
+        Argument<List> stringList = Argument.of(List.class, String.class);
+        DefaultBeanContext.BeanKey<List> fromClass = new DefaultBeanContext.BeanKey<>(List.class, listQualifier, String.class);
+
+        assertEquals(new DefaultBeanContext.BeanKey<>(stringList, listQualifier), fromClass);
+        assertEquals(listQualifier + " " + stringList.getName(), fromClass.toString());
+        assertNotEquals(fromClass, new DefaultBeanContext.BeanKey<>(List.class, listQualifier, Integer.class));
+        assertNotEquals(
+            new DefaultBeanContext.BeanKey<>(Argument.listOf(String.class), Qualifiers.byName("strings")),
+            new DefaultBeanContext.BeanKey<>(Argument.listOf(String.class), Qualifiers.byName("other"))
+        );
+    }
+
+    @Test
+    void runtimeSingletonRegistrationInvalidatesLookupCachesAndResolvesNamedCollections() {
+        try (DefaultBeanContext beanContext = minimalBeanContext()) {
+            beanContext.start();
+
+            Qualifier<AdoptedService> firstQualifier = Qualifiers.byName("first");
+            Qualifier<AdoptedService> secondQualifier = Qualifiers.byName("second");
+            AdoptedService first = new FirstAdoptedService();
+            AdoptedService second = new SecondAdoptedService();
+
+            assertFalse(beanContext.containsBean(AdoptedService.class, firstQualifier));
+
+            beanContext.registerSingleton(AdoptedService.class, first, firstQualifier, false);
+            beanContext.registerSingleton(AdoptedService.class, second, secondQualifier, false);
+
+            assertTrue(beanContext.containsBean(AdoptedService.class, firstQualifier));
+            assertSame(first, beanContext.getBean(AdoptedService.class, firstQualifier));
+            assertSame(second, beanContext.findBean(AdoptedService.class, secondQualifier).orElseThrow());
+
+            var services = beanContext.getBeansOfType(AdoptedService.class);
+            assertEquals(Set.of(first, second), Set.copyOf(services));
+            assertEquals(List.of(first), beanContext.streamOfType(AdoptedService.class, firstQualifier).toList());
+
+            var servicesByName = beanContext.mapOfType(Argument.of(AdoptedService.class), null);
+            assertEquals(Set.of("first", "second"), servicesByName.keySet());
+            assertSame(first, servicesByName.get("first"));
+            assertSame(second, servicesByName.get("second"));
+
+            assertSame(
+                beanContext.getBeanRegistrations(AdoptedService.class),
+                beanContext.getBeanRegistrations(AdoptedService.class)
+            );
+        }
+    }
+
+    private static DefaultBeanContext minimalBeanContext() {
+        return new DefaultBeanContext(new BeanContextConfiguration() {
+            @Override
+            public boolean eagerBeansEnabled() {
+                return false;
+            }
+
+            @Override
+            public boolean eventsEnabled() {
+                return false;
+            }
+        });
+    }
 }

--- a/test-suite/src/test/java/io/micronaut/context/DefaultBeanContextTest.java
+++ b/test-suite/src/test/java/io/micronaut/context/DefaultBeanContextTest.java
@@ -48,20 +48,19 @@ class DefaultBeanContextTest extends Specification {
     record SecondAdoptedService() implements AdoptedService {}
 
     @Test
+    @SuppressWarnings("rawtypes") // the BeanKey(Class, Qualifier, Class...) constructor under test is raw by design
     void beanKeyEqualityIncludesQualifierAndTypeArguments() {
         Qualifier<BeanFromDefinition> definitionQualifier = Qualifiers.byName("definitionBean");
         RuntimeBeanDefinition<BeanFromDefinition> definition = RuntimeBeanDefinition.of(BeanFromDefinition.class, BeanFromDefinition::new);
 
         DefaultBeanContext.BeanKey<BeanFromDefinition> fromDefinition = new DefaultBeanContext.BeanKey<>(definition, definitionQualifier);
         assertEquals(new DefaultBeanContext.BeanKey<>(definition.asArgument(), definitionQualifier), fromDefinition);
-        assertEquals(definitionQualifier + " " + definition.asArgument().getName(), fromDefinition.toString());
 
         Argument<CharSequence> beanType = Argument.of(CharSequence.class);
         DefaultBeanContext.BeanKey<CharSequence> unqualified = new DefaultBeanContext.BeanKey<>(beanType, null);
         DefaultBeanContext.BeanKey<CharSequence> sameUnqualified = new DefaultBeanContext.BeanKey<>(Argument.of(CharSequence.class), null);
 
-        assertTrue(unqualified.equals(unqualified));
-        assertFalse(unqualified.equals(null));
+        assertNotEquals(null, unqualified);
         assertEquals(unqualified, sameUnqualified);
         assertEquals(unqualified.hashCode(), sameUnqualified.hashCode());
         assertNotEquals(unqualified, new DefaultBeanContext.BeanKey<>(beanType, Qualifiers.byName("primaryString")));
@@ -71,7 +70,6 @@ class DefaultBeanContextTest extends Specification {
         DefaultBeanContext.BeanKey<List> fromClass = new DefaultBeanContext.BeanKey<>(List.class, listQualifier, String.class);
 
         assertEquals(new DefaultBeanContext.BeanKey<>(stringList, listQualifier), fromClass);
-        assertEquals(listQualifier + " " + stringList.getName(), fromClass.toString());
         assertNotEquals(fromClass, new DefaultBeanContext.BeanKey<>(List.class, listQualifier, Integer.class));
         assertNotEquals(
             new DefaultBeanContext.BeanKey<>(Argument.listOf(String.class), Qualifiers.byName("strings")),
@@ -107,7 +105,7 @@ class DefaultBeanContextTest extends Specification {
             assertSame(first, servicesByName.get("first"));
             assertSame(second, servicesByName.get("second"));
 
-            assertSame(
+            assertEquals(
                 beanContext.getBeanRegistrations(AdoptedService.class),
                 beanContext.getBeanRegistrations(AdoptedService.class)
             );


### PR DESCRIPTION
Rebase of #12758 onto `5.2.x`, with a follow-up commit tightening the assertions. Original work by @amirdeljouyi; #12758 is superseded and closed in favour of this one.

Two tests on `DefaultBeanContext`:

* `beanKeyEqualityIncludesQualifierAndTypeArguments` — `BeanKey` identity accounts for both the qualifier and the argument's type arguments (`List<String>` is not `List<Integer>`), across all three constructors.
* `runtimeSingletonRegistrationInvalidatesLookupCachesAndResolvesNamedCollections` — a negative `containsBean` result cached before a runtime singleton is registered does not survive the registration, and the new singleton is immediately visible through direct, optional, collection, stream, map and registration lookups.

The second one has teeth: with the `containsBeanCache` purges in both `purgeCacheForBeanInstance` and `purgeCacheForBeanDefinition` removed, it fails. (Removing either one alone does not — the two paths are redundant for this scenario, so the test pins the observable contract rather than one line.)

The follow-up commit drops two `toString` assertions that re-implemented `BeanKey`'s own formula and the `equals(self)`/`equals(null)` branch padding, and compares the two `getBeanRegistrations` results by value instead of by reference so the test survives the collection cache handing out a copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)