### PR TITLE
Let a runtime bean definition look beans up as it creates and disposes

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionLookupSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionLookupSpec.groovy
@@ -1,0 +1,309 @@
+package io.micronaut.inject.beans
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanRegistration
+import io.micronaut.context.RuntimeBeanDefinition
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.context.exceptions.CircularDependencyException
+import io.micronaut.context.exceptions.DependencyInjectionException
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.beans.injectionpoints.Colour
+import io.micronaut.inject.beans.injectionpoints.DisposableDependency
+import io.micronaut.inject.beans.injectionpoints.DisposableSingletonDependency
+import io.micronaut.inject.beans.lookups.CircularDependency
+import io.micronaut.inject.beans.lookups.LookupHolder
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+import java.util.function.BiConsumer
+import java.util.function.Function
+
+class RuntimeBeanDefinitionLookupSpec extends Specification {
+
+    private static RuntimeBeanDefinition.Builder<LookupHolder> holderBuilder(
+            Function<RuntimeBeanDefinition.CreationContext, LookupHolder> factory) {
+        RuntimeBeanDefinition.builder(LookupHolder, factory)
+    }
+
+    void 'test a compiled bean can be looked up by the creator'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(ctx.getBean(Argument.of(DisposableSingletonDependency))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        context.getBean(LookupHolder).created.is(context.getBean(DisposableSingletonDependency))
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a qualified compiled bean can be looked up by the creator'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx ->
+                                new LookupHolder(ctx.getBean(Argument.of(Colour), Qualifiers.byName("red"))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        (context.getBean(LookupHolder).created as Colour).name() == "red"
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a prototype the creator looked up is destroyed with the created bean and not before'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(ctx.getBean(Argument.of(DisposableDependency))))
+                                .scope(Prototype)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        BeanRegistration<LookupHolder> registration = context.getBeanRegistration(LookupHolder, null)
+        DisposableDependency dependency = registration.bean.created as DisposableDependency
+
+        then: 'the lookup went through the resolution context of the creation'
+        dependency != null
+        !dependency.destroyed
+
+        when:
+        registration.close()
+
+        then: 'core destroyed it as a dependent of the created bean'
+        dependency.destroyed
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a prototype the creator of a singleton looked up is destroyed with it'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(ctx.getBean(Argument.of(DisposableDependency))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+        LookupHolder holder = context.getBean(LookupHolder)
+        DisposableDependency dependency = holder.created as DisposableDependency
+
+        when:
+        context.destroyBean(holder)
+
+        then:
+        dependency.destroyed
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a singleton the creator looked up is not destroyed with the created bean'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(ctx.getBean(Argument.of(DisposableSingletonDependency))))
+                                .scope(Prototype)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        BeanRegistration<LookupHolder> registration = context.getBeanRegistration(LookupHolder, null)
+        def dependency = registration.bean.created as DisposableSingletonDependency
+        registration.close()
+
+        then:
+        !dependency.destroyed
+
+        when:
+        context.close()
+
+        then:
+        dependency.destroyed
+    }
+
+    void 'test a prototype the disposer looked up is destroyed when the disposer returns'() {
+        given:
+        def resolvedByDisposer = []
+        def destroyedInsideDisposer = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(ctx.getBean(Argument.of(DisposableDependency))))
+                                .singleton(true)
+                                .injectedDisposer((BiConsumer<RuntimeBeanDefinition.DisposalContext, LookupHolder>) { ctx, bean ->
+                                    def dependency = ctx.getBean(Argument.of(DisposableDependency))
+                                    resolvedByDisposer << dependency
+                                    destroyedInsideDisposer << dependency.destroyed
+                                })
+                                .build()
+                )
+                .build()
+                .start()
+        LookupHolder holder = context.getBean(LookupHolder)
+        DisposableDependency createdWith = holder.created as DisposableDependency
+
+        when:
+        context.destroyBean(holder)
+        DisposableDependency disposedWith = resolvedByDisposer[0] as DisposableDependency
+
+        then: 'the disposer resolved an instance of its own, not the one the creator got'
+        !disposedWith.is(createdWith)
+
+        and: 'it was still alive while the disposer ran and destroyed once it returned'
+        !destroyedInsideDisposer[0]
+        disposedWith.destroyed
+
+        and: 'the instance the creator got is destroyed with the bean as before'
+        createdWith.destroyed
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a singleton the disposer looked up is not destroyed when the disposer returns'() {
+        given:
+        def resolvedByDisposer = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(null))
+                                .singleton(true)
+                                .injectedDisposer((BiConsumer<RuntimeBeanDefinition.DisposalContext, LookupHolder>) { ctx, bean ->
+                                    resolvedByDisposer << ctx.getBean(Argument.of(DisposableSingletonDependency))
+                                })
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        context.destroyBean(context.getBean(LookupHolder))
+        def dependency = resolvedByDisposer[0] as DisposableSingletonDependency
+
+        then:
+        dependency.is(context.getBean(DisposableSingletonDependency))
+        !dependency.destroyed
+
+        when:
+        context.close()
+
+        then:
+        dependency.destroyed
+    }
+
+    void 'test the disposer runs with its lookups when the context is closed'() {
+        given:
+        def resolvedByDisposer = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(null))
+                                .singleton(true)
+                                .injectedDisposer((BiConsumer<RuntimeBeanDefinition.DisposalContext, LookupHolder>) { ctx, bean ->
+                                    resolvedByDisposer << ctx.getBean(Argument.of(DisposableDependency))
+                                })
+                                .build()
+                )
+                .build()
+                .start()
+        context.getBean(LookupHolder)
+
+        when:
+        context.close()
+
+        then:
+        resolvedByDisposer.size() == 1
+        (resolvedByDisposer[0] as DisposableDependency).destroyed
+    }
+
+    void 'test what the disposer resolved is destroyed even when the disposer fails'() {
+        given:
+        def resolvedByDisposer = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(null))
+                                .singleton(true)
+                                .injectedDisposer((BiConsumer<RuntimeBeanDefinition.DisposalContext, LookupHolder>) { ctx, bean ->
+                                    resolvedByDisposer << ctx.getBean(Argument.of(DisposableDependency))
+                                    ctx.getBean(Argument.of(NotABean))
+                                })
+                                .build()
+                )
+                .build()
+                .start()
+
+        when: 'the disposer fails on a lookup that cannot be satisfied'
+        context.destroyBean(context.getBean(LookupHolder))
+
+        then: 'the failure does not propagate, the way it does not for any other disposer'
+        noExceptionThrown()
+
+        and: 'what it resolved before failing is destroyed all the same'
+        (resolvedByDisposer[0] as DisposableDependency).destroyed
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a circular lookup is detected'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(ctx.getBean(Argument.of(CircularDependency))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        context.getBean(LookupHolder)
+
+        then:
+        thrown(CircularDependencyException)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test an unsatisfied lookup by the creator fails the creation'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(ctx.getBean(Argument.of(NotABean))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        context.getBean(LookupHolder)
+
+        then:
+        def e = thrown(DependencyInjectionException)
+        e.message.contains(NotABean.name)
+
+        cleanup:
+        context.close()
+    }
+
+    static class NotABean {
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionLookupSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionLookupSpec.groovy
@@ -11,6 +11,8 @@ import io.micronaut.inject.beans.injectionpoints.Colour
 import io.micronaut.inject.beans.injectionpoints.DisposableDependency
 import io.micronaut.inject.beans.injectionpoints.DisposableSingletonDependency
 import io.micronaut.inject.beans.lookups.CircularDependency
+import io.micronaut.inject.beans.lookups.CompiledHolder
+import io.micronaut.inject.beans.lookups.LifeCycleDependency
 import io.micronaut.inject.beans.lookups.LookupHolder
 import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Specification
@@ -256,6 +258,43 @@ class RuntimeBeanDefinitionLookupSpec extends Specification {
 
         and: 'what it resolved before failing is destroyed all the same'
         (resolvedByDisposer[0] as DisposableDependency).destroyed
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a life cycle dependent is destroyed the same way whichever context resolved it'() {
+        given: 'the same dependent reached three ways: a compiled constructor, a creator lookup and a disposer lookup'
+        def resolvedByDisposer = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        holderBuilder(ctx -> new LookupHolder(ctx.getBean(Argument.of(LifeCycleDependency))))
+                                .singleton(true)
+                                .injectedDisposer((BiConsumer<RuntimeBeanDefinition.DisposalContext, LookupHolder>) { ctx, bean ->
+                                    resolvedByDisposer << ctx.getBean(Argument.of(LifeCycleDependency))
+                                })
+                                .build()
+                )
+                .build()
+                .start()
+        LookupHolder holder = context.getBean(LookupHolder)
+        LifeCycleDependency createdWith = holder.created as LifeCycleDependency
+        CompiledHolder compiledHolder = context.getBean(CompiledHolder)
+        LifeCycleDependency injectedInto = compiledHolder.dependency
+
+        when:
+        context.destroyBean(holder)
+        context.destroyBean(compiledHolder)
+        LifeCycleDependency disposedWith = resolvedByDisposer[0] as LifeCycleDependency
+
+        then: 'all three are destroyed'
+        injectedInto.destroyed
+        createdWith.destroyed
+        disposedWith.destroyed
+
+        and: 'and reach the same life cycle state, so a lookup is destroyed no differently from an injection'
+        disposedWith.stopped == injectedInto.stopped
+        createdWith.stopped == injectedInto.stopped
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/lookups/CircularDependency.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/lookups/CircularDependency.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.beans.lookups;
+
+import io.micronaut.context.annotation.Prototype;
+
+/**
+ * A compiled bean that can only be created by creating the runtime built {@link LookupHolder}, so that a
+ * creator looking this up depends on the bean it is creating.
+ */
+@Prototype
+public class CircularDependency {
+
+    private final LookupHolder holder;
+
+    public CircularDependency(LookupHolder holder) {
+        this.holder = holder;
+    }
+
+    public LookupHolder getHolder() {
+        return holder;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/lookups/CompiledHolder.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/lookups/CompiledHolder.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.beans.lookups;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class CompiledHolder {
+
+    private final LifeCycleDependency dependency;
+
+    public CompiledHolder(LifeCycleDependency dependency) {
+        this.dependency = dependency;
+    }
+
+    public LifeCycleDependency getDependency() {
+        return dependency;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/lookups/LifeCycleDependency.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/lookups/LifeCycleDependency.java
@@ -1,0 +1,40 @@
+package io.micronaut.inject.beans.lookups;
+
+import io.micronaut.context.LifeCycle;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PreDestroy;
+
+/**
+ * A dependent bean that is also a {@link LifeCycle}, so that a test can tell the destruction of a dependent
+ * (which leaves {@link #stop()} alone) from the destruction of a bean in its own right (which calls it).
+ */
+@Prototype
+public class LifeCycleDependency implements LifeCycle<LifeCycleDependency> {
+
+    private boolean destroyed;
+    private boolean stopped;
+
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+
+    public boolean isStopped() {
+        return stopped;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return !stopped;
+    }
+
+    @Override
+    public LifeCycleDependency stop() {
+        stopped = true;
+        return this;
+    }
+
+    @PreDestroy
+    void preDestroy() {
+        destroyed = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/lookups/LookupHolder.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/lookups/LookupHolder.java
@@ -1,0 +1,18 @@
+package io.micronaut.inject.beans.lookups;
+
+/**
+ * The bean a runtime bean definition builds in the lookup tests. It is not itself a compiled bean, so that a
+ * compiled bean that injects it can only be satisfied by the runtime definition the test registers.
+ */
+public class LookupHolder {
+
+    private final Object created;
+
+    public LookupHolder(Object created) {
+        this.created = created;
+    }
+
+    public Object getCreated() {
+        return created;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1229,6 +1229,21 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         destroyBean(registration, false);
     }
 
+    /**
+     * Destroys a bean that another bean, or another bean's disposal, owns as a dependent object.
+     *
+     * <p>This is the destruction the dependents of a bean receive when that bean is destroyed, which leaves
+     * {@link LifeCycle#stop()} alone: stopping a bean is for a bean destroyed in its own right, not for one
+     * destroyed because whatever it was resolved for is gone.</p>
+     *
+     * @param registration The registration of the dependent
+     * @param <T>          The bean type
+     * @since 5.2.0
+     */
+    <T> void destroyDependentBean(BeanRegistration<T> registration) {
+        destroyBean(registration, true);
+    }
+
     private <T> void destroyBean(BeanRegistration<T> registration, boolean dependent) {
         if (LOG_LIFECYCLE.isDebugEnabled()) {
             LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", registration.bean, registration.identifier);

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -314,8 +314,10 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     }
 
     /**
-     * Destroys the dependent objects a disposal resolved, in the reverse of the order they were resolved in,
-     * the way the bean context destroys the dependents of a bean.
+     * Destroys the dependent objects a disposal resolved, in the reverse of the order they were resolved in
+     * and as dependents, the way the bean context destroys the dependents of a bean: what the disposer
+     * resolved is owned by the disposal, so a {@link LifeCycle} among them is no more stopped than one
+     * resolved for an injection point is.
      *
      * @param context    The bean context
      * @param dependents The dependent registrations
@@ -323,7 +325,12 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     private static void destroyDependents(BeanContext context, List<BeanRegistration<?>> dependents) {
         ListIterator<BeanRegistration<?>> i = dependents.listIterator(dependents.size());
         while (i.hasPrevious()) {
-            context.destroyBean(i.previous());
+            BeanRegistration<?> dependent = i.previous();
+            if (context instanceof DefaultBeanContext defaultBeanContext) {
+                defaultBeanContext.destroyDependentBean(dependent);
+            } else {
+                context.destroyBean(dependent);
+            }
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -303,6 +304,30 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     }
 
     /**
+     * Creates the lookup context handed to a disposer that takes one.
+     *
+     * @param resolutionContext The resolution context of the disposal
+     * @return The disposal context
+     */
+    RuntimeBeanDefinition.DisposalContext newDisposalContext(BeanResolutionContext resolutionContext) {
+        return new ResolutionLookupContext(resolutionContext);
+    }
+
+    /**
+     * Destroys the dependent objects a disposal resolved, in the reverse of the order they were resolved in,
+     * the way the bean context destroys the dependents of a bean.
+     *
+     * @param context    The bean context
+     * @param dependents The dependent registrations
+     */
+    private static void destroyDependents(BeanContext context, List<BeanRegistration<?>> dependents) {
+        ListIterator<BeanRegistration<?>> i = dependents.listIterator(dependents.size());
+        while (i.hasPrevious()) {
+            context.destroyBean(i.previous());
+        }
+    }
+
+    /**
      * A declared injection point of a runtime bean definition.
      *
      * @param argument  The type to inject
@@ -345,21 +370,65 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     }
 
     /**
-     * Implementation of {@link RuntimeBeanDefinition.CreationContext} over the resolution context of one
-     * creation and the beans resolved for the declared injection points.
+     * Implementation of {@link RuntimeBeanDefinition.LookupContext} over the resolution context of one creation
+     * or of one disposal.
+     *
+     * <p>Each lookup is resolved behind a segment of that context's path, so that a lookup made while the bean is
+     * being created participates in circularity detection and is reported as a dependency of this definition when
+     * it cannot be satisfied. The segment is a constructor argument segment for lack of anything more accurate: an
+     * undeclared lookup has no injection point of its own to name.</p>
      */
-    private final class DefaultCreationContext implements RuntimeBeanDefinition.CreationContext {
-        private final BeanResolutionContext resolutionContext;
-        private final Object[] resolved;
+    private class ResolutionLookupContext implements RuntimeBeanDefinition.DisposalContext {
+        protected final BeanResolutionContext resolutionContext;
 
-        DefaultCreationContext(BeanResolutionContext resolutionContext, Object[] resolved) {
+        ResolutionLookupContext(BeanResolutionContext resolutionContext) {
             this.resolutionContext = resolutionContext;
-            this.resolved = resolved;
         }
 
         @Override
         public BeanContext getBeanContext() {
             return resolutionContext.getContext();
+        }
+
+        @Override
+        public <V> V getBean(Argument<V> type, @Nullable Qualifier<V> qualifier) {
+            Objects.requireNonNull(type, "Bean type cannot be null");
+            try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(DefaultRuntimeBeanDefinition.this, type)) {
+                try {
+                    return resolutionContext.getBean(type, qualifier);
+                } catch (NoSuchBeanException e) {
+                    throw new DependencyInjectionException(resolutionContext, e);
+                }
+            }
+        }
+
+        @Override
+        public <V> Optional<V> findBean(Argument<V> type, @Nullable Qualifier<V> qualifier) {
+            Objects.requireNonNull(type, "Bean type cannot be null");
+            try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(DefaultRuntimeBeanDefinition.this, type)) {
+                return resolutionContext.findBean(type, qualifier);
+            }
+        }
+
+        @Override
+        public <V> Collection<V> getBeansOfType(Argument<V> type, @Nullable Qualifier<V> qualifier) {
+            Objects.requireNonNull(type, "Bean type cannot be null");
+            try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(DefaultRuntimeBeanDefinition.this, type)) {
+                return resolutionContext.getBeansOfType(type, qualifier);
+            }
+        }
+    }
+
+    /**
+     * Implementation of {@link RuntimeBeanDefinition.CreationContext} over the resolution context of one
+     * creation and the beans resolved for the declared injection points.
+     */
+    private final class DefaultCreationContext extends ResolutionLookupContext implements RuntimeBeanDefinition.CreationContext {
+        private final Object[] resolved;
+
+        DefaultCreationContext(BeanResolutionContext resolutionContext, Object[] resolved) {
+            super(resolutionContext);
+            this.resolved = resolved;
         }
 
         @Override
@@ -398,15 +467,23 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
      *
      * <p>Only this subclass is a {@link DisposableBeanDefinition}: the context disposes of a bean only when its
      * definition is one, so a definition built without a disposer keeps the behaviour it had before disposers
-     * existed. The disposer takes no {@link BeanResolutionContext} because a runtime built bean has no injection
-     * points or lifecycle advice of its own that a resolution context could carry into the disposal, so
-     * {@link #dispose(BeanContext, Object)} skips creating one.</p>
+     * existed.</p>
+     *
+     * <p>A disposer that takes only the {@link BeanContext} resolves nothing, so the disposal creates no
+     * {@link BeanResolutionContext} for it. A disposer that takes a
+     * {@link RuntimeBeanDefinition.DisposalContext} is given one created for the disposal alone rather than the
+     * one the context may pass in: that one belongs to the creation of the bean being disposed of, and the
+     * disposer is to share neither its dependents nor its instances. The dependent objects the disposer resolves
+     * through it are destroyed as soon as it returns.</p>
      *
      * @param <T> The bean type
      * @since 5.2.0
      */
     static final class Disposable<T> extends DefaultRuntimeBeanDefinition<T> implements DisposableBeanDefinition<T> {
+        @Nullable
         private final BiConsumer<BeanContext, T> disposer;
+        @Nullable
+        private final BiConsumer<RuntimeBeanDefinition.DisposalContext, T> injectedDisposer;
 
         Disposable(Argument<T> beanType,
                    Function<RuntimeBeanDefinition.CreationContext, T> beanFactory,
@@ -417,14 +494,31 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
                    Class<?>[] exposedTypes,
                    @Nullable Map<Class<?>, List<Argument<?>>> typeArguments,
                    InjectionPointSpec[] injectionPoints,
-                   BiConsumer<BeanContext, T> disposer) {
+                   @Nullable BiConsumer<BeanContext, T> disposer,
+                   @Nullable BiConsumer<RuntimeBeanDefinition.DisposalContext, T> injectedDisposer) {
             super(beanType, beanFactory, qualifier, annotationMetadata, isSingleton, scope, exposedTypes, typeArguments, injectionPoints);
-            this.disposer = Objects.requireNonNull(disposer, "Disposer cannot be null");
+            if ((disposer == null) == (injectedDisposer == null)) {
+                throw new IllegalArgumentException("Exactly one disposer form is required");
+            }
+            this.disposer = disposer;
+            this.injectedDisposer = injectedDisposer;
         }
 
         @Override
         public T dispose(BeanContext context, T bean) {
-            disposer.accept(context, bean);
+            BiConsumer<BeanContext, T> contextDisposer = disposer;
+            if (contextDisposer != null) {
+                contextDisposer.accept(context, bean);
+                return bean;
+            }
+            BiConsumer<RuntimeBeanDefinition.DisposalContext, T> resolvingDisposer = Objects.requireNonNull(injectedDisposer);
+            try (DefaultBeanResolutionContext disposalContext = new DefaultBeanResolutionContext(context, this)) {
+                try {
+                    resolvingDisposer.accept(newDisposalContext(disposalContext), bean);
+                } finally {
+                    destroyDependents(context, disposalContext.getAndResetDependentBeans());
+                }
+            }
             return bean;
         }
 
@@ -456,6 +550,8 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
         private Class<? extends B> replacesType;
         @Nullable
         private BiConsumer<BeanContext, B> disposer;
+        @Nullable
+        private BiConsumer<RuntimeBeanDefinition.DisposalContext, B> injectedDisposer;
 
         RuntimeBeanBuilder(Argument<B> beanType, Supplier<B> supplier) {
             this.beanType = Objects.requireNonNull(beanType, MSG_BEAN_TYPE_CANNOT_BE_NULL);
@@ -550,6 +646,14 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
         @Override
         public Builder<B> disposer(@Nullable BiConsumer<BeanContext, B> disposer) {
             this.disposer = disposer;
+            this.injectedDisposer = null;
+            return this;
+        }
+
+        @Override
+        public Builder<B> injectedDisposer(@Nullable BiConsumer<RuntimeBeanDefinition.DisposalContext, B> disposer) {
+            this.injectedDisposer = disposer;
+            this.disposer = null;
             return this;
         }
 
@@ -576,7 +680,7 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
             InjectionPointSpec[] declaredInjectionPoints = injectionPoints.isEmpty() ?
                 NO_INJECTION_POINTS :
                 injectionPoints.toArray(new InjectionPointSpec[0]);
-            if (disposer != null) {
+            if (disposer != null || injectedDisposer != null) {
                 return new Disposable<>(
                     beanType,
                     beanFactory,
@@ -587,7 +691,8 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
                     exposedTypes,
                     typeArguments,
                     declaredInjectionPoints,
-                    disposer
+                    disposer,
+                    injectedDisposer
                 );
             }
             return new DefaultRuntimeBeanDefinition<>(

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -290,13 +290,13 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
     @Nullable
     private Object resolveInjectionPoint(BeanResolutionContext resolutionContext, InjectionPointSpec injectionPoint) {
         Argument<Object> argument = (Argument<Object>) injectionPoint.argument();
-        Qualifier<Object> qualifier = (Qualifier<Object>) injectionPoint.qualifier();
+        Qualifier<Object> pointQualifier = (Qualifier<Object>) injectionPoint.qualifier();
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
             try {
                 if (argument.isDeclaredNullable()) {
-                    return resolutionContext.findBean(argument, qualifier).orElse(null);
+                    return resolutionContext.findBean(argument, pointQualifier).orElse(null);
                 }
-                return resolutionContext.getBean(argument, qualifier);
+                return resolutionContext.getBean(argument, pointQualifier);
             } catch (NoSuchBeanException e) {
                 throw new DependencyInjectionException(resolutionContext, e);
             }
@@ -311,27 +311,6 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
      */
     RuntimeBeanDefinition.DisposalContext newDisposalContext(BeanResolutionContext resolutionContext) {
         return new ResolutionLookupContext(resolutionContext);
-    }
-
-    /**
-     * Destroys the dependent objects a disposal resolved, in the reverse of the order they were resolved in
-     * and as dependents, the way the bean context destroys the dependents of a bean: what the disposer
-     * resolved is owned by the disposal, so a {@link LifeCycle} among them is no more stopped than one
-     * resolved for an injection point is.
-     *
-     * @param context    The bean context
-     * @param dependents The dependent registrations
-     */
-    private static void destroyDependents(BeanContext context, List<BeanRegistration<?>> dependents) {
-        ListIterator<BeanRegistration<?>> i = dependents.listIterator(dependents.size());
-        while (i.hasPrevious()) {
-            BeanRegistration<?> dependent = i.previous();
-            if (context instanceof DefaultBeanContext defaultBeanContext) {
-                defaultBeanContext.destroyDependentBean(dependent);
-            } else {
-                context.destroyBean(dependent);
-            }
-        }
     }
 
     /**
@@ -399,7 +378,7 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
 
         @Override
         public <V> V getBean(Argument<V> type, @Nullable Qualifier<V> qualifier) {
-            Objects.requireNonNull(type, "Bean type cannot be null");
+            Objects.requireNonNull(type, MSG_BEAN_TYPE_CANNOT_BE_NULL);
             try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(DefaultRuntimeBeanDefinition.this, type)) {
                 try {
                     return resolutionContext.getBean(type, qualifier);
@@ -411,7 +390,7 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
 
         @Override
         public <V> Optional<V> findBean(Argument<V> type, @Nullable Qualifier<V> qualifier) {
-            Objects.requireNonNull(type, "Bean type cannot be null");
+            Objects.requireNonNull(type, MSG_BEAN_TYPE_CANNOT_BE_NULL);
             try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(DefaultRuntimeBeanDefinition.this, type)) {
                 return resolutionContext.findBean(type, qualifier);
             }
@@ -419,7 +398,7 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
 
         @Override
         public <V> Collection<V> getBeansOfType(Argument<V> type, @Nullable Qualifier<V> qualifier) {
-            Objects.requireNonNull(type, "Bean type cannot be null");
+            Objects.requireNonNull(type, MSG_BEAN_TYPE_CANNOT_BE_NULL);
             try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(DefaultRuntimeBeanDefinition.this, type)) {
                 return resolutionContext.getBeansOfType(type, qualifier);
             }
@@ -532,6 +511,27 @@ sealed class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextConditio
         @Override
         public T dispose(BeanResolutionContext resolutionContext, BeanContext context, T bean) {
             return dispose(context, bean);
+        }
+
+        /**
+         * Destroys the dependent objects a disposal resolved, in the reverse of the order they were resolved in
+         * and as dependents, the way the bean context destroys the dependents of a bean: what the disposer
+         * resolved is owned by the disposal, so a {@link LifeCycle} among them is no more stopped than one
+         * resolved for an injection point is.
+         *
+         * @param context    The bean context
+         * @param dependents The dependent registrations
+         */
+        private static void destroyDependents(BeanContext context, List<BeanRegistration<?>> dependents) {
+            ListIterator<BeanRegistration<?>> i = dependents.listIterator(dependents.size());
+            while (i.hasPrevious()) {
+                BeanRegistration<?> dependent = i.previous();
+                if (context instanceof DefaultBeanContext defaultBeanContext) {
+                    defaultBeanContext.destroyDependentBean(dependent);
+                } else {
+                    context.destroyBean(dependent);
+                }
+            }
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
@@ -30,6 +30,7 @@ import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -238,28 +239,117 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
     }
 
     /**
+     * The lookups a runtime built bean can perform while it is being created or disposed of.
+     *
+     * <p>Every lookup here is resolved through the {@link BeanResolutionContext} of the creation or of the
+     * disposal, which is what makes core's own dependency handling apply to it: a dependent object
+     * (a {@code @Prototype} or {@code @Dependent} bean, for example) that a lookup resolves becomes a dependent
+     * of that creation or disposal and is destroyed with it, a circular dependency is detected, and an
+     * unsatisfied {@link #getBean(Argument)} fails with the usual
+     * {@link io.micronaut.context.exceptions.DependencyInjectionException}. Resolving the same bean from
+     * {@link #getBeanContext()} instead resolves it outside that context, where none of that applies.</p>
+     *
+     * <p>How long what a lookup resolves lives is decided by the context it was made from:
+     * a dependent resolved from a {@link CreationContext} is destroyed when the created bean is, and one
+     * resolved from a {@link DisposalContext} is destroyed when the disposer returns.</p>
+     *
+     * @since 5.2.0
+     */
+    @Experimental
+    interface LookupContext {
+
+        /**
+         * @return The bean context the bean belongs to
+         */
+        BeanContext getBeanContext();
+
+        /**
+         * Looks up a bean of the given type.
+         *
+         * @param type The type to look up
+         * @return The bean, never {@code null}
+         * @param <V> The looked up type
+         * @throws io.micronaut.context.exceptions.DependencyInjectionException If no bean of the type exists
+         */
+        default <V> V getBean(Argument<V> type) {
+            return getBean(type, null);
+        }
+
+        /**
+         * Looks up a bean of the given type and qualifier.
+         *
+         * @param type The type to look up
+         * @param qualifier The qualifier, or {@code null} for none
+         * @return The bean, never {@code null}
+         * @param <V> The looked up type
+         * @throws io.micronaut.context.exceptions.DependencyInjectionException If no such bean exists
+         */
+        <V> V getBean(Argument<V> type, @Nullable Qualifier<V> qualifier);
+
+        /**
+         * Looks up a bean of the given type if one exists.
+         *
+         * @param type The type to look up
+         * @return The bean, or empty if none exists
+         * @param <V> The looked up type
+         */
+        default <V> Optional<V> findBean(Argument<V> type) {
+            return findBean(type, null);
+        }
+
+        /**
+         * Looks up a bean of the given type and qualifier if one exists.
+         *
+         * @param type The type to look up
+         * @param qualifier The qualifier, or {@code null} for none
+         * @return The bean, or empty if none exists
+         * @param <V> The looked up type
+         */
+        <V> Optional<V> findBean(Argument<V> type, @Nullable Qualifier<V> qualifier);
+
+        /**
+         * Looks up all the beans of the given type.
+         *
+         * @param type The type to look up
+         * @return The beans, empty if there are none
+         * @param <V> The looked up type
+         */
+        default <V> Collection<V> getBeansOfType(Argument<V> type) {
+            return getBeansOfType(type, null);
+        }
+
+        /**
+         * Looks up all the beans of the given type and qualifier.
+         *
+         * @param type The type to look up
+         * @param qualifier The qualifier, or {@code null} for none
+         * @return The beans, empty if there are none
+         * @param <V> The looked up type
+         */
+        <V> Collection<V> getBeansOfType(Argument<V> type, @Nullable Qualifier<V> qualifier);
+    }
+
+    /**
      * The context of a single creation of a bean built at runtime, passed to the bean factory of a definition
      * built with {@link #builder(Argument, Function)}.
      *
      * <p>It carries the beans resolved for the injection points the definition declared with
      * {@link Builder#injectionPoint(Argument)}, the injection point the bean is being created for, and the
-     * {@link BeanContext} to look anything else up in.</p>
+     * lookups of {@link LookupContext} for anything the definition could not declare up front.</p>
      *
      * <p>The injected beans were resolved through the resolution context of this creation, so any of them that
      * is a dependent object (a {@code @Prototype} or {@code @Dependent} bean, for example) is a dependent of the
-     * created bean and is destroyed with it. The exception is a bean obtained from
-     * {@link BeanContext#createBean(Class)}, which records no dependents for any bean, runtime built or
-     * compiled.</p>
+     * created bean and is destroyed with it. A bean the factory looks up itself with
+     * {@link #getBean(Argument)} is resolved through the same resolution context and has the same lifetime; the
+     * difference between the two is only that a declared injection point is described by the definition and
+     * resolved before the factory runs, while a lookup is decided by the factory as it runs. The exception is a
+     * bean obtained from {@link BeanContext#createBean(Class)}, which records no dependents for any bean,
+     * runtime built or compiled.</p>
      *
      * @since 5.2.0
      */
     @Experimental
-    interface CreationContext {
-
-        /**
-         * @return The bean context creating the bean
-         */
-        BeanContext getBeanContext();
+    interface CreationContext extends LookupContext {
 
         /**
          * The injection point the bean is being created for.
@@ -314,6 +404,25 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
          * @throws IllegalArgumentException If no such injection point was declared
          */
         <V> @Nullable V getInjectedBean(Argument<V> type, @Nullable Qualifier<V> qualifier);
+    }
+
+    /**
+     * The context of a single disposal of a bean built at runtime, passed to the disposer of a definition built
+     * with {@link Builder#injectedDisposer(BiConsumer)}.
+     *
+     * <p>It offers the same lookups as the {@link CreationContext} of a creation, resolved fresh for this
+     * disposal: the disposer shares neither the resolution context nor the resolved instances with the creation
+     * of the bean it is disposing of, so a lookup of a dependent object returns an instance of its own, not the
+     * one the factory received for the same type.</p>
+     *
+     * <p>What a lookup resolves is destroyed when the disposer returns, unlike a bean resolved during creation,
+     * which is destroyed with the created bean. A bean whose lifetime the context manages, a singleton for
+     * example, is of course not destroyed by the disposal.</p>
+     *
+     * @since 5.2.0
+     */
+    @Experimental
+    interface DisposalContext extends LookupContext {
     }
 
     /**
@@ -445,12 +554,36 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
          * <p>A definition built with a disposer is a {@link io.micronaut.inject.DisposableBeanDefinition}; a
          * definition built without one is not, so existing definitions keep their current behaviour.</p>
          *
+         * <p>A disposer that needs to resolve beans of its own takes a {@link DisposalContext} instead, see
+         * {@link #injectedDisposer(BiConsumer)}. The two forms are alternatives: setting one clears the
+         * other.</p>
+         *
          * @param disposer The disposer, receiving the bean context and the instance being destroyed, or {@code null}
          *                 to clear a previously set disposer
          * @return This builder
          * @since 5.2.0
          */
         Builder<B> disposer(@Nullable BiConsumer<BeanContext, B> disposer);
+
+        /**
+         * The disposer to run when an instance created by this definition is destroyed, receiving a
+         * {@link DisposalContext} with which it can resolve the beans it needs to do the disposal.
+         *
+         * <p>It is invoked at the same point in the destruction of the instance as
+         * {@link #disposer(BiConsumer)}, and the two forms are alternatives: setting one clears the other.</p>
+         *
+         * <p>The lookups of the disposal context are resolved through a resolution context created for the
+         * disposal, which shares nothing with the creation of the bean being disposed of: what the disposer
+         * resolves is resolved fresh, and a dependent object among what it resolved is destroyed when the
+         * disposer returns rather than being kept for the lifetime of anything.</p>
+         *
+         * @param disposer The disposer, receiving the disposal context and the instance being destroyed, or
+         *                 {@code null} to clear a previously set disposer
+         * @return This builder
+         * @since 5.2.0
+         */
+        @Experimental
+        Builder<B> injectedDisposer(@Nullable BiConsumer<DisposalContext, B> disposer);
 
         /**
          * Builds the runtime bean.

--- a/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionLookupSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionLookupSpec.groovy
@@ -1,0 +1,217 @@
+package io.micronaut.context
+
+import io.micronaut.context.exceptions.CircularDependencyException
+import io.micronaut.context.exceptions.DependencyInjectionException
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+import java.util.function.BiConsumer
+import java.util.function.Function
+
+class RuntimeBeanDefinitionLookupSpec extends Specification {
+
+    private static RuntimeBeanDefinition.Builder<Bar> barBuilder(
+            Function<RuntimeBeanDefinition.CreationContext, Bar> factory) {
+        RuntimeBeanDefinition.builder(Bar, factory)
+    }
+
+    private static RuntimeBeanDefinition.Builder<Foo> fooBuilder(
+            Function<RuntimeBeanDefinition.CreationContext, Foo> factory) {
+        RuntimeBeanDefinition.builder(Foo, factory)
+    }
+
+    void 'test the creator can look up a bean that was not declared as an injection point'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).singleton(true).build(),
+                        barBuilder(ctx -> new Bar(ctx.getBean(Argument.of(Foo))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        context.getBean(Bar).foo.is(context.getBean(Foo))
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the creator can look up a qualified bean'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("red"))
+                                .named("red").singleton(true).build(),
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("green"))
+                                .named("green").singleton(true).build(),
+                        barBuilder(ctx -> new Bar(ctx.getBean(Argument.of(Foo), Qualifiers.byName("green"))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        context.getBean(Bar).foo.name == "green"
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test an unsatisfied lookup fails the creation'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        barBuilder(ctx -> new Bar(ctx.getBean(Argument.of(Foo))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        context.getBean(Bar)
+
+        then:
+        def e = thrown(DependencyInjectionException)
+        e.message.contains(Foo.name)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a lookup that cannot be satisfied can be found instead'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        barBuilder(ctx -> new Bar(ctx.findBean(Argument.of(Foo)).orElse(null)))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        context.getBean(Bar).foo == null
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the creator can look up all the beans of a type'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).named("one").singleton(true).build(),
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("two")).named("two").singleton(true).build(),
+                        barBuilder(ctx -> new Bar(null, ctx.getBeansOfType(Argument.of(Foo))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        expect:
+        context.getBean(Bar).all*.name.toSorted() == ["one", "two"]
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a circular lookup between two runtime bean definitions is detected'() {
+        given:
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        fooBuilder(ctx -> new Foo(ctx.getBean(Argument.of(Bar)).toString()))
+                                .singleton(true)
+                                .build(),
+                        barBuilder(ctx -> new Bar(ctx.getBean(Argument.of(Foo))))
+                                .singleton(true)
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        context.getBean(Bar)
+
+        then:
+        thrown(CircularDependencyException)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the disposer can look up a bean'() {
+        given:
+        def disposed = []
+        def context = ApplicationContext.builder()
+                .beanDefinitions(
+                        RuntimeBeanDefinition.builder(Foo, () -> new Foo("one")).singleton(true).build(),
+                        barBuilder(ctx -> new Bar(null))
+                                .singleton(true)
+                                .injectedDisposer((BiConsumer<RuntimeBeanDefinition.DisposalContext, Bar>) { ctx, bean ->
+                                    disposed << ctx.getBean(Argument.of(Foo))
+                                })
+                                .build()
+                )
+                .build()
+                .start()
+
+        when:
+        context.destroyBean(context.getBean(Bar))
+
+        then:
+        disposed.size() == 1
+        disposed[0].is(context.getBean(Foo))
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test setting one disposer form clears the other'() {
+        given:
+        def calls = []
+        def builder = RuntimeBeanDefinition.builder(Foo, () -> new Foo("one"))
+                .singleton(true)
+                .injectedDisposer((BiConsumer<RuntimeBeanDefinition.DisposalContext, Foo>) { ctx, bean ->
+                    calls << "injected"
+                })
+                .disposer((BiConsumer<BeanContext, Foo>) { ctx, bean -> calls << "plain" })
+        def context = ApplicationContext.builder()
+                .beanDefinitions(builder.build())
+                .build()
+                .start()
+
+        when: 'the disposer set last is the one that runs'
+        context.destroyBean(context.getBean(Foo))
+
+        then:
+        calls == ["plain"]
+
+        cleanup:
+        context.close()
+    }
+
+    static class Foo {
+        final String name
+
+        Foo(String name) {
+            this.name = name
+        }
+    }
+
+    static class Bar {
+        final Foo foo
+        final Collection<Foo> all
+
+        Bar(Foo foo, Collection<Foo> all = Collections.emptyList()) {
+            this.foo = foo
+            this.all = all
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #13065, which lets a runtime bean definition declare its injection points. That PR has since merged, and this branch is rebased onto `5.2.x` (28f6830314), so the diff here is this work alone.

#13065 covers a bean whose dependencies are known when the definition is built: each declared point is resolved through the `BeanResolutionContext` of the creation, so dependents land on the created bean's `BeanRegistration` and core's own circularity detection and failure messages apply. Two shapes cannot declare anything up front, and both come from Jakarta CDI, which [micronaut-cdi](https://github.com/dstepanov/micronaut-cdi) implements on Micronaut.

## 1. A lookup the creator decides on as it runs

CDI 4.1's synthetic bean creator is `create(Instance<Object>, Parameters)`: the container hands the creator a lookup, and what it asks for is decided by code inside the creator. `getInjectedBean` cannot serve that, and resolving through the `BeanContext` instead resolves outside the creation, which is why micronaut-cdi keeps a `creatorLookups` map and a `transientlyCreated` list to destroy what a creator looked up — bookkeeping core already does for declared points.

`CreationContext` now extends a new `LookupContext`:

```java
<V> V getBean(Argument<V> type);
<V> V getBean(Argument<V> type, @Nullable Qualifier<V> qualifier);
<V> Optional<V> findBean(Argument<V> type);
<V> Optional<V> findBean(Argument<V> type, @Nullable Qualifier<V> qualifier);
<V> Collection<V> getBeansOfType(Argument<V> type);
<V> Collection<V> getBeansOfType(Argument<V> type, @Nullable Qualifier<V> qualifier);
```

Each is resolved through the resolution context of the creation, so a dependent object a creator looks up is a dependent of the created bean and is destroyed with it, a circular lookup is detected, and an unsatisfied `getBean` fails with the usual `DependencyInjectionException`. `getInjectedBean` keeps its contract unchanged: a point that was declared, `IllegalArgumentException` otherwise. The only difference between the two is when the decision is made — a declared point is described by the definition and resolved before the factory runs, a lookup is decided by the factory as it runs.

Two questions the issue raised:

- **Does a lookup push a segment of its own?** Yes. Without one, a lookup is invisible to `detectCircularDependency` and to the message a failure builds from the path, which is most of the point of routing through the resolution context at all. An undeclared lookup has no injection point to name, so the segment is a constructor argument segment for the looked-up type — the same segment a declared point uses, for lack of anything more accurate.
- **Are `findBean` and `getBeansOfType` worth the same treatment?** Yes. CDI's `Instance` is not only `get()`: it is also `isUnsatisfied()` and iteration, and an implementor who has `getBean` alone falls back to the bean context for the other two, which is exactly the hole this closes. All three are one implementation over the resolution context, so the cost of the other two is small.

## 2. A disposer that is injected

`Builder.disposer(BiConsumer<BeanContext, B>)` from #12964 carries no injections, and #13065's description says the disposer takes none. The specification disagrees: a synthetic bean's disposer has been injected since CDI 4.0, and still is in 5.0.0-M1, where [`SyntheticBeanDisposer`](https://jakarta.ee/specifications/cdi/4.1/apidocs/jakarta.enterprise.cdi.api/jakarta/enterprise/inject/build/compatible/spi/syntheticbeandisposer) is unchanged:

```java
void dispose(T instance, Instance<Object> lookup, Parameters params);
```

> All `@Dependent` bean instances obtained from the `Instance` during execution are destroyed when execution completes.

The same rule is on the mainline portable-extension SPI, `BeanConfigurator.disposeWith(BiConsumer<T, Instance<Object>>)`, which is what Weld's build-compatible-extension translator delegates to. So this adds the injected form:

```java
Builder<B> injectedDisposer(@Nullable BiConsumer<DisposalContext, B> disposer);
```

`DisposalContext` offers the same lookups as `CreationContext`, resolved through a `BeanResolutionContext` created for the disposal alone: the disposer shares nothing with the creation, and the dependent objects it resolves are destroyed as soon as it returns — including when it throws, so a failing disposer leaks nothing. Singletons and other context-managed beans are of course untouched.

It is a separate method rather than an overload of `disposer` because `BiConsumer<BeanContext, B>` and `BiConsumer<DisposalContext, B>` erase to the same signature, and even if they did not, an implicitly typed lambda would be ambiguous between them at every existing call site. CDI reached the same shape for the same reason: `BeanConfigurator` pairs `createWith`/`produceWith` and `destroyWith`/`disposeWith` — differently named methods, the second of each pair being the one that takes lookups. The two forms are alternatives: setting one clears the other, and `disposer(BiConsumer<BeanContext, B>)` keeps working unchanged, resolving nothing and creating no resolution context.

The declared injection points are deliberately *not* re-resolved for the disposal: declared points are the creator's contract, and what the disposer needs it looks up.

## Lifetimes, pinned in tests

- a prototype the creator looked up is destroyed when the created bean is destroyed, and not before;
- a prototype the disposer looked up is destroyed when the disposer returns, and is a different instance from the one the creator got for the same argument;
- a singleton resolved either way is not destroyed with the bean, only with the context;
- an unsatisfied lookup fails with `DependencyInjectionException`; a circular one is detected;
- what the disposer resolved before failing is still destroyed;
- the existing `disposer(BiConsumer<BeanContext, B>)` behaviour is unchanged.

These are the numbers the CDI TCK's `SyntheticBeanWithLookupTest` pins, where the creator and the disposer each look up the same `@Dependent` bean and the synthetic bean is then destroyed: two created, two destroyed. Weld reaches them by handing the disposer the bean's own creational context and releasing it immediately afterwards; this implementation gives the disposal a resolution context of its own, which meets the "destroyed when execution completes" rule more literally and shares nothing with the creation.

New specs: `RuntimeBeanDefinitionLookupSpec` in `inject` over runtime built beans only, and one of the same name in `inject-java` against compiled collaborators, as #13065 did.

`:micronaut-inject:test`, `:micronaut-inject-java:test` and `:micronaut-inject:checkstyleMain` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


