### PR TITLE
fix: match @EachProperty record properties by name

### DIFF
--- a/core-processor/src/main/java/io/micronaut/context/visitor/ConfigurationMetadataWriterVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/context/visitor/ConfigurationMetadataWriterVisitor.java
@@ -52,6 +52,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -283,10 +284,13 @@ public class ConfigurationMetadataWriterVisitor implements TypeElementVisitor<Co
                 .getBeanProperties();
             final ParameterElement[] parameters = constructor.getParameters();
             if (beanProperties.size() == parameters.length) {
-                for (int i = 0; i < parameters.length; i++) {
-                    ParameterElement parameter = parameters[i];
-                    final PropertyElement bp = beanProperties.get(i);
-                    if (CONSTRUCTOR_PARAMETERS_INJECTION_ANN.stream().noneMatch(bp::hasStereotype)) {
+                final Map<String, PropertyElement> propertiesByName = new HashMap<>(beanProperties.size());
+                for (PropertyElement beanProperty : beanProperties) {
+                    propertiesByName.putIfAbsent(beanProperty.getName(), beanProperty);
+                }
+                for (ParameterElement parameter : parameters) {
+                    final PropertyElement bp = propertiesByName.get(parameter.getName());
+                    if (bp == null || CONSTRUCTOR_PARAMETERS_INJECTION_ANN.stream().noneMatch(bp::hasStereotype)) {
                         processConfigurationInjectParameter(constructor.getDeclaringType(), parameter, visitorContext);
                     }
                 }

--- a/core-processor/src/main/java/io/micronaut/context/visitor/ConfigurationMetadataWriterVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/context/visitor/ConfigurationMetadataWriterVisitor.java
@@ -30,6 +30,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.type.DefaultArgument;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.FieldElement;
@@ -52,7 +53,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -284,9 +284,11 @@ public class ConfigurationMetadataWriterVisitor implements TypeElementVisitor<Co
                 .getBeanProperties();
             final ParameterElement[] parameters = constructor.getParameters();
             if (beanProperties.size() == parameters.length) {
-                final Map<String, PropertyElement> propertiesByName = new HashMap<>(beanProperties.size());
+                // Record component names are unique and a record cannot inherit properties,
+                // so there is exactly one bean property per constructor parameter name.
+                final Map<String, PropertyElement> propertiesByName = CollectionUtils.newHashMap(beanProperties.size());
                 for (PropertyElement beanProperty : beanProperties) {
-                    propertiesByName.putIfAbsent(beanProperty.getName(), beanProperty);
+                    propertiesByName.put(beanProperty.getName(), beanProperty);
                 }
                 for (ParameterElement parameter : parameters) {
                     final PropertyElement bp = propertiesByName.get(parameter.getName());

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/records/RecordNestingSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/records/RecordNestingSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.inject.configproperties.records
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.inject.qualifiers.Qualifiers
 
 class RecordNestingSpec extends AbstractTypeElementSpec {
 
@@ -50,6 +51,29 @@ record RecordOuterConfig(
         config.inners().size() == 1
         config.inners()[0].count() == 30
         config.inners()[0].thirdLevel().num() == 40
+    }
+
+    void "test EachProperty record where @Parameter field is not alphabetically first"() {
+        given:
+        def context = buildContext('test.UnorderedConfig', '''
+package test;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+
+@EachProperty("demos")
+record UnorderedConfig(
+    @Parameter String name,
+    boolean enabled) {
+}
+''', false, ['demos.test.enabled': 'true'])
+
+        when:
+        def config = getBean(context, 'test.UnorderedConfig', Qualifiers.byName('test'))
+
+        then:
+        config.name() == 'test'
+        config.enabled()
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/records/RecordNestingSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/records/RecordNestingSpec.groovy
@@ -53,6 +53,12 @@ record RecordOuterConfig(
         config.inners()[0].thirdLevel().num() == 40
     }
 
+    // General coverage for @EachProperty records whose @Parameter component is not
+    // alphabetically first. This is NOT a regression guard for #12658: that bug only
+    // manifests under Eclipse JDT, whose TypeElement.getEnclosedElements() is alphabetical,
+    // while this suite compiles with javac, which returns declaration order and so always
+    // lines the bean properties up with the constructor parameters. Reproducing the failure
+    // automatically would require an ECJ-backed compilation path.
     void "test EachProperty record where @Parameter field is not alphabetically first"() {
         given:
         def context = buildContext('test.UnorderedConfig', '''


### PR DESCRIPTION
Rebase of #12659 onto `5.2.x`, taking over from @jochenseeber (original authorship preserved on the commit).

JDT returns `TypeElement.getEnclosedElements()` in alphabetical order while javac uses declaration order. The positional zip in `applyConfigurationInjectionIfNecessary` therefore applied `@Property`/`@Parameter` to the wrong constructor parameters under JDT. Matching record constructor parameters to bean properties by name removes the dependency on element ordering.

Fixes #12658. Closes #12659.

### Changes from the original PR

- Applied the review feedback from @copilot-pull-request-reviewer and @altro3: the per-parameter `beanProperties.stream().filter(...)` scan is replaced with a `Map<String, PropertyElement>` built once.

### On the added test

The review noted that the new spec cannot fail on unfixed code, since `AbstractTypeElementSpec` compiles with javac. **This is correct, and I verified it** — reverting only the production change and re-running leaves both cases passing (`tests="2" failures="0" errors="0"`, and both did execute).

I also looked for a javac-reachable way to make the two orders diverge and found none: for a plain record javac's enclosed-element order always matches constructor parameter order, and any extra bean property makes `beanProperties.size() != parameters.length`, which routes to the other branch entirely. Reproducing this in an automated test genuinely requires an ECJ-backed compilation path.

The test is retained as coverage of `@EachProperty` records with a non-first `@Parameter` component, but it should not be counted as a regression guard for #12658.

### Possibly redundant branch (not addressed here)

All five entries in `CONSTRUCTOR_PARAMETERS_INJECTION_ANN` are parameter-applicable — `@Parameter` and `@Value` list `PARAMETER` explicitly, and `@Property` declares no `@Target` at all — so javac propagates them to the record's constructor parameter, and the generic `processConfigurationInject` path would likely behave identically while being immune to element ordering by construction. That would be a deletion rather than a fix, so it is out of scope here and untested.

### Verification

`:micronaut-inject-java` (142 tests) and `:micronaut-inject-groovy` (72 tests) across the configproperties / EachProperty / ConfigurationProperties suites — 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
