### PR TITLE
Keep the name a type variable was declared with when its bounds are written

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
@@ -578,9 +578,9 @@ public final class ArgumentExpUtils {
                 METHOD_CREATE_TYPE_VAR_WITH_BOUNDS,
                 values.get(0),
                 values.get(1),
-                // The name the variable was declared with, which is not the name of the argument: the argument
-                // of a type argument is named after the parameter it stands in for - the E of List<E> - while
-                // the variable is the M of List<M>
+                // The name the variable was declared with, which is not the name of the argument: a type
+                // argument is named after the parameter it stands in for - the E of List<E> - while the
+                // variable is the M of List<M>
                 variableName == null ? ExpressionDef.nullValue() : ExpressionDef.constant(variableName),
                 values.get(2),
                 values.get(3),

--- a/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
@@ -482,8 +482,11 @@ public final class ArgumentExpUtils {
 
         List<ExpressionDef> values = new ArrayList<>();
 
-        // The bounds are read from the placeholder, before it is replaced by the type it resolves to
+        // The bounds and the variable's own name are read from the placeholder, before it is replaced by the
+        // type it resolves to
         List<? extends ClassElement> bounds = recordedBounds(argumentType);
+        String variableName = argumentType instanceof GenericPlaceholderElement placeholder
+            ? placeholder.getVariableName() : null;
 
         if (argumentType instanceof GenericPlaceholderElement placeholderElement) {
             // Persist resolved placeholder for backward compatibility
@@ -575,8 +578,10 @@ public final class ArgumentExpUtils {
                 METHOD_CREATE_TYPE_VAR_WITH_BOUNDS,
                 values.get(0),
                 values.get(1),
-                // The variable name is the argument name here, as it was before the bounds were kept
-                ExpressionDef.nullValue(),
+                // The name the variable was declared with, which is not the name of the argument: the argument
+                // of a type argument is named after the parameter it stands in for - the E of List<E> - while
+                // the variable is the M of List<M>
+                variableName == null ? ExpressionDef.nullValue() : ExpressionDef.constant(variableName),
                 values.get(2),
                 values.get(3),
                 pushBounds(annotationMetadataWithDefaults, owningType, bounds, visitedTypes, loadClassValueExpressionFn)

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
@@ -69,6 +69,10 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
         argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
     }
 
+    private static String variableName(Argument<?> argument) {
+        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).variableName : null
+    }
+
     private Map<String, Argument<?>> constructorArguments() {
         definition.constructor.arguments.collectEntries { [it.name, it] }
     }
@@ -78,7 +82,7 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
     }
 
     @Unroll
-    void "the type argument of constructor parameter #name erases to #type and keeps the bounds #declared"() {
+    void "the type argument of constructor parameter #name erases to #type, is the variable #variable and keeps the bounds #declared"() {
         given:
         Argument<?> typeArgument = constructorArguments()[name].typeParameters[0]
 
@@ -86,14 +90,17 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
         typeArgument.type.name == type
         typeArgument.isTypeVariable() == isVariable
         bounds(typeArgument) == declared
+        // the variable is named as it was declared, not after the parameter it stands in for: the T of
+        // Event<T> is the class's T, whether or not its bounds had to be written out
+        variableName(typeArgument) == variable
 
         where:
-        name                 | type               | isVariable | declared
-        'several'            | 'test.Payment'     | true       | ['test.Payment', 'test.Refundable']
-        'one'                | 'test.Payment'     | true       | ['test.Payment']
-        'none'               | 'java.lang.Object' | true       | ['java.lang.Object']
-        'parameterizedBound' | 'java.util.List'   | true       | ['java.util.List', 'test.Refundable']
-        'concrete'           | 'test.Payment'     | false      | null
+        name                 | type               | isVariable | declared                              | variable
+        'several'            | 'test.Payment'     | true       | ['test.Payment', 'test.Refundable']   | 'T'
+        'one'                | 'test.Payment'     | true       | ['test.Payment']                      | 'S'
+        'none'               | 'java.lang.Object' | true       | ['java.lang.Object']                  | 'U'
+        'parameterizedBound' | 'java.util.List'   | true       | ['java.util.List', 'test.Refundable'] | 'P'
+        'concrete'           | 'test.Payment'     | false      | null                                  | null
     }
 
     void "a bound keeps its own type arguments"() {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
@@ -23,6 +23,9 @@ import io.micronaut.inject.ExecutableMethod
 import spock.lang.Shared
 import spock.lang.Unroll
 
+import static io.micronaut.inject.test.Placeholders.bounds
+import static io.micronaut.inject.test.Placeholders.variableName
+
 class TypeVariableBoundsSpec extends AbstractBeanDefinitionSpec {
 
     private static final String SOURCE = '''
@@ -63,14 +66,6 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
 
     def setupSpec() {
         definition = buildBeanDefinition('test.Bean', SOURCE)
-    }
-
-    private static List<String> bounds(Argument<?> argument) {
-        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
-    }
-
-    private static String variableName(Argument<?> argument) {
-        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).variableName : null
     }
 
     private Map<String, Argument<?>> constructorArguments() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
@@ -23,6 +23,9 @@ import io.micronaut.inject.ExecutableMethod
 import spock.lang.Shared
 import spock.lang.Unroll
 
+import static io.micronaut.inject.test.Placeholders.bounds
+import static io.micronaut.inject.test.Placeholders.variableName
+
 class TypeVariableBoundsSpec extends AbstractTypeElementSpec {
 
     private static final String SOURCE = '''
@@ -64,14 +67,6 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
 
     def setupSpec() {
         definition = buildBeanDefinition('test.Bean', SOURCE)
-    }
-
-    private static List<String> bounds(Argument<?> argument) {
-        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
-    }
-
-    private static String variableName(Argument<?> argument) {
-        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).variableName : null
     }
 
     private Map<String, Argument<?>> constructorArguments() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeVariableBoundsSpec.groovy
@@ -70,6 +70,10 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
         argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
     }
 
+    private static String variableName(Argument<?> argument) {
+        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).variableName : null
+    }
+
     private Map<String, Argument<?>> constructorArguments() {
         definition.constructor.arguments.collectEntries { [it.name, it] }
     }
@@ -79,7 +83,7 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
     }
 
     @Unroll
