### PR TITLE
Handle empty form values when binding URL-encoded beans (rebased #12877)

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
@@ -170,7 +170,15 @@ final class NettyBodyAnnotationBinder<T> extends DefaultBodyAnnotationBinder<T> 
             for (RawFormField rff : toListNow(nhr.getRawFormFields(imm))) {
                 bodies.computeIfAbsent(rff.metadata().name(), k -> new ArrayList<>(1)).add(rff.byteBody());
             }
-            Object intermediate = io.micronaut.http.server.multipart.FormRouteCompleter.mapForGetBody(bodies, nhr.getCharacterEncoding());
+            Map<String, Object> intermediate = io.micronaut.http.server.multipart.FormRouteCompleter.mapForGetBody(bodies, nhr.getCharacterEncoding());
+            Class<T> targetType = context.getArgument().getType();
+            if (mediaType != null
+                    && mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+                    && !targetType.isInstance(intermediate)
+                    && !context.getArgument().isContainerType()
+                    && !ConvertibleValues.class.isAssignableFrom(targetType)) {
+                intermediate.values().removeIf(value -> value instanceof String text && text.isEmpty());
+            }
             Optional<T> converted = conversionService.convert(intermediate, context);
             nhr.setLegacyBody(converted.orElse(null));
             return converted;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
@@ -172,8 +172,10 @@ final class NettyBodyAnnotationBinder<T> extends DefaultBodyAnnotationBinder<T> 
             }
             Map<String, Object> intermediate = io.micronaut.http.server.multipart.FormRouteCompleter.mapForGetBody(bodies, nhr.getCharacterEncoding());
             Class<T> targetType = context.getArgument().getType();
+            // Use matches() rather than equals() so that this stays consistent with the
+            // hasFormBody() check above, which also uses matches() to detect the form type.
             if (mediaType != null
-                    && mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+                    && mediaType.matches(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
                     && !targetType.isInstance(intermediate)
                     && !context.getArgument().isContainerType()
                     && !ConvertibleValues.class.isAssignableFrom(targetType)) {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
@@ -78,6 +78,36 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
         e.response.status == HttpStatus.BAD_REQUEST
     }
 
+    void "test object body preserves empty form values"() {
+        when:
+        String result = client.exchange(HttpRequest.POST('/form/object', 'empty=&value=present')
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).body()
+
+        then:
+        result == '[empty:, value:present]'
+    }
+
+    void "test optional string property treats an empty form value as null"() {
+        when:
+        String result = client.exchange(HttpRequest.POST('/form/optional-pojo', 'name=')
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).body()
+
+        then:
+        result == 'null'
+    }
+
+    void "test multipart bean preserves an empty text field"() {
+        given:
+        MultipartBody body = MultipartBody.builder().addPart('name', '').build()
+
+        when:
+        String result = client.exchange(HttpRequest.POST('/multipart-form/pojo', body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE), String).body()
+
+        then:
+        result == '[]'
+    }
+
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/10446")
     @Unroll
     void "test application/x-www-form-urlencoded String #body is parsed to #parsedMapString"() {
@@ -290,10 +320,24 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
             formData.toMapString()
         }
 
+        @Post('/object')
+        String object(@Body Object formData) {
+            ((Map<String, Object>) formData).toMapString()
+        }
+
+        @Post('/optional-pojo')
+        String optionalPojo(@Body OptionalPerson person) {
+            person.name.toString()
+        }
+
         @EqualsAndHashCode
         static class Person {
             String name
             Integer age
+        }
+
+        static class OptionalPerson {
+            Optional<String> name
         }
     }
 
@@ -333,6 +377,19 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
     static class UrlEncodedPogo {
         String aaa0123456789
         String bbb0123456789
+    }
+
+    @Controller(value = '/multipart-form', consumes = MediaType.MULTIPART_FORM_DATA)
+    @Requires(property = "spec.name", value = "FormDataBindingSpec")
+    static class MultipartFormController {
+        @Post('/pojo')
+        String pojo(@Body MultipartPerson person) {
+            person.name == null ? 'null' : "[$person.name]"
+        }
+
+        static class MultipartPerson {
+            String name
+        }
     }
 
     @Client('/form/saml/test')

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
@@ -87,13 +87,32 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
         result == '[empty:, value:present]'
     }
 
