### PR TITLE
Don't instantiate an empty bean for an absent @QueryValue POJO

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
@@ -90,6 +90,8 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
         HttpMethod.GET  | '/parameter/query-object?age=30&title=JavaBook&author=JavaAuthor' | "Parameter Value: 30 JavaBook" | HttpStatus.OK
         HttpMethod.GET  | '/parameter/query-object?age=30'                | "Parameter Value: 30 null"  | HttpStatus.OK
         HttpMethod.GET  | '/parameter/query-object-nullable'              | "null"                      | HttpStatus.OK
+        HttpMethod.GET  | '/parameter/query-bean-nullable'                | "null"                      | HttpStatus.OK
+        HttpMethod.GET  | '/parameter/query-bean-nullable?type=CARD'      | "Filter(id=null, type=CARD)" | HttpStatus.OK
         HttpMethod.GET  | '/parameter/query-record?page=1&size=123' | "Parameter Value: 1 123" | HttpStatus.OK
     }
 
@@ -342,11 +344,48 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
             return book == null ? "null" : "not-null"
         }
 
+        @Get("/query-bean-nullable")
+        String queryBeanNullable(@QueryValue("filter") @Nullable Filter filter) {
+            return String.valueOf(filter)
+        }
+
         @Get('/query-record')
         String queryRecord(@QueryValue PaginationRequest paginationRequest) {
             "Parameter Value: $paginationRequest.page $paginationRequest.size"
         }
 
+
+        @Introspected
+        static class Filter {
+
+            @Nullable
+            private Long id
+            @Nullable
+            private String type
+
+            @Nullable
+            Long getId() {
+                return id
+            }
+
+            void setId(@Nullable Long id) {
+                this.id = id
+            }
+
+            @Nullable
+            String getType() {
+                return type
+            }
+
+            void setType(@Nullable String type) {
+                this.type = type
+            }
+
+            @Override
+            String toString() {
+                return "Filter(id=" + id + ", type=" + type + ")"
+            }
+        }
 
         @Introspected
         static class Book {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
@@ -345,7 +345,7 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
         }
 
         @Get("/query-bean-nullable")
-        String queryBeanNullable(@QueryValue("filter") @Nullable Filter filter) {
+        String queryBeanNullable(@QueryValue @Nullable Filter filter) {
             return String.valueOf(filter)
         }
 

--- a/http/src/main/java/io/micronaut/http/bind/binders/QueryValueArgumentBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/QueryValueArgumentBinder.java
@@ -165,6 +165,7 @@ public class QueryValueArgumentBinder<T> extends AbstractArgumentBinder<T> imple
         BeanIntrospection<T> introspection = introspectionOpt.get();
         BeanIntrospection.Builder<T> introspectionBuilder = introspection.builder();
         Argument<?>[] builderArguments = introspectionBuilder.getBuilderArguments();
+        boolean hasAnyValue = false;
 
         for (int index = 0; index < builderArguments.length; index++) {
             Argument<?> builderArg = builderArguments[index];
@@ -177,6 +178,10 @@ public class QueryValueArgumentBinder<T> extends AbstractArgumentBinder<T> imple
             @Nullable String defaultValue = hasNoValue ? builderArg
                 .getAnnotationMetadata()
                 .stringValue(Bindable.class, "defaultValue").orElse(null) : null;
+
+            if (!hasNoValue || defaultValue != null) {
+                hasAnyValue = true;
+            }
 
             ArgumentConversionContext<?> conversionContext = context.with(builderArg);
             Optional<?> converted = hasNoValue ? conversionService.convert(defaultValue, conversionContext) : conversionService.convert(values, conversionContext);
@@ -199,21 +204,29 @@ public class QueryValueArgumentBinder<T> extends AbstractArgumentBinder<T> imple
             }
         }
 
+        if (!hasAnyValue) {
+            // Nothing was supplied for the bean, don't instantiate an empty one
+            return nullResult(argument);
+        }
+
         try {
             T instance = introspectionBuilder.build();
 
             if (instance == null) {
-                if (argument.isNullable()) {
-                    return BindingResult.empty();
-                }
-
-                return BindingResult.unsatisfied();
+                return nullResult(argument);
             }
 
             return () -> Optional.of(instance);
         } catch (Exception e) {
             return BindingResult.unsatisfied();
         }
+    }
+
+    private BindingResult<T> nullResult(Argument<T> argument) {
+        if (argument.isNullable()) {
+            return BindingResult.empty();
+        }
+        return BindingResult.unsatisfied();
     }
 
     private BindingResult<T> propagateConversionError(Optional<ConversionError> conversionError) {

--- a/http/src/test/java/io/micronaut/http/bind/binders/QueryValueArgumentBinderTest.java
+++ b/http/src/test/java/io/micronaut/http/bind/binders/QueryValueArgumentBinderTest.java
@@ -43,6 +43,44 @@ class QueryValueArgumentBinderTest {
         }
     }
 
+    @Introspected
+    static class FilterTestType {
+        @Nullable
+        private Long id;
+        @Nullable
+        private String type;
+
+        @Nullable
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(@Nullable Long id) {
+            this.id = id;
+        }
+
+        @Nullable
+        public String getType() {
+            return type;
+        }
+
+        public void setType(@Nullable String type) {
+            this.type = type;
+        }
+    }
+
+    @Introspected
+    static class FailingCreatorTestType {
+        @Creator
+        public static FailingCreatorTestType getInstance(@Nullable String value) {
+            throw new IllegalStateException("Creator failed");
+        }
+    }
+
+    QueryValueArgumentBinder<FilterTestType> filterTestTypeQueryValueArgumentBinder =
+        new QueryValueArgumentBinder<>(ConversionService.SHARED);
+    QueryValueArgumentBinder<FailingCreatorTestType> failingCreatorTestTypeQueryValueArgumentBinder =
+        new QueryValueArgumentBinder<>(ConversionService.SHARED);
     QueryValueArgumentBinder<NullableTestType> nullableTestTypeQueryValueArgumentBinder =
         new QueryValueArgumentBinder<>(ConversionService.SHARED);
     QueryValueArgumentBinder<NonNullTestType> nonNullableTestTypeQueryValueArgumentBinder =
