### PR TITLE
Fix Python bridge conversions and processor isolation

### DIFF
--- a/context-python/src/main/java/io/micronaut/context/python/GraalPyHostAccessFactory.java
+++ b/context-python/src/main/java/io/micronaut/context/python/GraalPyHostAccessFactory.java
@@ -235,15 +235,40 @@ final class GraalPyHostAccessFactory {
         builder.targetTypeMapping(
             Value.class,
             Class.class,
-            v -> pythonClassResolver.findPythonClass(v) != null,
+            v -> resolvePythonClass(v, pythonClassResolver) != null,
             v -> {
-                Class<?> target = pythonClassResolver.findPythonClass(v);
+                Class<?> target = resolvePythonClass(v, pythonClassResolver);
                 if (target == null) {
                     throw new IllegalArgumentException("Cannot resolve Python class to a generated Java stub");
                 }
                 return target;
             }
         );
+    }
+
+    private static @Nullable Class<?> resolvePythonClass(@Nullable Value value, PythonClassResolver pythonClassResolver) {
+        try {
+            if (value != null && !value.isNull() && value.hasMembers()
+                && value.hasMember("_target") && value.hasMember("_resolved")) {
+                Value target = value.getMember("_target");
+                if (target != null && target.isString()) {
+                    target = value.invokeMember("_resolved");
+                }
+                if (target != null && !target.isNull()) {
+                    Class<?> facadeTarget = target.as(Class.class);
+                    if (facadeTarget != null) {
+                        return facadeTarget;
+                    }
+                }
+            }
+        } catch (RuntimeException ignored) {
+            // Fall through to regular generated Python class resolution.
+        }
+        try {
+            return pythonClassResolver.findPythonClass(value);
+        } catch (RuntimeException ignored) {
+            return null;
+        }
     }
 
     private static @Nullable TargetTypeMapping<?> findMapping(@Nullable Value value, PythonClassResolver pythonClassResolver) {

--- a/context-python/src/main/java/io/micronaut/context/python/PythonHttpConversion.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonHttpConversion.java
@@ -67,6 +67,31 @@ public final class PythonHttpConversion {
     }
 
     /**
+     * Convert publisher items with a generated wrapper converter. A generated converter preserves
+     * the concrete Python wrapper type after the publisher crosses the reactive boundary.
+     *
+     * @param publisher The source publisher
+     * @param converter The generated item converter
+     * @param <T> The item type
+     * @return The converted publisher
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Publisher<T> convertPublisher(Publisher<?> publisher, PolyglotValueConverter<T> converter) {
+        return Publishers.map((Publisher<Object>) publisher, item -> {
+            if (item == null) {
+                return null;
+            }
+            if (item instanceof Value value) {
+                return converter.convert(value);
+            }
+            if (item instanceof ValueCoercible valueCoercible) {
+                return converter.convert(valueCoercible.asPolyglotValue());
+            }
+            return (T) item;
+        });
+    }
+
+    /**
      * Convert a GraalPy Value representing a publisher to a typed Java publisher.
      *
      * @param value The source polyglot publisher
@@ -80,6 +105,22 @@ public final class PythonHttpConversion {
             return null;
         }
         return convertPublisher(publisher, itemType);
+    }
+
+    /**
+     * Convert a GraalPy publisher with a generated item converter.
+     *
+     * @param value The source polyglot publisher
+     * @param converter The generated item converter
+     * @param <T> The item type
+     * @return The converted publisher
+     */
+    public static <T> @Nullable Publisher<T> convertPublisher(Value value, PolyglotValueConverter<T> converter) {
+        Publisher<?> publisher = PythonConversion.convertValue(value, Publisher.class);
+        if (publisher == null) {
+            return null;
+        }
+        return convertPublisher(publisher, converter);
     }
 
     /**

--- a/context-python/src/main/java/io/micronaut/context/python/ValueCoercibles.java
+++ b/context-python/src/main/java/io/micronaut/context/python/ValueCoercibles.java
@@ -38,7 +38,7 @@ public final class ValueCoercibles {
      * Extracts a generated Java wrapper from a polyglot value when one is available.
      * <p>
      * This method recognizes both direct host objects and Micronaut's synthetic
-     * {@link #ValueCoercible.HOST_OBJECT_MEMBER} back-reference.
+     * {@link ValueCoercible#HOST_OBJECT_MEMBER} back-reference.
      *
      * @param value The polyglot value to inspect.
      * @return The generated wrapper, or {@code null} when the value is not backed by a
@@ -53,7 +53,7 @@ public final class ValueCoercibles {
      * Extracts a generated Java wrapper from a proxy object when one is available.
      * <p>
      * This overload is used when code already has a {@link ProxyObject} view and needs to inspect
-     * Micronaut's synthetic {@link #ValueCoercible.HOST_OBJECT_MEMBER} without first wrapping it as a
+     * Micronaut's synthetic {@link ValueCoercible#HOST_OBJECT_MEMBER} without first wrapping it as a
      * {@link Value}.
      *
      * @param value The proxy object to inspect.
@@ -68,7 +68,7 @@ public final class ValueCoercibles {
      * Extracts a host object of the requested type from a polyglot value.
      * <p>
      * The returned object may be a direct GraalPy host object or the generated Java wrapper
-     * recovered through {@link #ValueCoercible.HOST_OBJECT_MEMBER}.
+     * recovered through {@link ValueCoercible#HOST_OBJECT_MEMBER}.
      *
      * @param value The polyglot value to inspect.
      * @param targetType The required host object type.
@@ -82,7 +82,7 @@ public final class ValueCoercibles {
     /**
      * Extracts a host object of the requested type from a proxy object.
      * <p>
-     * This method checks Micronaut's synthetic {@link #ValueCoercible.HOST_OBJECT_MEMBER} and verifies the
+     * This method checks Micronaut's synthetic {@link ValueCoercible#HOST_OBJECT_MEMBER} and verifies the
      * recovered host object before returning it.
      *
      * @param value The proxy object to inspect.
@@ -139,7 +139,7 @@ public final class ValueCoercibles {
      * This quick check uses generated {@code ExecutableMethod} metadata and only boxes primitive
      * types through {@link ReflectionUtils}; it deliberately avoids reflective probing of the
      * generated proxy class while still letting Python-backed values expose their host wrapper via
-     * {@link #ValueCoercible.HOST_OBJECT_MEMBER}.
+     * {@link ValueCoercible#HOST_OBJECT_MEMBER}.
      *
      * @param value The Python argument
      * @param targetType The Java parameter type

--- a/context-python/src/test/java/io/micronaut/context/python/PythonConversionTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/PythonConversionTest.java
@@ -28,10 +28,14 @@ import java.time.ZoneOffset;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.micronaut.http.HttpResponse;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.context.ApplicationContext;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyObject;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -96,6 +100,36 @@ class PythonConversionTest {
     }
 
     @Test
+    void convertsPublisherValuesWithGeneratedElementConverter() {
+        Value pythonValue = context.eval("python", "'hello'");
+
+        List<String> result = new java.util.ArrayList<>();
+        PythonHttpConversion.convertPublisher(Publishers.just(pythonValue), Value::asString)
+            .subscribe(new Subscriber<>() {
+                @Override
+                public void onSubscribe(Subscription subscription) {
+                    subscription.request(1);
+                }
+
+                @Override
+                public void onNext(String value) {
+                    result.add(value);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    throw new AssertionError(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                }
+            });
+
+        assertEquals(List.of("hello"), result);
+    }
+
+    @Test
     void testConvertPythonEnumValueToJavaEnum() {
         Value language = context.eval("python", """
             from enum import Enum
@@ -138,6 +172,69 @@ class PythonConversionTest {
     }
 
     @Test
+    void convertsMicronautJavaTypeFacadeToClassArgument() {
+        try (Context mappedContext = Context.newBuilder("python")
+            .allowAllAccess(true)
+            .allowHostAccess(new GraalPyHostAccessFactory().hostAccess(List.of()))
+            .build()) {
+            Value result = mappedContext.eval("python", """
+                import java
+
+                class _MicronautJavaType:
+                    def __init__(self, target, interface=False):
+                        self._target = target
+                        self._interface = interface
+
+                    def _resolved(self):
+                        if isinstance(self._target, str):
+                            self._target = java.type(self._target)
+                        return self._target
+
+                    def __getattr__(self, name):
+                        return getattr(self._resolved(), name)
+
+                    def __call__(self, *args, **kwargs):
+                        return self._resolved()(*args, **kwargs)
+
+                ClassAcceptor = java.type("io.micronaut.context.python.PythonConversionTest$ClassAcceptor")
+                ClassAcceptor.name(_MicronautJavaType(java.type("java.lang.String"), True))
+                """);
+
+            assertEquals("java.lang.String", result.asString());
+        }
+    }
+
+    @Test
+    void passesMicronautJavaTypeFacadeToApplicationContextFindBean() {
+        try (ApplicationContext applicationContext = ApplicationContext.run();
+             Context mappedContext = Context.newBuilder("python")
+                 .allowAllAccess(true)
+                 .allowHostAccess(new GraalPyHostAccessFactory().hostAccess(List.of()))
+                 .build()) {
+            mappedContext.getBindings("python").putMember("applicationContext", applicationContext);
+
+            assertEquals(false, mappedContext.eval("python", """
+                import java
+
+                class _MicronautJavaType:
+                    def __init__(self, target, interface=False):
+                        self._target = target
+                        self._interface = interface
+
+                    def _resolved(self):
+                        if isinstance(self._target, str):
+                            self._target = java.type(self._target)
+                        return self._target
+
+                    def __getattr__(self, name):
+                        return getattr(self._resolved(), name)
+
+                applicationContext.findBean(_MicronautJavaType("java.lang.String", True)).isPresent()
+                """).asBoolean());
+        }
+    }
+
+    @Test
     void testInvokePythonMethodBindsClassDescriptorWhenAttributeShadowsMethod() {
         Value instance = context.eval("python", """
             class Example:
@@ -172,6 +269,26 @@ class PythonConversionTest {
         assertEquals(
             "static",
             PythonInvocation.invokePythonMethod(instance, "staticName", new Object[0]).asString()
+        );
+    }
+
+    @Test
+    void testInvokePythonMethodUsesPythonOverrideOfJavaDefaultMethod() {
+        Value instance = context.eval("python", """
+            import java
+
+            AsyncSender = java.type("io.micronaut.context.python.PythonConversionTest$AsyncSender")
+
+            class Sender(AsyncSender):
+                def sendAsync(self, email):
+                    return "python:" + email
+
+            Sender()
+            """);
+
+        assertEquals(
+            "python:hello",
+            PythonInvocation.invokePythonMethod(instance, "sendAsync", new Object[] {"hello"}).asString()
         );
     }
 
@@ -707,11 +824,23 @@ class PythonConversionTest {
         void addAttribute(String name, Object value);
     }
 
+    public interface AsyncSender {
+        default String sendAsync(String email) {
+            return "default:" + email;
+        }
+    }
+
     static final class HostModel extends java.util.HashMap<String, Object> implements HostModelInterface {
 
         @Override
         public void addAttribute(String name, Object value) {
             put(name, value);
+        }
+    }
+
+    public static final class ClassAcceptor {
+        public static String name(Class<?> type) {
+            return type.getName();
         }
     }
 }

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/inject/factory/beanmethod/FactoryBeanMethodSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/inject/factory/beanmethod/FactoryBeanMethodSpec.groovy
@@ -295,6 +295,31 @@ class ClientFactory:
         context.close()
     }
 
+    void "test factory can invoke a Java ResourceResolver method"() {
+        given:
+        def context = buildContext('''\
+from micronaut.context.annotation import Factory, Bean
+from io.micronaut.core.io import ResourceResolver
+
+@Factory
+class ResourceFactory:
+
+    @Bean
+    def resource_status(self) -> str:
+        ResourceResolver().getResourceAsStream("classpath:missing-resource")
+        return "invoked"
+''')
+
+        when:
+        def status = getBean(context, "java.lang.String")
+
+        then:
+        status == "invoked"
+
+        cleanup:
+        context.close()
+    }
+
     void "test factory method context scope"() {
         given:
         def context = buildContext('''\

--- a/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PythonBridgeReturnValueSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/compiler/PythonBridgeReturnValueSpec.groovy
@@ -36,4 +36,46 @@ class StreamLikeService:
         cleanup:
         tempDir.deleteDir()
     }
+
+    void "publisher bridge converts generated wrapper elements"() {
+        given:
+        def pythonCode = '''
+import java
+from dataclasses import dataclass
+from jakarta.inject import Singleton
+from micronaut.context.annotation import Executable
+from micronaut.serde.annotation import Serdeable
+from org.reactivestreams import Publisher
+
+Flux = java.type("reactor.core.publisher.Flux")
+
+@Serdeable
+@dataclass
+class Message:
+    body: str
+
+@Singleton
+class StreamService:
+    @Executable
+    def read(self) -> Publisher[Message]:
+        return Flux.just(Message("body"))
+'''
+        def tempDir = File.createTempDir("pyronaut-publisher-return", "")
+        def compiler = PyronautCompiler.builder()
+            .pythonCode(pythonCode)
+            .targetDir(tempDir)
+            .build()
+
+        when:
+        compiler.compile()
+
+        then:
+        def generated = new File(tempDir, "python/StreamService.java")
+        generated.exists()
+        generated.text.contains("PythonHttpConversion.convertPublisher")
+        generated.text.contains("Message.fromPolyglotValue")
+
+        cleanup:
+        tempDir.deleteDir()
+    }
 }

--- a/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
+++ b/inject-python/src/main/java/io/micronaut/python/compiler/PyronautJavaCompiler.java
@@ -949,8 +949,12 @@ final class PyronautJavaCompiler {
         return null;
     }
 
-    private static ClassLoader createAnnotationProcessorClassLoader(List<File> annotationProcessorPath) {
-        ClassLoader classLoader = PythonAnnotationProcessor.class.getClassLoader();
+    static ClassLoader createAnnotationProcessorClassLoader(List<File> annotationProcessorPath) {
+        return createAnnotationProcessorClassLoader(annotationProcessorPath, PythonAnnotationProcessor.class.getClassLoader());
+    }
+
+    static ClassLoader createAnnotationProcessorClassLoader(List<File> annotationProcessorPath, ClassLoader parent) {
+        ClassLoader classLoader = parent;
         if (annotationProcessorPath != null) {
             List<URL> cp = annotationProcessorPath.stream().flatMap(f -> {
                 try {
@@ -959,9 +963,48 @@ final class PyronautJavaCompiler {
                     return Stream.empty();
                 }
             }).toList();
-            classLoader = new URLClassLoader(cp.toArray(new URL[0]), classLoader);
+            classLoader = new AnnotationProcessorClassLoader(cp.toArray(new URL[0]), classLoader);
         }
         return classLoader;
+    }
+
+    /**
+     * Keeps application annotation processors isolated from processors bundled
+     * with the launcher. Micronaut Data discovers its method matchers through
+     * {@code RepositoryTypeElementVisitor.class.getClassLoader()}; if the
+     * launcher has already loaded that visitor, a parent-first loader prevents
+     * it from seeing an application's document processor service entries.
+     */
+    private static final class AnnotationProcessorClassLoader extends URLClassLoader {
+        private static final List<String> CHILD_FIRST_PACKAGES = List.of(
+            "io.micronaut.data.processor.",
+            "io.micronaut.data.document."
+        );
+
+        private AnnotationProcessorClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (!CHILD_FIRST_PACKAGES.stream().anyMatch(name::startsWith)) {
+                return super.loadClass(name, resolve);
+            }
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null) {
+                    try {
+                        loaded = findClass(name);
+                    } catch (ClassNotFoundException ignored) {
+                        loaded = super.loadClass(name, false);
+                    }
+                }
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+        }
     }
 
     private static void closeClassLoader(ClassLoader classLoader) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonStubGenerator.java