-    void "test optional string property treats an empty form value as null"() {
+    void "test optional string property treats an empty form value as absent"() {
         when:
         String result = client.exchange(HttpRequest.POST('/form/optional-pojo', 'name=')
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).body()
 
         then:
-        result == 'null'
+        result == 'absent'
+    }
+
+    void "test optional string property still binds a non-empty form value"() {
+        when:
+        String result = client.exchange(HttpRequest.POST('/form/optional-pojo', 'name=Fred')
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String).body()
+
+        then:
+        result == '[Fred]'
+    }
+
+    void "test empty form values are elided when the content type carries parameters"() {
+        when:
+        HttpResponse<?> response = client.exchange(HttpRequest.POST('/form/pojo', 'name=Fred&age=')
+                .contentType(MediaType.of('application/x-www-form-urlencoded;charset=UTF-8')), String)
+
+        then:
+        response.status == HttpStatus.OK
+        response.body.get() == 'name: Fred, age: null'
     }
 
     void "test multipart bean preserves an empty text field"() {
@@ -327,7 +346,7 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
 
         @Post('/optional-pojo')
         String optionalPojo(@Body OptionalPerson person) {
-            person.name.toString()
+            person.name == null ? 'absent' : "[${person.name.orElse('empty')}]"
         }
 
         @EqualsAndHashCode

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
@@ -33,6 +33,8 @@ import io.micronaut.http.tck.TestScenario;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,19 +49,36 @@ public class FormsJacksonAnnotationsTest {
     private static final String SPEC_NAME = "FormsJacksonAnnotationsTest";
     private static final String JSON_WITH_PAGES = "{\"title\":\"Building Microservices\",\"paginas\":100}";
     private static final String JSON_WITHOUT_PAGES = "{\"title\":\"Building Microservices\"}";
+    private static final String JSON_WITH_WHITESPACE = "{\"title\":\"Building Microservices\",\"notes\":\" \"}";
+    private static final String JSON_WITH_REPEATED_VALUES = "{\"title\":\"Building Microservices\",\"tags\":[\"\",\"java\",\"\"]}";
 
     @Test
     public void serverFormSubmissionsSupportJacksonAnnotations() throws IOException {
         String body = "title=Building+Microservices&paginas=100";
         assertWithBody(body, JSON_WITH_PAGES);
 
-        body = "title=Building+Microservices&pages=";
+        body = "title=Building+Microservices&paginas=";
         assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&publishedAt=";
+        assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&category=";
+        assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&notes=";
+        assertWithBody(body, JSON_WITHOUT_PAGES);
+
+        body = "title=Building+Microservices&notes=+";
+        assertWithBody(body, JSON_WITH_WHITESPACE);
+
+        body = "title=Building+Microservices&tags=&tags=java&tags=";
+        assertWithBody(body, JSON_WITH_REPEATED_VALUES);
     }
 
     @Test
     public void httpClientFormSubmissionsDoesNotSupportJacksonAnnotations() throws IOException {
-        Book book = new Book("Building Microservices", 100);
+        Book book = new Book("Building Microservices", 100, null, null, null, null);
         // Jackson annotations (@JsonProperty) are not supported by the HTTP Client and form-url encoded payload.
         assertWithBody(book, JSON_WITHOUT_PAGES);
     }
@@ -92,7 +111,16 @@ public class FormsJacksonAnnotationsTest {
 
     @Introspected
     @ReflectiveAccess
-    record Book(@JsonProperty("title") String title, @JsonProperty("paginas") @Nullable Integer pages) {
+    record Book(@JsonProperty("title") String title,
+                @JsonProperty("paginas") @Nullable Integer pages,
+                @JsonProperty("publishedAt") LocalDateTime publishedAt,
+                @JsonProperty("category") Category category,
+                @JsonProperty("notes") String notes,
+                @JsonProperty("tags") List<String> tags) {
+    }
+
+    enum Category {
+        TECHNICAL
     }
 
 }

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/forms/FormsJacksonAnnotationsTest.java
@@ -113,10 +113,10 @@ public class FormsJacksonAnnotationsTest {
     @ReflectiveAccess
     record Book(@JsonProperty("title") String title,
                 @JsonProperty("paginas") @Nullable Integer pages,
-                @JsonProperty("publishedAt") LocalDateTime publishedAt,
-                @JsonProperty("category") Category category,
-                @JsonProperty("notes") String notes,
-                @JsonProperty("tags") List<String> tags) {
+                @JsonProperty("publishedAt") @Nullable LocalDateTime publishedAt,
+                @JsonProperty("category") @Nullable Category category,
+                @JsonProperty("notes") @Nullable String notes,
+                @JsonProperty("tags") @Nullable List<String> tags) {
     }
 
     enum Category {


### PR DESCRIPTION
## Summary

Rebased version of #12877 (original work by @Boulea7) onto current `5.2.x`, with the Copilot review feedback addressed.

Carried over from #12877:

- treat single empty URL-encoded fields as absent when binding form data to beans or records
- preserve empty values for `Map` and `Object` bodies, repeated fields, whitespace, and multipart text parts
- correct the Jackson alias regression fixture so the empty field uses the annotated name

Fixes #11213

## Review feedback addressed

**1. Media type comparison** — the elision check now uses `mediaType.matches(APPLICATION_FORM_URLENCODED_TYPE)` instead of `equals(...)`.

A note on the original review comment, which claimed `equals` returns `false` when the `Content-Type` carries parameters (e.g. `; charset=UTF-8`): that is not accurate. `MediaType.equals` compares `lowerName`, which is the type *with parameters already stripped* by the constructor, so the parameterised case did already compare equal and there was no live bug. The change is still worth making, because `matches()` is what the `hasFormBody()` / `parseFormType()` gate that selects this branch uses, so the two checks now agree by construction rather than by coincidence. A regression test pins the parameterised `Content-Type` behaviour either way.

**2. Ambiguous test assertion** — the `/form/optional-pojo` endpoint returned `person.name.toString()` on an `Optional<String>` and the test asserted `'null'`. That only passed because Groovy routes method calls on `null` through `NullObject`, whose `toString()` returns `"null"` — so the assertion could not distinguish "field never set" from `Optional.empty` from an NPE-shaped failure. The endpoint now reports `absent` / `[empty]` / `[value]` explicitly, and a companion test asserts a non-empty value still binds.

**3. Additional fix (not from the review)** — the new `Book` record components in the TCK test were missing `@Nullable`. The `io.micronaut.http.server.tck.tests.forms` package is `@NullMarked`, and `httpClientFormSubmissionsDoesNotSupportJacksonAnnotations` constructs the record with `null` for all four.

## Verification

- `./gradlew :micronaut-http-server-netty:test --tests '*FormDataBindingSpec*'` — 42 tests, 0 failures (includes the 5 new/updated cases)
- `./gradlew :test-suite-http-server-tck-netty:test --tests '*FormsJacksonAnnotations*'` — 2 tests, 0 failures

The original commit is preserved with its authorship; the review fixes are a separate commit on top so the delta against #12877 is reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
