### PR TITLE
A lifecycle event whose bean declares no callback has no target method

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableInterceptedMethod.java
@@ -75,7 +75,9 @@ final class InitializableInterceptedMethod<T> extends InterceptedMethod<T, T> {
      */
     @Override
     @Nullable
-    @SuppressWarnings("NullAway")
+    // NullAway and java:S2638 both flag the widening the javadoc above explains: it is deliberate, and narrower
+    // here than on the interface.
+    @SuppressWarnings({"NullAway", "java:S2638"})
     public Method getTargetMethod() {
         ExecutableMethod<T, ?> callback = described(initializableIntercepted);
         return callback == null ? null : callback.getTargetMethod();

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableInterceptedMethod.java
@@ -63,11 +63,22 @@ final class InitializableInterceptedMethod<T> extends InterceptedMethod<T, T> {
      * The callback of the bean, resolved by the executable method that stands for it rather than by looking a
      * name up on the declaring type: the chain declares no arguments, since a callback's arguments are resolved
      * only once it proceeds, so a name and an empty signature would not find a callback that takes any.
+     *
+     * <p>A bean may bind the event without declaring a callback of that kind, which is deliberately supported: the
+     * binding promises an interception either way. Such an event has no target method, so this returns {@code null}
+     * rather than looking up the synthetic {@code initialize} the chain names itself by, which no bean declares.
+     * The package is {@code @NullMarked} and {@link io.micronaut.inject.MethodReference#getTargetMethod()} is
+     * therefore implicitly non-null, so the widening is declared here rather than left implicit, and NullAway is
+     * suppressed for it: widening the interface itself would change a contract every other implementation keeps.</p>
+     *
+     * @return The callback of the event, or {@code null} when the bean declares no callback of this kind
      */
     @Override
+    @Nullable
+    @SuppressWarnings("NullAway")
     public Method getTargetMethod() {
         ExecutableMethod<T, ?> callback = described(initializableIntercepted);
-        return callback == null ? super.getTargetMethod() : callback.getTargetMethod();
+        return callback == null ? null : callback.getTargetMethod();
     }
 
     @Override

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedDisposeMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedDisposeMethod.java
@@ -63,11 +63,22 @@ final class InterceptedDisposeMethod<T> extends InterceptedMethod<T, T> {
      * The callback of the bean, resolved by the executable method that stands for it rather than by looking a
      * name up on the declaring type: the chain declares no arguments, since a callback's arguments are resolved
      * only once it proceeds, so a name and an empty signature would not find a callback that takes any.
+     *
+     * <p>A bean may bind the event without declaring a callback of that kind, which is deliberately supported: the
+     * binding promises an interception either way. Such an event has no target method, so this returns {@code null}
+     * rather than looking up the synthetic {@code dispose} the chain names itself by, which no bean declares.
+     * The package is {@code @NullMarked} and {@link io.micronaut.inject.MethodReference#getTargetMethod()} is
+     * therefore implicitly non-null, so the widening is declared here rather than left implicit, and NullAway is
+     * suppressed for it: widening the interface itself would change a contract every other implementation keeps.</p>
+     *
+     * @return The callback of the event, or {@code null} when the bean declares no callback of this kind
      */
     @Override
+    @Nullable
+    @SuppressWarnings("NullAway")
     public Method getTargetMethod() {
         ExecutableMethod<T, ?> callback = described(disposableIntercepted);
-        return callback == null ? super.getTargetMethod() : callback.getTargetMethod();
+        return callback == null ? null : callback.getTargetMethod();
     }
 
     @Override

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedDisposeMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedDisposeMethod.java
@@ -75,7 +75,9 @@ final class InterceptedDisposeMethod<T> extends InterceptedMethod<T, T> {
      */
     @Override
     @Nullable
-    @SuppressWarnings("NullAway")
+    // NullAway and java:S2638 both flag the widening the javadoc above explains: it is deliberate, and narrower
+    // here than on the interface.
+    @SuppressWarnings({"NullAway", "java:S2638"})
     public Method getTargetMethod() {
         ExecutableMethod<T, ?> callback = described(disposableIntercepted);
         return callback == null ? null : callback.getTargetMethod();

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedMethod.java
@@ -19,7 +19,6 @@ import io.micronaut.context.EnvironmentConfigurable;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.type.UnsafeExecutable;
@@ -30,7 +29,6 @@ import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.annotation.AbstractEnvironmentAnnotationMetadata;
 import org.jspecify.annotations.Nullable;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -60,8 +58,6 @@ abstract sealed class InterceptedMethod<T, R> implements UnsafeExecutable<T, R>,
     private Environment environment;
     @Nullable
     private AnnotationMetadata methodAnnotationMetadata;
-    @Nullable
-    private Method method;
 
     /**
      * Creates a new executable method descriptor.
@@ -222,22 +218,6 @@ abstract sealed class InterceptedMethod<T, R> implements UnsafeExecutable<T, R>,
     @Override
     public Argument<?>[] getArguments() {
         return arguments;
-    }
-
-    /**
-     * Soft resolves the target {@link Method} avoiding reflection until as late as possible.
-     *
-     * @return The method
-     * @throws NoSuchMethodError if the method doesn't exist
-     */
-    @Override
-    public Method getTargetMethod() {
-        if (method == null) {
-            Method resolvedMethod = ReflectionUtils.getRequiredMethod(declaringType, methodName, argTypes);
-            resolvedMethod.setAccessible(true);
-            this.method = resolvedMethod;
-        }
-        return this.method;
     }
 
     /**

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleTargetMethodSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/LifecycleTargetMethodSpec.groovy
@@ -1,0 +1,439 @@
+package io.micronaut.aop.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+/**
+ * A lifecycle event describes itself by the callback the bean declares, so an interceptor asking
+ * {@code getExecutableMethod().getTargetMethod()} is answered with the most derived callback of that kind.
+ *
+ * A bean may bind a lifecycle kind without declaring a callback of it: the binding on the class promises an
+ * interception regardless. Such an event has no target method and reports {@code null}, rather than looking up the
+ * synthetic {@code initialize} / {@code dispose} the chain names itself by, which no bean declares. Only the
+ * reflective {@link java.lang.reflect.Method} becomes {@code null}; {@code getMethodName()} still reports the
+ * synthetic name of the event.
+ */
+class LifecycleTargetMethodSpec extends AbstractTypeElementSpec {
+
+    void 'test a post construct event of a bean declaring no callback has no target method'() {
+        given:
+        ApplicationContext context = buildContext('''
+package targetmethod.postconstruct;
+
+import io.micronaut.aop.*;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.lang.reflect.Method;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Tracked {
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+class TrackingInterceptor implements MethodInterceptor<Object, Object> {
+    static int intercepted;
+    static String methodName;
+    static Method target;
+    static Method contextTarget;
+    static Throwable failure;
+    static Object proceeded;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> ctx) {
+        intercepted++;
+        methodName = ctx.getExecutableMethod().getMethodName();
+        try {
+            target = ctx.getExecutableMethod().getTargetMethod();
+            contextTarget = ctx.getTargetMethod();
+        } catch (Throwable e) {
+            failure = e;
+        }
+        proceeded = ctx.proceed();
+        return proceeded;
+    }
+}
+
+@Singleton
+@Tracked
+class NoCallbackBean {
+    String work() {
+        return "done";
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('targetmethod.postconstruct.TrackingInterceptor')
+        Class<?> beanType = context.classLoader.loadClass('targetmethod.postconstruct.NoCallbackBean')
+
+        when:
+        def bean = context.getBean(beanType)
+
+        then: 'the event was intercepted and has no target method'
+        interceptorType.intercepted == 1
+        interceptorType.failure == null
+        interceptorType.target == null
+
+        and: 'the context itself answers the same, since it delegates to the executable method'
+        interceptorType.contextTarget == null
+
+        and: 'proceed() is a no-op that returns the bean'
+        interceptorType.proceeded.is(bean)
+
+        and: 'only the reflective Method is null: the event still names itself'
+        interceptorType.methodName == 'initialize'
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a pre destroy event of a bean declaring no callback has no target method'() {
+        given:
+        ApplicationContext context = buildContext('''
+package targetmethod.predestroy;
+
+import io.micronaut.aop.*;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.lang.reflect.Method;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements MethodInterceptor<Object, Object> {
+    static int intercepted;
+    static String methodName;
+    static Method target;
+    static Method contextTarget;
+    static Throwable failure;
+    static Object proceeded;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> ctx) {
+        intercepted++;
+        methodName = ctx.getExecutableMethod().getMethodName();
+        try {
+            target = ctx.getExecutableMethod().getTargetMethod();
+            contextTarget = ctx.getTargetMethod();
+        } catch (Throwable e) {
+            failure = e;
+        }
+        proceeded = ctx.proceed();
+        return proceeded;
+    }
+}
+
+@Singleton
+@Tracked
+class NoCallbackBean {
+    String work() {
+        return "done";
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('targetmethod.predestroy.TrackingInterceptor')
+        Class<?> beanType = context.classLoader.loadClass('targetmethod.predestroy.NoCallbackBean')
+
+        when:
+        def bean = context.getBean(beanType)
+
+        then: 'nothing is intercepted before the bean is destroyed'
+        interceptorType.intercepted == 0
+
+        when:
+        context.stop()
+
+        then: 'the event was intercepted and has no target method'
+        interceptorType.intercepted == 1
+        interceptorType.failure == null
+        interceptorType.target == null
+
+        and: 'the context itself answers the same, since it delegates to the executable method'
+        interceptorType.contextTarget == null
+
+        and: 'proceed() is a no-op that returns the bean'
+        interceptorType.proceeded.is(bean)
+
+        and: 'only the reflective Method is null: the event still names itself'
+        interceptorType.methodName == 'dispose'
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a bound post construct event has no target method where the bean only declares a pre destroy callback'() {
+        given:
+        ApplicationContext context = buildContext('''
+package targetmethod.otherkind.post;
+
+import io.micronaut.aop.*;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.lang.reflect.Method;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Tracked {
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+class TrackingInterceptor implements MethodInterceptor<Object, Object> {
+    static int intercepted;
+    static String methodName;
+    static Method target;
+    static Throwable failure;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> ctx) {
+        intercepted++;
+        methodName = ctx.getExecutableMethod().getMethodName();
+        try {
+            target = ctx.getExecutableMethod().getTargetMethod();
+        } catch (Throwable e) {
+            failure = e;
+        }
+        return ctx.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    int destroys;
+
+    @PreDestroy
+    void close() {
+        destroys++;
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('targetmethod.otherkind.post.TrackingInterceptor')
+        Class<?> beanType = context.classLoader.loadClass('targetmethod.otherkind.post.MyBean')
+
+        when:
+        def bean = context.getBean(beanType)
+
+        then: 'the bound kind is intercepted and the callback of the other kind is not its target'
+        interceptorType.intercepted == 1
+        interceptorType.failure == null
+        interceptorType.target == null
+        interceptorType.methodName == 'initialize'
+
+        when: 'the unbound kind runs uninterceptedly'
+        context.stop()
+
+        then:
+        bean.destroys == 1
+        interceptorType.intercepted == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a bound pre destroy event has no target method where the bean only declares a post construct callback'() {
+        given:
+        ApplicationContext context = buildContext('''
+package targetmethod.otherkind.pre;
+
+import io.micronaut.aop.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.lang.reflect.Method;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements MethodInterceptor<Object, Object> {
+    static int intercepted;
+    static String methodName;
+    static Method target;
+    static Throwable failure;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> ctx) {
+        intercepted++;
+        methodName = ctx.getExecutableMethod().getMethodName();
+        try {
+            target = ctx.getExecutableMethod().getTargetMethod();
+        } catch (Throwable e) {
+            failure = e;
+        }
+        return ctx.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    int inits;
+
+    @PostConstruct
+    void init() {
+        inits++;
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('targetmethod.otherkind.pre.TrackingInterceptor')
+        Class<?> beanType = context.classLoader.loadClass('targetmethod.otherkind.pre.MyBean')
+
+        when: 'the unbound kind runs uninterceptedly'
+        def bean = context.getBean(beanType)
+
+        then:
+        bean.inits == 1
+        interceptorType.intercepted == 0
+
+        when:
+        context.stop()
+
+        then: 'the bound kind is intercepted and the callback of the other kind is not its target'
+        interceptorType.intercepted == 1
+        interceptorType.failure == null
+        interceptorType.target == null
+        interceptorType.methodName == 'dispose'
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the target method of an event is the callback the bean declares'() {
+        given:
+        ApplicationContext context = buildContext('''
+package targetmethod.declared;
+
+import io.micronaut.aop.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.lang.reflect.Method;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Tracked {
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+class TrackingInterceptor implements MethodInterceptor<Object, Object> {
+    static String methodName;
+    static Method target;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> ctx) {
+        methodName = ctx.getExecutableMethod().getMethodName();
+        target = ctx.getExecutableMethod().getTargetMethod();
+        return ctx.proceed();
+    }
+}
+
+@Singleton
+@Tracked
+class MyBean {
+    int inits;
+
+    @PostConstruct
+    void init() {
+        inits++;
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('targetmethod.declared.TrackingInterceptor')
+        Class<?> beanType = context.classLoader.loadClass('targetmethod.declared.MyBean')
+
+        when:
+        def bean = context.getBean(beanType)
+
+        then:
+        bean.inits == 1
+        interceptorType.methodName == 'init'
+        interceptorType.target == beanType.getDeclaredMethod('init')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the target method of an event is the most derived callback where a superclass declares one too'() {
+        given:
+        ApplicationContext context = buildContext('''
+package targetmethod.hierarchy;
+
+import io.micronaut.aop.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.lang.reflect.Method;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Tracked {
+}
+
+@Singleton
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+class TrackingInterceptor implements MethodInterceptor<Object, Object> {
+    static String methodName;
+    static Method target;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> ctx) {
+        methodName = ctx.getExecutableMethod().getMethodName();
+        target = ctx.getExecutableMethod().getTargetMethod();
+        return ctx.proceed();
+    }
+}
+
+class Base {
+    int baseInits;
+
+    @PostConstruct
+    void baseInit() {
+        baseInits++;
+    }
+}
+
+@Singleton
+@Tracked
+class Sub extends Base {
+    int subInits;
+
+    @PostConstruct
+    void subInit() {
+        subInits++;
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('targetmethod.hierarchy.TrackingInterceptor')
+        Class<?> subType = context.classLoader.loadClass('targetmethod.hierarchy.Sub')
+
+        when:
+        def bean = context.getBean(subType)
+
+        then: 'both callbacks ran under the one event'
+        bean.baseInits == 1
+        bean.subInits == 1
+
+        and: 'the event describes itself by the most derived callback'
+        interceptorType.methodName == 'subInit'
+        interceptorType.target == subType.getDeclaredMethod('subInit')
+
+        cleanup:
+        context.close()
+    }
+}


### PR DESCRIPTION
A bean may bind `POST_CONSTRUCT` or `PRE_DESTROY` without declaring a callback of that kind. This is deliberately supported — the binding on the class promises an interception either way, the documented `ProductBean` example in the guide relies on it, and `InitializableIntercepted.initialize` has a comment saying so.

For such an event, a Micronaut-native `MethodInterceptor` inspecting what it is intercepting got:

```
PROBE kind=POST_CONSTRUCT name=initialize declaring=NoCallbackBean
PROBE getTargetMethod THREW java.lang.NoSuchMethodError:
      Required method initialize() not found for class: ...NoCallbackBean.
      Most likely cause of this error is the method declaration is not annotated with @Executable. ...
```

`InitializableInterceptedMethod.getTargetMethod()` (and `InterceptedDisposeMethod`) answers with the bean's real callback where it declares one. Where it declares none it fell through to `InterceptedMethod.getTargetMethod()`, which resolves the synthetic name the chain calls itself by — `initialize`, or `dispose` for pre-destroy — against the bean type. No bean declares such a method, so it threw. The `@Executable` advice in that message sends the reader somewhere irrelevant, which is a further reason not to reach the path.

`MethodInvocationContext.getTargetMethod()` delegates to the same object, so it threw too; both are fixed by the one change.

## What changed

- Both overrides return `null` when the bean declares no callback of that kind, and say so in the javadoc.
- The declaring packages (`io.micronaut.aop.beandefinition`, `io.micronaut.inject`) are `@NullMarked`, so `MethodReference.getTargetMethod()` is *implicitly* non-null even though it carries no annotation. The overrides therefore declare `@Nullable` explicitly and suppress NullAway locally, rather than widening the interface — a contract every other implementation keeps. Suppressing at the override is the narrowest option; NullAway rejects the widening otherwise.
- With both permitted subclasses of the sealed `InterceptedMethod` now supplying their own, the base class's reflective lookup became unreachable, so it and its cache field are removed with it.

Resolving `initialize(BeanResolutionContext, BeanContext, T)` on the bean definition was deliberately **not** used as a substitute: it is a real method, but it is container plumbing rather than anything an interceptor asked about.

## Tests

Six cases in a new `LifecycleTargetMethodSpec`, beside the existing lifecycle specs:

1. `POST_CONSTRUCT` bound, no callback declared → `null`, and `proceed()` still returns the bean.
2. Same for `PRE_DESTROY`.
3. Bound for one kind while declaring a callback of the *other* kind → the bound kind returns `null` and the interception still runs (both directions).
4. Regression: bean declaring one callback → that callback's `Method`, unchanged.
5. Regression: superclass callback plus the bean's own → the bean's own, unchanged from #13019.
6. In the no-callback case `getMethodName()` still reports the synthetic `initialize` / `dispose` — only the reflective `Method` becomes `null`. Asserted so the two are not conflated later.

The four new-behaviour cases fail on an unmodified checkout with exactly the `NoSuchMethodError` above; the two regression cases pass either way.

`./gradlew :micronaut-aop:test :micronaut-inject-java:test --rerun-tasks` — 5191 → 5197 tests, 0 failures, 9 skipped, before and after. (`:micronaut-aop:test` has no test sources and contributes 0.)

Found while bringing micronaut-jakarta-interceptors to full CDI TCK conformance; flagged as a follow-up in the #13019 PR body. That module is not itself affected — its `LifecycleInvocationContext.getMethod()` walks the class hierarchy and never calls `getTargetMethod()` for a lifecycle event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)