@@ -2737,8 +2737,16 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         Map<String, ClassElement> inferredMethodBounds = inferMethodTypeBounds(signatureMethod, methodElement);
         Map<String, ClassElement> bridgeSignatureTypeArguments = withoutDeclaredMethodTypeVariables(signatureTypeArguments, signatureMethod);
         ClassElement effectiveReturnType = effectiveBridgeReturnType(methodElement, returnTypeOverride);
-        TypeDef methodSourceReturnType = bridgeSourceReturnType(methodElement, signatureMethod, resolvedSignatureMethod, effectiveReturnType, returnTypeOverride, isJunit5Test, bridgeSignatureTypeArguments);
-        boolean returnsMethodTypeVariable = !(methodElement instanceof PythonMethodElement) && !signatureMethod.getDeclaredTypeVariables().isEmpty();
+        boolean genericToArray = "toArray".equals(signatureMethod.getName())
+            && signatureMethod.getParameters().length == 1
+            && (signatureMethod.getDeclaredTypeVariables().size() == 1 || resolvedSignatureMethod.getDeclaredTypeVariables().size() == 1);
+        MethodElement sourceSignatureMethod = resolvedSignatureMethod.getDeclaredTypeVariables().size() == 1
+            ? resolvedSignatureMethod
+            : signatureMethod;
+        TypeDef methodSourceReturnType = genericToArray
+            ? ClassTypeDef.of(sourceSignatureMethod.getDeclaredTypeVariables().getFirst().getVariableName()).array()
+            : bridgeSourceReturnType(methodElement, signatureMethod, resolvedSignatureMethod, effectiveReturnType, returnTypeOverride, isJunit5Test, bridgeSignatureTypeArguments);
+        boolean returnsMethodTypeVariable = !(methodElement instanceof PythonMethodElement) && !sourceSignatureMethod.getDeclaredTypeVariables().isEmpty();
         MethodDef.MethodDefBuilder methodBuilder = MethodDef.builder(pythonFunctionName)
             .returns(methodSourceReturnType);
         if (methodElement.isStatic()) {
@@ -2746,7 +2754,7 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         } else {
             methodBuilder.addModifiers(Modifier.PUBLIC);
         }
