### PR TITLE
Let a runtime bean definition declare its injection points

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionInjectionPointSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionInjectionPointSpec.groovy
@@ -2,7 +2,6 @@ package io.micronaut.inject.beans
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanRegistration
-import io.micronaut.context.BeanResolutionContext
 import io.micronaut.context.RuntimeBeanDefinition
 import io.micronaut.context.annotation.Prototype
 import io.micronaut.core.type.Argument
@@ -12,12 +11,12 @@ import io.micronaut.inject.beans.injectionpoints.DisposableSingletonDependency
 import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Specification
 
-import java.util.function.BiFunction
+import java.util.function.Function
 
 class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
 
     private static RuntimeBeanDefinition.Builder<Holder> holderBuilder(
-            BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, Holder> factory) {
+            Function<RuntimeBeanDefinition.CreationContext, Holder> factory) {
         RuntimeBeanDefinition.builder(Holder, factory)
     }
 
@@ -25,7 +24,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         given:
         def context = ApplicationContext.builder()
                 .beanDefinitions(
-                        holderBuilder((ctx, injections) -> new Holder(injections.get(0)))
+                        holderBuilder(ctx -> new Holder(ctx.getInjectedBean(0)))
                                 .injectionPoint(Argument.of(DisposableSingletonDependency))
                                 .singleton(true)
                                 .build()
@@ -44,7 +43,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         given:
         def context = ApplicationContext.builder()
                 .beanDefinitions(
-                        holderBuilder((ctx, injections) -> new Holder(injections.get(0)))
+                        holderBuilder(ctx -> new Holder(ctx.getInjectedBean(0)))
                                 .injectionPoint(Argument.of(DisposableDependency))
                                 .scope(Prototype)
                                 .build()
@@ -74,7 +73,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         given:
         def context = ApplicationContext.builder()
                 .beanDefinitions(
-                        holderBuilder((ctx, injections) -> new Holder(injections.get(0)))
+                        holderBuilder(ctx -> new Holder(ctx.getInjectedBean(0)))
                                 .injectionPoint(Argument.of(DisposableDependency))
                                 .singleton(true)
                                 .build()
@@ -98,7 +97,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         given:
         def context = ApplicationContext.builder()
                 .beanDefinitions(
-                        holderBuilder((ctx, injections) -> new Holder(injections.get(0)))
+                        holderBuilder(ctx -> new Holder(ctx.getInjectedBean(0)))
                                 .injectionPoint(Argument.of(DisposableSingletonDependency))
                                 .scope(Prototype)
                                 .build()
@@ -125,8 +124,8 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         given:
         def context = ApplicationContext.builder()
                 .beanDefinitions(
-                        holderBuilder((ctx, injections) ->
-                                new Holder(injections.get(Argument.of(Colour), Qualifiers.byName("green"))))
+                        holderBuilder(ctx ->
+                                new Holder(ctx.getInjectedBean(Argument.of(Colour), Qualifiers.byName("green"))))
                                 .injectionPoint(Argument.of(Colour), Qualifiers.byName("green"))
                                 .singleton(true)
                                 .build()

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionInjectionPointSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionInjectionPointSpec.groovy
@@ -1,0 +1,151 @@
+package io.micronaut.inject.beans
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanRegistration
+import io.micronaut.context.BeanResolutionContext
+import io.micronaut.context.RuntimeBeanDefinition
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.beans.injectionpoints.Colour
+import io.micronaut.inject.beans.injectionpoints.DisposableDependency
+import io.micronaut.inject.beans.injectionpoints.DisposableSingletonDependency
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+import java.util.function.BiFunction
+
+class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
+
+    private static RuntimeBeanDefinition.Builder<Holder> holderBuilder(
+            BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, Holder> factory) {
+        RuntimeBeanDefinition.builder(Holder, factory)
+    }
+
+    void 'test a compiled bean is resolved for a declared injection point'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder((ctx, injections) -> new Holder(injections.get(0)))
+                                .injectionPoint(Argument.of(DisposableSingletonDependency))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        context.getBean(Holder).injected.is(context.getBean(DisposableSingletonDependency))
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a prototype resolved for an injection point is destroyed with the synthetic bean'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder((ctx, injections) -> new Holder(injections.get(0)))
+                                .injectionPoint(Argument.of(DisposableDependency))
+                                .scope(Prototype)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        BeanRegistration<Holder> registration = context.getBeanRegistration(Holder, null)
+        DisposableDependency dependency = registration.bean.injected as DisposableDependency
+
+        then: 'the prototype was resolved through the resolution context'
+        dependency != null
+        !dependency.destroyed
+
+        when:
+        registration.close()
+
+        then: 'core destroys it as a dependent of the synthetic bean'
+        dependency.destroyed
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a prototype resolved for an injection point of a synthetic singleton is destroyed with it'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder((ctx, injections) -> new Holder(injections.get(0)))
+                                .injectionPoint(Argument.of(DisposableDependency))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+        Holder holder = context.getBean(Holder)
+        DisposableDependency dependency = holder.injected as DisposableDependency
+
+        when:
+        context.destroyBean(holder)
+
+        then:
+        dependency.destroyed
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a singleton resolved for an injection point is not destroyed with the synthetic bean'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder((ctx, injections) -> new Holder(injections.get(0)))
+                                .injectionPoint(Argument.of(DisposableSingletonDependency))
+                                .scope(Prototype)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        BeanRegistration<Holder> registration = context.getBeanRegistration(Holder, null)
+        def dependency = registration.bean.injected as DisposableSingletonDependency
+        registration.close()
+
+        then:
+        !dependency.destroyed
+
+        when:
+        context.close()
+
+        then:
+        dependency.destroyed
+    }
+
+    void 'test a qualified injection point selects the compiled bean with that qualifier'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder((ctx, injections) ->
+                                new Holder(injections.get(Argument.of(Colour), Qualifiers.byName("green"))))
+                                .injectionPoint(Argument.of(Colour), Qualifiers.byName("green"))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        (context.getBean(Holder).injected as Colour).name() == "green"
+
+        cleanup:
+        context.close()
+    }
+
+    static class Holder {
+        final Object injected
+
+        Holder(Object injected) {
+            this.injected = injected
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/Colour.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/Colour.java
@@ -1,0 +1,5 @@
+package io.micronaut.inject.beans.injectionpoints;
+
+public interface Colour {
+    String name();
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/DisposableDependency.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/DisposableDependency.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.beans.injectionpoints;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PreDestroy;
+
+@Prototype
+public class DisposableDependency {
+
+    private boolean destroyed;
+
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+
+    @PreDestroy
+    void close() {
+        destroyed = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/DisposableSingletonDependency.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/DisposableSingletonDependency.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.beans.injectionpoints;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class DisposableSingletonDependency {
+
+    private boolean destroyed;
+
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+
+    @PreDestroy
+    void close() {
+        destroyed = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/Green.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/Green.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.beans.injectionpoints;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Named("green")
+public class Green implements Colour {
+
+    @Override
+    public String name() {
+        return "green";
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/Red.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/injectionpoints/Red.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.beans.injectionpoints;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Named("red")
+public class Red implements Colour {
+
+    @Override
+    public String name() {
+        return "red";
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2802,13 +2802,14 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             @SuppressWarnings("unchecked")
             BeanDefinition<T> def = (BeanDefinition<T>) new DefaultRuntimeBeanDefinition<>(
                 Argument.of(beanClass),
-                ctx -> (T) this,
+                (ctx, injections) -> (T) this,
                 null,
                 null,
                 true,
                 null,
                 ReflectionUtils.EMPTY_CLASS_ARRAY,
-                java.util.Collections.emptyMap()
+                java.util.Collections.emptyMap(),
+                new DefaultRuntimeBeanDefinition.InjectionPointSpec[0]
             );
             return BeanRegistration.of(this, BeanIdentifier.of(beanClass.getName()), def, (T) this);
         }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2802,7 +2802,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             @SuppressWarnings("unchecked")
             BeanDefinition<T> def = (BeanDefinition<T>) new DefaultRuntimeBeanDefinition<>(
                 Argument.of(beanClass),
-                (ctx, injections) -> (T) this,
+                ctx -> (T) this,
                 null,
                 null,
                 true,

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -17,6 +17,8 @@ package io.micronaut.context;
 
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.exceptions.BeanInstantiationException;
+import io.micronaut.context.exceptions.DependencyInjectionException;
+import io.micronaut.context.exceptions.NoSuchBeanException;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Experimental;
@@ -28,6 +30,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ConstructorInjectionPoint;
 import io.micronaut.inject.DisposableBeanDefinition;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.qualifiers.ClosestTypeArgumentQualifier;
@@ -35,7 +38,9 @@ import io.micronaut.inject.qualifiers.PrimaryQualifier;
 import io.micronaut.inject.qualifiers.TypeArgumentQualifier;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -46,6 +51,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -63,8 +69,10 @@ import java.util.function.Supplier;
 sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditional implements RuntimeBeanDefinition<T> {
     private static final AtomicInteger REF_COUNT = new AtomicInteger(0);
     private static final String MSG_BEAN_TYPE_CANNOT_BE_NULL = "Bean type cannot be null";
+    private static final InjectionPointSpec[] NO_INJECTION_POINTS = new InjectionPointSpec[0];
     private final Argument<T> beanType;
-    private final Function<BeanResolutionContext, T> beanFactory;
+    private final BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, T> beanFactory;
+    private final InjectionPointSpec[] injectionPoints;
     private final AnnotationMetadata annotationMetadata;
     private final String beanName;
     @Nullable
@@ -78,19 +86,21 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     private final int order;
 
     DefaultRuntimeBeanDefinition(Argument<T> beanType,
-                                 Function<BeanResolutionContext, T> beanFactory,
+                                 BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, T> beanFactory,
                                  @Nullable Qualifier<T> qualifier,
                                  @Nullable AnnotationMetadata annotationMetadata,
                                  boolean isSingleton,
                                  @Nullable Class<? extends Annotation> scope,
                                  Class<?>[] exposedTypes,
                                  @Nullable
-                                 Map<Class<?>, List<Argument<?>>> typeArguments) {
+                                 Map<Class<?>, List<Argument<?>>> typeArguments,
+                                 InjectionPointSpec[] injectionPoints) {
         Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
         Objects.requireNonNull(beanFactory, "Bean factory cannot be null");
 
         this.beanType = beanType;
         this.beanFactory = beanFactory;
+        this.injectionPoints = injectionPoints;
         this.beanName = generateBeanName(beanType.getType());
         this.qualifier = qualifier;
         this.annotationMetadata = annotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : annotationMetadata;
@@ -234,8 +244,134 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     }
 
     @Override
+    public ConstructorInjectionPoint<T> getConstructor() {
+        if (injectionPoints.length == 0) {
+            return RuntimeBeanDefinition.super.getConstructor();
+        }
+        return new RuntimeConstructorInjectionPoint();
+    }
+
+    @Override
+    public Collection<Class<?>> getRequiredComponents() {
+        if (injectionPoints.length == 0) {
+            return Collections.emptyList();
+        }
+        Collection<Class<?>> requiredComponents = new ArrayList<>(injectionPoints.length);
+        for (InjectionPointSpec injectionPoint : injectionPoints) {
+            requiredComponents.add(injectionPoint.argument().getType());
+        }
+        return Collections.unmodifiableCollection(requiredComponents);
+    }
+
+    @Override
     public T instantiate(BeanResolutionContext resolutionContext, BeanContext context) throws BeanInstantiationException {
-        return beanFactory.apply(resolutionContext);
+        if (injectionPoints.length == 0) {
+            return beanFactory.apply(resolutionContext, ResolvedInjections.EMPTY);
+        }
+        Object[] resolved = new Object[injectionPoints.length];
+        for (int i = 0; i < injectionPoints.length; i++) {
+            resolved[i] = resolveInjectionPoint(resolutionContext, injectionPoints[i]);
+        }
+        return beanFactory.apply(resolutionContext, new ResolvedInjections(injectionPoints, resolved));
+    }
+
+    /**
+     * Resolves a declared injection point through the given resolution context, so that the bean it resolves
+     * to becomes a dependent of the bean being created and the failure to resolve it is reported the way it is
+     * for a compiled bean's constructor argument.
+     *
+     * @param resolutionContext The resolution context
+     * @param injectionPoint    The declared injection point
+     * @return The resolved bean, {@code null} only for a nullable injection point that could not be satisfied
+     */
+    @Nullable
+    private Object resolveInjectionPoint(BeanResolutionContext resolutionContext, InjectionPointSpec injectionPoint) {
+        Argument<Object> argument = (Argument<Object>) injectionPoint.argument();
+        Qualifier<Object> qualifier = (Qualifier<Object>) injectionPoint.qualifier();
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
+            try {
+                if (argument.isDeclaredNullable()) {
+                    return resolutionContext.findBean(argument, qualifier).orElse(null);
+                }
+                return resolutionContext.getBean(argument, qualifier);
+            } catch (NoSuchBeanException e) {
+                throw new DependencyInjectionException(resolutionContext, e);
+            }
+        }
+    }
+
+    /**
+     * A declared injection point of a runtime bean definition.
+     *
+     * @param argument  The type to inject
+     * @param qualifier The qualifier, or {@code null} for none
+     */
+    record InjectionPointSpec(Argument<?> argument, @Nullable Qualifier<?> qualifier) {
+        InjectionPointSpec {
+            Objects.requireNonNull(argument, "Injection point type cannot be null");
+        }
+
+        boolean matches(Argument<?> otherArgument, @Nullable Qualifier<?> otherQualifier) {
+            return argument.equalsType(otherArgument) && Objects.equals(qualifier, otherQualifier);
+        }
+    }
+
+    /**
+     * The constructor injection point of a definition that declared injection points, so that the declared
+     * points are described the way a compiled bean's constructor arguments are.
+     */
+    private final class RuntimeConstructorInjectionPoint implements ConstructorInjectionPoint<T> {
+
+        @Override
+        public Argument<?>[] getArguments() {
+            Argument<?>[] arguments = new Argument<?>[injectionPoints.length];
+            for (int i = 0; i < injectionPoints.length; i++) {
+                arguments[i] = injectionPoints[i].argument();
+            }
+            return arguments;
+        }
+
+        @Override
+        public BeanDefinition<T> getDeclaringBean() {
+            return DefaultRuntimeBeanDefinition.this;
+        }
+
+        @Override
+        public String toString() {
+            return getDeclaringBeanType().getName() + "(" + Argument.toString(getArguments()) + ")";
+        }
+    }
+
+    /**
+     * Implementation of {@link RuntimeBeanDefinition.Injections} over the declared injection points and the
+     * beans resolved for them.
+     */
+    private record ResolvedInjections(InjectionPointSpec[] injectionPoints, Object[] resolved)
+        implements RuntimeBeanDefinition.Injections {
+
+        static final RuntimeBeanDefinition.Injections EMPTY = new ResolvedInjections(NO_INJECTION_POINTS, ArrayUtils.EMPTY_OBJECT_ARRAY);
+
+        @Override
+        public int size() {
+            return resolved.length;
+        }
+
+        @Override
+        public <V> V get(int index) {
+            return (V) resolved[index];
+        }
+
+        @Override
+        public <V> V get(Argument<V> type, @Nullable Qualifier<V> qualifier) {
+            Objects.requireNonNull(type, "Injection point type cannot be null");
+            for (int i = 0; i < injectionPoints.length; i++) {
+                if (injectionPoints[i].matches(type, qualifier)) {
+                    return (V) resolved[i];
+                }
+            }
+            throw new IllegalArgumentException("No injection point declared for type [" + type + "]"
+                + (qualifier == null ? "" : " and qualifier [" + qualifier + "]"));
+        }
     }
 
     /**
@@ -254,15 +390,16 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
         private final BiConsumer<BeanContext, T> disposer;
 
         Disposable(Argument<T> beanType,
-                   Function<BeanResolutionContext, T> beanFactory,
+                   BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, T> beanFactory,
                    @Nullable Qualifier<T> qualifier,
                    @Nullable AnnotationMetadata annotationMetadata,
                    boolean isSingleton,
                    @Nullable Class<? extends Annotation> scope,
                    Class<?>[] exposedTypes,
                    @Nullable Map<Class<?>, List<Argument<?>>> typeArguments,
+                   InjectionPointSpec[] injectionPoints,
                    BiConsumer<BeanContext, T> disposer) {
-            super(beanType, beanFactory, qualifier, annotationMetadata, isSingleton, scope, exposedTypes, typeArguments);
+            super(beanType, beanFactory, qualifier, annotationMetadata, isSingleton, scope, exposedTypes, typeArguments, injectionPoints);
             this.disposer = Objects.requireNonNull(disposer, "Disposer cannot be null");
         }
 
@@ -284,7 +421,8 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
      */
     static final class RuntimeBeanBuilder<B> implements RuntimeBeanDefinition.Builder<B> {
         private Argument<B> beanType;
-        private final Function<BeanResolutionContext, B> beanFactory;
+        private final BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, B> beanFactory;
+        private final List<InjectionPointSpec> injectionPoints = new ArrayList<>(3);
         @Nullable
         private Qualifier<B> qualifier;
         private boolean singleton;
@@ -303,11 +441,18 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
         RuntimeBeanBuilder(Argument<B> beanType, Supplier<B> supplier) {
             this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
             Objects.requireNonNull(supplier, "Bean supplier cannot be null");
-            this.beanFactory = resolutionContext -> supplier.get();
+            this.beanFactory = (resolutionContext, injections) -> supplier.get();
             this.annotationMetadata = AnnotationMetadata.EMPTY_METADATA;
         }
 
         RuntimeBeanBuilder(Argument<B> beanType, Function<BeanResolutionContext, B> beanFactory) {
+            this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
+            Objects.requireNonNull(beanFactory, "Bean factory cannot be null");
+            this.beanFactory = (resolutionContext, injections) -> beanFactory.apply(resolutionContext);
+            this.annotationMetadata = AnnotationMetadata.EMPTY_METADATA;
+        }
+
+        RuntimeBeanBuilder(Argument<B> beanType, BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, B> beanFactory) {
             this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
             this.beanFactory = Objects.requireNonNull(beanFactory, "Bean factory cannot be null");
             this.annotationMetadata = AnnotationMetadata.EMPTY_METADATA;
@@ -385,6 +530,12 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
         }
 
         @Override
+        public Builder<B> injectionPoint(Argument<?> type, @Nullable Qualifier<?> qualifier) {
+            injectionPoints.add(new InjectionPointSpec(type, qualifier));
+            return this;
+        }
+
+        @Override
         public Builder<B> disposer(@Nullable BiConsumer<BeanContext, B> disposer) {
             this.disposer = disposer;
             return this;
@@ -410,6 +561,9 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
                 }
                 mutableAnnotationMetadata.addAnnotation(Replaces.class.getName(), values);
             }
+            InjectionPointSpec[] declaredInjectionPoints = injectionPoints.isEmpty() ?
+                NO_INJECTION_POINTS :
+                injectionPoints.toArray(new InjectionPointSpec[0]);
             if (disposer != null) {
                 return new Disposable<>(
                     beanType,
@@ -420,6 +574,7 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
                     scope,
                     exposedTypes,
                     typeArguments,
+                    declaredInjectionPoints,
                     disposer
                 );
             }
@@ -431,7 +586,8 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
                 singleton,
                 scope,
                 exposedTypes,
-                typeArguments
+                typeArguments,
+                declaredInjectionPoints
             );
         }
     }

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -31,6 +31,7 @@ import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ConstructorInjectionPoint;
+import io.micronaut.inject.InjectionPoint;
 import io.micronaut.inject.DisposableBeanDefinition;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.qualifiers.ClosestTypeArgumentQualifier;
@@ -51,7 +52,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -71,7 +71,7 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     private static final String MSG_BEAN_TYPE_CANNOT_BE_NULL = "Bean type cannot be null";
     private static final InjectionPointSpec[] NO_INJECTION_POINTS = new InjectionPointSpec[0];
     private final Argument<T> beanType;
-    private final BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, T> beanFactory;
+    private final Function<RuntimeBeanDefinition.CreationContext, T> beanFactory;
     private final InjectionPointSpec[] injectionPoints;
     private final AnnotationMetadata annotationMetadata;
     private final String beanName;
@@ -86,7 +86,7 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     private final int order;
 
     DefaultRuntimeBeanDefinition(Argument<T> beanType,
-                                 BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, T> beanFactory,
+                                 Function<RuntimeBeanDefinition.CreationContext, T> beanFactory,
                                  @Nullable Qualifier<T> qualifier,
                                  @Nullable AnnotationMetadata annotationMetadata,
                                  boolean isSingleton,
@@ -265,14 +265,16 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
 
     @Override
     public T instantiate(BeanResolutionContext resolutionContext, BeanContext context) throws BeanInstantiationException {
+        Object[] resolved;
         if (injectionPoints.length == 0) {
-            return beanFactory.apply(resolutionContext, ResolvedInjections.EMPTY);
+            resolved = ArrayUtils.EMPTY_OBJECT_ARRAY;
+        } else {
+            resolved = new Object[injectionPoints.length];
+            for (int i = 0; i < injectionPoints.length; i++) {
+                resolved[i] = resolveInjectionPoint(resolutionContext, injectionPoints[i]);
+            }
         }
-        Object[] resolved = new Object[injectionPoints.length];
-        for (int i = 0; i < injectionPoints.length; i++) {
-            resolved[i] = resolveInjectionPoint(resolutionContext, injectionPoints[i]);
-        }
-        return beanFactory.apply(resolutionContext, new ResolvedInjections(injectionPoints, resolved));
+        return beanFactory.apply(new DefaultCreationContext(resolutionContext, resolved));
     }
 
     /**
@@ -343,26 +345,43 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     }
 
     /**
-     * Implementation of {@link RuntimeBeanDefinition.Injections} over the declared injection points and the
-     * beans resolved for them.
+     * Implementation of {@link RuntimeBeanDefinition.CreationContext} over the resolution context of one
+     * creation and the beans resolved for the declared injection points.
      */
-    private record ResolvedInjections(InjectionPointSpec[] injectionPoints, Object[] resolved)
-        implements RuntimeBeanDefinition.Injections {
+    private final class DefaultCreationContext implements RuntimeBeanDefinition.CreationContext {
+        private final BeanResolutionContext resolutionContext;
+        private final Object[] resolved;
 
-        static final RuntimeBeanDefinition.Injections EMPTY = new ResolvedInjections(NO_INJECTION_POINTS, ArrayUtils.EMPTY_OBJECT_ARRAY);
+        DefaultCreationContext(BeanResolutionContext resolutionContext, Object[] resolved) {
+            this.resolutionContext = resolutionContext;
+            this.resolved = resolved;
+        }
 
         @Override
-        public int size() {
+        public BeanContext getBeanContext() {
+            return resolutionContext.getContext();
+        }
+
+        @Override
+        public Optional<InjectionPoint<?>> getInjectionPoint() {
+            return resolutionContext.getPath().currentSegment()
+                // the segment of a top level lookup is the creation of this bean itself, not an injection point
+                .filter(segment -> segment.getDeclaringType() != DefaultRuntimeBeanDefinition.this)
+                .map(BeanResolutionContext.Segment::getInjectionPoint);
+        }
+
+        @Override
+        public int getInjectedBeanCount() {
             return resolved.length;
         }
 
         @Override
-        public <V> V get(int index) {
+        public <V> V getInjectedBean(int index) {
             return (V) resolved[index];
         }
 
         @Override
-        public <V> V get(Argument<V> type, @Nullable Qualifier<V> qualifier) {
+        public <V> V getInjectedBean(Argument<V> type, @Nullable Qualifier<V> qualifier) {
             Objects.requireNonNull(type, "Injection point type cannot be null");
             for (int i = 0; i < injectionPoints.length; i++) {
                 if (injectionPoints[i].matches(type, qualifier)) {
@@ -390,7 +409,7 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
         private final BiConsumer<BeanContext, T> disposer;
 
         Disposable(Argument<T> beanType,
-                   BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, T> beanFactory,
+                   Function<RuntimeBeanDefinition.CreationContext, T> beanFactory,
                    @Nullable Qualifier<T> qualifier,
                    @Nullable AnnotationMetadata annotationMetadata,
                    boolean isSingleton,
@@ -421,7 +440,7 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
      */
     static final class RuntimeBeanBuilder<B> implements RuntimeBeanDefinition.Builder<B> {
         private Argument<B> beanType;
-        private final BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, B> beanFactory;
+        private final Function<RuntimeBeanDefinition.CreationContext, B> beanFactory;
         private final List<InjectionPointSpec> injectionPoints = new ArrayList<>(3);
         @Nullable
         private Qualifier<B> qualifier;
@@ -441,18 +460,11 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
         RuntimeBeanBuilder(Argument<B> beanType, Supplier<B> supplier) {
             this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
             Objects.requireNonNull(supplier, "Bean supplier cannot be null");
-            this.beanFactory = (resolutionContext, injections) -> supplier.get();
+            this.beanFactory = creationContext -> supplier.get();
             this.annotationMetadata = AnnotationMetadata.EMPTY_METADATA;
         }
 
-        RuntimeBeanBuilder(Argument<B> beanType, Function<BeanResolutionContext, B> beanFactory) {
-            this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
-            Objects.requireNonNull(beanFactory, "Bean factory cannot be null");
-            this.beanFactory = (resolutionContext, injections) -> beanFactory.apply(resolutionContext);
-            this.annotationMetadata = AnnotationMetadata.EMPTY_METADATA;
-        }
-
-        RuntimeBeanBuilder(Argument<B> beanType, BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, B> beanFactory) {
+        RuntimeBeanBuilder(Argument<B> beanType, Function<RuntimeBeanDefinition.CreationContext, B> beanFactory) {
             this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
             this.beanFactory = Objects.requireNonNull(beanFactory, "Bean factory cannot be null");
             this.annotationMetadata = AnnotationMetadata.EMPTY_METADATA;

--- a/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
@@ -24,6 +24,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanContextConditional;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
+import io.micronaut.inject.InjectionPoint;
 import io.micronaut.inject.InstantiatableBeanDefinition;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
@@ -32,8 +33,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -196,19 +197,19 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
 
     /**
      * A new builder for constructing and configuring runtime created beans where the bean factory
-     * receives the current {@link BeanResolutionContext}.
+     * receives the {@link CreationContext} of each creation.
      *
-     * <p>The resolution context allows the factory to introspect where in a resolution the bean is being
-     * created, for example via {@link BeanResolutionContext#getPath()} to discover the injection point
-     * the bean is being created for.</p>
+     * <p>The creation context carries the beans resolved for the injection points declared with
+     * {@link Builder#injectionPoint(Argument)} and the injection point the bean is being created for.</p>
      *
      * @param beanType The bean type
-     * @param beanFactory The bean factory that receives the current {@link BeanResolutionContext}
+     * @param beanFactory The bean factory that receives the {@link CreationContext}
      * @return The builder
      * @param <B> The bean type
      * @since 5.2.0
      */
-    static <B> Builder<B> builder(Class<B> beanType, Function<BeanResolutionContext, B> beanFactory) {
+    @Experimental
+    static <B> Builder<B> builder(Class<B> beanType, Function<CreationContext, B> beanFactory) {
         return new DefaultRuntimeBeanDefinition.RuntimeBeanBuilder<>(
             Argument.of(beanType),
             beanFactory
@@ -217,19 +218,19 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
 
     /**
      * A new builder for constructing and configuring runtime created beans where the bean factory
-     * receives the current {@link BeanResolutionContext}.
+     * receives the {@link CreationContext} of each creation.
      *
-     * <p>The resolution context allows the factory to introspect where in a resolution the bean is being
-     * created, for example via {@link BeanResolutionContext#getPath()} to discover the injection point
-     * the bean is being created for.</p>
+     * <p>The creation context carries the beans resolved for the injection points declared with
+     * {@link Builder#injectionPoint(Argument)} and the injection point the bean is being created for.</p>
      *
      * @param beanType The bean type
-     * @param beanFactory The bean factory that receives the current {@link BeanResolutionContext}
+     * @param beanFactory The bean factory that receives the {@link CreationContext}
      * @return The builder
      * @param <B> The bean type
      * @since 5.2.0
      */
-    static <B> Builder<B> builder(Argument<B> beanType, Function<BeanResolutionContext, B> beanFactory) {
+    @Experimental
+    static <B> Builder<B> builder(Argument<B> beanType, Function<CreationContext, B> beanFactory) {
         return new DefaultRuntimeBeanDefinition.RuntimeBeanBuilder<>(
             beanType,
             beanFactory
@@ -237,65 +238,49 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
     }
 
     /**
-     * A new builder for constructing and configuring runtime created beans where the bean factory
-     * receives the beans resolved for the injection points declared with
-     * {@link Builder#injectionPoint(Argument)}.
+     * The context of a single creation of a bean built at runtime, passed to the bean factory of a definition
+     * built with {@link #builder(Argument, Function)}.
      *
-     * @param beanType The bean type
-     * @param beanFactory The bean factory that receives the current {@link BeanResolutionContext} and the
-     *                    resolved injections
-     * @return The builder
-     * @param <B> The bean type
-     * @since 5.2.0
-     */
-    static <B> Builder<B> builder(Class<B> beanType, BiFunction<BeanResolutionContext, Injections, B> beanFactory) {
-        return new DefaultRuntimeBeanDefinition.RuntimeBeanBuilder<>(
-            Argument.of(beanType),
-            beanFactory
-        );
-    }
-
-    /**
-     * A new builder for constructing and configuring runtime created beans where the bean factory
-     * receives the beans resolved for the injection points declared with
-     * {@link Builder#injectionPoint(Argument)}.
+     * <p>It carries the beans resolved for the injection points the definition declared with
+     * {@link Builder#injectionPoint(Argument)}, the injection point the bean is being created for, and the
+     * {@link BeanContext} to look anything else up in.</p>
      *
-     * @param beanType The bean type
-     * @param beanFactory The bean factory that receives the current {@link BeanResolutionContext} and the
-     *                    resolved injections
-     * @return The builder
-     * @param <B> The bean type
-     * @since 5.2.0
-     */
-    static <B> Builder<B> builder(Argument<B> beanType, BiFunction<BeanResolutionContext, Injections, B> beanFactory) {
-        return new DefaultRuntimeBeanDefinition.RuntimeBeanBuilder<>(
-            beanType,
-            beanFactory
-        );
-    }
-
-    /**
-     * The beans resolved for the injection points a {@link RuntimeBeanDefinition} declared with
-     * {@link Builder#injectionPoint(Argument)} and {@link Builder#injectionPoint(Argument, Qualifier)}.
-     *
-     * <p>An instance is passed to the bean factory of a definition built with
-     * {@link #builder(Argument, BiFunction)} each time the bean is created. The beans it holds were resolved
-     * through the {@link BeanResolutionContext} of that creation, so any of them that is a dependent object
-     * (a {@code @Prototype} or {@code @Dependent} bean, for example) is a dependent of the created bean and is
-     * destroyed with it.</p>
+     * <p>The injected beans were resolved through the resolution context of this creation, so any of them that
+     * is a dependent object (a {@code @Prototype} or {@code @Dependent} bean, for example) is a dependent of the
+     * created bean and is destroyed with it. The exception is a bean obtained from
+     * {@link BeanContext#createBean(Class)}, which records no dependents for any bean, runtime built or
+     * compiled.</p>
      *
      * @since 5.2.0
      */
-    interface Injections {
+    @Experimental
+    interface CreationContext {
 
         /**
-         * @return The number of declared injection points
+         * @return The bean context creating the bean
          */
-        int size();
+        BeanContext getBeanContext();
 
         /**
-         * The bean resolved for the injection point at the given index, in the order the injection points
-         * were declared on the builder.
+         * The injection point the bean is being created for.
+         *
+         * <p>For a constructor or method argument this is an
+         * {@link io.micronaut.inject.ArgumentInjectionPoint}, which exposes the argument and the bean that
+         * declares it. It is empty when the bean is not being created for an injection point, as it is for a
+         * direct {@link BeanContext#getBean(Class)} lookup.</p>
+         *
+         * @return The injection point, or empty if there is none
+         */
+        Optional<InjectionPoint<?>> getInjectionPoint();
+
+        /**
+         * @return The number of injection points the definition declared
+         */
+        int getInjectedBeanCount();
+
+        /**
+         * The bean resolved for the injection point at the given index, in the order the injection points were
+         * declared on the builder.
          *
          * @param index The index
          * @return The resolved bean, which is {@code null} only when the injection point was declared with a
@@ -303,7 +288,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
          * @param <V> The injected type
          * @throws IndexOutOfBoundsException If the index is out of range
          */
-        <V> @Nullable V get(int index);
+        <V> @Nullable V getInjectedBean(int index);
 
         /**
          * The bean resolved for the injection point declared with the given type and no qualifier.
@@ -314,8 +299,8 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
          * @param <V> The injected type
          * @throws IllegalArgumentException If no such injection point was declared
          */
-        default <V> @Nullable V get(Argument<V> type) {
-            return get(type, null);
+        default <V> @Nullable V getInjectedBean(Argument<V> type) {
+            return getInjectedBean(type, null);
         }
 
         /**
@@ -328,7 +313,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
          * @param <V> The injected type
          * @throws IllegalArgumentException If no such injection point was declared
          */
-        <V> @Nullable V get(Argument<V> type, @Nullable Qualifier<V> qualifier);
+        <V> @Nullable V getInjectedBean(Argument<V> type, @Nullable Qualifier<V> qualifier);
     }
 
     /**
@@ -412,9 +397,9 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
         /**
          * Declares an injection point of this bean.
          *
-         * <p>The declared injection points are resolved through the {@link BeanResolutionContext} of the bean
-         * creation, in the order they were declared, and are handed to the bean factory of a definition built
-         * with {@link RuntimeBeanDefinition#builder(Argument, BiFunction)} as {@link Injections}. Resolving them
+         * <p>The declared injection points are resolved through the resolution context of the bean creation,
+         * in the order they were declared, and are handed to the bean factory of a definition built
+         * with {@link RuntimeBeanDefinition#builder(Argument, Function)} as its {@link CreationContext}. Resolving them
          * this way is what makes core's own dependency handling apply to a runtime built bean: a dependent object
          * resolved for an injection point becomes a dependent of the created bean and is destroyed with it,
          * a circular dependency is detected, and an unsatisfied injection point fails the creation with the usual
@@ -431,6 +416,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
          * @return This builder
          * @since 5.2.0
          */
+        @Experimental
         default Builder<B> injectionPoint(Argument<?> type) {
             return injectionPoint(type, null);
         }
@@ -444,6 +430,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
          * @see #injectionPoint(Argument)
          * @since 5.2.0
          */
+        @Experimental
         Builder<B> injectionPoint(Argument<?> type, @Nullable Qualifier<?> qualifier);
 
         /**

--- a/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -236,6 +237,101 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
     }
 
     /**
+     * A new builder for constructing and configuring runtime created beans where the bean factory
+     * receives the beans resolved for the injection points declared with
+     * {@link Builder#injectionPoint(Argument)}.
+     *
+     * @param beanType The bean type
+     * @param beanFactory The bean factory that receives the current {@link BeanResolutionContext} and the
+     *                    resolved injections
+     * @return The builder
+     * @param <B> The bean type
+     * @since 5.2.0
+     */
+    static <B> Builder<B> builder(Class<B> beanType, BiFunction<BeanResolutionContext, Injections, B> beanFactory) {
+        return new DefaultRuntimeBeanDefinition.RuntimeBeanBuilder<>(
+            Argument.of(beanType),
+            beanFactory
+        );
+    }
+
+    /**
+     * A new builder for constructing and configuring runtime created beans where the bean factory
+     * receives the beans resolved for the injection points declared with
+     * {@link Builder#injectionPoint(Argument)}.
+     *
+     * @param beanType The bean type
+     * @param beanFactory The bean factory that receives the current {@link BeanResolutionContext} and the
+     *                    resolved injections
+     * @return The builder
+     * @param <B> The bean type
+     * @since 5.2.0
+     */
+    static <B> Builder<B> builder(Argument<B> beanType, BiFunction<BeanResolutionContext, Injections, B> beanFactory) {
+        return new DefaultRuntimeBeanDefinition.RuntimeBeanBuilder<>(
+            beanType,
+            beanFactory
+        );
+    }
+
+    /**
+     * The beans resolved for the injection points a {@link RuntimeBeanDefinition} declared with
+     * {@link Builder#injectionPoint(Argument)} and {@link Builder#injectionPoint(Argument, Qualifier)}.
+     *
+     * <p>An instance is passed to the bean factory of a definition built with
+     * {@link #builder(Argument, BiFunction)} each time the bean is created. The beans it holds were resolved
+     * through the {@link BeanResolutionContext} of that creation, so any of them that is a dependent object
+     * (a {@code @Prototype} or {@code @Dependent} bean, for example) is a dependent of the created bean and is
+     * destroyed with it.</p>
+     *
+     * @since 5.2.0
+     */
+    interface Injections {
+
+        /**
+         * @return The number of declared injection points
+         */
+        int size();
+
+        /**
+         * The bean resolved for the injection point at the given index, in the order the injection points
+         * were declared on the builder.
+         *
+         * @param index The index
+         * @return The resolved bean, which is {@code null} only when the injection point was declared with a
+         *         nullable argument and no bean was found
+         * @param <V> The injected type
+         * @throws IndexOutOfBoundsException If the index is out of range
+         */
+        <V> @Nullable V get(int index);
+
+        /**
+         * The bean resolved for the injection point declared with the given type and no qualifier.
+         *
+         * @param type The type the injection point was declared with
+         * @return The resolved bean, which is {@code null} only when the injection point was declared with a
+         *         nullable argument and no bean was found
+         * @param <V> The injected type
+         * @throws IllegalArgumentException If no such injection point was declared
+         */
+        default <V> @Nullable V get(Argument<V> type) {
+            return get(type, null);
+        }
+
+        /**
+         * The bean resolved for the injection point declared with the given type and qualifier.
+         *
+         * @param type The type the injection point was declared with
+         * @param qualifier The qualifier the injection point was declared with
+         * @return The resolved bean, which is {@code null} only when the injection point was declared with a
+         *         nullable argument and no bean was found
+         * @param <V> The injected type
+         * @throws IllegalArgumentException If no such injection point was declared
+         */
+        <V> @Nullable V get(Argument<V> type, @Nullable Qualifier<V> qualifier);
+    }
+
+    /**
      * A builder for constructing {@link RuntimeBeanDefinition} instances.
      * @param <B> The bean type
      */
@@ -312,6 +408,43 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
          * @return This builder
          */
         Builder<B> annotationMetadata(@Nullable AnnotationMetadata annotationMetadata);
+
+        /**
+         * Declares an injection point of this bean.
+         *
+         * <p>The declared injection points are resolved through the {@link BeanResolutionContext} of the bean
+         * creation, in the order they were declared, and are handed to the bean factory of a definition built
+         * with {@link RuntimeBeanDefinition#builder(Argument, BiFunction)} as {@link Injections}. Resolving them
+         * this way is what makes core's own dependency handling apply to a runtime built bean: a dependent object
+         * resolved for an injection point becomes a dependent of the created bean and is destroyed with it,
+         * a circular dependency is detected, and an unsatisfied injection point fails the creation with the usual
+         * {@link io.micronaut.context.exceptions.DependencyInjectionException}.</p>
+         *
+         * <p>An injection point declared with a {@link Argument#isDeclaredNullable() nullable} argument resolves
+         * to {@code null} instead of failing when no bean is found.</p>
+         *
+         * <p>The declared injection points are also the arguments of {@link BeanDefinition#getConstructor()} and
+         * the types of {@link BeanDefinition#getRequiredComponents()}, so that the bean's dependencies can be
+         * described the way a compiled bean's are.</p>
+         *
+         * @param type The type to inject
+         * @return This builder
+         * @since 5.2.0
+         */
+        default Builder<B> injectionPoint(Argument<?> type) {
+            return injectionPoint(type, null);
+        }
+
+        /**
+         * Declares a qualified injection point of this bean.
+         *
+         * @param type The type to inject
+         * @param qualifier The qualifier, or {@code null} for none
+         * @return This builder
+         * @see #injectionPoint(Argument)
+         * @since 5.2.0
+         */
+        Builder<B> injectionPoint(Argument<?> type, @Nullable Qualifier<?> qualifier);
 
         /**
          * The disposer to run when an instance created by this definition is destroyed.

--- a/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionInjectionPointSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionInjectionPointSpec.groovy
@@ -7,7 +7,7 @@ import io.micronaut.inject.annotation.MutableAnnotationMetadata
 import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Specification
 
-import java.util.function.BiFunction
+import java.util.function.Function
 
 class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
 
@@ -18,7 +18,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
     }
 
     private static RuntimeBeanDefinition.Builder<Bar> barBuilder(
-            BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, Bar> factory) {
+            Function<RuntimeBeanDefinition.CreationContext, Bar> factory) {
         RuntimeBeanDefinition.builder(Bar, factory)
     }
 
@@ -27,7 +27,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         def context = ApplicationContext.builder()
                 .beanDefinitions(
                         RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).singleton(true).build(),
-                        barBuilder((ctx, injections) -> new Bar(injections.get(0) as Foo))
+                        barBuilder(ctx -> new Bar(ctx.getInjectedBean(0) as Foo))
                                 .injectionPoint(Argument.of(Foo))
                                 .singleton(true)
                                 .build()
@@ -51,7 +51,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         def context = ApplicationContext.builder()
                 .beanDefinitions(
                         RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).singleton(true).build(),
-                        barBuilder((ctx, injections) -> new Bar(injections.get(Argument.of(Foo))))
+                        barBuilder(ctx -> new Bar(ctx.getInjectedBean(Argument.of(Foo))))
                                 .injectionPoint(Argument.of(Foo))
                                 .singleton(true)
                                 .build()
@@ -72,8 +72,8 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
                 .beanDefinitions(
                         RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).named("one").singleton(true).build(),
                         RuntimeBeanDefinition.builder(Foo, () -> new Foo("two")).named("two").singleton(true).build(),
-                        barBuilder((ctx, injections) ->
-                                new Bar(injections.get(Argument.of(Foo), Qualifiers.byName("two"))))
+                        barBuilder(ctx ->
+                                new Bar(ctx.getInjectedBean(Argument.of(Foo), Qualifiers.byName("two"))))
                                 .injectionPoint(Argument.of(Foo), Qualifiers.byName("two"))
                                 .singleton(true)
                                 .build()
@@ -94,10 +94,10 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
                 .beanDefinitions(
                         RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).named("one").singleton(true).build(),
                         RuntimeBeanDefinition.builder(Foo, () -> new Foo("two")).named("two").singleton(true).build(),
-                        barBuilder((ctx, injections) -> {
-                            def created = new Bar(injections.get(0) as Foo)
-                            created.second = injections.get(1) as Foo
-                            created.size = injections.size()
+                        barBuilder(ctx -> {
+                            def created = new Bar(ctx.getInjectedBean(0) as Foo)
+                            created.second = ctx.getInjectedBean(1) as Foo
+                            created.size = ctx.getInjectedBeanCount()
                             created
                         })
                                 .injectionPoint(Argument.of(Foo), Qualifiers.byName("two"))
@@ -124,7 +124,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         given:
         def context = ApplicationContext.builder()
                 .beanDefinitions(
-                        barBuilder((ctx, injections) -> new Bar(injections.get(0) as Foo))
+                        barBuilder(ctx -> new Bar(ctx.getInjectedBean(0) as Foo))
                                 .injectionPoint(Argument.of(Foo, "foo"))
                                 .singleton(true)
                                 .build()
@@ -148,7 +148,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         given:
         def context = ApplicationContext.builder()
                 .beanDefinitions(
-                        barBuilder((ctx, injections) -> new Bar(injections.get(0) as Foo))
+                        barBuilder(ctx -> new Bar(ctx.getInjectedBean(0) as Foo))
                                 .injectionPoint(Argument.of(Foo, "foo", nullableMetadata()))
                                 .singleton(true)
                                 .build()
@@ -165,7 +165,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
 
     void 'test the declared injection points describe the bean dependencies'() {
         given:
-        RuntimeBeanDefinition<Bar> definition = barBuilder((ctx, injections) -> new Bar(injections.get(0) as Foo))
+        RuntimeBeanDefinition<Bar> definition = barBuilder(ctx -> new Bar(ctx.getInjectedBean(0) as Foo))
                 .injectionPoint(Argument.of(Foo, "foo"), Qualifiers.byName("one"))
                 .build()
 
@@ -190,7 +190,7 @@ class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
         def context = ApplicationContext.builder()
                 .beanDefinitions(
                         RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).singleton(true).build(),
-                        barBuilder((ctx, injections) -> new Bar(injections.get(Argument.of(Foo), Qualifiers.byName("nope"))))
+                        barBuilder(ctx -> new Bar(ctx.getInjectedBean(Argument.of(Foo), Qualifiers.byName("nope"))))
                                 .injectionPoint(Argument.of(Foo))
                                 .singleton(true)
                                 .build()

--- a/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionInjectionPointSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionInjectionPointSpec.groovy
@@ -1,0 +1,234 @@
+package io.micronaut.context
+
+import io.micronaut.context.exceptions.DependencyInjectionException
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.annotation.MutableAnnotationMetadata
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+import java.util.function.BiFunction
+
+class RuntimeBeanDefinitionInjectionPointSpec extends Specification {
+
+    private static MutableAnnotationMetadata nullableMetadata() {
+        def metadata = new MutableAnnotationMetadata()
+        metadata.addDeclaredAnnotation(AnnotationUtil.NULLABLE, [:])
+        metadata
+    }
+
+    private static RuntimeBeanDefinition.Builder<Bar> barBuilder(
+            BiFunction<BeanResolutionContext, RuntimeBeanDefinition.Injections, Bar> factory) {
+        RuntimeBeanDefinition.builder(Bar, factory)
+    }
+
+    void 'test a declared injection point is resolved and passed to the creator'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).singleton(true).build(),
+                        barBuilder((ctx, injections) -> new Bar(injections.get(0) as Foo))
+                                .injectionPoint(Argument.of(Foo))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        Bar bar = context.getBean(Bar)
+
+        then:
+        bar.foo.name == "one"
+        bar.foo.is(context.getBean(Foo))
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a declared injection point can be looked up by argument'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).singleton(true).build(),
+                        barBuilder((ctx, injections) -> new Bar(injections.get(Argument.of(Foo))))
+                                .injectionPoint(Argument.of(Foo))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        context.getBean(Bar).foo.name == "one"
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a qualified injection point is resolved with its qualifier'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).named("one").singleton(true).build(),
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("two")).named("two").singleton(true).build(),
+                        barBuilder((ctx, injections) ->
+                                new Bar(injections.get(Argument.of(Foo), Qualifiers.byName("two"))))
+                                .injectionPoint(Argument.of(Foo), Qualifiers.byName("two"))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        context.getBean(Bar).foo.name == "two"
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test injection points are resolved and handed over in declaration order'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).named("one").singleton(true).build(),
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("two")).named("two").singleton(true).build(),
+                        barBuilder((ctx, injections) -> {
+                            def created = new Bar(injections.get(0) as Foo)
+                            created.second = injections.get(1) as Foo
+                            created.size = injections.size()
+                            created
+                        })
+                                .injectionPoint(Argument.of(Foo), Qualifiers.byName("two"))
+                                .injectionPoint(Argument.of(Foo), Qualifiers.byName("one"))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        Bar bar = context.getBean(Bar)
+
+        then:
+        bar.size == 2
+        bar.foo.name == "two"
+        bar.second.name == "one"
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test an unsatisfied injection point fails the creation'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        barBuilder((ctx, injections) -> new Bar(injections.get(0) as Foo))
+                                .injectionPoint(Argument.of(Foo, "foo"))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        context.getBean(Bar)
+
+        then:
+        def e = thrown(DependencyInjectionException)
+        e.message.contains("Failed to inject value for parameter [foo]")
+        e.message.contains("No bean of type [" + Foo.name + "] exists")
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a nullable injection point resolves to null when unsatisfied'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        barBuilder((ctx, injections) -> new Bar(injections.get(0) as Foo))
+                                .injectionPoint(Argument.of(Foo, "foo", nullableMetadata()))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        context.getBean(Bar).foo == null
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the declared injection points describe the bean dependencies'() {
+        given:
+        RuntimeBeanDefinition<Bar> definition = barBuilder((ctx, injections) -> new Bar(injections.get(0) as Foo))
+                .injectionPoint(Argument.of(Foo, "foo"), Qualifiers.byName("one"))
+                .build()
+
+        expect:
+        definition.constructor.arguments.length == 1
+        definition.constructor.arguments[0].name == "foo"
+        definition.constructor.arguments[0].type == Foo
+        definition.requiredComponents as List == [Foo]
+    }
+
+    void 'test a definition without declared injection points is unchanged'() {
+        given:
+        RuntimeBeanDefinition<Bar> definition = RuntimeBeanDefinition.builder(Bar, () -> new Bar(null)).build()
+
+        expect:
+        definition.constructor.arguments.length == 0
+        definition.requiredComponents.isEmpty()
+    }
+
+    void 'test looking up an injection point that was not declared'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).singleton(true).build(),
+                        barBuilder((ctx, injections) -> new Bar(injections.get(Argument.of(Foo), Qualifiers.byName("nope"))))
+                                .injectionPoint(Argument.of(Foo))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        context.getBean(Bar)
+
+        then:
+        def e = thrown(Exception)
+        def cause = e
+        while (cause.cause != null) {
+            cause = cause.cause
+        }
+        cause instanceof IllegalArgumentException
+        cause.message.contains("No injection point declared")
+
+        cleanup:
+        context.close()
+    }
+
+    static class Foo {
+        final String name
+
+        Foo(String name) {
+            this.name = name
+        }
+    }
+
+    static class Bar {
+        final Foo foo
+        Foo second
+        int size
+
+        Bar(Foo foo) {
+            this.foo = foo
+        }
+    }
+}

--- a/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionResolutionContextSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionResolutionContextSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.context
 
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.type.Argument
+import io.micronaut.inject.ArgumentInjectionPoint
 import jakarta.inject.Singleton
 import spock.lang.Specification
 
@@ -9,19 +10,23 @@ import java.util.function.Function
 
 class RuntimeBeanDefinitionResolutionContextSpec extends Specification {
 
-    void "test runtime bean factory receives the resolution context of the injection point"() {
-        given:
-        ApplicationContext context = ApplicationContext.run(["spec.name": getClass().simpleName])
-        Function<BeanResolutionContext, RuntimeBean> factory = { BeanResolutionContext resolutionContext ->
-            def segment = resolutionContext.getPath().currentSegment().orElse(null)
+    private static Function<RuntimeBeanDefinition.CreationContext, RuntimeBean> factory() {
+        return { RuntimeBeanDefinition.CreationContext creationContext ->
+            def injectionPoint = creationContext.injectionPoint.orElse(null)
             new RuntimeBean(
-                segment?.declaringType?.beanType,
-                segment?.argument?.name,
-                resolutionContext.getPath().isEmpty()
+                injectionPoint?.declaringBean?.beanType,
+                injectionPoint instanceof ArgumentInjectionPoint ? injectionPoint.argument.name : null,
+                injectionPoint == null,
+                creationContext.beanContext
             )
         }
+    }
+
+    void "test runtime bean factory receives the injection point of the bean it is created for"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(["spec.name": getClass().simpleName])
         context.registerBeanDefinition(
-            RuntimeBeanDefinition.builder(RuntimeBean, factory).build()
+            RuntimeBeanDefinition.builder(RuntimeBean, factory()).build()
         )
 
         when:
@@ -30,32 +35,26 @@ class RuntimeBeanDefinitionResolutionContextSpec extends Specification {
         then: "the factory saw the injection point of the bean it was created for"
         consumer.runtimeBean.declaringBeanType == Consumer
         consumer.runtimeBean.argumentName == "runtimeBean"
-        !consumer.runtimeBean.pathWasEmpty
+        !consumer.runtimeBean.noInjectionPoint
+        consumer.runtimeBean.beanContext.is(context)
 
         cleanup:
         context.close()
     }
 
-    void "test runtime bean factory receives the resolution context for a top level lookup"() {
+    void "test runtime bean factory has no injection point for a top level lookup"() {
         given:
         ApplicationContext context = ApplicationContext.run(["spec.name": getClass().simpleName])
-        Function<BeanResolutionContext, RuntimeBean> factory = { BeanResolutionContext resolutionContext ->
-            def segment = resolutionContext.getPath().currentSegment().orElse(null)
-            new RuntimeBean(
-                segment?.declaringType?.beanType,
-                segment?.argument?.name,
-                resolutionContext.getPath().isEmpty()
-            )
-        }
         context.registerBeanDefinition(
-            RuntimeBeanDefinition.builder(Argument.of(RuntimeBean), factory).build()
+            RuntimeBeanDefinition.builder(Argument.of(RuntimeBean), factory()).build()
         )
 
         when:
         RuntimeBean bean = context.getBean(RuntimeBean)
 
-        then: "a direct lookup has an empty path or one rooted at the bean itself"
-        bean.pathWasEmpty || bean.declaringBeanType == RuntimeBean
+        then: "a direct lookup is not made for an injection point"
+        bean.noInjectionPoint
+        bean.declaringBeanType == null
 
         cleanup:
         context.close()
@@ -64,12 +63,14 @@ class RuntimeBeanDefinitionResolutionContextSpec extends Specification {
     static class RuntimeBean {
         final Class<?> declaringBeanType
         final String argumentName
-        final boolean pathWasEmpty
+        final boolean noInjectionPoint
+        final BeanContext beanContext
 
-        RuntimeBean(Class<?> declaringBeanType, String argumentName, boolean pathWasEmpty) {
+        RuntimeBean(Class<?> declaringBeanType, String argumentName, boolean noInjectionPoint, BeanContext beanContext) {
             this.declaringBeanType = declaringBeanType
             this.argumentName = argumentName
-            this.pathWasEmpty = pathWasEmpty
+            this.noInjectionPoint = noInjectionPoint
+            this.beanContext = beanContext
         }
     }
 


### PR DESCRIPTION
## Proposed API

`RuntimeBeanDefinition.Builder` gains two methods, mirroring what `disposer(...)` did for destruction:

```java
@Experimental default Builder<B> injectionPoint(Argument<?> type);
@Experimental Builder<B> injectionPoint(Argument<?> type, @Nullable Qualifier<?> qualifier);
```

The resolved beans reach the creator through a bean factory that receives one public creation context. `BeanResolutionContext` is deliberately not in this API — it is `@Internal`, it is the whole resolution's mutable state, and a factory only ever needed two things from it:

```java
@Experimental static <B> Builder<B> builder(Class<B> beanType, Function<CreationContext, B> beanFactory);
@Experimental static <B> Builder<B> builder(Argument<B> beanType, Function<CreationContext, B> beanFactory);

@Experimental
interface CreationContext {
    BeanContext getBeanContext();
    Optional<InjectionPoint<?>> getInjectionPoint();      // the point the bean is created for
    int getInjectedBeanCount();
    <V> V getInjectedBean(int index);                      // declaration order
    default <V> V getInjectedBean(Argument<V> type);       // == getInjectedBean(type, null)
    <V> V getInjectedBean(Argument<V> type, @Nullable Qualifier<V> qualifier);
}
```

This replaces the `Function<BeanResolutionContext, B>` overloads added in #12937. Those are new in 5.2.0 and unreleased, so nothing that was ever published changes; `getInjectionPoint()` serves their use case with the public `InjectionPoint` instead of asking the caller to walk `getPath()`, and is empty for a top level lookup rather than reporting the creation of the bean itself. The `Supplier` builders are untouched.

Everything else is the existing machinery — nothing was added to `BeanResolutionContext`, `DefaultBeanContext` or `BeanRegistration`.

```java
RuntimeBeanDefinition.builder(Bar.class, ctx -> new Bar(ctx.getInjectedBean(0)))
    .injectionPoint(Argument.of(Foo.class), Qualifiers.byName("two"))
    .scope(Prototype.class)
    .build();
```

## How it works

`DefaultRuntimeBeanDefinition.instantiate` resolves each declared point through the `BeanResolutionContext` of the creation, in declaration order, each behind its own `path.pushConstructorResolve(this, argument)` segment — the same call a compiled bean's `getBeanForConstructorArgument` makes. That single choice is what brings core's own handling to a synthetic bean:

- a dependent object resolved for a point is added to the context's dependent beans by `DefaultBeanContext.createRegistration`, so it lands on the created bean's `BeanRegistration` and is destroyed with it — no `transientlyCreated` list to keep;
- a circular dependency is detected by `detectCircularDependency` on the pushed segment;
- an unsatisfied point fails with the usual `DependencyInjectionException` (`Failed to inject value for parameter [foo] ... No bean of type [...] exists`);
- a point declared with a nullable `Argument` resolves to `null` instead of failing, as a `@Nullable` constructor parameter does.

The declared points are also `getConstructor().getArguments()` and the types of `getRequiredComponents()`, so a runtime built bean's dependencies can be described the way a compiled bean's are. A definition that declares no injection points keeps the constructor and required components it had before.

### One documented limitation

A bean obtained from `BeanContext.createBean(...)` records no dependents — for any bean, runtime built or compiled — because that path calls `resolveByBeanFactory` directly instead of `createRegistration`, as the javadoc on `DefaultBeanContext#retainedInterceptorDependents` already describes. A `@Prototype` resolved for a declared injection point of a bean created that way is therefore not destroyed with it. Verified both ways: destroyed via `getBean`/`getBeanRegistration`, not destroyed via `createBean`. This is noted on `CreationContext` and is left as it is; closing it means routing `createBean` through `createRegistration`, which changes destruction behaviour for every existing bean and belongs in its own change.

## Motivation

Jakarta CDI 5.0 adds `SyntheticBeanBuilder.withInjectionPoint(...)` and `SyntheticInjections`, and makes the lifetimes normative: a `@Dependent` obtained through a synthetic bean's injections becomes a dependent object of the synthetic instance and is destroyed with it, while one obtained in the disposer is destroyed when `dispose()` returns, and creator and disposer share neither injections nor instances.

[micronaut-cdi](https://github.com/dstepanov/micronaut-cdi) implements that today with a hand-rolled `creatorLookups` map and a `transientlyCreated` list threaded through its `Instance` implementation — exactly the bookkeeping core already does correctly for compiled beans. With this change that module can declare its injection points on the builder and let core track them.

The disposer added in #12964 stays as it is: it takes no injections, which is the CDI rule that creator and disposer share neither injections nor instances.

## Tests

`inject`, against runtime-registered collaborators — a declared point resolved and handed to the creator, lookup by argument and by argument plus qualifier, declaration order, an unsatisfied point failing with the usual message, a nullable point resolving to `null`, the constructor arguments and required components, and an undeclared lookup. `RuntimeBeanDefinitionResolutionContextSpec` is rewritten onto `CreationContext`.

`inject-java`, against compiled collaborators — a compiled bean resolved for a declared point, a `@Prototype` dependency destroyed when the synthetic bean's registration is closed and when a synthetic singleton is destroyed through the context, a singleton dependency **not** destroyed with it (only with the context), and a qualified point selecting the right compiled bean.

`:micronaut-inject:test`, `:micronaut-inject-java:test` and `:micronaut-inject:checkstyleMain` pass. `:micronaut-inject:japiCmp` reports every added member as source compatible; it also fails on `AbstractBeanResolutionContext$MethodArgumentSegment`, which this branch does not touch — that class is byte-identical to the one a clean `origin/5.2.x` build produces and the constructor it flags was changed by #13022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
