### PR TITLE
Keep the bounds of a type variable on the argument it compiles to

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
@@ -119,6 +119,17 @@ public final class ArgumentExpUtils {
         Class.class
     );
 
+    private static final Method METHOD_CREATE_TYPE_VAR_WITH_BOUNDS = ReflectionUtils.getRequiredInternalMethod(
+        Argument.class,
+        "ofTypeVariable",
+        Class.class,
+        String.class,
+        String.class,
+        AnnotationMetadata.class,
+        Argument[].class,
+        Argument[].class
+    );
+
     private static final Method METHOD_CREATE_WILDCARD = ReflectionUtils.getRequiredInternalMethod(
         Argument.class,
         "ofWildcard",
@@ -258,6 +269,8 @@ public final class ArgumentExpUtils {
 
         boolean hasAnnotations = !annotationMetadata.isEmpty();
         boolean hasTypeArguments = typeArguments != null && !typeArguments.isEmpty();
+        // The bounds are read from the placeholder, before it is replaced by the type it resolves to
+        List<? extends ClassElement> bounds = recordedBounds(argumentType);
         if (argumentType instanceof GenericPlaceholderElement placeholderElement) {
             // Persist resolved placeholder for backward compatibility
             argumentType = placeholderElement.getResolved().orElse(placeholderElement);
@@ -317,6 +330,18 @@ public final class ArgumentExpUtils {
         }
 
         if (isTypeVariable) {
+            if (!bounds.isEmpty()) {
+                // Argument.ofTypeVariable( .. ) keeping the bounds declared for the variable
+                return TYPE_ARGUMENT.invokeStatic(
+                    METHOD_CREATE_TYPE_VAR_WITH_BOUNDS,
+                    argumentTypeConstant,
+                    ExpressionDef.constant(argumentName),
+                    hasVariableName ? ExpressionDef.constant(variableName) : ExpressionDef.nullValue(),
+                    values.get(values.size() - 2),
+                    values.get(values.size() - 1),
+                    pushBounds(annotationMetadataWithDefaults, owningType, bounds, new HashSet<>(5), loadClassValueExpressionFn)
+                );
+            }
             // Argument.create( .. )
             return TYPE_ARGUMENT.invokeStatic(
                 hasVariableName ? METHOD_CREATE_GENERIC_PLACEHOLDER_WITH_ANNOTATION_METADATA_GENERICS : METHOD_CREATE_TYPE_VAR_WITH_ANNOTATION_METADATA_GENERICS,
@@ -417,7 +442,8 @@ public final class ArgumentExpUtils {
             Map<String, ClassElement> typeArguments = classElement.getTypeArguments();
             if (CollectionUtils.isNotEmpty(typeArguments)
                 || !classElement.getAnnotationMetadata().isEmpty()
-                || classElement instanceof WildcardElement) {
+                || classElement instanceof WildcardElement
+                || !recordedBounds(classElement).isEmpty()) {
                 return buildArgumentWithGenerics(
                     annotationMetadataWithDefaults,
                     owningType,
@@ -455,6 +481,9 @@ public final class ArgumentExpUtils {
         ExpressionDef.Constant argumentTypeConstant = ExpressionDef.constant(TypeDef.erasure(resolveArgument(argumentType)));
 
         List<ExpressionDef> values = new ArrayList<>();
+
+        // The bounds are read from the placeholder, before it is replaced by the type it resolves to
+        List<? extends ClassElement> bounds = recordedBounds(argumentType);
 
         if (argumentType instanceof GenericPlaceholderElement placeholderElement) {
             // Persist resolved placeholder for backward compatibility
@@ -534,10 +563,24 @@ public final class ArgumentExpUtils {
                 upperBounds = wildcardElement.getUpperBounds();
             }
             // 5th and 6th arguments: the bounds
-            values.add(pushWildcardBounds(annotationMetadataWithDefaults, owningType, upperBounds, visitedTypes, loadClassValueExpressionFn));
-            values.add(pushWildcardBounds(annotationMetadataWithDefaults, owningType, lowerBounds, visitedTypes, loadClassValueExpressionFn));
+            values.add(pushBounds(annotationMetadataWithDefaults, owningType, upperBounds, visitedTypes, loadClassValueExpressionFn));
+            values.add(pushBounds(annotationMetadataWithDefaults, owningType, lowerBounds, visitedTypes, loadClassValueExpressionFn));
             // Argument.ofWildcard( .. )
             return TYPE_ARGUMENT.invokeStatic(METHOD_CREATE_WILDCARD, values);
+        }
+
+        if (typeVariable && !bounds.isEmpty()) {
+            // Argument.ofTypeVariable( .. ) keeping the bounds declared for the variable
+            return TYPE_ARGUMENT.invokeStatic(
+                METHOD_CREATE_TYPE_VAR_WITH_BOUNDS,
+                values.get(0),
+                values.get(1),
+                // The variable name is the argument name here, as it was before the bounds were kept
+                ExpressionDef.nullValue(),
+                values.get(2),
+                values.get(3),
+                pushBounds(annotationMetadataWithDefaults, owningType, bounds, visitedTypes, loadClassValueExpressionFn)
+            );
         }
 
         // Argument.create( .. )
@@ -547,11 +590,30 @@ public final class ArgumentExpUtils {
         );
     }
 
-    private static ExpressionDef pushWildcardBounds(AnnotationMetadata annotationMetadataWithDefaults,
-                                                    ClassTypeDef owningType,
-                                                    List<? extends ClassElement> bounds,
-                                                    Set<Object> visitedTypes,
-                                                    Function<String, ExpressionDef> loadClassValueExpressionFn) {
+    /**
+     * The bounds to record for a type variable, empty when the type the variable compiles to already says what
+     * they are: a variable with a single bound erases to that bound, so only several bounds, or a resolved
+     * variable whose erasure is no longer its bound, need them written out.
+     *
+     * @param element The element
+     * @return The bounds to record
+     */
+    private static List<? extends ClassElement> recordedBounds(TypedElement element) {
+        if (element instanceof WildcardElement || !(element instanceof GenericPlaceholderElement placeholderElement)) {
+            return List.of();
+        }
+        List<? extends ClassElement> bounds = placeholderElement.getBounds();
+        if (bounds.size() < 2 && placeholderElement.getResolved().isEmpty()) {
+            return List.of();
+        }
+        return bounds;
+    }
+
+    private static ExpressionDef pushBounds(AnnotationMetadata annotationMetadataWithDefaults,
+                                            ClassTypeDef owningType,
+                                            List<? extends ClassElement> bounds,
+                                            Set<Object> visitedTypes,
+                                            Function<String, ExpressionDef> loadClassValueExpressionFn) {
         if (bounds.isEmpty()) {
             return ExpressionDef.nullValue();
         }

--- a/core/src/main/java/io/micronaut/core/type/Argument.java
+++ b/core/src/main/java/io/micronaut/core/type/Argument.java
@@ -376,6 +376,30 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     }
 
     /**
+     * Creates a new argument for the given type and name that is a type variable, keeping the bounds declared
+     * for the variable. See {@link GenericPlaceholder#getBounds()}.
+     *
+     * @param type               The type the variable erases to
+     * @param argumentName       The name of the argument
+     * @param variableName       The variable name, {@code null} when it is the argument name
+     * @param annotationMetadata The annotation metadata
+     * @param typeParameters     The type parameters
+     * @param bounds             The declared bounds, {@code null} when they are not recorded
+     * @param <T>                The generic type
+     * @return The argument instance
+     * @since 5.2.0
+     */
+    @UsedByGeneratedCode
+    static <T> Argument<T> ofTypeVariable(Class<T> type,
+                                          @Nullable String argumentName,
+                                          @Nullable String variableName,
+                                          @Nullable AnnotationMetadata annotationMetadata,
+                                          Argument<?> @Nullable [] typeParameters,
+                                          Argument<?> @Nullable [] bounds) {
+        return new DefaultGenericPlaceholder<>(type, argumentName, variableName, annotationMetadata, typeParameters, bounds);
+    }
+
+    /**
      * Creates an argument that stands for a wildcard type argument, compiled to the type it is bounded by.
      * See {@link WildcardArgument}.
      *

--- a/core/src/main/java/io/micronaut/core/type/DefaultGenericPlaceholder.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultGenericPlaceholder.java
@@ -40,6 +40,11 @@ final class DefaultGenericPlaceholder<T>
      */
     @Nullable
     private final List<Argument<?>> bounds;
+    /**
+     * The type the variable erases to, answered when no bounds were recorded, computed once.
+     */
+    @Nullable
+    private List<Argument<?>> erasedBounds;
 
     /**
      * Constructor for where@author variable name and argument name are@author same.
@@ -112,7 +117,15 @@ final class DefaultGenericPlaceholder<T>
 
     @Override
     public List<Argument<?>> getBounds() {
-        return bounds != null ? bounds : GenericPlaceholder.super.getBounds();
+        if (bounds != null) {
+            return bounds;
+        }
+        List<Argument<?>> erased = erasedBounds;
+        if (erased == null) {
+            erased = GenericPlaceholder.super.getBounds();
+            erasedBounds = erased;
+        }
+        return erased;
     }
 
     @Override
@@ -127,7 +140,9 @@ final class DefaultGenericPlaceholder<T>
 
     @Override
     public Argument<T> withName(@Nullable String name) {
-        return new DefaultGenericPlaceholder<>(getType(), name, variableName, getAnnotationMetadata(), getTypeParameters(), bounds);
+        // Renaming the argument does not rename the variable it stands for, so an implicit variable name,
+        // the name this argument was given, is resolved before the new one replaces it
+        return new DefaultGenericPlaceholder<>(getType(), name, getVariableName(), getAnnotationMetadata(), getTypeParameters(), bounds);
     }
 
     @Override

--- a/core/src/main/java/io/micronaut/core/type/DefaultGenericPlaceholder.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultGenericPlaceholder.java
@@ -19,6 +19,8 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
+
 /**
  * Implementation of {@link GenericPlaceholder}.
  *
@@ -30,7 +32,14 @@ final class DefaultGenericPlaceholder<T>
         extends DefaultArgument<T>
         implements GenericPlaceholder<T> {
     @Nullable
+    private final String name;
+    @Nullable
     private final String variableName;
+    /**
+     * The declared bounds, or {@code null} when they were not recorded.
+     */
+    @Nullable
+    private final List<Argument<?>> bounds;
 
     /**
      * Constructor for where@author variable name and argument name are@author same.
@@ -45,8 +54,7 @@ final class DefaultGenericPlaceholder<T>
             @Nullable String name,
             @Nullable AnnotationMetadata annotationMetadata,
             Argument<?> @Nullable ... genericTypes) {
-        super(type, name, annotationMetadata, genericTypes);
-        this.variableName = name;
+        this(type, name, name, annotationMetadata, genericTypes, (List<Argument<?>>) null);
     }
 
     /**
@@ -64,8 +72,47 @@ final class DefaultGenericPlaceholder<T>
             String variableName,
             @Nullable AnnotationMetadata annotationMetadata,
             Argument<?>... genericTypes) {
+        this(type, name, variableName, annotationMetadata, genericTypes, (List<Argument<?>>) null);
+    }
+
+    /**
+     * Constructor for a placeholder that keeps the bounds declared for its type variable.
+     *
+     * @param type               The type
+     * @param name               The name
+     * @param variableName       The variable name, {@code null} when it is the argument name
+     * @param annotationMetadata The annotation metadata
+     * @param genericTypes       The generic types
+     * @param bounds             The declared bounds, {@code null} or empty when they were not recorded
+     * @since 5.2.0
+     */
+    DefaultGenericPlaceholder(
+            Class<T> type,
+            @Nullable String name,
+            @Nullable String variableName,
+            @Nullable AnnotationMetadata annotationMetadata,
+            Argument<?> @Nullable [] genericTypes,
+            Argument<?> @Nullable [] bounds) {
+        this(type, name, variableName, annotationMetadata, genericTypes,
+            bounds == null || bounds.length == 0 ? null : List.of(bounds));
+    }
+
+    private DefaultGenericPlaceholder(
+            Class<T> type,
+            @Nullable String name,
+            @Nullable String variableName,
+            @Nullable AnnotationMetadata annotationMetadata,
+            Argument<?> @Nullable [] genericTypes,
+            @Nullable List<Argument<?>> bounds) {
         super(type, name, annotationMetadata, genericTypes);
+        this.name = name;
         this.variableName = variableName;
+        this.bounds = bounds;
+    }
+
+    @Override
+    public List<Argument<?>> getBounds() {
+        return bounds != null ? bounds : GenericPlaceholder.super.getBounds();
     }
 
     @Override
@@ -76,5 +123,15 @@ final class DefaultGenericPlaceholder<T>
     @Override
     public boolean isTypeVariable() {
         return true;
+    }
+
+    @Override
+    public Argument<T> withName(@Nullable String name) {
+        return new DefaultGenericPlaceholder<>(getType(), name, variableName, getAnnotationMetadata(), getTypeParameters(), bounds);
+    }
+
+    @Override
+    public Argument<T> withAnnotationMetadata(AnnotationMetadata annotationMetadata) {
+        return new DefaultGenericPlaceholder<>(getType(), name, variableName, annotationMetadata, getTypeParameters(), bounds);
     }
 }

--- a/core/src/main/java/io/micronaut/core/type/GenericPlaceholder.java
+++ b/core/src/main/java/io/micronaut/core/type/GenericPlaceholder.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.core.type;
 
+import io.micronaut.core.annotation.Experimental;
+
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -26,6 +29,27 @@ import java.util.Objects;
  * @since 3.2.0
  */
 public interface GenericPlaceholder<T> extends Argument<T> {
+
+    /**
+     * The bounds declared for the type variable this placeholder stands for: the {@code Payment} and
+     * {@code Refundable} of {@code <T extends Payment & Refundable>}.
+     *
+     * <p>The annotation processors compile a type variable to an argument of the type it erases to, so
+     * {@link #getType()} stays the first bound, or the type the variable was resolved to; the bounds are kept
+     * alongside, the way {@link java.lang.reflect.TypeVariable#getBounds()} reports them: a variable that
+     * declares no bound is bounded by {@code Object}. They are not considered by {@link #equals(Object)},
+     * {@link #equalsType(Argument)} or {@link #typeHashCode()}.</p>
+     *
+     * <p>A placeholder that carries no recorded bounds, one built by hand or compiled before the bounds were
+     * recorded, answers the type it erases to.</p>
+     *
+     * @return The bounds, never empty
+     * @since 5.2.0
+     */
+    @Experimental
+    default List<Argument<?>> getBounds() {
+        return List.of(Argument.of(getType(), (String) null, getTypeParameters()));
+    }
 
     /**
      * @return The variable name, never {@code null}.

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.generics
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.GenericPlaceholder
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ExecutableMethod
+import spock.lang.Shared
+import spock.lang.Unroll
+
+class TypeVariableBoundsSpec extends AbstractBeanDefinitionSpec {
+
+    private static final String SOURCE = '''
+package test
+
+import io.micronaut.context.annotation.Executable
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+interface Payment {}
+interface Refundable {}
+interface Event<T> {}
+
+@Singleton
+class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<String> & Refundable> {
+
+    @Inject Event<T> field
+
+    Bean(Event<T> several,
+         Event<S> one,
+         Event<U> none,
+         Event<P> parameterizedBound,
+         Event<Payment> concrete,
+         T direct) {}
+
+    @Inject
+    void inject(Event<T> injected) {}
+
+    @Executable
+    public <M extends Payment & Refundable> void observe(Event<M> event, M directMethodVariable) {}
+
+    @Executable
+    Event<T> returns() { null }
+}
+'''
+
+    @Shared BeanDefinition<?> definition
+
+    def setupSpec() {
+        definition = buildBeanDefinition('test.Bean', SOURCE)
+    }
+
+    private static List<String> bounds(Argument<?> argument) {
+        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
+    }
+
+    private Map<String, Argument<?>> constructorArguments() {
+        definition.constructor.arguments.collectEntries { [it.name, it] }
+    }
+
+    private ExecutableMethod<?, ?> method(String name) {
+        definition.executableMethods.find { it.methodName == name }
+    }
+
+    @Unroll
+    void "the type argument of constructor parameter #name erases to #type and keeps the bounds #declared"() {
+        given:
+        Argument<?> typeArgument = constructorArguments()[name].typeParameters[0]
+
+        expect:
+        typeArgument.type.name == type
+        typeArgument.isTypeVariable() == isVariable
+        bounds(typeArgument) == declared
+
+        where:
+        name                 | type               | isVariable | declared
+        'several'            | 'test.Payment'     | true       | ['test.Payment', 'test.Refundable']
+        'one'                | 'test.Payment'     | true       | ['test.Payment']
+        'none'               | 'java.lang.Object' | true       | ['java.lang.Object']
+        'parameterizedBound' | 'java.util.List'   | true       | ['java.util.List', 'test.Refundable']
+        'concrete'           | 'test.Payment'     | false      | null
+    }
+
+    void "a bound keeps its own type arguments"() {
+        given:
+        Argument<?> variable = constructorArguments().parameterizedBound.typeParameters[0]
+
+        expect:
+        variable.typeParameters[0].type == String
+
+        and: 'both when the bounds are recorded'
+        bounds(variable) == ['java.util.List', 'test.Refundable']
+        ((GenericPlaceholder<?>) variable).bounds[0].typeParameters[0].type == String
+
+        and: 'and when the single bound is the erasure the variable compiles to'
+        Argument<?> single = constructorArguments().one.typeParameters[0]
+        ((GenericPlaceholder<?>) single).bounds[0].type.name == 'test.Payment'
+    }
+
+    void "the bounds are kept for a type variable that is the argument itself"() {
+        given:
+        Argument<?> direct = constructorArguments().direct
+
+        expect:
+        direct.type.name == 'test.Payment'
+        bounds(direct) == ['test.Payment', 'test.Refundable']
+        ((GenericPlaceholder<?>) direct).variableName == 'T'
+    }
+
+    void "the bounds are kept for an injected property and an injected method parameter"() {
+        given: 'the field is injected through the property setter Groovy generates for it'
+        def setField = definition.injectedMethods.find { it.name == 'setField' }
+        def inject = definition.injectedMethods.find { it.name == 'inject' }
+
+        expect:
+        bounds(setField.arguments[0].typeParameters[0]) == ['test.Payment', 'test.Refundable']
+        bounds(inject.arguments[0].typeParameters[0]) == ['test.Payment', 'test.Refundable']
+    }
+
+    void "the bounds of a method type variable are kept"() {
+        given:
+        Map<String, Argument<?>> arguments = method('observe').arguments.collectEntries { [it.name, it] }
+
+        expect:
+        bounds(arguments.event.typeParameters[0]) == ['test.Payment', 'test.Refundable']
+        bounds(arguments.directMethodVariable) == ['test.Payment', 'test.Refundable']
+    }
+
+    void "the bounds are kept for an executable method return type"() {
+        expect:
+        bounds(method('returns').returnType.asArgument().typeParameters[0]) == ['test.Payment', 'test.Refundable']
+    }
+
+    void "a renamed variable keeps its bounds"() {
+        given:
+        Argument<?> variable = constructorArguments().several.typeParameters[0]
+        Argument<?> renamed = variable.withName('other')
+
+        expect:
+        renamed instanceof GenericPlaceholder
+        renamed.name == 'other'
+        bounds(renamed) == ['test.Payment', 'test.Refundable']
+        bounds(variable.withAnnotationMetadata(variable.annotationMetadata)) == ['test.Payment', 'test.Refundable']
+
+        and: 'the bounds do not take part in equality'
+        variable == Argument.ofTypeVariable(variable.type, variable.name)
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
@@ -155,6 +155,10 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
         renamed instanceof GenericPlaceholder
         renamed.name == 'other'
         bounds(renamed) == ['test.Payment', 'test.Refundable']
+
+        and: 'renaming the argument does not rename the variable it stands for'
+        ((GenericPlaceholder<?>) renamed).variableName == ((GenericPlaceholder<?>) variable).variableName
+        ((GenericPlaceholder<?>) variable).variableName != null
         bounds(variable.withAnnotationMetadata(variable.annotationMetadata)) == ['test.Payment', 'test.Refundable']
 
         and: 'the bounds do not take part in equality'

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.generics
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.GenericPlaceholder
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ExecutableMethod
+import spock.lang.Shared
+import spock.lang.Unroll
+
+class TypeVariableBoundsSpec extends AbstractTypeElementSpec {
+
+    private static final String SOURCE = '''
+package test;
+
+import io.micronaut.context.annotation.Executable;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.List;
+
+interface Payment {}
+interface Refundable {}
+interface Event<T> {}
+
+@Singleton
+class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<String> & Refundable> {
+
+    @Inject Event<T> field;
+
+    Bean(Event<T> several,
+         Event<S> one,
+         Event<U> none,
+         Event<P> parameterizedBound,
+         Event<Payment> concrete,
+         T direct) {}
+
+    @Inject
+    void inject(Event<T> injected) {}
+
+    @Executable
+    <M extends Payment & Refundable> void observe(Event<M> event, M directMethodVariable) {}
+
+    @Executable
+    Event<T> returns() { return null; }
+}
+'''
+
+    @Shared BeanDefinition<?> definition
+
+    def setupSpec() {
+        definition = buildBeanDefinition('test.Bean', SOURCE)
+    }
+
+    private static List<String> bounds(Argument<?> argument) {
+        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
+    }
+
+    private Map<String, Argument<?>> constructorArguments() {
+        definition.constructor.arguments.collectEntries { [it.name, it] }
+    }
+
+    private ExecutableMethod<?, ?> method(String name) {
+        definition.executableMethods.find { it.methodName == name }
+    }
+
+    @Unroll
+    void "the type argument of constructor parameter #name erases to #type and keeps the bounds #declared"() {
+        given:
+        Argument<?> typeArgument = constructorArguments()[name].typeParameters[0]
+
+        expect:
+        typeArgument.type.name == type
+        typeArgument.isTypeVariable() == isVariable
+        bounds(typeArgument) == declared
+
+        where:
+        name                 | type               | isVariable | declared
+        'several'            | 'test.Payment'     | true       | ['test.Payment', 'test.Refundable']
+        'one'                | 'test.Payment'     | true       | ['test.Payment']
+        'none'               | 'java.lang.Object' | true       | ['java.lang.Object']
+        'parameterizedBound' | 'java.util.List'   | true       | ['java.util.List', 'test.Refundable']
+        'concrete'           | 'test.Payment'     | false      | null
+    }
+
+    void "a bound keeps its own type arguments"() {
+        given:
+        Argument<?> variable = constructorArguments().parameterizedBound.typeParameters[0]
+
+        expect:
+        variable.typeParameters[0].type == String
+
+        and: 'both when the bounds are recorded'
+        bounds(variable) == ['java.util.List', 'test.Refundable']
+        ((GenericPlaceholder<?>) variable).bounds[0].typeParameters[0].type == String
+
+        and: 'and when the single bound is the erasure the variable compiles to'
+        Argument<?> single = constructorArguments().one.typeParameters[0]
+        ((GenericPlaceholder<?>) single).bounds[0].type.name == 'test.Payment'
+    }
+
+    void "the bounds are kept for a type variable that is the argument itself"() {
+        given:
+        Argument<?> direct = constructorArguments().direct
+
+        expect:
+        direct.type.name == 'test.Payment'
+        bounds(direct) == ['test.Payment', 'test.Refundable']
+        ((GenericPlaceholder<?>) direct).variableName == 'T'
+    }
+
+    void "the bounds are kept for an injected field and an injected method parameter"() {
+        given:
+        Argument<?> field = definition.injectedFields.find { it.name == 'field' }.asArgument().typeParameters[0]
+        def inject = definition.injectedMethods.find { it.name == 'inject' }
+
+        expect:
+        bounds(field) == ['test.Payment', 'test.Refundable']
+        bounds(inject.arguments[0].typeParameters[0]) == ['test.Payment', 'test.Refundable']
+    }
+
+    void "the bounds of a method type variable are kept"() {
+        given:
+        Map<String, Argument<?>> arguments = method('observe').arguments.collectEntries { [it.name, it] }
+
+        expect:
+        bounds(arguments.event.typeParameters[0]) == ['test.Payment', 'test.Refundable']
+        bounds(arguments.directMethodVariable) == ['test.Payment', 'test.Refundable']
+    }
+
+    void "the bounds are kept for an executable method return type"() {
+        expect:
+        bounds(method('returns').returnType.asArgument().typeParameters[0]) == ['test.Payment', 'test.Refundable']
+    }
+
+    void "a renamed variable keeps its bounds"() {
+        given:
+        Argument<?> variable = constructorArguments().several.typeParameters[0]
+        Argument<?> renamed = variable.withName('other')
+
+        expect:
+        renamed instanceof GenericPlaceholder
+        renamed.name == 'other'
+        bounds(renamed) == ['test.Payment', 'test.Refundable']
+        bounds(variable.withAnnotationMetadata(variable.annotationMetadata)) == ['test.Payment', 'test.Refundable']
+
+        and: 'the bounds do not take part in equality'
+        variable == Argument.ofTypeVariable(variable.type, variable.name)
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
@@ -156,6 +156,10 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
         renamed instanceof GenericPlaceholder
         renamed.name == 'other'
         bounds(renamed) == ['test.Payment', 'test.Refundable']
+
+        and: 'renaming the argument does not rename the variable it stands for'
+        ((GenericPlaceholder<?>) renamed).variableName == ((GenericPlaceholder<?>) variable).variableName
+        ((GenericPlaceholder<?>) variable).variableName != null
         bounds(variable.withAnnotationMetadata(variable.annotationMetadata)) == ['test.Payment', 'test.Refundable']
 
         and: 'the bounds do not take part in equality'

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/TypeVariableBoundsSpec.groovy
@@ -156,6 +156,10 @@ class Bean<T, S : Payment, U, P>(
         renamed instanceof GenericPlaceholder
         renamed.name == 'other'
         bounds(renamed) == ['test.Payment', 'test.Refundable']
+
+        and: 'renaming the argument does not rename the variable it stands for'
+        ((GenericPlaceholder<?>) renamed).variableName == ((GenericPlaceholder<?>) variable).variableName
+        ((GenericPlaceholder<?>) variable).variableName != null
         bounds(variable.withAnnotationMetadata(variable.annotationMetadata)) == ['test.Payment', 'test.Refundable']
 
         and: 'the bounds do not take part in equality'

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/TypeVariableBoundsSpec.groovy
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.processing.inject.generics
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.GenericPlaceholder
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ExecutableMethod
+import spock.lang.Shared
+import spock.lang.Unroll
+
+class TypeVariableBoundsSpec extends AbstractKotlinCompilerSpec {
+
+    private static final String SOURCE = '''
+package test
+
+import io.micronaut.context.annotation.Executable
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+interface Payment
+interface Refundable
+interface Event<T>
+
+@Singleton
+class Bean<T, S : Payment, U, P>(
+    val several: Event<T>,
+    val one: Event<S>,
+    val none: Event<U>,
+    val parameterizedBound: Event<P>,
+    val concrete: Event<Payment>,
+    val direct: T
+) where T : Payment, T : Refundable, P : java.util.List<String>, P : Refundable {
+
+    @Inject
+    lateinit var field: Event<T>
+
+    @Inject
+    fun inject(injected: Event<T>) {}
+
+    @Executable
+    fun <M> observe(event: Event<M>, directMethodVariable: M) where M : Payment, M : Refundable {}
+
+    @Executable
+    fun returns(): Event<T>? = null
+}
+'''
+
+    @Shared BeanDefinition<?> definition
+
+    def setupSpec() {
+        definition = buildBeanDefinition('test.Bean', SOURCE)
+    }
+
+    private static List<String> bounds(Argument<?> argument) {
+        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
+    }
+
+    private Map<String, Argument<?>> constructorArguments() {
+        definition.constructor.arguments.collectEntries { [it.name, it] }
+    }
+
+    private ExecutableMethod<?, ?> method(String name) {
+        definition.executableMethods.find { it.methodName == name }
+    }
+
+    @Unroll
+    void "the type argument of constructor parameter #name erases to #type and keeps the bounds #declared"() {
+        given:
+        Argument<?> typeArgument = constructorArguments()[name].typeParameters[0]
+
+        expect:
+        typeArgument.type.name == type
+        typeArgument.isTypeVariable() == isVariable
+        bounds(typeArgument) == declared
+
+        where:
+        name                 | type               | isVariable | declared
+        'several'            | 'test.Payment'     | true       | ['test.Payment', 'test.Refundable']
+        'one'                | 'test.Payment'     | true       | ['test.Payment']
+        'none'               | 'java.lang.Object' | true       | ['java.lang.Object']
+        'parameterizedBound' | 'java.util.List'   | true       | ['java.util.List', 'test.Refundable']
+        'concrete'           | 'test.Payment'     | false      | null
+    }
+
+    void "a bound keeps its own type arguments"() {
+        given:
+        Argument<?> variable = constructorArguments().parameterizedBound.typeParameters[0]
+
+        expect:
+        variable.typeParameters[0].type == String
+
+        and: 'both when the bounds are recorded'
+        bounds(variable) == ['java.util.List', 'test.Refundable']
+        ((GenericPlaceholder<?>) variable).bounds[0].typeParameters[0].type == String
+
+        and: 'and when the single bound is the erasure the variable compiles to'
+        Argument<?> single = constructorArguments().one.typeParameters[0]
+        ((GenericPlaceholder<?>) single).bounds[0].type.name == 'test.Payment'
+    }
+
+    void "the bounds are kept for a type variable that is the argument itself"() {
+        given:
+        Argument<?> direct = constructorArguments().direct
+
+        expect:
+        direct.type.name == 'test.Payment'
+        bounds(direct) == ['test.Payment', 'test.Refundable']
+        ((GenericPlaceholder<?>) direct).variableName == 'T'
+    }
+
+    void "the bounds are kept for an injected property and an injected method parameter"() {
+        given: 'the property is injected through its setter'
+        def setField = definition.injectedMethods.find { it.name == 'setField' }
+        def inject = definition.injectedMethods.find { it.name == 'inject' }
+
+        expect:
+        bounds(setField.arguments[0].typeParameters[0]) == ['test.Payment', 'test.Refundable']
+        bounds(inject.arguments[0].typeParameters[0]) == ['test.Payment', 'test.Refundable']
+    }
+
+    void "the bounds of a method type variable are kept"() {
+        given:
+        Map<String, Argument<?>> arguments = method('observe').arguments.collectEntries { [it.name, it] }
+
+        expect:
+        bounds(arguments.event.typeParameters[0]) == ['test.Payment', 'test.Refundable']
+        bounds(arguments.directMethodVariable) == ['test.Payment', 'test.Refundable']
+    }
+
+    void "the bounds are kept for an executable method return type"() {
+        expect:
+        bounds(method('returns').returnType.asArgument().typeParameters[0]) == ['test.Payment', 'test.Refundable']
+    }
+
+    void "a renamed variable keeps its bounds"() {
+        given:
+        Argument<?> variable = constructorArguments().several.typeParameters[0]
+        Argument<?> renamed = variable.withName('other')
+
+        expect:
+        renamed instanceof GenericPlaceholder
+        renamed.name == 'other'
+        bounds(renamed) == ['test.Payment', 'test.Refundable']
+        bounds(variable.withAnnotationMetadata(variable.annotationMetadata)) == ['test.Payment', 'test.Refundable']
+
+        and: 'the bounds do not take part in equality'
+        variable == Argument.ofTypeVariable(variable.type, variable.name)
+    }
+}

--- a/reflection/src/main/java/io/micronaut/reflection/MethodHierarchy.java
+++ b/reflection/src/main/java/io/micronaut/reflection/MethodHierarchy.java
@@ -201,7 +201,8 @@ public record MethodHierarchy(Declaration local,
         AnnotationMetadata metadata = mergeMetadata(levels.stream().map(Argument::getAnnotationMetadata).toList());
         if (local instanceof GenericPlaceholder<?> placeholder) {
             // a variable stays a variable: an overriding `<T> T id(T)` is a placeholder to a generated method
-            return Argument.ofTypeVariable((Class) local.getType(), local.getName(), placeholder.getVariableName(), metadata, typeParameters);
+            return Argument.ofTypeVariable((Class) local.getType(), local.getName(), placeholder.getVariableName(), metadata, typeParameters,
+                placeholder.getBounds().toArray(Argument[]::new));
         }
         return Argument.of((Class) local.getType(), local.getName(), metadata, typeParameters);
     }
@@ -529,7 +530,8 @@ public record MethodHierarchy(Declaration local,
             AnnotationMetadata declared = declaredOf(argument.getAnnotationMetadata());
             if (argument instanceof GenericPlaceholder<?> placeholder) {
                 // a variable stays a variable: `<T> T id(T)` returns a placeholder to a generated method
-                return Argument.ofTypeVariable((Class) returnType.getType(), null, placeholder.getVariableName(), declared, returnType.getTypeParameters());
+                return Argument.ofTypeVariable((Class) returnType.getType(), null, placeholder.getVariableName(), declared, returnType.getTypeParameters(),
+                    placeholder.getBounds().toArray(Argument[]::new));
             }
             return Argument.of((Class) returnType.getType(), declared, returnType.getTypeParameters());
         }

--- a/reflection/src/main/java/io/micronaut/reflection/ReflectionArguments.java
+++ b/reflection/src/main/java/io/micronaut/reflection/ReflectionArguments.java
@@ -378,7 +378,8 @@ public final class ReflectionArguments {
     @SuppressWarnings({"unchecked", "rawtypes"})
     private static Argument<?> rebuild(Argument<?> argument, @Nullable String name, AnnotationMetadata metadata, Argument<?>[] typeParameters) {
         if (argument instanceof GenericPlaceholder<?> placeholder) {
-            return Argument.ofTypeVariable((Class) argument.getType(), name, placeholder.getVariableName(), metadata, typeParameters);
+            return Argument.ofTypeVariable((Class) argument.getType(), name, placeholder.getVariableName(), metadata, typeParameters,
+                placeholder.getBounds().toArray(Argument[]::new));
         }
         return Argument.of((Class) argument.getType(), name, metadata, typeParameters);
     }
@@ -584,14 +585,19 @@ public final class ReflectionArguments {
             if (resolving.contains(tv)) {
                 // a bound naming the variable it bounds - `T extends Comparable<T>` - would be converted for
                 // ever: inside its own bound the variable stands for the erasure of that bound
-                return Argument.ofTypeVariable(getRawType(tv.getBounds()[0]), name, tv.getName(), declared, Argument.ZERO_ARGUMENTS);
+                return Argument.ofTypeVariable(getRawType(tv.getBounds()[0]), name, tv.getName(), declared, Argument.ZERO_ARGUMENTS, null);
             }
             Set<TypeVariable<?>> nested = new HashSet<>(resolving);
             nested.add(tv);
             // an unresolved variable is a placeholder of its bound, as the processors generate it
-            Argument<?> bound = toArgument(null, tv.getAnnotatedBounds()[0], Map.of(), nested);
+            AnnotatedType[] annotatedBounds = tv.getAnnotatedBounds();
+            Argument<?>[] bounds = new Argument[annotatedBounds.length];
+            for (int i = 0; i < annotatedBounds.length; i++) {
+                bounds[i] = toArgument(null, annotatedBounds[i], Map.of(), nested);
+            }
+            Argument<?> bound = bounds[0];
             return Argument.ofTypeVariable(bound.getType(), name, tv.getName(),
-                combine(declared, bound.getAnnotationMetadata()), bound.getTypeParameters());
+                combine(declared, bound.getAnnotationMetadata()), bound.getTypeParameters(), bounds);
         } else {
             throw new IllegalArgumentException("Unsupported type " + type.getClass().getName());
         }

--- a/reflection/src/main/java/io/micronaut/reflection/ReflectionBeanIntrospection.java
+++ b/reflection/src/main/java/io/micronaut/reflection/ReflectionBeanIntrospection.java
@@ -929,7 +929,8 @@ public final class ReflectionBeanIntrospection<T> implements ReflectiveIntrospec
         }
         if (argument instanceof GenericPlaceholder<?> placeholder) {
             // a property of type `T` stays a variable, as it is to a generated introspection
-            return Argument.ofTypeVariable((Class) argument.getType(), argument.getName(), placeholder.getVariableName(), metadata, typeParameters);
+            return Argument.ofTypeVariable((Class) argument.getType(), argument.getName(), placeholder.getVariableName(), metadata, typeParameters,
+                placeholder.getBounds().toArray(Argument[]::new));
         }
         return Argument.of(argument.getType(), argument.getName(), metadata, typeParameters);
     }
@@ -1549,7 +1550,8 @@ public final class ReflectionBeanIntrospection<T> implements ReflectiveIntrospec
         @SuppressWarnings({"unchecked", "rawtypes"})
         public Argument<P> asArgument() {
             if (typed instanceof GenericPlaceholder<?> placeholder) {
-                return Argument.ofTypeVariable((Class) getType(), getName(), placeholder.getVariableName(), this.getAnnotationMetadata(), typed.getTypeParameters());
+                return Argument.ofTypeVariable((Class) getType(), getName(), placeholder.getVariableName(), this.getAnnotationMetadata(), typed.getTypeParameters(),
+                    placeholder.getBounds().toArray(Argument[]::new));
             }
             return super.asArgument();
         }

--- a/reflection/src/test/groovy/io/micronaut/reflection/ReflectionTypesSpec.groovy
+++ b/reflection/src/test/groovy/io/micronaut/reflection/ReflectionTypesSpec.groovy
@@ -73,8 +73,17 @@ class ReflectionTypesSpec extends Specification {
     }
 
     void "a placeholder with no recorded bounds answers the type it erases to"() {
+        given:
+        def placeholder = (GenericPlaceholder) Argument.ofTypeVariable(Number, "value")
+
         expect:
-        ((GenericPlaceholder) Argument.ofTypeVariable(Number, "value")).bounds*.type == [Number]
+        placeholder.bounds*.type == [Number]
+
+        and: "the answer is the same list every time"
+        placeholder.bounds.is(placeholder.bounds)
+
+        and: "and renaming keeps the variable it stands for"
+        ((GenericPlaceholder) placeholder.withName("other")).variableName == "value"
     }
 
     void "a placeholder renders as the type it is bounded by when the caller compares types"() {

--- a/reflection/src/test/groovy/io/micronaut/reflection/ReflectionTypesSpec.groovy
+++ b/reflection/src/test/groovy/io/micronaut/reflection/ReflectionTypesSpec.groovy
@@ -46,6 +46,37 @@ class ReflectionTypesSpec extends Specification {
         type.bounds == [Object] as Object[]
     }
 
+    void "a placeholder keeps every bound the variable declares"() {
+        given:
+        def arguments = ReflectionArguments.argumentsOf(Types.getDeclaredMethod("several", Comparable, List))
+
+        expect: "the argument still erases to the first bound"
+        arguments[0].type == Comparable
+        arguments[0] instanceof GenericPlaceholder
+
+        and: "and answers both bounds, the first with its own type arguments"
+        ((GenericPlaceholder) arguments[0]).bounds*.type == [Comparable, Cloneable]
+        ((GenericPlaceholder) arguments[0]).bounds[0].typeParameters[0].type == String
+
+        and: "the variable inside a type argument keeps them too"
+        def inside = arguments[1].typeParameters[0]
+        inside instanceof GenericPlaceholder
+        ((GenericPlaceholder) inside).bounds*.type == [Comparable, Cloneable]
+    }
+
+    void "a variable bounded by a type naming it answers that bound"() {
+        given:
+        def argument = ReflectionArguments.argumentsOf(Types.getDeclaredMethod("recursive", Comparable))[0]
+
+        expect:
+        ((GenericPlaceholder) argument).bounds*.type == [Comparable]
+    }
+
+    void "a placeholder with no recorded bounds answers the type it erases to"() {
+        expect:
+        ((GenericPlaceholder) Argument.ofTypeVariable(Number, "value")).bounds*.type == [Number]
+    }
+
     void "a placeholder renders as the type it is bounded by when the caller compares types"() {
         given:
         def method = Types.getDeclaredMethod("identity", Object)

--- a/reflection/src/test/java/io/micronaut/reflection/Types.java
+++ b/reflection/src/test/java/io/micronaut/reflection/Types.java
@@ -23,4 +23,10 @@ public class Types {
     public <T> T identity(T value) {
         return value;
     }
+
+    public <T extends Comparable<String> & Cloneable> void several(T value, List<T> inside) {
+    }
+
+    public <T extends Comparable<T>> void recursive(T value) {
+    }
 }

--- a/reflection/src/test/java/io/micronaut/reflection/Types.java
+++ b/reflection/src/test/java/io/micronaut/reflection/Types.java
@@ -25,8 +25,10 @@ public class Types {
     }
 
     public <T extends Comparable<String> & Cloneable> void several(T value, List<T> inside) {
+        // the signature is what is read, the body is never called
     }
 
     public <T extends Comparable<T>> void recursive(T value) {
+        // the signature is what is read, the body is never called
     }
 }


### PR DESCRIPTION
Closes #13059.

[#13023](https://github.com/micronaut-projects/micronaut-core/pull/13023) gave a wildcard type argument a runtime representation that keeps its bounds. A type variable was still erased to its first bound with nowhere to say what it was, so `<T extends Payment & Refundable>` and `Payment` were the same argument at runtime except for a name.

**The runtime model.** `GenericPlaceholder` now answers `getBounds()`, the way `java.lang.reflect.TypeVariable` reports them, with the bounds as `Argument`s so a parameterized bound keeps its own type arguments:

```java
<T extends List<String> & Refundable> void observe(Event<T> e) {}
// the type argument of Event: getType() == List, getBounds() == [List<String>, Refundable]
```

`getType()` is still the erasure the processor chose, so nothing existing changes; `equals`, `equalsType` and `typeHashCode` ignore the bounds. `withName` and `withAnnotationMetadata` on a placeholder now return a placeholder that keeps its variable name and bounds, instead of a plain argument.

**What the writer records.** A variable with a single bound erases to that bound, so the bounds are written out only when they say more than the argument already does — several bounds, or a resolved variable whose erasure is no longer its bound. A placeholder that carries none, one built by hand or compiled before this change, answers the type it erases to, so `getBounds()` is never empty and a consumer needs no fallback of its own. `Argument.ofTypeVariable(Class, String, String, AnnotationMetadata, Argument[], Argument[])` is the factory the generated code calls.

**The reflection module.** A variable converted from `java.lang.reflect` keeps every bound it declares, and the places that rebuild a placeholder with other metadata or type parameters keep the bounds it had, so the reflective model says the same as the compiled one.

Covered by a new `TypeVariableBoundsSpec` for the Java, Groovy and Kotlin processors — constructor, injected field or property, injected method, executable parameter and return type, class and method variables, a parameterized bound, an unbounded variable and a concrete type argument — and by reflection specs for several bounds, a bound naming the variable it bounds, and a placeholder with none recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)