-        addMethodTypeVariables(signatureMethod, methodBuilder, bridgeSignatureTypeArguments, inferredMethodBounds);
+        addMethodTypeVariables(sourceSignatureMethod, methodBuilder, bridgeSignatureTypeArguments, inferredMethodBounds);
 
         copyAnnotations(methodElement, methodBuilder, ANNOTATION_PACKAGES_TO_COPY, visitorContext);
         if (isJunit5Test && !methodElement.hasDeclaredAnnotation(JUNIT_TEST)) {
@@ -2760,8 +2768,11 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             @NonNull ParameterElement parameter = parameters[i];
             ParameterElement signatureParameter = i < signatureParameters.length ? signatureParameters[i] : parameter;
             ParameterElement resolvedSignatureParameter = i < resolvedSignatureParameters.length ? resolvedSignatureParameters[i] : signatureParameter;
+            TypeDef parameterType = genericToArray
+                ? ClassTypeDef.of(sourceSignatureMethod.getDeclaredTypeVariables().getFirst().getVariableName()).array()
+                : bridgeSourceParameterType(signatureMethod, signatureParameter, resolvedSignatureParameter, parameter, bridgeSignatureTypeArguments);
             ParameterDef parameterDef = ParameterDef
-                .builder(parameter.getName(), bridgeSourceParameterType(signatureMethod, signatureParameter, resolvedSignatureParameter, parameter, bridgeSignatureTypeArguments)).build();
+                .builder(parameter.getName(), parameterType).build();
             methodBuilder.addParameter(parameterDef);
         }
 
