### PR TITLE
Add the SslHandler for every wss connection

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -189,7 +189,14 @@ public class ConnectionManager {
     private final HttpClientConfiguration configuration;
     private final SslContextAutoLoader sslContextWrapper;
     private final SslContextAutoLoader sslContextWrapperWs;
-    private volatile boolean wsContextLoaded;
+    /**
+     * Lock that guards the lazy initialization of {@link #sslContextWrapperWs}. Without mutual
+     * exclusion, concurrent first-time websocket connections can each trigger
+     * {@link SslContextAutoLoader#autoLoad()}, and the resulting generation conflict can leave the
+     * loader without a context.
+     */
+    private final Object wsContextLock;
+    private boolean wsContextLoaded;
     @Nullable
     private final String informationalServiceId;
 
@@ -217,6 +224,10 @@ public class ConnectionManager {
         this.certificateProviders = from.certificateProviders;
         this.sslContextWrapper = from.sslContextWrapper;
         this.sslContextWrapperWs = from.sslContextWrapperWs;
+        this.wsContextLock = from.wsContextLock;
+        synchronized (wsContextLock) {
+            this.wsContextLoaded = from.wsContextLoaded;
+        }
         this.running.set(from.running.get());
     }
 
@@ -248,6 +259,7 @@ public class ConnectionManager {
         } : builder.certificateProviders;
         this.sslContextWrapper = new ClientContextWrapper(false);
         this.sslContextWrapperWs = new ClientContextWrapper(true);
+        this.wsContextLock = new Object();
 
         if (builder.eventLoopGroup != null) {
             group = builder.eventLoopGroup;
@@ -268,8 +280,10 @@ public class ConnectionManager {
         } else {
             sslContextWrapper.clear();
         }
-        sslContextWrapperWs.clear();
-        wsContextLoaded = false;
+        synchronized (wsContextLock) {
+            sslContextWrapperWs.clear();
+            wsContextLoaded = false;
+        }
         initBootstrap();
         running.set(true);
         for (PoolHolder pool : pools.values()) {
@@ -433,7 +447,10 @@ public class ConnectionManager {
                 }
             }
             sslContextWrapper.clear();
-            sslContextWrapperWs.clear();
+            synchronized (wsContextLock) {
+                sslContextWrapperWs.clear();
+                wsContextLoaded = false;
+            }
             resolverGroup.close();
         }
     }
