### PR TITLE
Answer the static analysis on the raw type argument

### DIFF
--- a/core/src/main/java/io/micronaut/core/type/DefaultRawArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultRawArgument.java
@@ -29,6 +29,10 @@ import org.jspecify.annotations.Nullable;
  * @since 5.2.0
  */
 @Internal
+// equals is the one DefaultArgument declares on purpose: rawness does not take part in it, any more than the
+// bounds or the variable name of DefaultGenericPlaceholder do, and the only field here is the name the
+// superclass was given
+@SuppressWarnings("java:S2160")
 final class DefaultRawArgument<T> extends DefaultArgument<T> {
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultFieldInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultFieldInjectionPoint.java
@@ -81,12 +81,12 @@ class DefaultFieldInjectionPoint<B, T> implements FieldInjectionPoint<B, T>, Env
      * @param rawType            Whether the field type was written raw
      */
     DefaultFieldInjectionPoint(
-        BeanDefinition declaringBean,
-        Class declaringType,
+        BeanDefinition<?> declaringBean,
+        Class<?> declaringType,
         Class<T> fieldType,
         String field,
         @Nullable AnnotationMetadata annotationMetadata,
-        Argument @Nullable [] typeArguments,
+        Argument<?> @Nullable [] typeArguments,
         boolean rawType) {
 
         this.rawType = rawType;

--- a/reflection/src/main/java/io/micronaut/reflection/ReflectionBeanIntrospection.java
+++ b/reflection/src/main/java/io/micronaut/reflection/ReflectionBeanIntrospection.java
@@ -1548,7 +1548,9 @@ public final class ReflectionBeanIntrospection<T> implements ReflectiveIntrospec
         @SuppressWarnings({"unchecked", "rawtypes"})
         public Argument<P> asArgument() {
             if (typed instanceof GenericPlaceholder<?> || typed.isRawType()) {
-                return (Argument<P>) ReflectionArguments.rebuild(typed, getName(), getAnnotationMetadata(), typed.getTypeParameters());
+                // qualified, as the enclosing introspection declares a getAnnotationMetadata of its own
+                return (Argument<P>) ReflectionArguments.rebuild(
+                    typed, getName(), this.getAnnotationMetadata(), typed.getTypeParameters());
             }
             return super.asArgument();
         }


### PR DESCRIPTION
Follow-up to #13086, which merged before these landed.

Sonar reported four new issues on that change. Three are worth acting on, one is declined and now says so in the code.

- **`java:S2388`** — the argument of a property member is rebuilt with `this.getAnnotationMetadata()` again, the qualifier the line carried before #13086 rewrote it. The enclosing introspection declares a `getAnnotationMetadata` of its own, so the unqualified call reads as ambiguous even though Java resolves it to the inherited one either way.
- **`java:S3740`** (twice) — the constructor that takes the rawness of a field now takes `BeanDefinition<?>`, `Class<?>` and `Argument<?>[]`. It had copied the raw types of the older constructor beside it; the older one is left as it is, so this is the only signature that changes, and every caller passes the same values as before.
- **`java:S2160`** — that `DefaultRawArgument` declares a field and so should override `equals`. Declined, with a `@SuppressWarnings("java:S2160")` and the reason on the class: rawness deliberately takes no part in equality, no more than the bounds or the variable name of `DefaultGenericPlaceholder` do — `ArgumentSpec` and the three language specs pin that a raw argument equals the plain one of the same type and parameters — and the only field the class declares is a copy of the name its superclass was already given, kept because `getName()` answers a derived name for an argument that has none.

No behaviour changes. `:micronaut-core:test`, `:micronaut-inject:test`, `:micronaut-inject-java:test`, `:micronaut-inject-groovy:test`, `:micronaut-inject-kotlin:test` and `:micronaut-reflection:test` pass — 15,462 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