@@ -2852,6 +2863,9 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
         }
         if (isJunit5Test) {
             return TypeDef.Primitive.VOID;
+        }
+        if ("toArray".equals(signatureMethod.getName()) && signatureMethod.getParameters().length == 0) {
+            return TypeDef.OBJECT.array();
         }
         ClassElement resolvedReturnType = signatureMethod == resolvedSignatureMethod
             ? methodElement.getGenericReturnType()
@@ -2987,6 +3001,12 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
             return null;
         }
         ClassElement genericReturnType = method.getGenericReturnType();
+        // Array return types (notably List.toArray() and List.toArray(T[]))
+        // must retain their array shape. The interface type argument fallback
+        // below is only valid for an erased scalar Object return type.
+        if (genericReturnType.isArray()) {
+            return null;
+        }
         if ("getAnnotationType".equals(method.getName())) {
             ClassElement annotationType = annotationTypeArgument(typeArguments);
             if (annotationType != null) {
@@ -3589,6 +3609,15 @@ public class PythonStubGenerator implements TypeElementVisitor<Object, Object> {
                                 invokedValue, genericType), returnType);
                     } else if (returnType.isAssignable(PUBLISHER)) {
                         ClassElement componentType = returnType.getFirstTypeArgument().orElse(null);
+                        if (componentType != null && isGeneratedWrapperType(allClasses, componentType)) {
+                            yield uncheckedCast(PYTHON_HTTP_CONVERSION.invokeStatic(
+                                "convertPublisher",
+                                List.of(POLYGLOT_VALUE, POLYGLOT_VALUE_CONVERTER),
+                                ClassTypeDef.of(PUBLISHER),
+                                invokedValue,
+                                generatedWrapperConverter(componentType)
+                            ), returnType);
+                        }
                         yield uncheckedCast(PYTHON_HTTP_CONVERSION.invokeStatic("convertPublisher", ClassTypeDef.of(PUBLISHER),
                                 invokedValue, toClassExpression(componentType)), returnType);
                     } else if (returnType.isAssignable(HTTP_RESPONSE)) {

--- a/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
+++ b/inject-python/src/test/java/io/micronaut/python/compiler/PyronautCompilerTest.java
@@ -19,12 +19,19 @@ import io.micronaut.context.python.annotation.PythonApplication;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import javax.tools.ToolProvider;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -62,6 +69,96 @@ final class PyronautCompilerTest {
     }
 
     @Test
+    void loadsApplicationDataProcessorsBeforeLauncherProcessors(@TempDir Path directory) throws Exception {
+        Path sourceDirectory = Files.createDirectories(directory.resolve("source/io/micronaut/data/processor"));
+        Path source = sourceDirectory.resolve("ProcessorClassLoaderMarker.java");
+        Files.writeString(source, """
+            package io.micronaut.data.processor;
+
+            public final class ProcessorClassLoaderMarker {
+                private ProcessorClassLoaderMarker() {}
+                public static String origin() { return "application"; }
+            }
+            """);
+        Path classes = Files.createDirectories(directory.resolve("classes"));
+        assertEquals(0, ToolProvider.getSystemJavaCompiler().run(
+            null,
+            null,
+            null,
+            "-d",
+            classes.toString(),
+            source.toString()
+        ));
+
+        Path launcherSourceDirectory = Files.createDirectories(directory.resolve("launcher-source/io/micronaut/data/processor"));
+        Path launcherSource = launcherSourceDirectory.resolve("ProcessorClassLoaderMarker.java");
+        Files.writeString(launcherSource, """
+            package io.micronaut.data.processor;
+
+            public final class ProcessorClassLoaderMarker {
+                private ProcessorClassLoaderMarker() {}
+                public static String origin() { return "launcher"; }
+            }
+            """);
+        Path launcherClasses = Files.createDirectories(directory.resolve("launcher-classes"));
+        assertEquals(0, ToolProvider.getSystemJavaCompiler().run(
+            null,
+            null,
+            null,
+            "-d",
+            launcherClasses.toString(),
+            launcherSource.toString()
+        ));
+
+        Path launcherJar = directory.resolve("launcher-processors.jar");
+        try (OutputStream output = Files.newOutputStream(launcherJar);
+             JarOutputStream jar = new JarOutputStream(output);
+             var paths = Files.walk(launcherClasses)) {
+            for (Path path : paths.filter(Files::isRegularFile).toList()) {
+                String entryName = launcherClasses.relativize(path).toString().replace(java.io.File.separatorChar, '/');
+                jar.putNextEntry(new JarEntry(entryName));
+                Files.copy(path, jar);
+                jar.closeEntry();
+            }
+        }
+
+        Path processorJar = directory.resolve("application-processors.jar");
+        try (OutputStream output = Files.newOutputStream(processorJar);
+             JarOutputStream jar = new JarOutputStream(output)) {
+            try (var paths = Files.walk(classes)) {
+                for (Path path : paths.filter(Files::isRegularFile).toList()) {
+                    String entryName = classes.relativize(path).toString().replace(java.io.File.separatorChar, '/');
+                    jar.putNextEntry(new JarEntry(entryName));
+                    Files.copy(path, jar);
+                    jar.closeEntry();
+                }
+            }
+        }
+
+        try (URLClassLoader launcherClassLoader = new URLClassLoader(
+            new URL[] {launcherJar.toUri().toURL()},
+            PyronautCompilerTest.class.getClassLoader());
+             URLClassLoader classLoader = (URLClassLoader) PyronautJavaCompiler
+                 .createAnnotationProcessorClassLoader(List.of(processorJar.toFile()), launcherClassLoader)) {
+            // Parent-first loading is the pre-fix behavior: the launcher's copy wins
+            // when both classpaths contain the same processor FQCN.
+            Class<?> parentMarker = Class.forName(
+                "io.micronaut.data.processor.ProcessorClassLoaderMarker",
+                true,
+                launcherClassLoader
+            );
+            assertEquals("launcher", parentMarker.getMethod("origin").invoke(null));
+
+            Class<?> marker = Class.forName(
+                "io.micronaut.data.processor.ProcessorClassLoaderMarker",
+                true,
+                classLoader
+            );
+            assertEquals("application", marker.getMethod("origin").invoke(null));
+        }
+    }
+
+    @Test
     void compilesPythonMethodsReturningHttpResponseSubtypes(@TempDir Path sourceDirectory) throws Exception {
         Files.writeString(sourceDirectory.resolve("responses.py"), """
             from micronaut.http import MutableHttpResponse
@@ -77,6 +174,99 @@ final class PyronautCompilerTest {
             .buildClassLoader();
 
         assertNotNull(classLoader.loadClass("pyronaut_application.PyronautMain"));
+    }
+
+    @Test
+    void compilesPythonListSubclass(@TempDir Path sourceDirectory) throws Exception {
+        Files.writeString(sourceDirectory.resolve("candidates.py"), """
+            class Candidates(list):
+                def __init__(self):
+                    super().__init__()
+            """);
+
+        Path outputDirectory = Files.createDirectories(sourceDirectory.resolve("output"));
+        PyronautCompiler.builder()
+            .pythonSrc(sourceDirectory.toString())
+            .targetDir(outputDirectory.toFile())
+            .build()
+            .compile();
+
+        String generated = Files.readString(findGeneratedSource(outputDirectory, "Candidates.java"));
+        assertTrue(generated.contains("Object[] toArray()"));
+        assertTrue(generated.contains("<T> T[] toArray(T[]"));
+    }
+
+    @Test
+    void generatedJavaInterfaceBridgeInvokesPythonMethod(@TempDir Path directory) throws Exception {
+        Path javaSource = Files.createDirectories(directory.resolve("java").resolve("callback"));
+        Files.writeString(javaSource.resolve("Callback.java"), """
+            package callback;
+
+            public interface Callback {
+                String invoke(String value);
+            }
+            """);
+        Path pythonSource = Files.createDirectories(directory.resolve("python"));
+        Files.writeString(pythonSource.resolve("implementation.py"), """
+            from callback import Callback
+
+            class Implementation(Callback):
+                def invoke(self, value: str) -> str:
+                    return value
+            """);
+        Path output = Files.createDirectories(directory.resolve("output"));
+
+        PyronautCompiler.builder()
+            .javaSrc(directory.resolve("java").toString())
+            .pythonSrc(pythonSource.toString())
+            .targetDir(output.toFile())
+            .build()
+            .compile();
+
+        String generated = Files.readString(findGeneratedSource(output, "Implementation.java"));
+        assertEquals(1, generated.split("PythonInvocation.invokePythonMethod", -1).length - 1);
+    }
+
+    @Test
+    void generatedBridgePreservesDefaultAsyncInterfaceMethod(@TempDir Path directory) throws Exception {
+        Path javaSource = Files.createDirectories(directory.resolve("java").resolve("callback"));
+        Files.writeString(javaSource.resolve("AsyncSender.java"), """
+            package callback;
+
+            import io.micronaut.core.naming.Named;
+            import java.util.function.Consumer;
+
+            public interface AsyncSender extends Named {
+                default String sendAsync(String email) {
+                    return sendAsync(email, ignored -> { });
+                }
+
+                String sendAsync(String email, Consumer<String> emailRequest);
+            }
+            """);
+        Path pythonSource = Files.createDirectories(directory.resolve("python"));
+        Files.writeString(pythonSource.resolve("sender.py"), """
+            from callback import AsyncSender
+
+            class Sender(AsyncSender):
+                def getName(self) -> str:
+                    return "sender"
+
+                def sendAsync(self, email: str, email_request=None) -> str:
+                    return email
+            """);
+        Path output = Files.createDirectories(directory.resolve("output"));
+
+        PyronautCompiler.builder()
+            .javaSrc(directory.resolve("java").toString())
+            .pythonSrc(pythonSource.toString())
+            .targetDir(output.toFile())
+            .build()
+            .compile();
+
+        String generated = Files.readString(findGeneratedSource(output, "Sender.java"));
+        assertEquals(0, generated.split("sendAsync\\(String email\\)", -1).length - 1);
+        assertEquals(1, generated.split("sendAsync\\(String email,", -1).length - 1);
     }
 
     @Test


### PR DESCRIPTION
Fix the remaining Python bridge edge cases around Micronaut Java type facades, generated wrapper values crossing reactive publishers, generic list toArray methods, default interface methods, and application annotation-processor class loading. The changes are covered by focused conversion and compiler regressions.

Tests:
`./gradlew -Ppython-ci :micronaut-context-python:test --tests io.micronaut.context.python.PythonConversionTest :micronaut-inject-python:test --tests io.micronaut.python.compiler.PyronautCompilerTest --rerun-tasks --stacktrace`