### PR TITLE
Let construct advice enforce constraints on a container-invoked constructor

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/chain/ConstructorInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/ConstructorInterceptorChain.java
@@ -23,6 +23,7 @@ import io.micronaut.aop.InvocationContext;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.context.exceptions.ConstructorAdviceException;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
@@ -107,7 +108,13 @@ public final class ConstructorInterceptorChain<T> extends AbstractInterceptorCha
             } else {
                 finalParameters = getParameterValues();
             }
-            return beanConstructor.instantiate(finalParameters);
+            try {
+                return beanConstructor.instantiate(finalParameters);
+            } catch (RuntimeException | Error e) {
+                // Marks the throwable as coming from the constructor body rather than from advice, so that it
+                // keeps the wrapping an unadvised constructor's throwable gets. Unwrapped again in instantiate.
+                throw new ConstructorBodyException(e);
+            }
         } else {
             interceptor = this.interceptors[index++];
             if (LOG.isTraceEnabled()) {
@@ -197,13 +204,47 @@ public final class ConstructorInterceptorChain<T> extends AbstractInterceptorCha
         final InterceptorRegistry interceptorRegistry = beanContext.getBean(InterceptorRegistry.ARGUMENT);
         final Interceptor<T1, T1>[] resolvedInterceptors = interceptorRegistry
             .resolveConstructorInterceptors(constructor, interceptors);
-        return Objects.requireNonNull(new ConstructorInterceptorChain<>(
+        ConstructorInterceptorChain<T1> chain = new ConstructorInterceptorChain<>(
             definition,
             constructor,
             resolvedInterceptors,
             additionalProxyConstructorParametersCount,
             parameters
-        ).proceed(), "Constructor interceptor chain illegally returned null for constructor: " + constructor.getDescription());
+        );
+        T1 bean;
+        try {
+            bean = chain.proceed();
+        } catch (ConstructorBodyException e) {
+            throw e.rethrowCause();
+        } catch (ConstructorAdviceException e) {
+            throw e;
+        } catch (RuntimeException | Error e) {
+            // Anything else escaped the advice itself rather than the constructor it wraps. Advice around a
+            // method reaches its caller as it was thrown; carry this one so construction advice does too.
+            throw new ConstructorAdviceException(e);
+        }
+        return Objects.requireNonNull(bean, "Constructor interceptor chain illegally returned null for constructor: " + constructor.getDescription());
+    }
+
+    /**
+     * Carries a throwable out of the intercepted constructor's own body, so that
+     * {@link #instantiate} can tell it apart from one thrown by the advice around it.
+     */
+    private static final class ConstructorBodyException extends RuntimeException {
+
+        private final transient Throwable bodyCause;
+
+        private ConstructorBodyException(Throwable cause) {
+            super(cause.getMessage(), cause, false, false);
+            this.bodyCause = cause;
+        }
+
+        private RuntimeException rethrowCause() {
+            if (bodyCause instanceof Error error) {
+                throw error;
+            }
+            return (RuntimeException) bodyCause;
+        }
     }
 
     private static @Nullable Object[] resolveConcreteSubset(BeanDefinition<?> beanDefinition,

--- a/aop/src/main/java/io/micronaut/aop/chain/ConstructorInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/ConstructorInterceptorChain.java
@@ -65,6 +65,12 @@ public final class ConstructorInterceptorChain<T> extends AbstractInterceptorCha
      */
     private final BeanConstructor<T> interceptedConstructor;
     private final @Nullable Object[] internalParameters;
+    /**
+     * The exception the intercepted constructor's own body threw, if it threw one. Kept so that
+     * {@link #instantiate} can tell it apart from an exception thrown by the advice around it: the two are
+     * propagated differently.
+     */
+    private @Nullable RuntimeException bodyFailure;
 
     /**
      * Default constructor.
@@ -110,10 +116,9 @@ public final class ConstructorInterceptorChain<T> extends AbstractInterceptorCha
             }
             try {
                 return beanConstructor.instantiate(finalParameters);
-            } catch (RuntimeException | Error e) {
-                // Marks the throwable as coming from the constructor body rather than from advice, so that it
-                // keeps the wrapping an unadvised constructor's throwable gets. Unwrapped again in instantiate.
-                throw new ConstructorBodyException(e);
+            } catch (RuntimeException e) {
+                bodyFailure = e;
+                throw e;
             }
         } else {
             interceptor = this.interceptors[index++];
@@ -214,37 +219,19 @@ public final class ConstructorInterceptorChain<T> extends AbstractInterceptorCha
         T1 bean;
         try {
             bean = chain.proceed();
-        } catch (ConstructorBodyException e) {
-            throw e.rethrowCause();
         } catch (ConstructorAdviceException e) {
+            // Already carried, by the advice around a bean this one's construction depends on
             throw e;
-        } catch (RuntimeException | Error e) {
-            // Anything else escaped the advice itself rather than the constructor it wraps. Advice around a
-            // method reaches its caller as it was thrown; carry this one so construction advice does too.
+        } catch (RuntimeException e) {
+            if (e == chain.bodyFailure) {
+                // The constructor's own body threw. Keep the wrapping an unadvised constructor's throwable gets
+                throw e;
+            }
+            // The advice around the constructor threw. Advice around a method reaches its caller as it was
+            // thrown; carry this one so that construction advice does too
             throw new ConstructorAdviceException(e);
         }
         return Objects.requireNonNull(bean, "Constructor interceptor chain illegally returned null for constructor: " + constructor.getDescription());
-    }
-
-    /**
-     * Carries a throwable out of the intercepted constructor's own body, so that
-     * {@link #instantiate} can tell it apart from one thrown by the advice around it.
-     */
-    private static final class ConstructorBodyException extends RuntimeException {
-
-        private final transient Throwable bodyCause;
-
-        private ConstructorBodyException(Throwable cause) {
-            super(cause.getMessage(), cause, false, false);
-            this.bodyCause = cause;
-        }
-
-        private RuntimeException rethrowCause() {
-            if (bodyCause instanceof Error error) {
-                throw error;
-            }
-            return (RuntimeException) bodyCause;
-        }
     }
 
     private static @Nullable Object[] resolveConcreteSubset(BeanDefinition<?> beanDefinition,

--- a/inject-java/src/test/groovy/io/micronaut/aop/constructor/ConstructorValidationAdviceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/constructor/ConstructorValidationAdviceSpec.groovy
@@ -287,6 +287,29 @@ class Event implements Titled {
         context.close()
     }
 
+    void "a violation while an eager bean is initialized at startup fails the startup"() {
+        when: 'a @Context bean the container initializes eagerly cannot satisfy its constraint'
+        buildContext(VALIDATION_STACK + '''
+@Factory
+class Titles {
+    @Singleton
+    String title() { return "Hi"; }
+}
+
+@Context
+class Event implements Titled {
+    private final String title;
+    Event(@Size(min = 5) String title) { this.title = title; }
+    @Override public String getTitle() { return title; }
+}
+''')
+
+        then: 'the startup fails, reporting the definition that could not be loaded'
+        def e = thrown(io.micronaut.context.exceptions.BeanInstantiationException)
+        e.message.contains('test.Event')
+        e.message.contains('title: size must be at least 5')
+    }
+
     void "an exception thrown by the constructor body of an advised bean is still wrapped"() {
         given:
         ApplicationContext context = buildContext(VALIDATION_STACK + '''

--- a/inject-java/src/test/groovy/io/micronaut/aop/constructor/ConstructorValidationAdviceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/constructor/ConstructorValidationAdviceSpec.groovy
@@ -1,0 +1,344 @@
+package io.micronaut.aop.constructor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.Intercepted
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ConstructorElement
+import io.micronaut.inject.ast.ParameterElement
+import io.micronaut.inject.validation.RequiresValidation
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+import jakarta.validation.ConstraintViolationException
+
+/**
+ * Jakarta Validation 5.1.2 requires an integration to validate a constrained constructor the container
+ * invokes. A library does that by declaring construct advice on the constructor from its own
+ * {@link TypeElementVisitor}; core supplies the mechanism and does not need to know the library's annotation.
+ *
+ * <p>These specs stand in for micronaut-validation with the smallest thing shaped like it:
+ * {@code ConstraintVisitor} plays the part of its {@code ValidationVisitor}, which already visits every
+ * constructor and already marks a constrained one with {@link RequiresValidation}, and
+ * {@code ValidatingConstructorInterceptor} plays the part of a validating {@code ConstructorInterceptor},
+ * reading the constraints off the invocation context and rejecting the construction the way a real validator
+ * would.</p>
+ */
+class ConstructorValidationAdviceSpec extends AbstractTypeElementSpec {
+
+    /** The advice annotation and the validating interceptor micronaut-validation would ship. */
+    private static final String VALIDATION_STACK = '''
+package test;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.*;
+import io.micronaut.core.type.Argument;
+import jakarta.inject.Singleton;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.Size;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.CONSTRUCTOR})
+@AroundConstruct
+@interface ValidatedConstructor {}
+
+/** A constraint on the constructor itself: the instance it returns must have a title. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.CONSTRUCTOR)
+@jakarta.validation.Constraint(validatedBy = {})
+@interface ValidEvent {
+    String message() default "must have a title";
+    Class<?>[] groups() default {};
+    Class<? extends jakarta.validation.Payload>[] payload() default {};
+}
+
+interface Titled {
+    String getTitle();
+}
+
+@Singleton
+@InterceptorBinding(value = ValidatedConstructor.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+class ValidatingConstructorInterceptor implements ConstructorInterceptor<Object> {
+
+    public static final List<String> VALIDATED = new ArrayList<>();
+
+    @Override
+    public Object intercept(ConstructorInvocationContext<Object> context) {
+        VALIDATED.add(context.getDeclaringType().getSimpleName());
+
+        Argument<?>[] arguments = context.getArguments();
+        Object[] values = context.getParameterValues();
+        for (int i = 0; i < arguments.length; i++) {
+            int min = arguments[i].getAnnotationMetadata().intValue(Size.class, "min").orElse(-1);
+            if (min >= 0 && values[i] instanceof String s && s.length() < min) {
+                throw new ConstraintViolationException(
+                    arguments[i].getName() + ": size must be at least " + min, Collections.emptySet());
+            }
+        }
+
+        Object instance = context.proceed();
+
+        if (context.getConstructor().getAnnotationMetadata().hasAnnotation(ValidEvent.class)
+                && ((Titled) instance).getTitle().isEmpty()) {
+            throw new ConstraintViolationException("<return value>: must have a title", Collections.emptySet());
+        }
+        return instance;
+    }
+}
+'''
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        return [new ConstraintVisitor()]
+    }
+
+    void "a constrained constructor parameter is validated when the container creates the bean"() {
+        given:
+        ApplicationContext context = buildContext(VALIDATION_STACK + '''
+@Factory
+class Titles {
+    @Singleton
+    String title() { return "Hi"; }
+}
+
+@Singleton
+class Event implements Titled {
+    private final String title;
+    Event(@Size(min = 5) String title) { this.title = title; }
+    @Override public String getTitle() { return title; }
+}
+''')
+
+        when: 'the container resolves a title that violates the constraint'
+        context.getBean(context.classLoader.loadClass('test.Event'))
+
+        then: 'the violation reaches the caller as itself, not wrapped in a BeanInstantiationException'
+        ConstraintViolationException e = thrown()
+        e.message == 'title: size must be at least 5'
+
+        cleanup:
+        context.close()
+    }
+
+    void "a constructor whose arguments satisfy their constraints creates the bean"() {
+        given:
+        ApplicationContext context = buildContext(VALIDATION_STACK + '''
+@Factory
+class Titles {
+    @Singleton
+    String title() { return "Release party"; }
+}
+
+@Singleton
+class Event implements Titled {
+    private final String title;
+    Event(@Size(min = 5) String title) { this.title = title; }
+    @Override public String getTitle() { return title; }
+}
+''')
+
+        when:
+        def event = context.getBean(context.classLoader.loadClass('test.Event'))
+
+        then:
+        event.title == 'Release party'
+        context.classLoader.loadClass('test.ValidatingConstructorInterceptor').VALIDATED == ['Event']
+
+        cleanup:
+        context.close()
+    }
+
+    void "a constraint declared on the constructor validates the instance it returns"() {
+        given:
+        ApplicationContext context = buildContext(VALIDATION_STACK + '''
+@Factory
+class Titles {
+    @Singleton
+    String title() { return ""; }
+}
+
+@Singleton
+class Event implements Titled {
+    private final String title;
+    @ValidEvent
+    Event(String title) { this.title = title; }
+    @Override public String getTitle() { return title; }
+}
+''')
+
+        when: 'the constructor runs, and the instance it produced violates the constructor\'s own constraint'
+        context.getBean(context.classLoader.loadClass('test.Event'))
+
+        then:
+        ConstraintViolationException e = thrown()
+        e.message == '<return value>: must have a title'
+
+        cleanup:
+        context.close()
+    }
+
+    void "an unconstrained constructor is not advised"() {
+        given:
+        ApplicationContext context = buildContext(VALIDATION_STACK + '''
+@Singleton
+class Venue {}
+
+@Singleton
+class Event implements Titled {
+    Event(Venue venue) {}
+    @Override public String getTitle() { return "Release party"; }
+}
+''')
+
+        when:
+        def event = context.getBean(context.classLoader.loadClass('test.Event'))
+
+        then: 'construction goes straight to the constructor'
+        event != null
+        context.classLoader.loadClass('test.ValidatingConstructorInterceptor').VALIDATED.isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void "an around advised bean is validated once, on the construction of its proxy"() {
+        given:
+        ApplicationContext context = buildContext(VALIDATION_STACK + '''
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Around
+@interface Traced {}
+
+@Singleton
+@Traced
+class TraceInterceptor implements MethodInterceptor<Object, Object> {
+    @Override public Object intercept(MethodInvocationContext<Object, Object> context) { return context.proceed(); }
+}
+
+@Factory
+class Titles {
+    @Singleton
+    String title() { return "Hi"; }
+}
+
+@Singleton
+@Traced
+class Event implements Titled {
+    private final String title;
+    Event(@Size(min = 5) String title) { this.title = title; }
+    @Override public String getTitle() { return title; }
+    String work() { return "done"; }
+}
+''')
+
+        when:
+        context.getBean(context.classLoader.loadClass('test.Event'))
+
+        then: 'the proxy is constructed through the advice, which still describes the target constructor'
+        ConstraintViolationException e = thrown()
+        e.message == 'title: size must be at least 5'
+        context.classLoader.loadClass('test.ValidatingConstructorInterceptor').VALIDATED == ['Event']
+
+        cleanup:
+        context.close()
+    }
+
+    void "an around advised bean that satisfies its constraints is still proxied"() {
+        given:
+        ApplicationContext context = buildContext(VALIDATION_STACK + '''
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Around
+@interface Traced {}
+
+@Singleton
+@Traced
+class TraceInterceptor implements MethodInterceptor<Object, Object> {
+    @Override public Object intercept(MethodInvocationContext<Object, Object> context) { return context.proceed(); }
+}
+
+@Factory
+class Titles {
+    @Singleton
+    String title() { return "Release party"; }
+}
+
+@Singleton
+@Traced
+class Event implements Titled {
+    private final String title;
+    Event(@Size(min = 5) String title) { this.title = title; }
+    @Override public String getTitle() { return title; }
+    String work() { return "done"; }
+}
+''')
+
+        when:
+        def event = context.getBean(context.classLoader.loadClass('test.Event'))
+
+        then:
+        event instanceof Intercepted
+        event.work() == 'done'
+        event.title == 'Release party'
+        context.classLoader.loadClass('test.ValidatingConstructorInterceptor').VALIDATED == ['Event']
+
+        cleanup:
+        context.close()
+    }
+
+    void "an exception thrown by the constructor body of an advised bean is still wrapped"() {
+        given:
+        ApplicationContext context = buildContext(VALIDATION_STACK + '''
+@Factory
+class Titles {
+    @Singleton
+    String title() { return "Release party"; }
+}
+
+@Singleton
+class Event implements Titled {
+    Event(@Size(min = 5) String title) { throw new IllegalStateException("bad constructor"); }
+    @Override public String getTitle() { return ""; }
+}
+''')
+
+        when:
+        context.getBean(context.classLoader.loadClass('test.Event'))
+
+        then: 'the wrapping an unadvised constructor gets, unchanged'
+        def e = thrown(io.micronaut.context.exceptions.BeanInstantiationException)
+        e.cause instanceof IllegalStateException
+        e.cause.message == 'bad constructor'
+
+        cleanup:
+        context.close()
+    }
+
+    /**
+     * Stands in for micronaut-validation's {@code ValidationVisitor}, which already marks a constructor whose
+     * parameters or return value carry constraints. Declaring the construct advice alongside that marker is
+     * the one step it does not take today.
+     */
+    static class ConstraintVisitor implements TypeElementVisitor<Object, Object> {
+
+        @Override
+        void visitConstructor(ConstructorElement element, VisitorContext context) {
+            boolean constrained = element.hasStereotype('jakarta.validation.Constraint')
+                || element.getParameters().any { ParameterElement p -> p.hasStereotype('jakarta.validation.Constraint') }
+            if (constrained) {
+                element.annotate(RequiresValidation)
+                element.annotate('test.ValidatedConstructor')
+            }
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+        }
+
+        @Override
+        VisitorKind getVisitorKind() {
+            return VisitorKind.ISOLATING
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2316,7 +2316,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         } catch (ConstructorAdviceException e) {
             // Advice around the constructor rejected the construction. An exception thrown by advice reaches
             // its caller as it was thrown when the advice is around a method, so it does here too.
-            throw e.rethrowCause();
+            throw e.getAdviceCause();
         } catch (DependencyInjectionException | DisabledBeanException |
                  BeanInstantiationException e) {
             throw e;

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -44,6 +44,7 @@ import io.micronaut.context.exceptions.BeanCreationException;
 import io.micronaut.context.exceptions.BeanDestructionException;
 import io.micronaut.context.exceptions.BeanInstantiationException;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.context.exceptions.ConstructorAdviceException;
 import io.micronaut.context.exceptions.DependencyInjectionException;
 import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.context.exceptions.NoSuchBeanException;
@@ -2312,6 +2313,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 qualified.$withBeanQualifier(declaredQualifier);
             }
             return bean;
+        } catch (ConstructorAdviceException e) {
+            // Advice around the constructor rejected the construction. An exception thrown by advice reaches
+            // its caller as it was thrown when the advice is around a method, so it does here too.
+            throw e.rethrowCause();
         } catch (DependencyInjectionException | DisabledBeanException |
                  BeanInstantiationException e) {
             throw e;

--- a/inject/src/main/java/io/micronaut/context/exceptions/ConstructorAdviceException.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/ConstructorAdviceException.java
@@ -26,8 +26,10 @@ import io.micronaut.core.annotation.Internal;
  * lets the container tell the two apart, so that an exception thrown by construction advice is rethrown
  * unchanged while an exception thrown by the constructor body keeps being wrapped.</p>
  *
- * <p>Instances never reach user code: {@code DefaultBeanContext} unwraps them at the bean creation
- * boundary.</p>
+ * <p>Used for flow control only: it is thrown and caught between
+ * {@code ConstructorInterceptorChain#instantiate} and the bean creation boundary in
+ * {@code DefaultBeanContext}, and never reaches user code. It carries no stack trace of its own — the
+ * exception the advice threw keeps its own, and it is that one the caller sees.</p>
  *
  * @author Denis Stepanov
  * @since 5.2.0
@@ -35,29 +37,25 @@ import io.micronaut.core.annotation.Internal;
 @Internal
 public final class ConstructorAdviceException extends RuntimeException {
 
-    private final transient Throwable adviceCause;
+    private final transient RuntimeException adviceCause;
 
     /**
-     * @param cause The throwable the advice threw
+     * @param cause The exception the advice threw
      */
-    public ConstructorAdviceException(Throwable cause) {
-        super(cause.getMessage(), cause, false, false);
+    public ConstructorAdviceException(RuntimeException cause) {
+        super(cause.getMessage(), cause);
         this.adviceCause = cause;
     }
 
     /**
-     * Rethrows the exception the advice threw.
-     *
-     * <p>Advice cannot throw a checked exception, so the cause is always a {@link RuntimeException} or an
-     * {@link Error}. An {@link Error} is thrown directly; a {@link RuntimeException} is returned so that the
-     * call site can {@code throw} it and keep the compiler informed that the flow ends there.</p>
-     *
-     * @return The runtime exception the advice threw
+     * @return The exception the advice threw, to be rethrown in place of this carrier
      */
-    public RuntimeException rethrowCause() {
-        if (adviceCause instanceof Error error) {
-            throw error;
-        }
-        return (RuntimeException) adviceCause;
+    public RuntimeException getAdviceCause() {
+        return adviceCause;
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/exceptions/ConstructorAdviceException.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/ConstructorAdviceException.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.exceptions;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Carries an exception thrown by advice applied around a bean's constructor.
+ *
+ * <p>An exception thrown by advice is the user's exception: when advice around a <em>method</em> throws, the
+ * caller sees it as it was thrown. Advice around a <em>constructor</em> runs while the container is creating
+ * the bean, where any throwable is otherwise wrapped in a {@link BeanInstantiationException}. This carrier
+ * lets the container tell the two apart, so that an exception thrown by construction advice is rethrown
+ * unchanged while an exception thrown by the constructor body keeps being wrapped.</p>
+ *
+ * <p>Instances never reach user code: {@code DefaultBeanContext} unwraps them at the bean creation
+ * boundary.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.2.0
+ */
+@Internal
+public final class ConstructorAdviceException extends RuntimeException {
+
+    private final transient Throwable adviceCause;
+
+    /**
+     * @param cause The throwable the advice threw
+     */
+    public ConstructorAdviceException(Throwable cause) {
+        super(cause.getMessage(), cause, false, false);
+        this.adviceCause = cause;
+    }
+
+    /**
+     * Rethrows the exception the advice threw.
+     *
+     * <p>Advice cannot throw a checked exception, so the cause is always a {@link RuntimeException} or an
+     * {@link Error}. An {@link Error} is thrown directly; a {@link RuntimeException} is returned so that the
+     * call site can {@code throw} it and keep the compiler informed that the flow ends there.</p>
+     *
+     * @return The runtime exception the advice threw
+     */
+    public RuntimeException rethrowCause() {
+        if (adviceCause instanceof Error error) {
+            throw error;
+        }
+        return (RuntimeException) adviceCause;
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/validation/RequiresValidation.java
+++ b/inject/src/main/java/io/micronaut/inject/validation/RequiresValidation.java
@@ -25,14 +25,14 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
- * Internal method marks a type, method or a field for validation.
+ * Internal marker that marks a type, method, constructor or field for validation.
  *
  * @author Denis Stepanov
  * @since 4.0.0
  */
 @Documented
 @Retention(CLASS)
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.FIELD})
 @Internal
 public @interface RequiresValidation {
 }

--- a/src/main/docs/guide/aop/lifecycleAdvice.adoc
+++ b/src/main/docs/guide/aop/lifecycleAdvice.adoc
@@ -43,6 +43,38 @@ snippet::io.micronaut.docs.aop.lifecycle.ProductInterceptors[tags="method-interc
 <2> `@PostConstruct` interception is handled
 <3> `@PreDestroy` interception is handled
 
+=== Exceptions Thrown by Construct Advice
+
+An exception thrown by a api:aop.ConstructorInterceptor[] reaches whoever asked for the bean as it was thrown,
+the same way an exception thrown by a api:aop.MethodInterceptor[] reaches the caller of the method it advises.
+It is not wrapped in a api:context.exceptions.BeanInstantiationException[]. This holds whether the interceptor
+throws before `proceed()`, rejecting the arguments the constructor was about to receive, or after it, rejecting
+the instance the constructor produced:
+
+[source,java]
+----
+@InterceptorBean(ProductBean.class)
+class ProductInterceptor implements ConstructorInterceptor<Product> {
+    @Override
+    public Product intercept(ConstructorInvocationContext<Product> context) {
+        if (context.getParameterValues()[0] == null) {
+            throw new IllegalArgumentException("A product needs a name"); // <1>
+        }
+        return context.proceed();
+    }
+}
+----
+
+<1> `context.getBean(Product.class)` throws this `IllegalArgumentException`, not a `BeanInstantiationException`
+
+This lets advice reject a construction in its own terms. It is what allows constraints declared on a
+constructor to be enforced when the container creates the bean, so that the caller catches the validation
+exception rather than a wrapper around it.
+
+An exception thrown by the constructor's own body is not advice throwing, and is wrapped in a
+api:context.exceptions.BeanInstantiationException[] as it is for a bean with no construct advice at all. So is
+any failure during eager initialization at startup, where the bean is not being created on anyone's behalf.
+
 === Intercepted Callbacks
 
 A `@PostConstruct` or `@PreDestroy` interception runs once per lifecycle event of the bean, not once per callback.


### PR DESCRIPTION
Draft. Makes it possible for micronaut-validation to enforce constraints declared on a constructor the
container invokes — Jakarta Validation §5.1.2, `ExecutableType.CONSTRUCTORS` — which today is never checked:

```java
@Singleton
class Event {
    Event(@NotNull String title) {}      // parameters not validated on construction
}
```

Describing a constrained constructor and validating one explicitly already work (#12909). What was missing is
the container enforcing them on invocation.

## The premise that made this look big was wrong

An earlier write-up said a constructor cannot be advised, and rated closing this as *large*. Constructors
**are** advisable, and the machinery is mature: `@AroundConstruct`, `ConstructorInterceptor`,
`ConstructorInterceptorChain`, and — since #12959 — a target-constructor view so an interceptor of a proxied
bean sees the bean's own constructor rather than the generated proxy one.

Probing it in this branch, everything a Jakarta `ExecutableValidator` needs is already reachable from a
`ConstructorInterceptor`: constructor-level metadata (cross-parameter and return-value constraints) via
`getConstructor().getAnnotationMetadata()`, per-parameter metadata via `getArguments()`, the resolved
`getParameterValues()`, and `getDeclaringType()` reporting the target type even under a proxy.

So micronaut-validation can declare construct advice on a constrained constructor from its own
`ValidationVisitor` — which already visits constructors and already marks the constrained ones with
`@RequiresValidation`. **Core needs no processor change for that**, and this PR deliberately does not add one:
core supplies the mechanism and stays ignorant of the library's annotation.

Two things in core did stand in the way.

## 1. An exception thrown by construct advice was swallowed

Advice around a *method* reaches its caller as it was thrown. Advice around a *constructor* runs while the
container is creating the bean, where `DefaultBeanContext` wraps any throwable in a
`BeanInstantiationException`. Validation advice that rejects a construction was therefore invisible as itself
— and the TCK asserts `catch (ConstraintViolationException e)`.

`ConstructorInterceptorChain` now distinguishes a throwable from the constructor *body* — still wrapped,
behaviour unchanged — from one thrown by the *advice* around it, which is carried in an `@Internal`
`ConstructorAdviceException` that `DefaultBeanContext` unwraps at the single instantiation choke point. Both
the before-proceed case (parameter constraints) and the after-proceed case (return-value constraints) are
covered.

**This is the part I would most like a second opinion on**, and it is a separate commit so it can be dropped.
The alternative is to keep today's wrapping, which preserves the `BeanInstantiationException` contract but
leaves the TCK methods red.

## 2. `@RequiresValidation` did not allow `ElementType.CONSTRUCTOR`

`ValidationVisitor` already applies it to constructors synthetically; the declaration just did not say so,
which makes it impossible to write in source or in a test.

## Behaviour this enables

Measured with an `@AroundConstruct` annotation on a constructor:

| Case | Behaviour |
|---|---|
| plain `@Singleton` / `@Prototype`, records | advised on every container instantiation |
| constructor injection | advice runs after dependencies resolve, before the body |
| around-advised type | intercepted once, on the `$Intercepted` construction; the advice sees the target constructor |
| `@Around(proxyTarget = true)` | intercepted on the target's construction |
| `@Factory` method | not advised — and correctly so: §5.1.2 asks for constructors *the container* invokes, and a factory body's `new` is user code. A constrained factory method is already advised as a *method* |
| abstract / `@Introduction` type, inherited superclass constructor | not advised; construct advice is not inherited |
| plain `new Event(...)` in user code | untouched |
| failure during eager startup | `BeanInstantiationException` as today; a lazy `getBean` sees the advice's own exception |

## Follow-up, not in this PR

- **micronaut-validation:** a `@ValidatedConstructor` (`@AroundConstruct`, deliberately separate from
  `@Validated`, which is `@Around` — putting that on a constructor would drag around-advice semantics onto its
  metadata), applied from `ValidationVisitor.visitConstructor`, and a `ValidatingConstructorInterceptor` at
  `InterceptPhase.VALIDATE` calling the existing `validateConstructorParameters` /
  `validateConstructorReturnValue`. Return-value constraints must be evaluated against `getDeclaringType()`,
  not `instance.getClass()` — under `proxyTarget=false` the latter is the `$Intercepted` subclass.
  `@ConfigurationProperties` should be skipped there: those already validate after construction, and advising
  them too would double-validate.
- Then un-exclude the TCK classes and re-measure. Note the TCK has **four** constructor methods, not two, and
  `ExecutableValidationTest` / `ExecutableTypesTest` are excluded wholesale rather than per-method.
- **Separate defect found while probing:** a bean with **type-level** `@Around` **and type-level**
  `@AroundConstruct` gets no construct interception, silently. Constructor-level construct advice on the same
  bean works, so it does not block this. Worth its own issue.

## Tests

`ConstructorValidationAdviceSpec` in `inject-java` exercises the whole path a validation library would take,
with nothing core-internal short-circuited. The beans under test carry real constraints — `@Size(min = 5)` on
a constructor parameter, and a `jakarta.validation.Constraint`-meta-annotated `@ValidEvent` on the constructor
itself — a local `TypeElementVisitor` stands in for `ValidationVisitor`, deriving `@RequiresValidation` and the
construct advice from those constraints, and a stand-in `ValidatingConstructorInterceptor` reads the
constraints off the invocation context and throws a real `jakarta.validation.ConstraintViolationException`.

Covered: a violated parameter constraint surfacing from `getBean` as a `ConstraintViolationException` and not a
wrapper; a satisfied one constructing the bean; a constraint on the constructor rejecting the instance it
returned (the after-proceed case); an unconstrained constructor not advised at all; an around-advised bean
validated once on its proxy's construction, in both the violating and the passing case; and a constructor-body
exception still being wrapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