-    void "the type argument of constructor parameter #name erases to #type and keeps the bounds #declared"() {
+    void "the type argument of constructor parameter #name erases to #type, is the variable #variable and keeps the bounds #declared"() {
         given:
         Argument<?> typeArgument = constructorArguments()[name].typeParameters[0]
 
@@ -87,14 +91,17 @@ class Bean<T extends Payment & Refundable, S extends Payment, U, P extends List<
         typeArgument.type.name == type
         typeArgument.isTypeVariable() == isVariable
         bounds(typeArgument) == declared
+        // the variable is named as it was declared, not after the parameter it stands in for: the T of
+        // Event<T> is the class's T, whether or not its bounds had to be written out
+        variableName(typeArgument) == variable
 
         where:
-        name                 | type               | isVariable | declared
-        'several'            | 'test.Payment'     | true       | ['test.Payment', 'test.Refundable']
-        'one'                | 'test.Payment'     | true       | ['test.Payment']
-        'none'               | 'java.lang.Object' | true       | ['java.lang.Object']
-        'parameterizedBound' | 'java.util.List'   | true       | ['java.util.List', 'test.Refundable']
-        'concrete'           | 'test.Payment'     | false      | null
+        name                 | type               | isVariable | declared                              | variable
+        'several'            | 'test.Payment'     | true       | ['test.Payment', 'test.Refundable']   | 'T'
+        'one'                | 'test.Payment'     | true       | ['test.Payment']                      | 'S'
+        'none'               | 'java.lang.Object' | true       | ['java.lang.Object']                  | 'U'
+        'parameterizedBound' | 'java.util.List'   | true       | ['java.util.List', 'test.Refundable'] | 'P'
+        'concrete'           | 'test.Payment'     | false      | null                                  | null
     }
 
     void "a bound keeps its own type arguments"() {

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/TypeVariableBoundsSpec.groovy
@@ -70,6 +70,10 @@ class Bean<T, S : Payment, U, P>(
         argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
     }
 
+    private static String variableName(Argument<?> argument) {
+        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).variableName : null
+    }
+
     private Map<String, Argument<?>> constructorArguments() {
         definition.constructor.arguments.collectEntries { [it.name, it] }
     }
@@ -79,7 +83,7 @@ class Bean<T, S : Payment, U, P>(
     }
 
     @Unroll
-    void "the type argument of constructor parameter #name erases to #type and keeps the bounds #declared"() {
+    void "the type argument of constructor parameter #name erases to #type, is the variable #variable and keeps the bounds #declared"() {
         given:
         Argument<?> typeArgument = constructorArguments()[name].typeParameters[0]
 
@@ -87,14 +91,17 @@ class Bean<T, S : Payment, U, P>(
         typeArgument.type.name == type
         typeArgument.isTypeVariable() == isVariable
         bounds(typeArgument) == declared
+        // the variable is named as it was declared, not after the parameter it stands in for: the T of
+        // Event<T> is the class's T, whether or not its bounds had to be written out
+        variableName(typeArgument) == variable
 
         where:
-        name                 | type               | isVariable | declared
-        'several'            | 'test.Payment'     | true       | ['test.Payment', 'test.Refundable']
-        'one'                | 'test.Payment'     | true       | ['test.Payment']
-        'none'               | 'java.lang.Object' | true       | ['java.lang.Object']
-        'parameterizedBound' | 'java.util.List'   | true       | ['java.util.List', 'test.Refundable']
-        'concrete'           | 'test.Payment'     | false      | null
+        name                 | type               | isVariable | declared                              | variable
+        'several'            | 'test.Payment'     | true       | ['test.Payment', 'test.Refundable']   | 'T'
+        'one'                | 'test.Payment'     | true       | ['test.Payment']                      | 'S'
+        'none'               | 'java.lang.Object' | true       | ['java.lang.Object']                  | 'U'
+        'parameterizedBound' | 'java.util.List'   | true       | ['java.util.List', 'test.Refundable'] | 'P'
+        'concrete'           | 'test.Payment'     | false      | null                                  | null
     }
 
     void "a bound keeps its own type arguments"() {

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/TypeVariableBoundsSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/TypeVariableBoundsSpec.groovy
@@ -23,6 +23,9 @@ import io.micronaut.inject.ExecutableMethod
 import spock.lang.Shared
 import spock.lang.Unroll
 
+import static io.micronaut.inject.test.Placeholders.bounds
+import static io.micronaut.inject.test.Placeholders.variableName
+
 class TypeVariableBoundsSpec extends AbstractKotlinCompilerSpec {
 
     private static final String SOURCE = '''
@@ -64,14 +67,6 @@ class Bean<T, S : Payment, U, P>(
 
     def setupSpec() {
         definition = buildBeanDefinition('test.Bean', SOURCE)
-    }
-
-    private static List<String> bounds(Argument<?> argument) {
-        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
-    }
-
-    private static String variableName(Argument<?> argument) {
-        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).variableName : null
     }
 
     private Map<String, Argument<?>> constructorArguments() {

--- a/inject-test-utils/src/main/groovy/io/micronaut/inject/test/Placeholders.groovy
+++ b/inject-test-utils/src/main/groovy/io/micronaut/inject/test/Placeholders.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.test
+
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.GenericPlaceholder
+
+/**
+ * What an argument says about the type variable it stands for, in the shapes an assertion wants: the names of
+ * its bounds, and the name the variable was declared with. Both answer {@code null} for an argument that is
+ * not a variable, so a table of expectations can hold the concrete cases beside the variable ones.
+ *
+ * <p>Shared by the specs of every processor, which compile the same sources and must agree about the answers.</p>
+ */
+class Placeholders {
+
+    /**
+     * The names of the bounds the variable declares.
+     *
+     * @param argument The argument
+     * @return The names, or {@code null} where the argument is not a variable
+     */
+    static List<String> bounds(Argument<?> argument) {
+        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).bounds*.type*.name : null
+    }
+
+    /**
+     * The name the variable was declared with, which is not the name of the argument: an argument that is a
+     * type argument is named after the parameter it stands in for.
+     *
+     * @param argument The argument
+     * @return The name, or {@code null} where the argument is not a variable
+     */
+    static String variableName(Argument<?> argument) {
+        argument instanceof GenericPlaceholder ? ((GenericPlaceholder<?>) argument).variableName : null
+    }
+}

--- a/reflection/src/test/groovy/io/micronaut/reflection/ReflectionTypesSpec.groovy
+++ b/reflection/src/test/groovy/io/micronaut/reflection/ReflectionTypesSpec.groovy
@@ -62,6 +62,21 @@ class ReflectionTypesSpec extends Specification {
         def inside = arguments[1].typeParameters[0]
         inside instanceof GenericPlaceholder
         ((GenericPlaceholder) inside).bounds*.type == [Comparable, Cloneable]
+
+        and: "and is named as the variable was declared"
+        ((GenericPlaceholder) inside).variableName == "T"
+    }
+
+    void "a variable inside a type argument is named unlike the parameter it stands in for"() {
+        given:
+        def argument = ReflectionArguments.argumentsOf(Types.getDeclaredMethod("distinctlyNamed", List))[0]
+        def inside = argument.typeParameters[0]
+
+        expect: "the M of List<M>, rather than the E java.util.List declares"
+        inside instanceof GenericPlaceholder
+        ((GenericPlaceholder) inside).variableName == "M"
+        ((GenericPlaceholder) inside).bounds*.type == [Comparable, Cloneable]
+        inside.type == Comparable
     }
 
     void "a variable bounded by a type naming it answers that bound"() {

--- a/reflection/src/test/java/io/micronaut/reflection/Types.java
+++ b/reflection/src/test/java/io/micronaut/reflection/Types.java
@@ -28,6 +28,10 @@ public class Types {
         // the signature is what is read, the body is never called
     }
 
+    public <M extends Comparable<String> & Cloneable> void distinctlyNamed(List<M> inside) {
+        // the variable is named unlike the parameter of the type holding it, which is the E of List<E>
+    }
+
     public <T extends Comparable<T>> void recursive(T value) {
         // the signature is what is read, the body is never called
     }


### PR DESCRIPTION
Fixes #13075, a regression from #13063.

A type variable used as a **type argument** lost the name it was declared with, as soon as its bounds were
recorded. Probed either side of #13063 on the same source:

```java
class Bean<T extends Payment & Refundable, P extends List<String> & Refundable> {
    Bean(Event<T> several, Event<P> parameterizedBound) {}
}
```

```
before  several: name=T    parameterizedBound: name=P
after   several: name=T    parameterizedBound: name=T   <- T, the parameter of Event<T>
```

A variable with a single bound is unaffected, because its bounds are not written out — the erasure already
says them, so the branch #13063 added is not taken. `several` looks unaffected only by coincidence: its
variable and the parameter it stands in for are both spelled `T`. `parameterizedBound` shows what happens.

## Cause

In `ArgumentExpUtils`, on the type-argument path, the placeholder is replaced by what it resolves to before the
argument is written, and the new branch then passed `null` as the variable name:

```java
if (argumentType instanceof GenericPlaceholderElement placeholderElement) {
    // Persist resolved placeholder for backward compatibility
    argumentType = placeholderElement.getResolved().orElse(argumentType);
}
…
if (typeVariable && !bounds.isEmpty()) {
    return TYPE_ARGUMENT.invokeStatic(
        METHOD_CREATE_TYPE_VAR_WITH_BOUNDS,
        values.get(0),
        values.get(1),
        // The variable name is the argument name here, as it was before the bounds were kept
        ExpressionDef.nullValue(),
        …
```

`DefaultGenericPlaceholder#getVariableName()` is `variableName != null ? variableName : getName()`, and the
name of a *type argument* is the key it is held under — the parameter it stands in for, the `T` of `Event<T>`
— not the variable's own name. The comment's assumption holds for a parameter or a field, which is where the
other call site in the same file reads the placeholder's name and passes it.

## The change

Read the variable's name off the placeholder before it is replaced, and pass it, exactly as the other call site
does. Two lines of production code; the bounds themselves, the argument name and every other path are
untouched.

## Tests

`TypeVariableBoundsSpec` asserted the type, the variable flag and the bounds of each type argument, but never
the name, which is why this got through. All three copies — `inject-java`, `inject-groovy`, `inject-kotlin` —
now assert the name in the same table: `T`, `S`, `U`, `P` for the four variables and `null` for the concrete
argument. Without the production change, the `parameterizedBound` row fails with `T != P`; with it, all three
suites pass.

`:micronaut-inject-java:test`, `:micronaut-inject-groovy:test`, `:micronaut-inject-kotlin:test` and
`:micronaut-inject:checkstyleMain` pass.

## Not in scope

Two neighbouring cases are unchanged, and neither is this bug:

- a recursively bounded variable (`R extends Comparable<R>`) reported the container's parameter name before
  #13063 as well;
- a wildcard is named after the parameter it stands in for by design (#13023).

Found while adopting #13063 in [micronaut-cdi](https://github.com/dstepanov/micronaut-cdi), where a variable's
name and its bounds together decide type-safe resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
