### PR TITLE
Honour @Bean(preDestroy) on a bean class

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -17,6 +17,7 @@ package io.micronaut.inject.processing;
 
 import io.micronaut.aop.Adapter;
 import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
+import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Value;
@@ -75,11 +76,19 @@ sealed class DeclaredBeanElementCreator<R> extends AbstractBeanElementCreator<R>
     private static final String MSG_ADAPTER_METHOD_PREFIX = "Cannot adapt method [";
     private static final String MSG_TARGET_METHOD_PREFIX = "] to target method [";
 
+    private static final String MEMBER_PRE_DESTROY = "preDestroy";
+
     protected final boolean isAopProxy;
     protected final List<Buildable<List<R>>> additionalBuilders = new ArrayList<>();
     private final AtomicInteger adaptedMethodIndex = new AtomicInteger(0);
     @Nullable
     private ElementProxyBuilder<R> aopProxyBuilder;
+    /**
+     * The method named by {@link Bean#preDestroy()} on the bean class, resolved before the members are visited so
+     * that it can be claimed as a lifecycle callback instead of being advised or made executable.
+     */
+    @Nullable
+    private MethodElement declaredPreDestroyMethod;
 
     protected DeclaredBeanElementCreator(ClassElement classElement, VisitorContext visitorContext, boolean isAopProxy, ElementBeanDefinitionBuilderFactory<R> beanDefinitionBuilderFactory) {
         super(classElement, visitorContext, beanDefinitionBuilderFactory);
@@ -158,6 +167,7 @@ sealed class DeclaredBeanElementCreator<R> extends AbstractBeanElementCreator<R>
     }
 
     protected void build(ElementBeanDefinitionBuilder<R> beanDefinitionBuilder) {
+        declaredPreDestroyMethod = resolveDeclaredPreDestroyMethod();
         Set<FieldElement> processedFields = new HashSet<>();
         ElementQuery<MemberElement> memberQuery = ElementQuery.ALL_FIELD_AND_METHODS.includeHiddenElements();
         if (processAsProperties()) {
@@ -185,6 +195,56 @@ sealed class DeclaredBeanElementCreator<R> extends AbstractBeanElementCreator<R>
                 throw new IllegalStateException("Unknown element");
             }
         }
