### PR TITLE
Document immutable configuration with record-like types

### DIFF
--- a/src/main/docs/guide/config/immutableConfig.adoc
+++ b/src/main/docs/guide/config/immutableConfig.adoc
@@ -4,47 +4,72 @@ dependency::micronaut-context[]
 
 `micronaut-context` is a transitive dependency of `micronaut-http`. If you use a Micronaut HTTP runtime, your project already includes the `micronaut-context` dependency.
 
-There are two ways to define immutable configuration. The preferred way is to define an interface annotated with ann:context.annotation.ConfigurationProperties[]. For example:
+Micronaut framework offers several styles of immutable configuration. They bind values the same way but differ in how a bean behaves when the configuration is <<refreshable, refreshed>> at runtime.
 
-snippet::io.micronaut.docs.config.itfce.EngineConfig[tags="imports,class",indent=0,title="@ConfigurationProperties Example"]
+== Interface-based configuration
+
+One approach is to declare an interface annotated with ann:context.annotation.ConfigurationProperties[]. It reflects refreshed configuration automatically, without any additional annotation:
+
+snippet::io.micronaut.docs.config.itfce.EngineConfig[tags="imports,class",indent=0,title="@ConfigurationProperties Interface"]
 
 <1> The ann:context.annotation.ConfigurationProperties[] annotation takes the configuration prefix and is declared on an interface
 <2> You can use ann:core.bind.annotation.Bindable[] to set a default value
 <3> Validation annotations can also be used
-<4> You can also specify references to other ann:context.annotation.ConfigurationProperties[] beans.
+<4> You can reference other ann:context.annotation.ConfigurationProperties[] beans
 <5> You can nest immutable configuration
-<6> Optional configuration can be indicated by returning an `Optional` or specifying `@Nullable`
+<6> Optional configuration is indicated by returning an `Optional` or specifying `@Nullable`
 
-In this case the Micronaut framework provides a compile-time implementation that delegates all getters to call the `getProperty(..)` method of the api:context.env.Environment[] interface.
+Micronaut framework provides a compile-time implementation whose getters delegate to the `getProperty(..)` method of the api:context.env.Environment[] interface. Because each getter reads the `Environment` on every call, an interface bean always reflects the current configuration, including after a <<refreshable, refresh>> — even when it was injected into a long-lived bean before the refresh happened.
 
-This has the advantage that if the application configuration is <<refreshable, refreshed>> (for example by invoking the `/refresh` endpoint), the injected interface automatically sees the new values.
+NOTE: Only getter methods are allowed (default methods are supported). Declaring any other abstract method causes a compilation error.
 
-NOTE: If you try to specify any other abstract method other than a getter, a compilation error occurs (default methods are supported).
+== Constructor-based configuration
 
-Another way to implement immutable configuration is to define a class and use the ann:context.annotation.ConfigurationInject[] annotation on a constructor of a ann:context.annotation.ConfigurationProperties[] or ann:context.annotation.EachProperty[] bean.
+Alternatively, define a class and annotate one of its constructors with ann:context.annotation.ConfigurationInject[] on a ann:context.annotation.ConfigurationProperties[] or ann:context.annotation.EachProperty[] bean:
 
-For example:
-
-snippet::io.micronaut.docs.config.immutable.EngineConfig[tags="imports,class",indent=0,title="@ConfigurationProperties Example"]
+snippet::io.micronaut.docs.config.immutable.EngineConfig[tags="imports,class",indent=0,title="@ConfigurationInject Constructor"]
 
 <1> The ann:context.annotation.ConfigurationProperties[] annotation takes the configuration prefix
-<2> The ann:context.annotation.ConfigurationInject[] annotation is defined on the constructor
+<2> The ann:context.annotation.ConfigurationInject[] annotation is declared on the constructor
 <3> You can use ann:core.bind.annotation.Bindable[] to set a default value
 <4> Validation annotations can be used too
 <5> You can nest immutable configuration
-<6> Optional configuration can be indicated with `@Nullable`
+<6> Optional configuration is indicated with `@Nullable`
 
-The ann:context.annotation.ConfigurationInject[] annotation provides a hint to the Micronaut framework to prioritize binding values from configuration instead of injecting beans.
-
-NOTE: Using this approach, to make the configuration refreshable, add the ann:runtime.context.scope.Refreshable[] annotation to the class as well. This allows the bean to be re-created in the case of a <<refreshable,runtime configuration refresh event>>.
-
-There are a few exceptions to this rule. Micronaut framework will not perform configuration binding for a parameter if any of these conditions is met:
+The ann:context.annotation.ConfigurationInject[] annotation tells the framework to prioritize binding values from configuration over injecting beans. Binding is skipped for a constructor parameter that meets any of these conditions:
 
 * The parameter is annotated with `@Value` (explicit binding)
 * The parameter is annotated with `@Property` (explicit binding)
 * The parameter is annotated with `@Parameter` (parameterized bean handling)
 * The parameter is annotated with `@Inject` (generic bean injection)
 * The type of the parameter is annotated with a bean scope (such as `@Singleton`)
