### PR TITLE
Reject AOP advice on a sealed type at compile time

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/AopIntroductionProxySupportedBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/AopIntroductionProxySupportedBeanElementCreator.java
@@ -46,9 +46,7 @@ final class AopIntroductionProxySupportedBeanElementCreator<R> extends DeclaredB
                                                     boolean isAopProxy,
                                                     ElementBeanDefinitionBuilderFactory<R> beanDefinitionBuilder) {
         super(classElement, visitorContext, isAopProxy, beanDefinitionBuilder);
-        if (classElement.isFinal()) {
-            throw new ProcessingException(classElement, "Cannot apply AOP advice to final class. Class must be made non-final to support proxying: " + classElement.getName());
-        }
+        ProxyableTypeValidator.validateProxyable(classElement, classElement);
         introductionProxyBuilder = beanDefinitionBuilderFactory.introductionProxy(classElement);
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/processing/FactoryBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/FactoryBeanElementCreator.java
@@ -214,6 +214,9 @@ final class FactoryBeanElementCreator<R> extends DeclaredBeanElementCreator<R> {
             if (originalProducedType.isFinal()) { // Test on the original type to avoid KSP annotations isFinal bypass, because of the new merged annotations
                 throw new ProcessingException(producingElement, "Cannot apply AOP advice to final class. Class must be made non-final to support proxying: " + producedType.getName());
             }
+            if (originalProducedType.isSealed()) {
+                throw new ProcessingException(producingElement, "Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: " + producedType.getName());
+            }
 
             MethodElement constructorElement = producedType.getPrimaryConstructor().orElse(null);
             MethodElement defaultConstructor = producedType.getDefaultConstructor().orElse(null);

--- a/core-processor/src/main/java/io/micronaut/inject/processing/FactoryBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/FactoryBeanElementCreator.java
@@ -211,12 +211,8 @@ final class FactoryBeanElementCreator<R> extends DeclaredBeanElementCreator<R> {
             if (producedType.isPrimitive()) {
                 throw new ProcessingException(producingElement, "Cannot apply AOP advice to primitive beans");
             }
-            if (originalProducedType.isFinal()) { // Test on the original type to avoid KSP annotations isFinal bypass, because of the new merged annotations
-                throw new ProcessingException(producingElement, "Cannot apply AOP advice to final class. Class must be made non-final to support proxying: " + producedType.getName());
-            }
-            if (originalProducedType.isSealed()) {
-                throw new ProcessingException(producingElement, "Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: " + producedType.getName());
-            }
+            // Validate the original type to avoid KSP annotations isFinal bypass, because of the new merged annotations
+            ProxyableTypeValidator.validateProxyable(originalProducedType, producingElement);
 
             MethodElement constructorElement = producedType.getPrimaryConstructor().orElse(null);
             MethodElement defaultConstructor = producedType.getDefaultConstructor().orElse(null);

--- a/core-processor/src/main/java/io/micronaut/inject/processing/ProxyableTypeValidator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/ProxyableTypeValidator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.processing;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
+
+/**
+ * Validates that a type can be proxied by a build time generated subclass or implementation.
+ *
+ * <p>Every proxy writer generates a type that extends or implements the proxied one, so a type that cannot be
+ * extended cannot carry advice. The checks live here rather than at each proxy creation path so that the paths
+ * stay consistent with each other.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.2.0
+ */
+@Internal
+public final class ProxyableTypeValidator {
+
+    private ProxyableTypeValidator() {
+    }
+
+    /**
+     * Validates that the given type can be proxied, failing with a message that names the type.
+     *
+     * @param type         The type to be proxied
+     * @param errorElement The element the failure is reported against
+     * @throws ProcessingException if the type cannot be extended by a generated proxy
+     */
+    public static void validateProxyable(ClassElement type, Element errorElement) {
+        if (type.isFinal()) {
+            throw new ProcessingException(errorElement, "Cannot apply AOP advice to final class. Class must be made non-final to support proxying: " + type.getName());
+        }
+        if (type.isSealed()) {
+            // A sealed type permits only the subclasses it lists, which a generated proxy can never be
+            throw new ProcessingException(errorElement, "Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: " + type.getName());
+        }
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
@@ -160,6 +160,9 @@ public class DefaultElementBeanDefinitionBuilderFactory implements ElementBeanDe
         if (targetType.isFinal()) {
             throw new ProcessingException(targetType, "Cannot apply AOP advice to final class. Class must be made non-final to support proxying: " + targetType.getName());
         }
+        if (targetType.isSealed()) {
+            throw new ProcessingException(targetType, "Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: " + targetType.getName());
+        }
         BeanDefinitionWriter targetBeanWriter = (BeanDefinitionWriter) targetBeanDefinitionBuilder;
         MemberDefinition<ClassElement> elementProducerDefinition = targetBeanWriter.getElementProducerDefinition();
         boolean isFactoryMethod = !(elementProducerDefinition instanceof ConstructorDefinition<ClassElement, ?>);
@@ -211,6 +214,10 @@ public class DefaultElementBeanDefinitionBuilderFactory implements ElementBeanDe
 
     @Override
     public ElementProxyBuilder<OutputObjectDef> introductionProxy(ClassElement target) {
+        // An introduction proxy is a generated subclass or implementation, which a sealed type cannot permit
+        if (target.isSealed()) {
+            throw new ProcessingException(target, "Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: " + target.getName());
+        }
         AnnotationMetadata annotationMetadata = target.getAnnotationMetadata();
 
         List<ClassElement> interfaceTypes = Arrays.stream(annotationMetadata.getValue(Introduction.class, "interfaces", String[].class).orElse(EMPTY_STRING_ARRAY))

--- a/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
@@ -38,6 +38,7 @@ import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.processing.ProxyableTypeValidator;
 import io.micronaut.inject.utils.BeanInjectionUtils;
 import io.micronaut.inject.validation.RequiresValidation;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -157,12 +158,7 @@ public class DefaultElementBeanDefinitionBuilderFactory implements ElementBeanDe
                                                             AnnotationMetadata aopElementAnnotationProcessor,
                                                             ElementBeanDefinitionBuilder<OutputObjectDef> targetBeanDefinitionBuilder) {
 
-        if (targetType.isFinal()) {
-            throw new ProcessingException(targetType, "Cannot apply AOP advice to final class. Class must be made non-final to support proxying: " + targetType.getName());
-        }
-        if (targetType.isSealed()) {
-            throw new ProcessingException(targetType, "Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: " + targetType.getName());
-        }
+        ProxyableTypeValidator.validateProxyable(targetType, targetType);
         BeanDefinitionWriter targetBeanWriter = (BeanDefinitionWriter) targetBeanDefinitionBuilder;
         MemberDefinition<ClassElement> elementProducerDefinition = targetBeanWriter.getElementProducerDefinition();
         boolean isFactoryMethod = !(elementProducerDefinition instanceof ConstructorDefinition<ClassElement, ?>);
@@ -214,10 +210,7 @@ public class DefaultElementBeanDefinitionBuilderFactory implements ElementBeanDe
 
     @Override
     public ElementProxyBuilder<OutputObjectDef> introductionProxy(ClassElement target) {
-        // An introduction proxy is a generated subclass or implementation, which a sealed type cannot permit
-        if (target.isSealed()) {
-            throw new ProcessingException(target, "Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: " + target.getName());
-        }
+        ProxyableTypeValidator.validateProxyable(target, target);
         AnnotationMetadata annotationMetadata = target.getAnnotationMetadata();
 
         List<ClassElement> interfaceTypes = Arrays.stream(annotationMetadata.getValue(Introduction.class, "interfaces", String[].class).orElse(EMPTY_STRING_ARRAY))

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -261,6 +261,18 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
     }
 
     @Override
+    public boolean isSealed() {
+        return classNode.isSealed();
+    }
+
+    @Override
+    public Collection<ClassElement> getPermittedSubclasses() {
+        return classNode.getPermittedSubclasses().stream()
+            .map(this::newClassElement)
+            .toList();
+    }
+
+    @Override
     public <T extends Element> @NonNull List<T> getEnclosedElements(@NonNull ElementQuery<T> query) {
         return groovyEnclosedElementsQuery.getEnclosedElements(this, query);
     }

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/compile/SealedModifierSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/compile/SealedModifierSpec.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.compile
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.inject.writer.BeanDefinitionWriter
+
+class SealedModifierSpec extends AbstractBeanDefinitionSpec {
+
+    void "test around advice on a sealed class doesn't compile"() {
+        when:
+        buildBeanDefinition('test.$SealedMyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
+package test
+
+import io.micronaut.aop.proxytarget.*
+
+@Mutating("someVal")
+@jakarta.inject.Singleton
+sealed class SealedMyBean permits SealedMyBeanOnly {
+
+    String someMethod() {
+        return "x"
+    }
+}
+
+non-sealed class SealedMyBeanOnly extends SealedMyBean {
+}
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains 'Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.SealedMyBean'
+    }
+
+    void "test introduction advice on a sealed interface doesn't compile"() {
+        when:
+        buildBeanDefinition('test.$SealedMyContract' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
+package test
+
+import io.micronaut.aop.introduction.*
+
+@Stub
+@jakarta.inject.Singleton
+sealed interface SealedMyContract permits SealedMyContractOnly {
+
+    String someMethod()
+}
+
+non-sealed class SealedMyContractOnly implements SealedMyContract {
+    String someMethod() {
+        return "only"
+    }
+}
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains 'Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.SealedMyContract'
+    }
+
+    void "test around advice on a non-sealed subclass of a sealed class still compiles"() {
+        when:
+        def definition = buildBeanDefinition('test.$SealedMyBean2' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
+package test
+
+import io.micronaut.aop.proxytarget.*
+
+sealed class SealedMyBase permits SealedMyBean2 {
+
+    String someMethod() {
+        return "x"
+    }
+}
+
+@Mutating("someVal")
+@jakarta.inject.Singleton
+non-sealed class SealedMyBean2 extends SealedMyBase {
+}
+''')
+        then:
+        definition != null
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
@@ -67,6 +67,57 @@ class Test {
             element.getPackageName() == ""
     }
 
+    void "test sealed class"() {
+        given:
+            def element = buildClassElement("test.Test", """
+package test
+
+sealed class Test permits TestOne, TestTwo {
+}
+
+non-sealed class TestOne extends Test {
+}
+
+final class TestTwo extends Test {
+}
+""")
+
+        expect:
+            element.isSealed()
+            element.getPermittedSubclasses()*.getName() as Set == ['test.TestOne', 'test.TestTwo'] as Set
+    }
+
+    void "test sealed interface"() {
+        given:
+            def element = buildClassElement("test.Test", """
+package test
+
+sealed interface Test permits TestOne {
+}
+
+non-sealed interface TestOne extends Test {
+}
+""")
+
+        expect:
+            element.isSealed()
+            element.getPermittedSubclasses()*.getName() == ['test.TestOne']
+    }
+
+    void "test non-sealed class"() {
+        given:
+            def element = buildClassElement("""
+package test
+
+class Test {
+}
+""")
+
+        expect:
+            !element.isSealed()
+            element.getPermittedSubclasses().isEmpty()
+    }
+
     void "test equals with primitive"() {
         given:
             def element = buildClassElement("""

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/SealedModifierSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/SealedModifierSpec.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.compile
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class SealedModifierSpec extends AbstractTypeElementSpec {
+
+    void "test around advice on a sealed class doesn't compile"() {
+        when:
+        buildContext('test.MyBean', '''
+package test;
+
+import io.micronaut.aop.simple.*;
+
+@Mutating("someVal")
+@jakarta.inject.Singleton
+sealed class MyBean permits MyBean.Only {
+
+    public String someMethod() {
+        return "x";
+    }
+
+    static non-sealed class Only extends MyBean {
+    }
+}
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains 'Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.MyBean'
+    }
+
+    void "test introduction advice on a sealed interface doesn't compile"() {
+        when:
+        buildContext('test.MyContract', '''
+package test;
+
+import io.micronaut.aop.introduction.*;
+
+@Stub
+@jakarta.inject.Singleton
+sealed interface MyContract permits MyContract.Only {
+
+    String someMethod();
+
+    final class Only implements MyContract {
+        public String someMethod() {
+            return "only";
+        }
+    }
+}
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains 'Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.MyContract'
+    }
+
+    void "test scoped proxy on a sealed class doesn't compile"() {
+        when:
+        buildContext('test.MyBean', '''
+package test;
+
+import io.micronaut.inject.scope.custom.definitionlookup.LookupProxyScope;
+
+@LookupProxyScope
+sealed class MyBean permits MyBean.Only {
+
+    public String someMethod() {
+        return "x";
+    }
+
+    static non-sealed class Only extends MyBean {
+    }
+}
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains 'Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.MyBean'
+    }
+
+    void "test introduction advice on a sealed abstract class doesn't compile"() {
+        when:
+        buildContext('test.MyContract', '''
+package test;
+
+import io.micronaut.aop.introduction.*;
+
+@Stub
+@jakarta.inject.Singleton
+sealed abstract class MyContract permits MyContract.Only {
+
+    public abstract String someMethod();
+
+    static non-sealed class Only extends MyContract {
+        public String someMethod() {
+            return "only";
+        }
+    }
+}
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains 'Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.MyContract'
+    }
+
+    void "test around advice on a sealed type produced by a factory doesn't compile"() {
+        when:
+        buildContext('test.MyBeanFactory', '''
+package test;
+
+import io.micronaut.aop.simple.*;
+import io.micronaut.context.annotation.*;
+
+@Factory
+class MyBeanFactory {
+    @Mutating("someVal")
+    @jakarta.inject.Singleton
+    MyBean myBean() {
+        return new MyBean.Only();
+    }
+}
+
+sealed class MyBean permits MyBean.Only {
+
+    public String someMethod() {
+        return "x";
+    }
+
+    static non-sealed class Only extends MyBean {
+    }
+}
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains 'Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.MyBean'
+    }
+
+    void "test around advice on a non-sealed subclass of a sealed class still works"() {
+        when:
+        def context = buildContext('test.MyBean', '''
+package test;
+
+import io.micronaut.aop.simple.*;
+
+sealed class MyBase permits MyBean {
+
+    public String someMethod() {
+        return "x";
+    }
+}
+
+@Mutating("someVal")
+@jakarta.inject.Singleton
+non-sealed class MyBean extends MyBase {
+}
+''')
+        def bean = getBean(context, 'test.MyBean')
+
+        then:
+        bean instanceof io.micronaut.aop.Intercepted
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -648,6 +648,14 @@ internal open class KotlinClassElement(
 
     override fun isAbstract(): Boolean = declaration.isAbstract()
 
+    override fun isSealed() = declaration.modifiers.contains(Modifier.SEALED)
+
+    override fun getPermittedSubclasses(): Collection<ClassElement> =
+        declaration.getSealedSubclasses()
+            .mapNotNull { it.qualifiedName?.asString() }
+            .mapNotNull { visitorContext.getClassElement(it).orElse(null) }
+            .toList()
+
     override fun withAnnotationMetadata(annotationMetadata: AnnotationMetadata) =
         super<AbstractKotlinElement>.withAnnotationMetadata(annotationMetadata) as ClassElement
 

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -650,6 +650,8 @@ internal open class KotlinClassElement(
 
     override fun isSealed() = declaration.modifiers.contains(Modifier.SEALED)
 
+    // KSP resolves the sealed subclasses through the current round's resolver, so this has to be read while
+    // that session is live rather than from an element retained past it
     override fun getPermittedSubclasses(): Collection<ClassElement> =
         declaration.getSealedSubclasses()
             .mapNotNull { it.qualifiedName?.asString() }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/SealedModifierSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/SealedModifierSpec.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.processing.aop.compile
+
+import io.micronaut.inject.writer.BeanDefinitionWriter
+import spock.lang.Specification
+
+import static io.micronaut.annotation.processing.test.KotlinCompiler.buildBeanDefinition
+
+class SealedModifierSpec extends Specification {
+
+    void "test introduction advice on a sealed interface doesn't compile"() {
+        when:
+        buildBeanDefinition('test.MyContract', '''
+package test
+
+import io.micronaut.kotlin.processing.aop.introduction.Stub
+
+@Stub
+@jakarta.inject.Singleton
+sealed interface MyContract {
+
+    fun someMethod(): String
+}
+
+class MyContractOnly : MyContract {
+    override fun someMethod(): String {
+        return "only"
+    }
+}
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains 'Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.MyContract'
+    }
+
+    void "test around advice on a sealed type produced by a factory doesn't compile"() {
+        when:
+        buildBeanDefinition('test.MyBeanFactory', '''
+package test
+
+import io.micronaut.kotlin.processing.aop.simple.Mutating
+import io.micronaut.context.annotation.*
+
+@Factory
+class MyBeanFactory {
+
+    @Mutating("someVal")
+    @jakarta.inject.Singleton
+    fun myBean(): MyBean {
+        return MyBeanOnly()
+    }
+}
+
+sealed class MyBean {
+    open fun someMethod(): String {
+        return "x"
+    }
+}
+
+open class MyBeanOnly : MyBean()
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains 'Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.MyBean'
+    }
+
+    void "test around advice on a subclass of a sealed class still compiles"() {
+        when:
+        def definition = buildBeanDefinition('test.$MyBean2' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
+package test
+
+import io.micronaut.kotlin.processing.aop.simple.Mutating
+
+sealed class MyBase {
+    open fun someMethod(): String {
+        return "x"
+    }
+}
+
+@Mutating("someVal")
+@jakarta.inject.Singleton
+open class MyBean2 : MyBase()
+''')
+        then:
+        definition != null
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
@@ -48,6 +48,49 @@ record Product2(Double price, String name) {
             properties.get(1).name == "name"
     }
 
+    void "test sealed class"() {
+        expect:
+            // getPermittedSubclasses() resolves through KSP, so it has to be read while the resolver session is live
+            buildClassElement('test.Test', """
+package test
+
+sealed class Test
+
+class TestOne : Test()
+
+class TestTwo : Test()
+""") { ClassElement classElement ->
+                assert classElement.isSealed()
+                assert classElement.getPermittedSubclasses()*.getName() as Set == ['test.TestOne', 'test.TestTwo'] as Set
+            }
+    }
+
+    void "test sealed interface"() {
+        expect:
+            buildClassElement('test.Test', """
+package test
+
+sealed interface Test
+
+class TestOne : Test
+""") { ClassElement classElement ->
+                assert classElement.isSealed()
+                assert classElement.getPermittedSubclasses()*.getName() == ['test.TestOne']
+            }
+    }
+
+    void "test non-sealed class"() {
+        expect:
+            buildClassElement('test.Test', """
+package test
+
+open class Test
+""") { ClassElement classElement ->
+                assert !classElement.isSealed()
+                assert classElement.getPermittedSubclasses().isEmpty()
+            }
+    }
+
     void "test Java annotations"() {
         def ce = buildClassElementJava('test.Product', '''
 package test;

--- a/src/main/docs/guide/appendix/architecture/aopArch.adoc
+++ b/src/main/docs/guide/appendix/architecture/aopArch.adoc
@@ -15,7 +15,7 @@ One or many instances of api:aop.Interceptor[] can be associated with an ann:aop
 
 At an implementation level, the <<compilerArch, Micronaut Compiler>> will visit types that are meta-annotated with ann:aop.InterceptorBinding[] and construct a new instance of api:aop.writer.AopProxyWriter[] which uses the ASM bytecode generation library to generate a subclass (or an implementation in the case of interfaces) of the annotated type.
 
-NOTE: Micronaut at no point modifies existing user byte code, the use of build-time generated proxies allows Micronaut to generate additional code that sits alongside user code and enhances behaviour. This approach does have limitations however, for example it is required that annotated types are non-final and AOP advice cannot be applied to final or effectively final types such as Java 17 Records.
+NOTE: Micronaut at no point modifies existing user byte code, the use of build-time generated proxies allows Micronaut to generate additional code that sits alongside user code and enhances behaviour. This approach does have limitations however, for example it is required that annotated types are non-final and non-sealed, and AOP advice cannot be applied to final or effectively final types such as Java 17 Records, nor to sealed types, which permit only the subclasses they list.
 
 For example given the following annotation:
 

--- a/src/main/docs/guide/appendix/architecture/aopArch.adoc
+++ b/src/main/docs/guide/appendix/architecture/aopArch.adoc
@@ -15,7 +15,13 @@ One or many instances of api:aop.Interceptor[] can be associated with an ann:aop
 
 At an implementation level, the <<compilerArch, Micronaut Compiler>> will visit types that are meta-annotated with ann:aop.InterceptorBinding[] and construct a new instance of api:aop.writer.AopProxyWriter[] which uses the ASM bytecode generation library to generate a subclass (or an implementation in the case of interfaces) of the annotated type.
 
-NOTE: Micronaut at no point modifies existing user byte code, the use of build-time generated proxies allows Micronaut to generate additional code that sits alongside user code and enhances behaviour. This approach does have limitations however, for example it is required that annotated types are non-final and non-sealed, and AOP advice cannot be applied to final or effectively final types such as Java 17 Records, nor to sealed types, which permit only the subclasses they list.
+[NOTE]
+====
+Micronaut at no point modifies existing user bytecode, the use of build-time generated proxies allows Micronaut to generate additional code that sits alongside user code and enhances behaviour. This approach does have limitations however, since the generated proxy has to extend or implement the annotated type. An annotated type must therefore be:
+
+* Non-final. AOP advice cannot be applied to final or effectively final types such as Java 17 Records.
+* Non-sealed. A sealed type permits only the subclasses it lists, which a generated proxy can never be.
+====
 
 For example given the following annotation:
 


### PR DESCRIPTION
A `final` class carrying AOP advice is caught while it is compiled:

```
error: Cannot apply AOP advice to final class. Class must be made non-final to support proxying: test.MyBean
```

A `sealed` type was not checked at all. Proxies are written as bytecode rather than source, so javac never sees the illegal subclass, compilation succeeds, and the JVM rejects the generated class at load:

```
java.lang.IncompatibleClassChangeError: Failed listed permitted subclass check:
  class test.$MyBean$Definition$Intercepted is not a permitted subclass of test.MyBean
```

That is the contrast this PR closes: the same unproxyable shape, reported the same way, at the same time.

## The check

It lands beside the final-class one, in `core-processor`:

- `DefaultElementBeanDefinitionBuilderFactory.aroundProxy` — around advice on a class, and every **scoped proxy**. `@ScopedProxy` is how each normal-scoped bean is served and reaches the same generator, so a sealed class annotated with a normal scope hits this trap with no advice written anywhere. One check covers both; there is a test for the scoped case regardless.
- `DefaultElementBeanDefinitionBuilderFactory.introductionProxy` — introduction advice on a sealed class **and** on a sealed interface. An interface is proxied by generating an implementation, and a sealed interface permits only its listed implementors, so the interface case is exactly as broken as the class one.
- `FactoryBeanElementCreator` — a sealed type produced by a `@Factory` method, reported against the producing element the way the final check is.

The message is in the same register, and says *type* rather than *class* because a sealed interface is equally affected:

```
Cannot apply AOP advice to sealed type. Type must be made non-sealed to support proxying: test.MyBean
```

There is no legitimate case being turned away. A sealed type whose permitted subclass *is* the proxy cannot occur — the proxy name is generated, so it can never appear in a `permits` clause.

## What still works

A `non-sealed` subclass carrying the advice is proxied normally, and that has a test in each of the three languages.

## Element model

`ClassElement.isSealed()` and `getPermittedSubclasses()` existed but were implemented for Java only, so a check in shared code would have been silent for Groovy and Kotlin. They are now implemented for both — `ClassNode.isSealed()` for Groovy, `Modifier.SEALED` for Kotlin. No new API.

## Tests

`SealedModifierSpec` in each of `inject-java`, `inject-groovy` and `inject-kotlin`. Every case was confirmed to reproduce as a `LinkageError` before the fix. `:micronaut-inject-java:test`, `:micronaut-inject-groovy:test` and `:micronaut-inject-kotlin:test` all pass.

## Where this came from

Working out what Jakarta CDI 5.0 needs from Micronaut for https://github.com/dstepanov/micronaut-cdi. CDI 5.0 states that a sealed bean type requiring a client proxy is an unproxyable bean type and therefore a deployment problem, and its TCK has three tests for it under `lookup/clientProxy/unproxyable/sealed/`. Micronaut needs the same answer at compile time rather than a `LinkageError` at run time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)