### PR TITLE
Decide between bean candidates that are all @Secondary

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/secondary/SecondaryOrderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/secondary/SecondaryOrderSpec.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.qualifiers.secondary
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.NonUniqueBeanException
+
+class SecondaryOrderSpec extends AbstractTypeElementSpec {
+
+    void "test @Order decides between candidates that are all @Secondary"() {
+        given:
+        ApplicationContext context = buildContext('''
+package test;
+
+import io.micronaut.context.annotation.Secondary;
+import io.micronaut.core.annotation.Order;
+import jakarta.inject.Singleton;
+
+interface Service {
+}
+
+@Singleton
+@Secondary
+@Order(10)
+class Low implements Service {
+}
+
+@Singleton
+@Secondary
+@Order(-10)
+class High implements Service {
+}
+''')
+
+        when:
+        def service = getBean(context, 'test.Service')
+
+        then:"the highest precedence secondary is picked, as it would be without @Secondary"
+        service.getClass().name == 'test.High'
+
+        cleanup:
+        context.close()
+    }
+
+    void "test candidates that are all @Secondary with the same order are still ambiguous"() {
+        given:
+        ApplicationContext context = buildContext('''
+package test;
+
+import io.micronaut.context.annotation.Secondary;
+import io.micronaut.core.annotation.Order;
+import jakarta.inject.Singleton;
+
+interface Service {
+}
+
+@Singleton
+@Secondary
+@Order(10)
+class One implements Service {
+}
+
+@Singleton
+@Secondary
+@Order(10)
+class Two implements Service {
+}
+''')
+
+        when:
+        getBean(context, 'test.Service')
+
+        then:
+        def e = thrown(NonUniqueBeanException)
+        e.message.contains('Multiple possible bean candidates found')
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a non-secondary candidate still wins over secondary ones with a better order"() {
+        given:
+        ApplicationContext context = buildContext('''
+package test;
+
+import io.micronaut.context.annotation.Secondary;
+import io.micronaut.core.annotation.Order;
+import jakarta.inject.Singleton;
+
+interface Service {
+}
+
+@Singleton
+@Secondary
+@Order(-100)
+class SecondaryOne implements Service {
+}
+
+@Singleton
+@Secondary
+@Order(-200)
+class SecondaryTwo implements Service {
+}
+
+@Singleton
+@Order(100)
+class Regular implements Service {
+}
+''')
+
+        when:
+        def service = getBean(context, 'test.Service')
+
+        then:
+        service.getClass().name == 'test.Regular'
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -3481,8 +3481,12 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (candidates.size() == 1) {
             return candidates.iterator().next();
         }
-        if (candidates.isEmpty()) {
-            throw new NonUniqueBeanException(beanType.getType(), originalCandidates.iterator());
+        // When every candidate is @Secondary none of them is preferable to another, but lowering the
+        // precedence of all of them shouldn't remove the ability to decide between them: carry on with
+        // the original candidates so that the order and @DefaultImplementation still get a say.
+        boolean allSecondary = candidates.isEmpty();
+        if (allSecondary) {
+            candidates = originalCandidates;
         }
         // pick the bean with the highest priority
         ArrayList<BeanDefinition<T>> listCandidates = new ArrayList<>(candidates);
@@ -3510,6 +3514,9 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         Collection<BeanDefinition<T>> exactMatches = filterExactMatch(beanType.getType(), candidates);
         if (exactMatches.size() == 1) {
             return exactMatches.iterator().next();
+        }
+        if (allSecondary) {
+            throw new NonUniqueBeanException(beanType.getType(), originalCandidates.iterator());
         }
         if (throwNonUnique) {
             return findConcreteCandidate(beanType.getType(), qualifier, candidates);


### PR DESCRIPTION
Bean resolution fails when every candidate is `@Secondary`, even when their `@Order` decides between them:

```java
interface Service {}
@Singleton @Secondary @Order(10)  class Low  implements Service {}
@Singleton @Secondary @Order(-10) class High implements Service {}
// context.getBean(Service) -> NonUniqueBeanException: Multiple possible bean candidates found: [Low, High]
```

Without the `@Secondary` annotations the same pair resolves to `High` by order.

`DefaultBeanContext.lastChanceResolve` narrows to `@Primary`, asks the `BeanResolutionCustomizer`, then filters `@Secondary` candidates out — and if nothing survives it throws `NonUniqueBeanException` immediately, before the order comparison and the `@DefaultImplementation` handling that follow. Lowering the precedence of every candidate shouldn't remove the container's ability to decide between them: `@Secondary` means "prefer something else if there is one", not "make this type unresolvable".

When the secondary filter empties the candidate list this now carries on with the original candidates through the remaining steps, and throws `NonUniqueBeanException` only if those cannot decide either. Every other shape is unchanged: a single non-secondary still wins over any number of secondaries, and equal orders among the survivors are still ambiguous.

`lastChanceResolve` is the only place in `DefaultBeanContext` that filters on `@Secondary`, so the `getBeanDefinitions`/`findBeanDefinition` paths don't carry the same gap.

Specs added in `inject-java/src/test/groovy/.../secondary/SecondaryOrderSpec.groovy` for all three shapes: all candidates secondary with distinct orders, all secondary with equal orders (still ambiguous), and one secondary plus one not. Against the unpatched `lastChanceResolve` only the first of the three fails, confirming the other two document existing behaviour. `:micronaut-inject:test`, `:micronaut-inject-java:test` and `:micronaut-context:test` all pass.

Found while working out how Jakarta CDI 5.0's new "reserve" beans (the opposite of alternatives: any non-reserve candidate eliminates every reserve, and among reserves the highest priority wins) would map onto Micronaut for https://github.com/dstepanov/micronaut-cdi — `@Secondary` is the same idea one step later in the algorithm, which is how the gap surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)