+        if (declaredPreDestroyMethod != null) {
+            beanDefinitionBuilder.addPreDestroy(
+                declaredPreDestroyMethod,
+                declaredPreDestroyMethod.isReflectionRequired(classElement),
+                visitorContext
+            );
+        }
+    }
+
+    /**
+     * Resolves the pre-destroy callback the bean class names with {@link Bean#preDestroy()}. This mirrors what
+     * {@link FactoryBeanElementCreator} does for a produced bean: the member names a no-argument, accessible instance
+     * method of the bean type, and a name that resolves to nothing is a compilation error rather than silence.
+     *
+     * @return The method, {@code null} when the member is not declared or the method it names is already registered
+     * as a callback because it declares {@code @PreDestroy} itself
+     */
+    @Nullable
+    private MethodElement resolveDeclaredPreDestroyMethod() {
+        AnnotationMetadata annotationMetadata = classElement.getAnnotationMetadata();
+        if (!annotationMetadata.isPresent(Bean.class, MEMBER_PRE_DESTROY)) {
+            return null;
+        }
+        String destroyMethodName = annotationMetadata.stringValue(Bean.class, MEMBER_PRE_DESTROY).orElse(null);
+        if (StringUtils.isEmpty(destroyMethodName)) {
+            return null;
+        }
+        MethodElement destroyMethod = classElement.getEnclosedElement(
+            // Named filtering should avoid processing all methods and fail on possible missing classes and compilation errors
+            ElementQuery.ALL_METHODS.onlyAccessible(classElement)
+                .onlyInstance()
+                .named(destroyMethodName)
+                .filter(e -> !e.hasParameters())
+        ).orElseThrow(() -> new ProcessingException(classElement, "@Bean defines a preDestroy method that does not exist or is not public: " + destroyMethodName));
+        if (destroyMethod.hasDeclaredAnnotation(AnnotationUtil.PRE_DESTROY)) {
+            // Already registered as a callback by the member visitor
+            return null;
+        }
+        return destroyMethod;
+    }
+
+    /**
+     * @param methodElement The method
+     * @return true if the method is the pre-destroy callback named by {@link Bean#preDestroy()} on the bean class
+     */
+    private boolean isDeclaredPreDestroyCallback(MethodElement methodElement) {
+        return declaredPreDestroyMethod != null
+            && !methodElement.hasParameters()
+            && !methodElement.isStatic()
+            && methodElement.getName().equals(declaredPreDestroyMethod.getName());
     }
 
     private void visitFieldInternal(ElementBeanDefinitionBuilder<R> beanDefinitionBuilder, FieldElement fieldElement) {
@@ -380,6 +440,11 @@ sealed class DeclaredBeanElementCreator<R> extends AbstractBeanElementCreator<R>
     }
 
     private boolean visitAopAndExecutableMethod(ElementBeanDefinitionBuilder<R> beanDefinitionBuilder, MethodElement methodElement) {
+        if (isDeclaredPreDestroyCallback(methodElement)) {
+            // The callback is a lifecycle method of the bean, not an executable method of it, so it must not be
+            // advised. This is the same rule a method annotated with @PreDestroy gets from visitInjectAndLifecycleMethod.
+            return true;
+        }
         if (methodElement.isStatic() && !isStaticExecutableMethod(methodElement)) {
             // Only allow static executable methods when the method itself is annotated with @Executable
             // (directly or via an annotation meta-annotated with @Executable)

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/lifecyle/PreDestroyOnBeanClassSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/lifecyle/PreDestroyOnBeanClassSpec.groovy
@@ -1,0 +1,66 @@
+package io.micronaut.inject.lifecyle
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.context.ApplicationContext
+
+class PreDestroyOnBeanClassSpec extends AbstractBeanDefinitionSpec {
+
+    void "test preDestroy declared on the bean class"() {
+        given:
+        ApplicationContext context = buildContext('''
+package predestroyclass
+
+import io.micronaut.context.annotation.*
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "close")
+class Test implements AutoCloseable {
+
+    boolean closed = false
+
+    @Override
+    void close() {
+        closed = true
+    }
+}
+''')
+
+        when:
+        Class<?> beanType = context.classLoader.loadClass('predestroyclass.Test')
+        def bean = context.getBean(beanType)
+
+        then:
+        bean != null
+        !bean.closed
+
+        when:
+        context.destroyBean(beanType)
+
+        then:
+        bean.closed
+
+        cleanup:
+        context.close()
+    }
+
+    void "test preDestroy declared on the bean class that does not exist"() {
+        when:
+        buildContext('''
+package predestroyclass2
+
+import io.micronaut.context.annotation.*
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "notthere")
+class Test {
+
+    void close() {
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("@Bean defines a preDestroy method that does not exist or is not public: notthere")
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/PreDestroyOnBeanClassSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/PreDestroyOnBeanClassSpec.groovy
@@ -1,0 +1,308 @@
+package io.micronaut.inject.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+class PreDestroyOnBeanClassSpec extends AbstractTypeElementSpec {
+
+    void "test preDestroy declared on the bean class"() {
+        given:
+        ApplicationContext context = buildContext('''\
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "close")
+class Test implements AutoCloseable {
+
+    public boolean closed = false;
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+}
+''')
+
+        when:
+        Class<?> beanType = context.classLoader.loadClass('test.Test')
+        def bean = context.getBean(beanType)
+
+        then:
+        bean != null
+        !bean.closed
+
+        when:
+        context.destroyBean(beanType)
+
+        then:
+        bean.closed
+        bean != context.getBean(beanType)
+
+        cleanup:
+        context.close()
+    }
+
+    void "test preDestroy declared on the bean class is called when the context is closed"() {
+        given:
+        ApplicationContext context = buildContext('''\
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "close")
+class Test implements AutoCloseable {
+
+    public boolean closed = false;
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+}
+''')
+        Class<?> beanType = context.classLoader.loadClass('test.Test')
+        def bean = context.getBean(beanType)
+
+        when:
+        context.close()
+
+        then:
+        bean.closed
+    }
+
+    void "test preDestroy declared on the bean class resolving a method of a parent class"() {
+        given:
+        ApplicationContext context = buildContext('''\
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "close")
+class Test extends AbstractTest {}
+
+class AbstractTest implements AutoCloseable {
+
+    public boolean closed = false;
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+}
+''')
+
+        when:
+        Class<?> beanType = context.classLoader.loadClass('test.Test')
+        def bean = context.getBean(beanType)
+
+        then:
+        bean != null
+
+        when:
+        context.destroyBean(beanType)
+
+        then:
+        bean.closed
+
+        cleanup:
+        context.close()
+    }
+
+    void "test preDestroy declared on the bean class naming an overloaded method"() {
+        given:
+        ApplicationContext context = buildContext('''\
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "close")
+class Test {
+
+    public boolean closed = false;
+
+    public void close(Object context) {
+        throw new RuntimeException("Should never have been called");
+    }
+
+    public void close() {
+        closed = true;
+    }
+}
+''')
+
+        when:
+        Class<?> beanType = context.classLoader.loadClass('test.Test')
+        def bean = context.getBean(beanType)
+        context.destroyBean(beanType)
+
+        then:
+        bean.closed
+
+        cleanup:
+        context.close()
+    }
+
+    void "test preDestroy declared on the bean class naming a method that is also annotated @PreDestroy is invoked once"() {
+        given:
+        ApplicationContext context = buildContext('''\
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "close")
+class Test {
+
+    public int closedCount = 0;
+
+    @jakarta.annotation.PreDestroy
+    public void close() {
+        closedCount++;
+    }
+}
+''')
+
+        when:
+        Class<?> beanType = context.classLoader.loadClass('test.Test')
+        def bean = context.getBean(beanType)
+        context.destroyBean(beanType)
+
+        then:
+        bean.closedCount == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void "test preDestroy declared on the bean class that does not exist"() {
+        when:
+        buildContext('''\
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "notthere")
+class Test {
+
+    public void close() {
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("@Bean defines a preDestroy method that does not exist or is not public: notthere")
+    }
+
+    void "test preDestroy declared on the bean class naming a private method"() {
+        when:
+        buildContext('''\
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "close")
+class Test {
+
+    private void close() {
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("@Bean defines a preDestroy method that does not exist or is not public: close")
+    }
+
+    void "test preDestroy declared on the bean class naming a method with parameters"() {
+        when:
+        buildContext('''\
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@jakarta.inject.Singleton
+@Bean(preDestroy = "close")
+class Test {
+
+    public void close(Object context) {
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("@Bean defines a preDestroy method that does not exist or is not public: close")
+    }
+
+    void "test preDestroy declared on an AOP advised bean class is not advised"() {
+        given:
+        ApplicationContext context = buildContext('''\
+package test;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.aop.*;
+import java.lang.annotation.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.ElementType.*;
+
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+@Around
+@interface Mutating {
+}
+
+@InterceptorBean(Mutating.class)
+class MutatingInterceptor implements MethodInterceptor<Object, Object> {
+    public static int invocations = 0;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        invocations++;
+        return context.proceed();
+    }
+}
+
+@jakarta.inject.Singleton
+@Mutating
+@Bean(preDestroy = "close")
+class Test {
+
+    public boolean closed = false;
+
+    public void doStuff() {
+    }
+
+    public void close() {
+        closed = true;
+    }
+}
+''')
+
+        when:
+        Class<?> beanType = context.classLoader.loadClass('test.Test')
+        Class<?> interceptorType = context.classLoader.loadClass('test.MutatingInterceptor')
+        def bean = context.getBean(beanType)
+        bean.doStuff()
+        int invocationsAfterDoStuff = interceptorType.invocations
+
+        then:
+        invocationsAfterDoStuff > 0
+
+        when:
+        context.destroyBean(beanType)
+
+        then: "the callback ran but was not advised"
+        interceptorType.invocations == invocationsAfterDoStuff
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/lifecycle/PreDestroyOnBeanClassSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/lifecycle/PreDestroyOnBeanClassSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.kotlin.processing.inject.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.context.ApplicationContext
+
+class PreDestroyOnBeanClassSpec extends AbstractKotlinCompilerSpec {
+
+    void "test preDestroy declared on the bean class"() {
+        given:
+        ApplicationContext context = buildContext('''
+package test
+
+import io.micronaut.context.annotation.Bean
+import jakarta.inject.Singleton
+
+@Singleton
+@Bean(preDestroy = "close")
+open class Test : AutoCloseable {
+
+    var closed = false
+
+    override fun close() {
+        closed = true
+    }
+}
+''')
+
+        when:
+        Class<?> beanType = context.classLoader.loadClass('test.Test')
+        def bean = context.getBean(beanType)
+
+        then:
+        bean != null
+        !bean.closed
+
+        when:
+        context.destroyBean(beanType)
+
+        then:
+        bean.closed
+
+        cleanup:
+        context.close()
+    }
+
+    void "test preDestroy declared on the bean class that does not exist"() {
+        when:
+        buildContext('''
+package test
+
+import io.micronaut.context.annotation.Bean
+import jakarta.inject.Singleton
+
+@Singleton
+@Bean(preDestroy = "notthere")
+open class Test {
+
+    fun close() {
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("@Bean defines a preDestroy method that does not exist or is not public: notthere")
+    }
+}

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -101,6 +101,8 @@ import io.micronaut.python.processing.util.ObjectHelper;
 public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
 
     public static final TypeDef POLYGLOT_VALUE = TypeDef.of(Value.class);
+
+    private static final String MEMBER_PRE_DESTROY = "preDestroy";
     public static final TypeDef POLYGLOT_CONTEXT = TypeDef.of(Context.class);
     public static final VariableDef.StaticField CLASS_OBJECT = ClassTypeDef.of(Object.class).getStaticField("class", TypeDef.CLASS);
     public static final String AS_POLYGLOT_VALUE = "asPolyglotValue";
@@ -619,6 +621,19 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             }
             addBridgeMethod(BridgeMethodSpec.of(methodElement, element).junit5Test(methodElement.hasDeclaredAnnotation(JUNIT_TEST)), builder, context, addedMethodNames);
         }
+        // A class can name its own pre-destroy callback with @Bean(preDestroy), the class-level counterpart of the
+        // factory case handled in addBridgeMethod. The generated bean definition invokes the callback directly on the
+        // stub, so it needs a bridge even though it carries no annotation of its own. A name that resolves to nothing
+        // is reported by DeclaredBeanElementCreator.
+        element.stringValue(Bean.class, MEMBER_PRE_DESTROY)
+            .filter(name -> !name.isEmpty())
+            .flatMap(name -> element.getEnclosedElement(
+                ElementQuery.ALL_METHODS
+                    .onlyAccessible()
+                    .onlyInstance()
+                    .named(name)
+                    .filter(method -> !method.hasParameters())))
+            .ifPresent(method -> addBridgeMethod(BridgeMethodSpec.of(method, element), builder, context, addedMethodNames));
         if (hasIntroductionAdviceMethod) {
             List<MethodElement> concreteDeclaredMethods = element.getEnclosedElements(
                 ElementQuery.ALL_METHODS
@@ -2704,7 +2719,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                     "    def foo(self) -> Foo:");
             }
 
-            String preDestroy = methodElement.stringValue(Bean.class, "preDestroy").orElse(null);
+            String preDestroy = methodElement.stringValue(Bean.class, MEMBER_PRE_DESTROY).orElse(null);
             if (preDestroy != null && genericReturnType instanceof AbstractPythonClassElement) {
                 StubEntry stubEntry = this.classBuilders.get(genericReturnType.getName());
                 if (stubEntry != null) {

--- a/inject/src/main/java/io/micronaut/context/annotation/Bean.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/Bean.java
@@ -45,6 +45,10 @@ import java.lang.annotation.Target;
 public @interface Bean {
 
     /**
+     * The name of a public, no-argument method of the bean type to invoke when the bean is destroyed. Can be declared
+     * on the bean class itself or on the factory method or field that produces the bean. A name that resolves to no
+     * such method is a compilation error.
+     *
      * @return The method to invoke to destroy the bean
      */
     String preDestroy() default "";

--- a/src/main/docs/guide/ioc/lifecycle.adoc
+++ b/src/main/docs/guide/ioc/lifecycle.adoc
@@ -19,7 +19,24 @@ snippet::io.micronaut.docs.lifecycle.PreDestroyBean[tags="class", indent=0]
 <1> The `PreDestroy` annotation is imported
 <2> A method is annotated with `@PreDestroy` and will be invoked when the context is closed.
 
-For factory beans, the `preDestroy` value in the api:context.annotation.Bean[] annotation tells Micronaut framework which method to invoke.
+The `preDestroy` value in the api:context.annotation.Bean[] annotation names the method to invoke instead, which is useful when the destroy method cannot be annotated. It works both on a factory method and on the bean class itself:
+
+[source,java]
+----
+@Singleton
+@Bean(preDestroy = "close")
+public class Resource implements AutoCloseable {
+
+    @Override
+    public void close() {
+        // release the resource
+    }
+}
+----
+
+The named method must be a public, no-argument method of the bean type; a name that resolves to no such method is a compilation error.
+
+For factory beans, the value is set on the factory method:
 
 snippet::io.micronaut.docs.lifecycle.ConnectionFactory[tags="class", indent=0]
 

--- a/src/main/docs/guide/ioc/lifecycle.adoc
+++ b/src/main/docs/guide/ioc/lifecycle.adoc
@@ -19,24 +19,16 @@ snippet::io.micronaut.docs.lifecycle.PreDestroyBean[tags="class", indent=0]
 <1> The `PreDestroy` annotation is imported
 <2> A method is annotated with `@PreDestroy` and will be invoked when the context is closed.
 
-The `preDestroy` value in the api:context.annotation.Bean[] annotation names the method to invoke instead, which is useful when the destroy method cannot be annotated. It works both on a factory method and on the bean class itself:
+The `preDestroy` value in the api:context.annotation.Bean[] annotation names the method to invoke instead of annotating it. It can be declared on the bean class itself:
 
-[source,java]
-----
-@Singleton
-@Bean(preDestroy = "close")
-public class Resource implements AutoCloseable {
+snippet::io.micronaut.docs.lifecycle.Cache[tags="class", indent=0]
 
-    @Override
-    public void close() {
-        // release the resource
-    }
-}
-----
+<1> The `preDestroy` value is set on the annotation declared on the class
+<2> The annotation value matches the method name
 
 The named method must be a public, no-argument method of the bean type; a name that resolves to no such method is a compilation error.
 
-For factory beans, the value is set on the factory method:
+For factory beans, the value is set on the factory method or field that produces the bean:
 
 snippet::io.micronaut.docs.lifecycle.ConnectionFactory[tags="class", indent=0]
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/Cache.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/Cache.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+// tag::class[]
+import io.micronaut.context.annotation.Bean
+
+import jakarta.inject.Singleton
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Singleton
+@Bean(preDestroy = "flush") // <1>
+class Cache {
+
+    AtomicBoolean flushed = new AtomicBoolean(false)
+
+    void flush() { // <2>
+        flushed.compareAndSet(false, true)
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/PreDestroyBeanSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/lifecycle/PreDestroyBeanSpec.groovy
@@ -12,11 +12,13 @@ class PreDestroyBeanSpec extends Specification {
         ApplicationContext ctx = ApplicationContext.run()
         PreDestroyBean preDestroyBean = ctx.getBean(PreDestroyBean)
         Connection connection = ctx.getBean(Connection)
+        Cache cache = ctx.getBean(Cache)
         ctx.stop()
         // end::start[]
 
         then:
         preDestroyBean.stopped.get()
         connection.stopped.get()
+        cache.flushed.get()
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/Cache.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/Cache.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle
+
+// tag::class[]
+import io.micronaut.context.annotation.Bean
+
+import jakarta.inject.Singleton
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Singleton
+@Bean(preDestroy = "flush") // <1>
+open class Cache {
+
+    internal var flushed = AtomicBoolean(false)
+
+    open fun flush() { // <2>
+        flushed.compareAndSet(false, true)
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/PreDestroyBeanSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/lifecycle/PreDestroyBeanSpec.kt
@@ -12,11 +12,13 @@ class PreDestroyBeanSpec: StringSpec() {
             val ctx = ApplicationContext.run()
             val preDestroyBean = ctx.getBean(PreDestroyBean::class.java)
             val connection = ctx.getBean(Connection::class.java)
+            val cache = ctx.getBean(Cache::class.java)
             ctx.stop()
             // end::start[]
 
             preDestroyBean.stopped.get() shouldBe true
             connection.stopped.get() shouldBe true
+            cache.flushed.get() shouldBe true
         }
     }
 }

--- a/test-suite-python/src/test/python/micronaut/docs/lifecycle/Cache.py
+++ b/test-suite-python/src/test/python/micronaut/docs/lifecycle/Cache.py
@@ -1,0 +1,13 @@
+# tag::class[]
+from micronaut.context.annotation import Bean
+from jakarta.inject import Singleton
+
+
+@Singleton
+@Bean(preDestroy = "flush") # <1>
+class Cache:
+    flushed : bool = False
+
+    def flush(self): # <2>
+        self.flushed = True
+# end::class[]

--- a/test-suite-python/src/test/python/micronaut/docs/lifecycle/CacheFlushSpec.py
+++ b/test-suite-python/src/test/python/micronaut/docs/lifecycle/CacheFlushSpec.py
@@ -1,0 +1,24 @@
+from org.junit.jupiter.api import Test
+from micronaut.context import ApplicationContext
+from micronaut.test.extensions.junit5.annotation import MicronautTest
+from jakarta.inject import Inject
+from typing import Annotated
+import java
+
+
+# tag::class[]
+@MicronautTest
+class CacheFlushSpec:
+    context : Annotated[ApplicationContext, Inject] = None
+
+    @Test
+    def test_class_predestroy(self):
+        CacheBean = java.type("micronaut.docs.lifecycle.Cache")
+        cache = self.context.getBean(CacheBean).asPolyglotValue()
+
+        assert cache.flushed == False, "Should not be flushed"
+
+        self.context.stop()
+
+        assert cache.flushed == True, "Should be flushed"
+# end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/lifecycle/Cache.java
+++ b/test-suite/src/test/java/io/micronaut/docs/lifecycle/Cache.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.lifecycle;
+
+// tag::class[]
+import io.micronaut.context.annotation.Bean;
+
+import jakarta.inject.Singleton;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Singleton
+@Bean(preDestroy = "flush") // <1>
+public class Cache {
+
+    AtomicBoolean flushed = new AtomicBoolean(false);
+
+    public void flush() { // <2>
+        flushed.compareAndSet(false, true);
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/lifecycle/PreDestroyBeanSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/lifecycle/PreDestroyBeanSpec.java
@@ -28,10 +28,12 @@ class PreDestroyBeanSpec {
         ApplicationContext ctx = ApplicationContext.run();
         PreDestroyBean preDestroyBean = ctx.getBean(PreDestroyBean.class);
         Connection connection = ctx.getBean(Connection.class);
+        Cache cache = ctx.getBean(Cache.class);
         ctx.stop();
         // end::start[]
 
         assertTrue(preDestroyBean.stopped.get());
         assertTrue(connection.stopped.get());
+        assertTrue(cache.flushed.get());
     }
 }


### PR DESCRIPTION
## The asymmetry

`io.micronaut.context.annotation.Bean` is `@Target({METHOD, ANNOTATION_TYPE, TYPE, FIELD})` and its `preDestroy()` member is documented as "The method to invoke to destroy the bean". Only `FactoryBeanElementCreator` ever read it. `DeclaredBeanElementCreator` registers pre-destroy callbacks from methods annotated `@PreDestroy` and nothing else, so on a managed bean the member did nothing at all — no callback, no error, no warning:

```java
@Singleton
@Bean(preDestroy = "close")   // silently ignored
class Closeable1 implements AutoCloseable {
    @Override public void close() { ... }   // never called on context.close()
}

@Factory
class ProducedFactory {
    @Singleton @Bean(preDestroy = "close")  // honoured
    Produced produced() { return new Produced(); }
}
```

Nothing in the code suggests the class case was left out deliberately — the member simply has a factory-scoped implementation, and the guide describes it as a factory feature while the javadoc does not. So this honours it rather than rejecting it: it is what a reader of the javadoc expects, and it gives an `AutoCloseable` bean a destroy callback without writing `@PreDestroy`.

## What changed

`DeclaredBeanElementCreator` resolves the named method on the bean type before its members are visited and registers it as a pre-destroy callback:

- Same validation as the factory case — a public, no-argument, accessible instance method of the bean type. A name that resolves to nothing (missing, private, or taking parameters) is now a `ProcessingException`, not silence.
- The callback is claimed as a lifecycle method, so it is excluded from around advice and from the bean's executable methods. That is what a method annotated `@PreDestroy` already gets, and it matches the exclusion `FactoryBeanElementCreator` applies to a produced bean's callback.
- A method that carries `@PreDestroy` itself is left to the member visitor, so naming it in `preDestroy` does not register the callback twice.

This is in the shared `core-processor` path, so it applies to Java, Groovy and Kotlin alike. The javadoc on `Bean#preDestroy()` and `src/main/docs/guide/ioc/lifecycle.adoc` were updated — the guide said "For factory beans, the `preDestroy` value…".

## Tests

New `PreDestroyOnBeanClassSpec` in `inject-java` covers the honoured case (plain, on context close, method inherited from a parent class, overloaded name), the no-duplicate-callback case, the AOP case, and three invalid-name cases (missing, private, takes parameters). Mirrored for Groovy (`inject-groovy`) and Kotlin (`inject-kotlin`) with the honoured and invalid-name cases.

`:micronaut-inject:test`, `:micronaut-inject-java:test`, `:micronaut-inject-groovy:test` and `:micronaut-inject-kotlin:test` all pass.

## Context

Found while working out what Jakarta CDI 5.0's `@AutoClose` would cost to implement in https://github.com/dstepanov/micronaut-cdi. That mapping is free if this member works on a class, and needs a compile-time rewrite of every auto-closeable bean if it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)