+
+Unlike the interface approach, a constructor-based bean binds its values once, when it is constructed, and stores them in fields. Adding the ann:runtime.context.scope.Refreshable[] annotation to the class puts it in the refresh scope, so that a <<refreshable,runtime configuration refresh event>> discards the instance and the next lookup or injection builds a new one from the current configuration.
+
+WARNING: ann:runtime.context.scope.Refreshable[] does not update a reference that has already been injected. A bean that received the configuration in its constructor — a singleton, for example — keeps the instance it was given, with the values it held at that time. Use interface-based configuration, or look the configuration bean up from the api:context.BeanContext[] when you need it, if a long-lived bean must observe a refresh.
+
+== Record classes
+
+It is also possible to use a record class -- a https://docs.oracle.com/en/java/javase/17/language/records.html[Java record], a Kotlin data class or a frozen Python dataclass -- for immutable configuration with ann:context.annotation.ConfigurationProperties[]. The canonical (record) or primary (data class) constructor is treated as though it were annotated with ann:context.annotation.ConfigurationInject[], so no annotation is needed on the constructor:
+
+snippet::io.micronaut.docs.config.immutable.ValueAddedTaxConfiguration[tags="imports,class",title="Record Example"]
+
+<1> The `percentage` field defines a configuration property for "vat"
+
+Record classes are constructor-based configuration and behave exactly as described above with respect to a refresh, including when annotated with ann:runtime.context.scope.Refreshable[]. Being `final` makes no difference here: no AOP proxy is generated for a ann:context.annotation.ConfigurationProperties[] class in any case.
+
+NOTE: From a performance perspective records are better than interfaces, because an interface getter resolves its value through the `Environment` on every call whereas a record returns an already-bound field. The difference is small; let your refresh requirements drive the choice.
+
+== Default values
+
+You can supply a default for a property in two ways:
+
+* the `defaultValue` member of ann:core.bind.annotation.Bindable[], for example `@Bindable(defaultValue = "Ford")`
+* a constructor default parameter, in languages that support them (such as Kotlin)
+
+Prefer ann:core.bind.annotation.Bindable[]. Its default value is written to the generated configuration metadata, so IDE completion, JSON schema validation, and generated documentation all display it. A language-level default parameter works at runtime but is invisible to that tooling.
+
+== Using immutable configuration
 
 Once you have prepared a type-safe configuration it can be injected into your beans like any other bean:
 
@@ -58,16 +83,6 @@ Configuration values can then be supplied when running the application. For exam
 snippet::io.micronaut.docs.config.immutable.VehicleSpec[tags="start",indent=0,title="Supply Configuration"]
 
 The above example prints: `"Ford Engine Starting V8 [rodLength=7.0]"`
-
-==== Using Record Classes to define immutable configuration
-
-It is also possible to use a record class -- a https://docs.oracle.com/en/java/javase/17/language/records.html[Java record], a Kotlin data class or a frozen Python dataclass -- for immutable configuration with ann:context.annotation.ConfigurationProperties[]. For example:
-
-snippet::io.micronaut.docs.config.immutable.ValueAddedTaxConfiguration[tags="imports,class",title="Record Example"]
-
-<1> The `percentage` field defines a configuration property for "vat"
-
-NOTE: From a performance perspective records are better than interfaces.
 
 == Customizing accessors
 


### PR DESCRIPTION
Takes over #12802 (by @MariusVolkhart), rebased onto `5.2.x`.

Much of the original PR has already landed on `5.2.x` via #13034 — the `micronaut-context` casing fix, the stale `rodLength=7B.0` → `7.0` output, the generalization from "Java Record Classes" to record classes (Java records, Kotlin data classes, frozen Python dataclasses), and equivalent Kotlin tests. `5.2.x`'s `ValueAddedTaxConfiguration.kt` is the better of the two, using `@field:NotNull` rather than `@NotNull`, so the original's two Kotlin files are dropped. What remains is the guide itself:

- Splits the page into sections and reframes the choice between styles around the behaviour that actually differs: an interface reflects a refreshed `Environment` automatically because each getter reads it on every call, whereas constructor-based styles bind their values once at construction.
- States that a record class binds through its canonical/primary constructor with no annotation needed.
- Adds a "Default values" section: prefer `@Bindable(defaultValue = …)` over a language-level default parameter, because only `@Bindable` is written to the generated configuration metadata that IDE completion and JSON schema consume.

## The review comment on #12802

@graemerocher questioned whether `@Refreshable` works on a record, since records are `final` and AOP cannot subclass them. I compiled and ran all four variants against a real `RefreshEvent`:

| style | `getBean` after refresh | already injected into a singleton |
|---|---|---|
| interface | changed | **changed** |
| class + `@ConfigurationInject`, no `@Refreshable` | stale | stale |
| class + `@ConfigurationInject` + `@Refreshable` | **changed** | stale |
| record, no `@Refreshable` | stale | stale |
| record + `@Refreshable` | **changed** | stale |

Records turn out not to be special. `@Refreshable` on a record compiles without error and behaves exactly as it does on a non-final class, because no AOP proxy is generated for a `@ConfigurationProperties` class in the first place: `BeanDefinitionCreatorFactory` routes every non-interface `@ConfigurationProperties` type to `ConfigurationReaderBeanElementCreator`, which passes `aopProxyType = false`. The runtime bean class is the raw type, never `$Intercepted`.

The concern behind the comment is nevertheless valid, and points at an error that predates the PR. The existing note claims `@Refreshable` "allows the bean to be re-created", which holds only for a fresh lookup — without the proxy, a singleton that received the configuration in its constructor keeps the stale instance indefinitely. That is equally true of plain classes and records. This PR therefore keeps the `@Refreshable` guidance for record classes, adds a `WARNING` describing the real limitation, and notes that being `final` changes nothing here.

`./gradlew docs` builds clean and the page renders correctly in all four languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)