### PR TITLE
Preserve IPv6 hosts in UriBuilder

### DIFF
--- a/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
+++ b/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
@@ -317,7 +317,7 @@ class DefaultUriBuilder implements UriBuilder {
             }
 
             if (hasHost) {
-                host = expandOrEncode(Objects.requireNonNull(host), values);
+                host = expandOrEncodeHost(Objects.requireNonNull(host), values);
                 builder.append(host);
             }
 
@@ -401,6 +401,41 @@ class DefaultUriBuilder implements UriBuilder {
             value = encode(value);
         }
         return value;
+    }
+
+    private String expandOrEncodeHost(String host, @Nullable Map<String, ? super Object> values) {
+        boolean expanded = isTemplate(host, values);
+        if (expanded) {
+            host = UriTemplate.of(host).expand(values);
+        }
+        if (expanded || host.startsWith("[") || host.endsWith("]") || host.indexOf(':') > -1) {
+            return validateHost(host);
+        }
+        return encode(host);
+    }
+
+    private String validateHost(String host) {
+        boolean startsWithBracket = host.startsWith("[");
+        boolean endsWithBracket = host.endsWith("]");
+        if (startsWithBracket != endsWithBracket ||
+            startsWithBracket && (host.indexOf('[', 1) > -1 || host.indexOf(']') != host.length() - 1)) {
+            throw invalidHost(host);
+        }
+        String formattedHost = startsWithBracket || host.indexOf(':') < 0 ? host : '[' + host + ']';
+        try {
+            URI uri = new URI("http://" + formattedHost + '/');
+            if (!formattedHost.equals(uri.getRawAuthority()) || uri.getRawUserInfo() != null || uri.getPort() != -1 ||
+                !"/".equals(uri.getRawPath()) || uri.getRawQuery() != null || uri.getRawFragment() != null || uri.getHost() == null) {
+                throw invalidHost(host);
+            }
+            return formattedHost;
+        } catch (URISyntaxException e) {
+            throw new UriSyntaxException(e);
+        }
+    }
+
+    private UriSyntaxException invalidHost(String host) {
+        return new UriSyntaxException(new URISyntaxException(host, "Invalid host"));
     }
 
     private String encode(String userInfo) {

--- a/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.uri
 
+import io.micronaut.http.exceptions.UriSyntaxException
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -195,5 +196,85 @@ class UriBuilderSpec extends Specification {
 
         then:
         builder.build().toString() == "https://google.com/search?q1=v1&q2=v2"
+    }
+
+    void "test uri builder preserves IPv6 host and port"() {
+        given:
+        List<String> sources = [
+                "http://[140d:c0e0:1f1:5463:6518:2:52:7002]:31500",
+                "http://[fe80::1%25eth0]:31500",
+                "http://[fe80::1%eth0]:31500",
+                "http://[fe80::1%ZZ]:31500"
+        ]
+
+        expect:
+        sources.each { source ->
+            [UriBuilder.of(source), UriBuilder.of(URI.create(source))].each { builder ->
+                URI uri = builder.build()
+
+                assert uri.host == URI.create(source).host
+                assert uri.port == 31500
+            }
+        }
+    }
+
+    void "test uri builder supports unbracketed IPv6 host"() {
+        when:
+        URI uri = UriBuilder.of("http://localhost")
+                .host("2001:db8::1")
+                .port(31500)
+                .build()
+
+        then:
+        uri.host == "[2001:db8::1]"
+        uri.port == 31500
+    }
+
+    void "test uri builder expands host templates once"() {
+        expect:
+        UriBuilder.of("http://localhost")
+                .host("{host}")
+                .expand(host: "example.com")
+                .toString() == "http://example.com"
+
+        and:
+        UriBuilder.of("http://localhost")
+                .host("{+host}")
+                .expand(host: "2001:db8::1")
+                .host == "[2001:db8::1]"
+    }
+
+    @Unroll
+    void "test uri builder rejects invalid or unsupported host #host"() {
+        when:
+        UriBuilder.of("http://localhost/base")
+                .host(host)
+                .build()
+
+        then:
+        thrown(UriSyntaxException)
+
+        where:
+        host << [
+                "[::1]/admin?x]",
+                "[::1]?admin=true]",
+                "[::1]#fragment]",
+                "[::1]:8080#]",
+                "[::1]/%0d%0aX-Test:yes#]",
+                "[fe80::1%25eth-0]",
+                "[fe80::1%25eth~0]",
+                "[fe80::1%25eth%2D0]",
+                "example.com:443"
+        ]
+    }
+
+    void "test uri builder rejects malicious reserved host expansion"() {
+        when:
+        UriBuilder.of("http://localhost/base")
+                .host("{+host}")
+                .expand(host: "user@evil.example")
+
+        then:
+        thrown(UriSyntaxException)
     }
 }


### PR DESCRIPTION
## Background

`DefaultUriBuilder` form-encoded IPv6 host syntax while reconstructing a URI. Brackets and colons became percent-encoded, so the resulting `URI` reported a null host and `-1` port.

## Changes

- preserve bracketed IPv6 literals and bracket valid unbracketed IPv6 hosts
- validate unencoded and template-expanded hosts as isolated authority components to prevent userinfo, port, path, query, or fragment injection
- accept scoped IPv6 addresses supported by `java.net.URI`
- add regression coverage for String and URI factories, host templates, scoped addresses, and invalid host input

## Validation

- `./gradlew spotlessCheck :micronaut-http:check -x japiCmp -x checkVersionCatalogCompatibility`
- 1,853 `micronaut-http` tests passed