@@ -149,7 +187,7 @@ class QueryValueArgumentBinderTest {
     }
 
     @Test
-    void shouldBindUnsatisfiedWhenInstanceCreatedByIntrospectionIsNotNullAndArgumentIsNullableAndCreatorFails() {
+    void shouldBindEmptyWhenNoValuesArePresentAndArgumentIsNullable() {
         var context = new ArgumentConversionContext<NonNullTestType>() {
             @Override
             @NonNull
@@ -161,6 +199,83 @@ class QueryValueArgumentBinderTest {
 
 
         var bound = nonNullableTestTypeQueryValueArgumentBinder.bind(context, source);
+
+
+        assertTrue(bound.isSatisfied());
+        assertFalse(bound.getValue().isPresent());
+    }
+
+    @Test
+    void shouldBindEmptyWhenNoBeanPropertyIsPresentAndArgumentIsNullable() {
+        var context = new ArgumentConversionContext<FilterTestType>() {
+            @Override
+            @NonNull
+            public Argument<FilterTestType> getArgument() {
+                return Argument.of(FilterTestType.class, NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var source = get("/");
+
+
+        var bound = filterTestTypeQueryValueArgumentBinder.bind(context, source);
+
+
+        assertTrue(bound.isSatisfied());
+        assertFalse(bound.getValue().isPresent());
+    }
+
+    @Test
+    void shouldBindUnsatisfiedWhenNoBeanPropertyIsPresentAndArgumentIsNotNullable() {
+        var context = new ArgumentConversionContext<FilterTestType>() {
+            @Override
+            @NonNull
+            public Argument<FilterTestType> getArgument() {
+                return Argument.of(FilterTestType.class, NON_NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var source = get("/");
+
+
+        var bound = filterTestTypeQueryValueArgumentBinder.bind(context, source);
+
+
+        assertFalse(bound.isSatisfied());
+        assertFalse(bound.getValue().isPresent());
+    }
+
+    @Test
+    void shouldBindWithValueWhenSomeBeanPropertiesArePresent() {
+        var context = new ArgumentConversionContext<FilterTestType>() {
+            @Override
+            @NonNull
+            public Argument<FilterTestType> getArgument() {
+                return Argument.of(FilterTestType.class, NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var source = get("/", Map.of("type", "CARD"));
+
+
+        var bound = filterTestTypeQueryValueArgumentBinder.bind(context, source);
+
+
+        assertTrue(bound.isPresentAndSatisfied());
+        assertEquals("CARD", bound.get().getType());
+        assertNull(bound.get().getId());
+    }
+
+    @Test
+    void shouldBindUnsatisfiedWhenValuesArePresentAndCreatorFailsAndArgumentIsNullable() {
+        var context = new ArgumentConversionContext<FailingCreatorTestType>() {
+            @Override
+            @NonNull
+            public Argument<FailingCreatorTestType> getArgument() {
+                return Argument.of(FailingCreatorTestType.class, NULLABLE_ANNOTATION_METADATA);
+            }
+        };
+        var source = get("/", Map.of("value", "test-value"));
+
+
+        var bound = failingCreatorTestTypeQueryValueArgumentBinder.bind(context, source);
 
 
         assertFalse(bound.isSatisfied());


### PR DESCRIPTION
Fixes #12913

## What changed

`QueryValueArgumentBinder#bindPojo` built the introspected bean even when the request supplied none of its properties, so an absent `@Nullable @QueryValue` parameter bound an empty instance instead of `null` (a regression in 4.10.0). The no-input guard added in #12632 was dropped in #12759 while handling creator-produced nulls.

This restores it: the binder now tracks whether any property received a value or a `@Bindable` default. If none did, the result goes through the same handling as a null instance — `BindingResult.empty()` for a nullable argument (binds `null`), `unsatisfied()` otherwise (400) — which is the pre-4.10 behaviour.

This also covers the classpath-wide case from the issue, where an `@Introspected(classes = {String.class})` anywhere made every absent `String` query parameter bind `""` instead of `null`.

## Tests

- `QueryValueArgumentBinderTest`: added absent-bean cases for nullable and non-nullable arguments, plus a partial-binding case.
- `ParameterBindingSpec`: added a Netty end-to-end regression for the issue's setter-based bean. Verified it fails without the main-source change and passes with it.

## Note for reviewers

One existing test, `shouldBindUnsatisfiedWhenInstanceCreatedByIntrospectionIsNotNullAndArgumentIsNullableAndCreatorFails`, asserted *unsatisfied* for a nullable argument with no query parameters at all. That case is indistinguishable from "nothing was supplied", which is exactly what this issue says must bind `null`, so its expectation is updated and a separate creator-failure test that does supply a value was added to keep that path covered.

Unrelated, found while writing the tests and deliberately left alone: for setter-based beans, `IntrospectionBuilder` marks a writable property required when `argument.isDeclaredNonNull()`, so a bean whose properties are not explicitly `@Nullable` throws on partial binding (`?type=CARD` with no `id`) and ends up unsatisfied. That is why the test beans are annotated `@Nullable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)