### PR TITLE
Keep reusable GraalPy context alive across app shutdown

### DIFF
--- a/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonPool.java
@@ -742,6 +742,9 @@ final class PythonPool implements PythonContextExecutor, BeanDestroyedEventListe
 
     @Override
     public void onDestroyed(BeanDestroyedEvent<Context> event) {
+        if (PythonContextRuntime.isReuseContext()) {
+            return;
+        }
         PythonContextRegistry.onNoActiveExecutionsAfterCurrentFrame(event.getBean(), this::closePool);
     }
 

--- a/context-python/src/test/java/io/micronaut/context/python/PythonPoolShutdownTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/PythonPoolShutdownTest.java
@@ -1,6 +1,8 @@
 package io.micronaut.context.python;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import org.graalvm.polyglot.Context;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -87,6 +89,29 @@ final class PythonPoolShutdownTest {
             // Requests still draining may need a context after the pool reported idle.
             Integer late = pool.<Integer>withContext(ctx -> ctx.eval(PYTHON, "4").asInt());
             assertEquals(4, late.intValue());
+        }
+    }
+
+    @Test
+    void reusablePrimaryContextSurvivesApplicationClose() {
+        PythonContextRuntime.setReuseContext(true);
+        Context primary = null;
+        try {
+            try (ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+                "micronaut.python.pool.enabled", true,
+                "micronaut.python.pool.size", 1
+            ))) {
+                primary = applicationContext.getBean(Context.class, Qualifiers.byName(PYTHON));
+                assertEquals(1, primary.eval(PYTHON, "1").asInt());
+            }
+            assertEquals(1, primary.eval(PYTHON, "1").asInt(),
+                "closing a Micronaut context must not close a reusable GraalPy context");
+        } finally {
+            PythonContextRuntime.setReuseContext(false);
+            PythonContextRuntime.resetContext();
+            if (primary != null) {
+                GraalPyContextFactory.closeContext(primary);
+            }
         }
     }
 }


### PR DESCRIPTION
When Pyronaut reuses the primary GraalPy context, closing a Micronaut ApplicationContext currently closes that context through the Python pool destroy callback. Skip pool shutdown for reusable contexts and add a lifecycle regression that evaluates the context after ApplicationContext.close().

Observed native error: after the first fixture closed its ApplicationContext, later tests raised KeyError for FruitRepository followed by java.lang.IllegalStateException: The Python context is closing. JVM tests did not reuse the same GraalPy context.

Test: PythonPoolShutdownTest focused lifecycle regression passes in the Core checkout.