@@ -527,12 +544,23 @@ public class ConnectionManager {
     private SslContext buildWebsocketSslContext(NettyHttpClient.RequestKey requestKey) {
         if (requestKey.isSecure()) {
             if (configuration.getSslConfiguration().isEnabled()) {
-                if (!wsContextLoaded) {
-                    sslContextWrapperWs.autoLoad();
-                    wsContextLoaded = true;
+                SslContextHolder holder;
+                synchronized (wsContextLock) {
+                    if (!wsContextLoaded) {
+                        sslContextWrapperWs.autoLoad();
+                        wsContextLoaded = true;
+                    }
+                    holder = sslContextWrapperWs.takeRetained();
                 }
-                SslContextHolder holder = sslContextWrapperWs.takeRetained();
-                return holder == null ? null : holder.sslContext();
+                SslContext sslCtx = holder == null ? null : holder.sslContext();
+                if (holder != null && sslCtx == null) {
+                    holder.release();
+                }
+                // Allow wss requests to be sent without an SslHandler if a proxy is present
+                if (sslCtx == null && configuration.getProxyAddress().isEmpty()) {
+                    throw decorate(new HttpClientException("Cannot send WSS request. SSL context is unavailable"));
+                }
+                return sslCtx;
             } else if (configuration.getProxyAddress().isEmpty()) {
                 throw decorate(new HttpClientException("Cannot send WSS request. SSL is disabled"));
             }
@@ -556,13 +584,20 @@ public class ConnectionManager {
             protected void initChannel(Channel ch) {
                 addLogHandler(ch);
 
-                SslContext sslContext = buildWebsocketSslContext(requestKey);
-                if (sslContext != null) {
-                    try {
-                        ch.pipeline().addLast(configureSslHandler(sslContext.newHandler(ch.alloc(), requestKey.getHost(), requestKey.getPort())));
-                    } finally {
-                        ReferenceCountUtil.release(sslContext);
+                try {
+                    SslContext sslContext = buildWebsocketSslContext(requestKey);
+                    if (sslContext != null) {
+                        try {
+                            ch.pipeline().addLast(configureSslHandler(sslContext.newHandler(ch.alloc(), requestKey.getHost(), requestKey.getPort())));
+                        } finally {
+                            ReferenceCountUtil.release(sslContext);
+                        }
                     }
+                } catch (Throwable e) {
+                    // report the failure instead of letting the channel close with a generic error
+                    initial.tryEmitError(new WebSocketSessionException("Error opening WebSocket client session: " + e.getMessage(), e));
+                    ch.close();
+                    return;
                 }
 
                 ch.pipeline()

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -569,6 +569,18 @@ public class ConnectionManager {
     }
 
     /**
+     * Describe a failure for an error message. Falls back to the exception type when the exception
+     * carries no message.
+     *
+     * @param e The failure
+     * @return The description
+     */
+    private static String describe(Throwable e) {
+        String message = e.getMessage();
+        return message == null ? e.toString() : message;
+    }
+
+    /**
      * Connect to a remote websocket. The given {@link ChannelHandler} is added to the pipeline
      * when the handshakes complete.
      *
@@ -595,7 +607,7 @@ public class ConnectionManager {
                     }
                 } catch (Throwable e) {
                     // report the failure instead of letting the channel close with a generic error
-                    initial.tryEmitError(new WebSocketSessionException("Error opening WebSocket client session: " + e.getMessage(), e));
+                    initial.tryEmitError(new WebSocketSessionException("Error opening WebSocket client session: " + describe(e), e));
                     ch.close();
                     return;
                 }
@@ -626,7 +638,7 @@ public class ConnectionManager {
                         return;
                     }
                 } catch (Throwable e) {
-                    initial.tryEmitError(new WebSocketSessionException("Error opening WebSocket client session: " + e.getMessage(), e));
+                    initial.tryEmitError(new WebSocketSessionException("Error opening WebSocket client session: " + describe(e), e));
                 }
                 // failed
                 ch.close();

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -553,9 +553,6 @@ public class ConnectionManager {
                     holder = sslContextWrapperWs.takeRetained();
                 }
                 SslContext sslCtx = holder == null ? null : holder.sslContext();
-                if (holder != null && sslCtx == null) {
-                    holder.release();
-                }
                 // Allow wss requests to be sent without an SslHandler if a proxy is present
                 if (sslCtx == null && configuration.getProxyAddress().isEmpty()) {
                     throw decorate(new HttpClientException("Cannot send WSS request. SSL context is unavailable"));

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/SimpleTextWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/SimpleTextWebSocketSpec.groovy
@@ -29,9 +29,11 @@ import spock.lang.Retry
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.function.Supplier
 
 class SimpleTextWebSocketSpec extends Specification {
@@ -225,7 +227,7 @@ class SimpleTextWebSocketSpec extends Specification {
             wsClients.add(wsClient)
             List<CompletableFuture<ChatClientWebSocket>> futures = (1..8).collect { int i ->
                 CompletableFuture.supplyAsync({
-                    Flux.from(wsClient.connect(ChatClientWebSocket, "/chat/stuff/user" + i)).blockFirst()
+                    Flux.from(wsClient.connect(ChatClientWebSocket, "/chat/stuff/user" + i)).blockFirst(Duration.ofSeconds(30))
                 } as Supplier<ChatClientWebSocket>, executor)
             }
             clients.addAll(futures.collect { it.join() })
@@ -237,7 +239,8 @@ class SimpleTextWebSocketSpec extends Specification {
 
         cleanup:
         clients.each { it.close() }
-        executor.shutdown()
+        executor.shutdownNow()
+        executor.awaitTermination(30, TimeUnit.SECONDS)
         wsClients.each { it.close() }
         embeddedServer.close()
     }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/SimpleTextWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/SimpleTextWebSocketSpec.groovy
@@ -24,9 +24,15 @@ import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import spock.lang.Issue
 import spock.lang.Retry
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.function.Supplier
 
 class SimpleTextWebSocketSpec extends Specification {
 
@@ -194,6 +200,46 @@ class SimpleTextWebSocketSpec extends Specification {
 
         where:
         scheme << ['https', 'wss'] // test with wss as well
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/12610")
+    void "test concurrent first websocket connections over SSL"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.builder([
+                'spec.name': 'SimpleTextWebSocketSpec',
+                'micronaut.server.ssl.enabled': true,
+                'micronaut.server.ssl.port': -1,
+                'micronaut.server.ssl.build-self-signed': true,
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
+        ]).run(EmbeddedServer)
+        def uri = embeddedServer.getURI()
+        uri = new URI('wss', uri.schemeSpecificPart, uri.fragment) // apply wss scheme
+        ExecutorService executor = Executors.newFixedThreadPool(8)
+        List<WebSocketClient> wsClients = []
+        List<ChatClientWebSocket> clients = []
+
+        when: "connections race to lazily initialize the websocket SSL context of a fresh client"
+        // repeated a few times because the race window is only open until the context is loaded
+        for (int attempt = 0; attempt < 4; attempt++) {
+            WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient, uri)
+            wsClients.add(wsClient)
+            List<CompletableFuture<ChatClientWebSocket>> futures = (1..8).collect { int i ->
+                CompletableFuture.supplyAsync({
+                    Flux.from(wsClient.connect(ChatClientWebSocket, "/chat/stuff/user" + i)).blockFirst()
+                } as Supplier<ChatClientWebSocket>, executor)
+            }
+            clients.addAll(futures.collect { it.join() })
+        }
+
+        then: "all of them complete the TLS handshake instead of sending plaintext"
+        clients.size() == 32
+        clients.every { it.session.open }
+
+        cleanup:
+        clients.each { it.close() }
+        executor.shutdown()
+        wsClients.each { it.close() }
+        embeddedServer.close()
     }
 
     void "test simple text websocket connection with query"() {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebsocketSslContextUnavailableSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebsocketSslContextUnavailableSpec.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.websocket
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.ssl.CertificateProvider
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.websocket.WebSocketClient
+import io.micronaut.websocket.annotation.ClientWebSocket
+import io.micronaut.websocket.annotation.OnMessage
+import io.micronaut.websocket.exceptions.WebSocketSessionException
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.security.KeyStore
+import java.time.Duration
+
+/**
+ * A websocket client must never fall back to plaintext when its SSL context cannot be built.
+ */
+@Issue("https://github.com/micronaut-projects/micronaut-core/issues/12610")
+class WebsocketSslContextUnavailableSpec extends Specification {
+
+    void "wss connection fails fast when the SSL context is unavailable"() {
+        given: "a client whose certificate provider never emits, so no SSL context is ever built"
+        EmbeddedServer embeddedServer = ApplicationContext.builder([
+                'spec.name': 'WebsocketSslContextUnavailableSpec',
+                'micronaut.server.ssl.enabled': true,
+                'micronaut.server.ssl.port': -1,
+                'micronaut.server.ssl.build-self-signed': true,
+                'micronaut.http.client.ssl.enabled': true,
+                'micronaut.http.client.ssl.trust-name': 'never-emits',
+        ]).run(EmbeddedServer)
+        def uri = embeddedServer.getURI()
+        uri = new URI('wss', uri.schemeSpecificPart, uri.fragment) // apply wss scheme
+        WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient, uri)
+
+        when:
+        Flux.from(wsClient.connect(EchoClient, "/ws-ssl-unavailable")).blockFirst(Duration.ofSeconds(30))
+
+        then: "the connection is rejected instead of sending plaintext to the TLS port"
+        def e = thrown WebSocketSessionException
+        e.message.contains('Cannot send WSS request. SSL context is unavailable')
+
+        cleanup:
+        wsClient.close()
+        embeddedServer.close()
+    }
+
+    @Singleton
+    @Named('never-emits')
+    @Requires(property = 'spec.name', value = 'WebsocketSslContextUnavailableSpec')
+    static class NeverEmittingCertificateProvider implements CertificateProvider {
+        @Override
+        String getName() {
+            return 'never-emits'
+        }
+
+        @Override
+        Publisher<KeyStore> getKeyStore() {
+            return Flux.never()
+        }
+    }
+
+    @ClientWebSocket("/ws-ssl-unavailable")
+    @Requires(property = 'spec.name', value = 'WebsocketSslContextUnavailableSpec')
+    static class EchoClient implements AutoCloseable {
+        @OnMessage
+        void onMessage(String message) {
+        }
+
+        @Override
+        void close() throws Exception {
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-core/issues/12610

## What was wrong

`ConnectionManager` loads the websocket SSL context lazily on the first secure connection, guarded only by a `volatile boolean`. Concurrent first `wss://` connections therefore each called `SslContextAutoLoader.autoLoad()`. The second `autoLoad()` bumps the loader's generation counter, so the first thread's `replace()` is rejected as stale and its `takeRetained()` returns `null`.

`buildWebsocketSslContext()` then silently returned `null`, the `SslHandler` was never added to the pipeline, and the client sent plaintext HTTP to the TLS port — the server answers with a 400 and the connection dies. Reported in production on FIPS environments (BCJSSE/BCFIPS), where first-time provider init takes 100-500ms and widens the window.

## What changed

`http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java`:

- The lazy load and the `takeRetained()` that follows it now run under a `wsContextLock`, so only one thread ever calls `autoLoad()` and no generation conflict can occur. `refresh()`, `shutdown()` and the copy constructor take the same lock; the copy shares the lock instance, since it shares the loader.
- If no context is available, `buildWebsocketSslContext()` throws `HttpClientException("Cannot send WSS request. SSL context is unavailable")` instead of returning `null` — the same fail-fast as `buildSslContext()` on the plain HTTP path, still letting the proxy case through.
- A failure while building the context is emitted on the connection `Mono` as a `WebSocketSessionException`, instead of being swallowed by Netty's `ChannelInitializer` and resurfacing as a bare `ClosedChannelException`.

The loading stays lazy rather than moving into `refresh()` (one option the issue suggested), so clients that never open a websocket don't pay for a second SSL context.

## Test

`SimpleTextWebSocketSpec."test concurrent first websocket connections over SSL"` opens 8 concurrent `wss://` connections against a self-signed embedded server on a freshly created client, repeated four times (the race window is only open until the context is loaded).

- Without the fix: failed 4/4 runs with `Error opening WebSocket client session: Abnormal Closure` — the plaintext-to-TLS-port symptom.
- With the fix: passed 3/3 runs.

`:micronaut-http-client:test` and the http-server-netty websocket packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)