### PR TITLE
Propagate the context of pre-matching filters into the route match

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/mdc/MdcLegacyFilterDownstreamSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/mdc/MdcLegacyFilterDownstreamSpec.groovy
@@ -23,6 +23,8 @@ import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.util.concurrent.atomic.AtomicReference
+
 import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN
 
 class MdcLegacyFilterDownstreamSpec extends Specification {
@@ -40,16 +42,15 @@ class MdcLegacyFilterDownstreamSpec extends Specification {
 
     void 'MDC propagated by a legacy filter is visible to the later filters, the route and the response filters'() {
         given:
-        LaterFilter.seenOnRequest = null
-        LaterFilter.seenOnResponse = null
+        LaterFilter laterFilter = embeddedServer.applicationContext.getBean(LaterFilter)
 
         when:
         String response = client.toBlocking().retrieve(HttpRequest.GET('/mdc-legacy'))
 
         then:
         response == '1234567890'
-        LaterFilter.seenOnRequest == '1234567890'
-        LaterFilter.seenOnResponse == '1234567890'
+        laterFilter.seenOnRequest.get() == '1234567890'
+        laterFilter.seenOnResponse.get() == '1234567890'
     }
 
     @Controller
@@ -81,17 +82,17 @@ class MdcLegacyFilterDownstreamSpec extends Specification {
     @ServerFilter(MATCH_ALL_PATTERN)
     @Requires(property = 'spec.name', value = 'MdcLegacyFilterDownstreamSpec')
     static class LaterFilter {
-        static String seenOnRequest
-        static String seenOnResponse
+        final AtomicReference<String> seenOnRequest = new AtomicReference<>()
+        final AtomicReference<String> seenOnResponse = new AtomicReference<>()
 
         @RequestFilter
         void filterRequest(HttpRequest<?> request) {
-            seenOnRequest = MDC.get('trace_id')
+            seenOnRequest.set(MDC.get('trace_id'))
         }
 
         @ResponseFilter
         void filterResponse(MutableHttpResponse<?> response) {
-            seenOnResponse = MDC.get('trace_id')
+            seenOnResponse.set(MDC.get('trace_id'))
         }
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/mdc/MdcLegacyFilterDownstreamSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/mdc/MdcLegacyFilterDownstreamSpec.groovy
@@ -1,0 +1,97 @@
+package io.micronaut.http.server.netty.mdc
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.propagation.slf4j.MdcPropagationContext
+import io.micronaut.core.propagation.PropagatedContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.RequestFilter
+import io.micronaut.http.annotation.ResponseFilter
+import io.micronaut.http.annotation.ServerFilter
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.filter.ServerFilterPhase
+import io.micronaut.runtime.server.EmbeddedServer
+import org.reactivestreams.Publisher
+import org.slf4j.MDC
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN
+
+class MdcLegacyFilterDownstreamSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name'           : 'MdcLegacyFilterDownstreamSpec',
+            'micronaut.propagation': 'thread-local'
+    ])
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = HttpClient.create(embeddedServer.URL)
+
+    void 'MDC propagated by a legacy filter is visible to the later filters, the route and the response filters'() {
+        given:
+        LaterFilter.seenOnRequest = null
+        LaterFilter.seenOnResponse = null
+
+        when:
+        String response = client.toBlocking().retrieve(HttpRequest.GET('/mdc-legacy'))
+
+        then:
+        response == '1234567890'
+        LaterFilter.seenOnRequest == '1234567890'
+        LaterFilter.seenOnResponse == '1234567890'
+    }
+
+    @Controller
+    @Requires(property = 'spec.name', value = 'MdcLegacyFilterDownstreamSpec')
+    static class TheController {
+        @Get('/mdc-legacy')
+        String get() {
+            return MDC.get('trace_id')
+        }
+    }
+
+    @Filter(MATCH_ALL_PATTERN)
+    @Requires(property = 'spec.name', value = 'MdcLegacyFilterDownstreamSpec')
+    static class LegacyMdcFilter implements HttpServerFilter {
+        @Override
+        Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+            def context = PropagatedContext.getOrEmpty().plus(new MdcPropagationContext(Map.of('trace_id', '1234567890')))
+            try (PropagatedContext.Scope ignore = context.propagate()) {
+                return chain.proceed(request)
+            }
+        }
+
+        @Override
+        int getOrder() {
+            return ServerFilterPhase.FIRST.order()
+        }
+    }
+
+    @ServerFilter(MATCH_ALL_PATTERN)
+    @Requires(property = 'spec.name', value = 'MdcLegacyFilterDownstreamSpec')
+    static class LaterFilter {
+        static String seenOnRequest
+        static String seenOnResponse
+
+        @RequestFilter
+        void filterRequest(HttpRequest<?> request) {
+            seenOnRequest = MDC.get('trace_id')
+        }
+
+        @ResponseFilter
+        void filterResponse(MutableHttpResponse<?> response) {
+            seenOnResponse = MDC.get('trace_id')
+        }
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/mdc/MdcPreMatchingFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/mdc/MdcPreMatchingFilterSpec.groovy
@@ -56,6 +56,7 @@ class MdcPreMatchingFilterSpec extends Specification {
 
         cleanup:
         logger.detachAppender(appender)
+        appender.stop()
         logger.setLevel(previousLevel)
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/mdc/MdcPreMatchingFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/mdc/MdcPreMatchingFilterSpec.groovy
@@ -1,0 +1,80 @@
+package io.micronaut.http.server.netty.mdc
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.propagation.slf4j.MdcPropagationContext
+import io.micronaut.core.propagation.MutablePropagatedContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.server.annotation.PreMatching
+import io.micronaut.http.annotation.RequestFilter
+import io.micronaut.http.annotation.ServerFilter
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN
+
+class MdcPreMatchingFilterSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': 'MdcPreMatchingFilterSpec'])
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = HttpClient.create(embeddedServer.URL)
+
+    void 'MDC added by a pre-matching filter is visible during route matching'() {
+        given:
+        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory()
+        def logger = lc.getLogger('io.micronaut.http.server.RequestLifecycle')
+        def previousLevel = logger.getLevel()
+        logger.setLevel(Level.TRACE)
+        def appender = new ListAppender<ILoggingEvent>()
+        appender.setContext(lc)
+        appender.start()
+        logger.addAppender(appender)
+
+        when:
+        String response = client.toBlocking().retrieve(HttpRequest.GET('/pre-matching-mdc'))
+        def matched = appender.list.find { it.formattedMessage.startsWith('Matched route') }
+
+        then:
+        response == '1234567890'
+        matched != null
+        matched.MDCPropertyMap.get('trace_id') == '1234567890'
+
+        cleanup:
+        logger.detachAppender(appender)
+        logger.setLevel(previousLevel)
+    }
+
+    @Controller
+    @Requires(property = 'spec.name', value = 'MdcPreMatchingFilterSpec')
+    static class TheController {
+        @Get('/pre-matching-mdc')
+        String get() {
+            return MDC.get('trace_id')
+        }
+    }
+
+    @ServerFilter(MATCH_ALL_PATTERN)
+    @Requires(property = 'spec.name', value = 'MdcPreMatchingFilterSpec')
+    static class PreMatchingMdcFilter {
+        @PreMatching
+        @RequestFilter
+        void filterRequest(MutablePropagatedContext mutablePropagatedContext) {
+            mutablePropagatedContext.add(new MdcPropagationContext(Map.of('trace_id', '1234567890')))
+        }
+    }
+}

--- a/http/src/main/java/io/micronaut/http/filter/FilterRunner.java
+++ b/http/src/main/java/io/micronaut/http/filter/FilterRunner.java
@@ -403,6 +403,17 @@ public class FilterRunner {
 
         @Override
         public ExecutionFlow<FilterContext> processRequestFilter(FilterContext context) {
+            // The route match and the resolution of the post-matching filters need to run with the
+            // context propagated by the pre-matching filters, otherwise elements added there
+            // (e.g. the MDC) are not in scope for the route matching
+            PropagatedContext propagatedContext = context.propagatedContext();
+            if (propagatedContext.isBound()) {
+                return resolveRouteMatch(context);
+            }
+            return propagatedContext.propagate(() -> resolveRouteMatch(context));
+        }
+
+        private ExecutionFlow<FilterContext> resolveRouteMatch(FilterContext context) {
             HttpRequest<?> request = context.request();
             try {
                 doRouteMatch(request);

--- a/src/main/docs/guide/contextPropagation/httpFilterContextPropagation.adoc
+++ b/src/main/docs/guide/contextPropagation/httpFilterContextPropagation.adoc
@@ -17,3 +17,5 @@ To use the legacy reactive HTTP filters, simply modify and propagate the context
 ----
 include::{testsuitejava}/propagation/MdcLegacyFilter.java[tags="class", indent=0]
 ----
+
+NOTE: The context added by a filter only covers the work that happens *after* that filter runs. Framework log statements emitted earlier in the request - for example when the request is received - do not see it. An ordinary server filter also runs after the route has been matched, so route matching is not covered either. If you need the context in place for route matching, add it from a filter annotated with api:http.server.annotation.PreMatching[].

--- a/src/main/docs/guide/contextPropagation/httpFilterContextPropagation.adoc
+++ b/src/main/docs/guide/contextPropagation/httpFilterContextPropagation.adoc
@@ -18,4 +18,7 @@ To use the legacy reactive HTTP filters, simply modify and propagate the context
 include::{testsuitejava}/propagation/MdcLegacyFilter.java[tags="class", indent=0]
 ----
 
-NOTE: The context added by a filter only covers the work that happens *after* that filter runs. Framework log statements emitted earlier in the request - for example when the request is received - do not see it. An ordinary server filter also runs after the route has been matched, so route matching is not covered either. If you need the context in place for route matching, add it from a filter annotated with api:http.server.annotation.PreMatching[].
+NOTE: The context added by a filter only covers the work that happens *after* that filter runs.
+Framework log statements emitted earlier in the request - for example when the request is received - do not see it.
+An ordinary server filter also runs after the route has been matched, so route matching is not covered either.
+If you need the context in place for route matching, add it from a filter annotated with api:http.server.annotation.PreMatching[].


### PR DESCRIPTION
## What

`FilterRunner.RouteMatchResolverHttpFilter` ran `doRouteMatch` — and the resolution of the filters that come after it — outside the context carried in the `FilterContext`. A `@PreMatching` request filter that adds an element to the propagated context (for example an `MdcPropagationContext`) therefore had no effect on anything happening during route matching.

The route-match filter now runs inside `context.propagatedContext()`, skipping the propagate call when that context is already bound — the same pattern `MethodFilter.filter` uses.

## Why

Investigating #12405. The reporter set the MDC from a server filter and found framework log lines without it. Reproducing their app as a test showed that every line missing the value is emitted *before* their filter runs:

- `NettyRequestLifecycle - Request GET /…` — the request has just been received, no filter has run yet.
- `CorsFilter - Http Header Origin not present…` — this is `CorsFilter.isEnabled()`, a `ConditionalFilter` condition evaluated while the filter list is being built.
- `RequestLifecycle - Matched route …` — route matching, which precedes ordinary (post-matching) filters.

Everything from their filter onward — later filters, the controller, response filters, `Response 200` — did carry the MDC, so `MdcPropagationContext` itself works as intended.

The documented escape hatch for covering route matching is a `@PreMatching` filter, and that is what turned out to be broken. This PR fixes it, and adds a note to the context-propagation guide spelling out that a filter's context only covers work that happens after that filter runs.

## Tests

- `MdcPreMatchingFilterSpec` asserts the MDC attached to the `Matched route` log event. It fails on `5.2.x` and passes with this change.
- `MdcLegacyFilterDownstreamSpec` locks in the behaviour the issue was actually about: an MDC propagated by a legacy `HttpServerFilter` is visible to later filters, the route and the response filters.

Green: `:micronaut-http`, `:micronaut-router`, `:micronaut-context-propagation`, `:micronaut-http-client`, the `:micronaut-http-server-netty` filter/CORS/propagation subset (117 tests) and the `test-suite` propagation tests.

## Note for reviewers

Not addressed here, and possibly worth a separate issue: on `5.2.x` the outbound client loses the propagated MDC once `Pool49` has to open a new connection — `Sending HTTP GET to …` and the header trace lines come out with an empty MDC, while the reporter's 4.10.8 log has the value on those same lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)