### PR TITLE
Tell a resolved binding on a bean definition apart from a written type variable

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/ArgumentExpUtils.java
@@ -625,7 +625,7 @@ public final class ArgumentExpUtils {
      * @param element The element
      * @return true if the type is raw
      */
-    private static boolean isRawType(TypedElement element) {
+    static boolean isRawType(TypedElement element) {
         if (element instanceof GenericPlaceholderElement || element instanceof WildcardElement
             || !(element instanceof ClassElement classElement)) {
             // a variable or a wildcard is written as such, it is never a raw usage of a type

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -523,7 +523,8 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
         boolean.class, // isConfigurationProperties
         boolean.class, // isContainerType
         boolean.class,  // requiresMethodProcessing,
-        boolean.class // hasEvaluatedExpressions
+        boolean.class, // hasEvaluatedExpressions
+        boolean.class // isRawBeanType
     );
 
     private static final String FIELD_CONSTRUCTOR = "$CONSTRUCTOR";
@@ -2425,7 +2426,9 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
                                 )
                             : ExpressionDef.constant(false),
                         // 9: hasEvaluatedExpressions
-                        ExpressionDef.constant(evaluatedExpressionProcessor.hasEvaluatedExpressions())
+                        ExpressionDef.constant(evaluatedExpressionProcessor.hasEvaluatedExpressions()),
+                        // 10: isRawBeanType - a producer of a type written without its type arguments
+                        ExpressionDef.constant(ArgumentExpUtils.isRawType(beanTypeElement))
 
                     )
                 )

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/DefinitionTypeArgumentSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/DefinitionTypeArgumentSpec.groovy
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.generics
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.GenericPlaceholder
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+/**
+ * A bean definition's own type argument answers what the source wrote: a binding of a concrete type is an
+ * ordinary argument, a parameter the bean leaves unbound is a placeholder of that name, and a bean type
+ * written without its type arguments is raw.
+ */
+class DefinitionTypeArgumentSpec extends AbstractBeanDefinitionSpec {
+
+    private static final String SOURCE = '''
+package test
+
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Singleton
+
+class Box<T extends Number> {}
+
+@Factory
+class Boxes {
+
+    @Singleton
+    Box<Integer> typed() { new Box<Integer>() }
+
+    @Singleton
+    Box raw() { new Box() }
+}
+
+@Singleton
+class OpenBox<T extends Number> extends Box<T> {}
+
+@Singleton
+class ClosedBox extends Box<Integer> {}
+'''
+
+    @Shared @AutoCleanup ApplicationContext context
+    @Shared Class<?> boxType
+
+    def setupSpec() {
+        context = buildContext(SOURCE)
+        boxType = context.classLoader.loadClass('test.Box')
+    }
+
+    private BeanDefinition<?> definitionOf(String beanTypeName) {
+        context.getBeanDefinitions(boxType).find { it.beanType.name == beanTypeName }
+    }
+
+    private BeanDefinition<?> producedBy(String factoryMethod) {
+        context.getBeanDefinitions(boxType).find {
+            it.beanType.name == 'test.Box' && it.getBeanDefinitionName().contains(factoryMethod)
+        }
+    }
+
+    void "a concrete binding on a definition is not read as a type variable"() {
+        given:
+        Argument<?> argument = producedBy('Typed').asArgument()
+
+        expect: 'the bean type itself was written with its type arguments'
+        !argument.isRawType()
+        !argument.isTypeVariable()
+
+        and: 'and the argument bound to the declaration parameter is the type that was written there'
+        argument.typeParameters.length == 1
+        argument.typeParameters[0].type == Integer
+        !argument.typeParameters[0].isTypeVariable()
+        !argument.typeParameters[0].isRawType()
+        !(argument.typeParameters[0] instanceof GenericPlaceholder)
+    }
+
+    void "a parameter the bean leaves unbound is read as a type variable"() {
+        given:
+        Argument<?> argument = definitionOf('test.OpenBox').asArgument()
+
+        expect:
+        !argument.isRawType()
+        argument.typeParameters.length == 1
+
+        and: 'the type argument stands for the variable the class declares, bounded as it declared it'
+        argument.typeParameters[0].isTypeVariable()
+        argument.typeParameters[0] instanceof GenericPlaceholder
+        ((GenericPlaceholder) argument.typeParameters[0]).variableName == 'T'
+        argument.typeParameters[0].type == Number
+    }
+
+    void "a raw producer's argument is raw"() {
+        given:
+        Argument<?> argument = producedBy('Raw').asArgument()
+
+        expect: 'the bean type was written without its type arguments'
+        argument.isRawType()
+
+        and: 'it keeps the type arguments the declaring type declares, as a raw injection point does'
+        argument.typeParameters.length == 1
+        argument.typeParameters[0].isTypeVariable()
+        ((GenericPlaceholder) argument.typeParameters[0]).variableName == 'T'
+    }
+
+    void "a bean class binding the parameter of its super type is not read as a type variable"() {
+        given:
+        BeanDefinition<?> definition = definitionOf('test.ClosedBox')
+
+        expect: 'the bean type declares no parameter of its own'
+        !definition.asArgument().isRawType()
+        definition.asArgument().typeParameters.length == 0
+
+        and: 'and the binding it gives its super type is the type that was written there'
+        definition.getTypeArguments(boxType).size() == 1
+        definition.getTypeArguments(boxType)[0].type == Integer
+        !definition.getTypeArguments(boxType)[0].isTypeVariable()
+    }
+
+    void "the type arguments of a definition stay keyed by the name of the parameter they bind"() {
+        expect: 'the argument is named after the parameter it stands in for, whatever is bound to it'
+        producedBy('Typed').getTypeArguments(boxType)[0].name == 'T'
+        producedBy('Raw').getTypeArguments(boxType)[0].name == 'T'
+        definitionOf('test.OpenBox').getTypeArguments(boxType)[0].name == 'T'
+        definitionOf('test.ClosedBox').getTypeArguments(boxType)[0].name == 'T'
+
+        and: 'and reachable by that name from the bean type as an argument'
+        producedBy('Typed').asArgument().typeVariables.keySet() == ['T'] as Set
+        definitionOf('test.OpenBox').asArgument().typeVariables.keySet() == ['T'] as Set
+    }
+
+    void "a bean is still resolved by the type arguments of its definition"() {
+        expect: 'the two definitions that bind the parameter to Integer are the ones selected by it'
+        context.getBeanDefinitions(boxType, Qualifiers.byExactTypeArgumentName(Integer.name))*.beanType.name.toSorted() ==
+            ['test.Box', 'test.ClosedBox']
+
+        and: 'a definition that leaves the parameter unbound still matches by assignability'
+        context.getBeanDefinitions(boxType, Qualifiers.byTypeArguments(Integer))*.beanType.name.toSorted() ==
+            ['test.Box', 'test.Box', 'test.ClosedBox', 'test.OpenBox']
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/DefinitionTypeArgumentSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/DefinitionTypeArgumentSpec.groovy
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.generics
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.GenericPlaceholder
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+/**
+ * A bean definition's own type argument answers what the source wrote: a binding of a concrete type is an
+ * ordinary argument, a parameter the bean leaves unbound is a placeholder of that name, and a bean type
+ * written without its type arguments is raw.
+ */
+class DefinitionTypeArgumentSpec extends AbstractTypeElementSpec {
+
+    private static final String SOURCE = '''
+package test;
+
+import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Singleton;
+
+class Box<T extends Number> {}
+
+@Factory
+class Boxes {
+
+    @Singleton
+    Box<Integer> typed() { return new Box<>(); }
+
+    @Singleton
+    @SuppressWarnings("rawtypes")
+    Box raw() { return new Box(); }
+}
+
+@Singleton
+class OpenBox<T extends Number> extends Box<T> {}
+
+@Singleton
+class ClosedBox extends Box<Integer> {}
+'''
+
+    @Shared @AutoCleanup ApplicationContext context
+    @Shared Class<?> boxType
+
+    def setupSpec() {
+        context = buildContext('test.Boxes', SOURCE)
+        boxType = context.classLoader.loadClass('test.Box')
+    }
+
+    private BeanDefinition<?> definitionOf(String beanTypeName) {
+        context.getBeanDefinitions(boxType).find { it.beanType.name == beanTypeName }
+    }
+
+    private BeanDefinition<?> producedBy(String factoryMethod) {
+        context.getBeanDefinitions(boxType).find {
+            it.beanType.name == 'test.Box' && it.getBeanDefinitionName().contains(factoryMethod)
+        }
+    }
+
+    void "a concrete binding on a definition is not read as a type variable"() {
+        given:
+        Argument<?> argument = producedBy('Typed').asArgument()
+
+        expect: 'the bean type itself was written with its type arguments'
+        !argument.isRawType()
+        !argument.isTypeVariable()
+
+        and: 'and the argument bound to the declaration parameter is the type that was written there'
+        argument.typeParameters.length == 1
+        argument.typeParameters[0].type == Integer
+        !argument.typeParameters[0].isTypeVariable()
+        !argument.typeParameters[0].isRawType()
+        !(argument.typeParameters[0] instanceof GenericPlaceholder)
+    }
+
+    void "a parameter the bean leaves unbound is read as a type variable"() {
+        given:
+        Argument<?> argument = definitionOf('test.OpenBox').asArgument()
+
+        expect:
+        !argument.isRawType()
+        argument.typeParameters.length == 1
+
+        and: 'the type argument stands for the variable the class declares, bounded as it declared it'
+        argument.typeParameters[0].isTypeVariable()
+        argument.typeParameters[0] instanceof GenericPlaceholder
+        ((GenericPlaceholder) argument.typeParameters[0]).variableName == 'T'
+        argument.typeParameters[0].type == Number
+    }
+
+    void "a raw producer's argument is raw"() {
+        given:
+        Argument<?> argument = producedBy('Raw').asArgument()
+
+        expect: 'the bean type was written without its type arguments'
+        argument.isRawType()
+
+        and: 'it keeps the type arguments the declaring type declares, as a raw injection point does'
+        argument.typeParameters.length == 1
+        argument.typeParameters[0].isTypeVariable()
+        ((GenericPlaceholder) argument.typeParameters[0]).variableName == 'T'
+    }
+
+    void "a bean class binding the parameter of its super type is not read as a type variable"() {
+        given:
+        BeanDefinition<?> definition = definitionOf('test.ClosedBox')
+
+        expect: 'the bean type declares no parameter of its own'
+        !definition.asArgument().isRawType()
+        definition.asArgument().typeParameters.length == 0
+
+        and: 'and the binding it gives its super type is the type that was written there'
+        definition.getTypeArguments(boxType).size() == 1
+        definition.getTypeArguments(boxType)[0].type == Integer
+        !definition.getTypeArguments(boxType)[0].isTypeVariable()
+    }
+
+    void "the type arguments of a definition stay keyed by the name of the parameter they bind"() {
+        expect: 'the argument is named after the parameter it stands in for, whatever is bound to it'
+        producedBy('Typed').getTypeArguments(boxType)[0].name == 'T'
+        producedBy('Raw').getTypeArguments(boxType)[0].name == 'T'
+        definitionOf('test.OpenBox').getTypeArguments(boxType)[0].name == 'T'
+        definitionOf('test.ClosedBox').getTypeArguments(boxType)[0].name == 'T'
+
+        and: 'and reachable by that name from the bean type as an argument'
+        producedBy('Typed').asArgument().typeVariables.keySet() == ['T'] as Set
+        definitionOf('test.OpenBox').asArgument().typeVariables.keySet() == ['T'] as Set
+    }
+
+    void "a bean is still resolved by the type arguments of its definition"() {
+        expect: 'the two definitions that bind the parameter to Integer are the ones selected by it'
+        context.getBeanDefinitions(boxType, Qualifiers.byExactTypeArgumentName(Integer.name))*.beanType.name.toSorted() ==
+            ['test.Box', 'test.ClosedBox']
+
+        and: 'a definition that leaves the parameter unbound still matches by assignability'
+        context.getBeanDefinitions(boxType, Qualifiers.byTypeArguments(Integer))*.beanType.name.toSorted() ==
+            ['test.Box', 'test.Box', 'test.ClosedBox', 'test.OpenBox']
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/DefinitionTypeArgumentSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/DefinitionTypeArgumentSpec.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.processing.inject.generics
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.GenericPlaceholder
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+/**
+ * A bean definition's own type argument answers what the source wrote: a binding of a concrete type is an
+ * ordinary argument and a parameter the bean leaves unbound is a placeholder of that name. Kotlin has no raw
+ * types, so the third of the shapes the Java and Groovy specs pin has no Kotlin equivalent.
+ */
+class DefinitionTypeArgumentSpec extends AbstractKotlinCompilerSpec {
+
+    private static final String SOURCE = '''
+package test
+
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Singleton
+
+open class Box<T : Number>
+
+@Factory
+class Boxes {
+
+    @Singleton
+    fun typed(): Box<Int> = Box()
+}
+
+@Singleton
+open class OpenBox<T : Number> : Box<T>()
+
+@Singleton
+class ClosedBox : Box<Int>()
+'''
+
+    @Shared @AutoCleanup ApplicationContext context
+    @Shared Class<?> boxType
+
+    def setupSpec() {
+        context = buildContext(SOURCE)
+        boxType = context.classLoader.loadClass('test.Box')
+    }
+
+    private BeanDefinition<?> definitionOf(String beanTypeName) {
+        context.getBeanDefinitions(boxType).find { it.beanType.name == beanTypeName }
+    }
+
+    void "a concrete binding on a definition is not read as a type variable"() {
+        given:
+        Argument<?> argument = definitionOf('test.Box').asArgument()
+
+        expect:
+        !argument.isRawType()
+        !argument.isTypeVariable()
+
+        and: 'the argument bound to the declaration parameter is the type that was written there'
+        argument.typeParameters.length == 1
+        argument.typeParameters[0].type == Integer
+        !argument.typeParameters[0].isTypeVariable()
+        !(argument.typeParameters[0] instanceof GenericPlaceholder)
+    }
+
+    void "a parameter the bean leaves unbound is read as a type variable"() {
+        given:
+        Argument<?> argument = definitionOf('test.OpenBox').asArgument()
+
+        expect:
+        !argument.isRawType()
+        argument.typeParameters.length == 1
+
+        and: 'the type argument stands for the variable the class declares, bounded as it declared it'
+        argument.typeParameters[0].isTypeVariable()
+        argument.typeParameters[0] instanceof GenericPlaceholder
+        ((GenericPlaceholder) argument.typeParameters[0]).variableName == 'T'
+        argument.typeParameters[0].type == Number
+    }
+
+    void "a bean class binding the parameter of its super type is not read as a type variable"() {
+        given:
+        BeanDefinition<?> definition = definitionOf('test.ClosedBox')
+
+        expect:
+        definition.asArgument().typeParameters.length == 0
+        definition.getTypeArguments(boxType).size() == 1
+        definition.getTypeArguments(boxType)[0].type == Integer
+        !definition.getTypeArguments(boxType)[0].isTypeVariable()
+    }
+
+    void "the type arguments of a definition stay keyed by the name of the parameter they bind"() {
+        expect:
+        definitionOf('test.Box').getTypeArguments(boxType)[0].name == 'T'
+        definitionOf('test.OpenBox').getTypeArguments(boxType)[0].name == 'T'
+        definitionOf('test.ClosedBox').getTypeArguments(boxType)[0].name == 'T'
+
+        and:
+        definitionOf('test.Box').asArgument().typeVariables.keySet() == ['T'] as Set
+        definitionOf('test.OpenBox').asArgument().typeVariables.keySet() == ['T'] as Set
+    }
+
+    void "a bean is still resolved by the type arguments of its definition"() {
+        expect: 'the two definitions that bind the parameter to Int are the ones selected by it'
+        context.getBeanDefinitions(boxType, Qualifiers.byExactTypeArgumentName(Integer.name))*.beanType.name.toSorted() ==
+            ['test.Box', 'test.ClosedBox']
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -225,6 +225,28 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
         return precalculatedInfo.hasEvaluatedExpressions();
     }
 
+    /**
+     * The bean type as an argument, raw when the bean type was written without its type arguments.
+     *
+     * <p>A raw usage compiles to the type arguments the type declares, so a raw producer's bean type is
+     * otherwise indistinguishable from one written with those variables; the rawness is recorded at compile
+     * time and answered here, as {@link Argument#isRawType()} answers it of a raw injection point.</p>
+     *
+     * @return The bean type as an argument
+     */
+    @Override
+    public Argument<T> asArgument() {
+        if (!precalculatedInfo.isRawBeanType()) {
+            return InstantiatableBeanDefinition.super.asArgument();
+        }
+        return Argument.ofRawType(
+            getBeanType(),
+            null,
+            getAnnotationMetadata(),
+            getTypeArguments().toArray(Argument.ZERO_ARGUMENTS)
+        );
+    }
+
     @Override
     public final List<Argument<?>> getTypeArguments(@Nullable String type) {
         if (type == null || typeArgumentsMap == null) {
@@ -2673,10 +2695,15 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
         boolean isConfigurationProperties,
         boolean isContainerType,
         boolean requiresMethodProcessing,
-        boolean hasEvaluatedExpressions
+        boolean hasEvaluatedExpressions,
+        boolean isRawBeanType
     ) {
         public PrecalculatedInfo(Optional<String> scope, boolean isAbstract, boolean isIterable, boolean isSingleton, boolean isPrimary, boolean isConfigurationProperties, boolean isContainerType, boolean requiresMethodProcessing) {
-            this(scope, isAbstract, isIterable, isSingleton, isPrimary, isConfigurationProperties, isContainerType, requiresMethodProcessing, false);
+            this(scope, isAbstract, isIterable, isSingleton, isPrimary, isConfigurationProperties, isContainerType, requiresMethodProcessing, false, false);
+        }
+
+        public PrecalculatedInfo(Optional<String> scope, boolean isAbstract, boolean isIterable, boolean isSingleton, boolean isPrimary, boolean isConfigurationProperties, boolean isContainerType, boolean requiresMethodProcessing, boolean hasEvaluatedExpressions) {
+            this(scope, isAbstract, isIterable, isSingleton, isPrimary, isConfigurationProperties, isContainerType, requiresMethodProcessing, hasEvaluatedExpressions, false);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -367,12 +367,23 @@ public interface BeanDefinition<T> extends QualifiedBeanType<T>, Named, BeanType
         return Collections.emptyList();
     }
 
+    /**
+     * The bean type as an argument, with the type arguments the bean binds to the parameters its own type
+     * declares.
+     *
+     * <p>The arguments are the ones {@link #getTypeArguments()} answers, rather than being rebuilt from their
+     * erasures: a binding of a concrete type - the {@code String} of a {@code Box<String>} produced by a
+     * factory - reads as an ordinary argument, and only a parameter the bean leaves unbound - the {@code T} of
+     * a {@code class Box<T>} - reads as a {@link io.micronaut.core.type.GenericPlaceholder} of that name.</p>
+     *
+     * @return The bean type as an argument
+     */
     @Override
     default Argument<T> asArgument() {
         return Argument.of(
                 getBeanType(),
                 getAnnotationMetadata(),
-                getTypeParameters()
+                getTypeArguments().toArray(Argument.ZERO_ARGUMENTS)
         );
     }
 

--- a/reflection/src/main/java/io/micronaut/reflection/ReflectionBeanDefinition.java
+++ b/reflection/src/main/java/io/micronaut/reflection/ReflectionBeanDefinition.java
@@ -60,6 +60,7 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.RecordComponent;
+import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1149,12 +1150,26 @@ public final class ReflectionBeanDefinition<T> extends AbstractInitializableBean
         }
 
         /**
-         * The type arguments the type gives to each of its generic super types, by the name of the super type.
+         * The type arguments the type gives to each of its generic super types, by the name of the super type,
+         * and the parameters the type itself declares.
+         *
+         * <p>A bean read from a class binds nothing to its own parameters - there is no usage to read a binding
+         * from - so they are its own type arguments unbound, which is what a generated definition of the same
+         * class writes for itself and what {@code asArgument()} reads back.</p>
          */
         private static Map<String, Argument<?>[]> typeArgumentsOf(Class<?> type) {
             Map<String, Argument<?>[]> typeArguments = new LinkedHashMap<>();
             for (Class<?> superType : ClassUtils.resolveHierarchy(type)) {
-                if (superType == type || superType == Object.class || superType.getTypeParameters().length == 0) {
+                if (superType == Object.class || superType.getTypeParameters().length == 0) {
+                    continue;
+                }
+                if (superType == type) {
+                    TypeVariable<?>[] variables = type.getTypeParameters();
+                    var own = new Argument<?>[variables.length];
+                    for (int i = 0; i < own.length; i++) {
+                        own[i] = ReflectionArguments.of(variables[i].getName(), variables[i]);
+                    }
+                    typeArguments.put(type.getName(), own);
                     continue;
                 }
                 Argument<?> resolved = ReflectionArguments.resolveGenericToArgument(type, superType);

--- a/reflection/src/test/groovy/io/micronaut/reflection/DefinitionTypeArgumentParitySpec.groovy
+++ b/reflection/src/test/groovy/io/micronaut/reflection/DefinitionTypeArgumentParitySpec.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.reflection
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.GenericPlaceholder
+import io.micronaut.inject.BeanDefinition
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+/**
+ * A bean read reflectively must not disagree with the same bean compiled about its own type arguments: which
+ * of the parameters its type declares it leaves unbound, and which it binds to a type that was written there.
+ *
+ * <p>Each definition is rendered whole - the bean type as an argument, and the arguments it gives every generic
+ * type in its hierarchy - so a difference anywhere in the description fails here.</p>
+ *
+ * <p>One shape of the issue has no reflective counterpart and so is absent: a bean type written raw. A
+ * reflective definition is built from a {@link Class}, which is a declaration rather than a usage of a type,
+ * so there is no raw bean type for it to read; a raw <em>super</em> type, which a class can name, is here.</p>
+ */
+class DefinitionTypeArgumentParitySpec extends AbstractTypeElementSpec {
+
+    private static final String SOURCE = '''
+package test;
+
+import jakarta.inject.Singleton;
+
+class Box<B extends Number> {}
+
+@Singleton
+class OpenBox<T extends Number> extends Box<T> {}
+
+@Singleton
+class ClosedBox extends Box<Integer> {}
+
+@Singleton
+@SuppressWarnings("rawtypes")
+class RawSuperBox extends Box {}
+'''
+
+    @Shared @AutoCleanup ApplicationContext context
+
+    def setupSpec() {
+        context = buildContext('test.OpenBox', SOURCE)
+    }
+
+    /**
+     * What the argument erases to, whether it is raw, the variable it stands for with its declared bounds, and
+     * the same of each type argument.
+     */
+    private static String render(Argument<?> argument) {
+        StringBuilder rendered = new StringBuilder(argument.type.simpleName)
+        if (argument.isRawType()) {
+            rendered.append('!raw')
+        }
+        if (argument instanceof GenericPlaceholder) {
+            rendered.append('<var=').append(((GenericPlaceholder<?>) argument).variableName)
+                    .append(' bounds=').append(((GenericPlaceholder<?>) argument).bounds*.type*.simpleName)
+                    .append('>')
+        }
+        if (argument.typeParameters.length > 0) {
+            rendered.append('(').append(argument.typeParameters.collect { render(it) }.join(', ')).append(')')
+        }
+        return rendered.toString()
+    }
+
+    private static Map<String, String> describe(BeanDefinition<?> definition, Class<?> boxType) {
+        [
+                'as an argument': render(definition.asArgument()),
+                'named after'   : definition.asArgument().typeVariables.keySet().toList().toString(),
+                'given to Box'  : definition.getTypeArguments(boxType).collect { render(it) }.toString(),
+                'given to self' : definition.getTypeArguments(definition.beanType).collect { render(it) }.toString()
+        ]
+    }
+
+    void "a bean read reflectively says the same of its own type arguments as the same bean compiled"() {
+        given:
+        Class<?> boxType = context.classLoader.loadClass('test.Box')
+        Map<String, String> generatedShapes = [:]
+        Map<String, String> reflectiveShapes = [:]
+
+        when:
+        context.getBeanDefinitions(boxType).each { generated ->
+            def reflective = ReflectionBeanDefinition.of(generated.beanType)
+            describe(generated, boxType).each { key, value ->
+                generatedShapes["$generated.beanType.simpleName $key"] = value
+            }
+            describe(reflective, boxType).each { key, value ->
+                reflectiveShapes["$generated.beanType.simpleName $key"] = value
+            }
+        }
+
+        then:
+        generatedShapes == reflectiveShapes
+
+        and: 'and the description they agree on is the one the source says'
+        generatedShapes['OpenBox as an argument'] == 'OpenBox(Number<var=T bounds=[Number]>)'
+        generatedShapes['OpenBox given to Box'] == '[Number<var=T bounds=[Number]>]'
+        generatedShapes['OpenBox named after'] == '[T]'
+
+        and: 'a binding of a concrete type is an ordinary argument, and leaves the bean type without one'
+        generatedShapes['ClosedBox as an argument'] == 'ClosedBox'
+        generatedShapes['ClosedBox given to Box'] == '[Integer]'
+
+        and: 'a raw super type keeps the variables the super type declares, as a raw usage does'
+        generatedShapes['RawSuperBox as an argument'] == 'RawSuperBox'
+        generatedShapes['RawSuperBox given to Box'] == '[Number<var=B bounds=[Number]>]'
+    }
+}


### PR DESCRIPTION
A bean definition's own type argument could not answer two questions that Jakarta CDI's assignability rules (4.0 §2.4.2.1) ask differently of each: whether the source wrote a type variable there, and whether the bean type was written raw. `isTypeVariable()` was true of the `String` in a `Box<String>` producer as much as of the `T` in `class Box<T>`, and a raw producer's bean type was not raw at all.

Follow-up to #13074 / #13086, which made a raw *usage* answerable with `Argument.isRawType()`.

Fixes #13089

## What was wrong

Both halves had a single narrow cause, so `isTypeVariable()` keeps the meaning it always had and no additive API was needed.

**A resolved binding read as a written variable.** The definition's `$TYPE_ARGUMENTS` were already right — the writer emits `Argument.of(String.class, "T")` for a `Box<String>` producer and `Argument.ofTypeVariable(Object.class, "T")` only for a parameter the bean leaves unbound. The loss was in `BeanDefinition.asArgument()`, which rebuilt the bean type from `getTypeParameters()`, a `Class[]`; `Argument.of(Class, AnnotationMetadata, Class[])` names each entry after the parameter the declaring type declares and makes it a type variable, so every argument came back a placeholder whatever had been bound to it. It now takes the arguments from `getTypeArguments()` directly.

**A raw producer's bean type was not raw.** A factory method's return type is a usage like any other, but the bean type of a definition is not written as an argument — it is rebuilt from the class and the recorded type arguments — and a raw usage compiles to the type arguments the declaring type declares, so `Box raw()` and `Box<T>` reached the runtime as the same shape. The writer already knows: `beanTypeElement` is the generic return type, and the same `ArgumentExpUtils.isRawType` the argument writer asks of a usage answers for it across the three languages. It is recorded on `PrecalculatedInfo` and `AbstractInitializableBeanDefinition.asArgument()` builds `Argument.ofRawType` from it. The type parameters stay the declared placeholders, which is what a raw injection point keeps, so the two read alike.

## Why not change what the flag means

The issue offered an additive answer if the blast radius of redefining `isTypeVariable()` was too wide. It was not needed: nothing about the flag changed. Every caller that reads a definition's type arguments — `ExactTypeArgumentNameQualifier`, `TypeArgumentQualifier`, `ClosestTypeArgumentQualifier`, `MatchArgumentQualifier`, `BeanDefinition#getTypeArguments(Class)` — goes through `getTypeArguments`, which is untouched, and those arguments were already distinguishing the two cases. Only `asArgument()` (and `getGenericBeanType()`, which delegates to it) was fabricating placeholders, and it now stops. The arguments keep the names they had, so `asArgument().getTypeVariables()` is keyed the same way and a placeholder's `getVariableName()` is still reachable wherever a definition leaves a parameter unbound.

One note in passing: `ExactTypeArgumentNameQualifier` matches on the *erasure's* class name, not on the variable name, so it was never affected either way.

## Reflection

`ReflectionBeanDefinition` recorded the arguments a class gives its generic super types but nothing for the class itself, where a generated definition writes its own parameters too — so `asArgument()` of a reflective `class OpenBox<T>` had no type parameters where the generated one had a placeholder. It now records them, and a new parity spec diffs the two whole descriptions of one class.

## Behaviour

The four combinations, read from a compiled definition:

| declaration | `asArgument()` raw | type argument |
| --- | --- | --- |
| `Box<Integer> typed()` | false | `Integer`, `isTypeVariable()` false |
| `Box raw()` | **true** | `Number` var=`T` |
| `class OpenBox<T extends Number> extends Box<T>` | false | `Number` var=`T` |
| `class ClosedBox extends Box<Integer>` | false | `Integer`, `isTypeVariable()` false |

## Compatibility

`PrecalculatedInfo` gains a tenth component. Both constructors it had are kept, so a definition generated before this still loads. Reviewers may want to confirm whether japicmp wants an entry in `config/accepted-api-changes.json` for the new record component — I could not check it here without the released baseline.

## Tests

New specs in `inject-java`, `inject-groovy` and `inject-kotlin` covering the combinations above (Kotlin has no raw types, so it pins the other three), each also asserting that the arguments stay keyed by the name of the parameter they bind and that beans still resolve by type argument; and `DefinitionTypeArgumentParitySpec` in `reflection`, which compares a generated definition with the reflective one for the same class and records the one shape reflection cannot express — a raw bean type, since a `Class` is a declaration rather than a usage.

`:micronaut-inject:test`, `:micronaut-core:test`, `:micronaut-reflection:test`, `:micronaut-inject-java:test`, `:micronaut-inject-groovy:test` and `:micronaut-inject-kotlin:test` all pass, as does checkstyle on the four changed main source sets.

## Motivation

https://github.com/dstepanov/micronaut-cdi answers CDI's assignability rules from `@CdiGenericVariables`, a compile-time recording of what the source declared. #13023, #13063 and #13086 retired three quarters of it; this is the rest. Read back as they were, a `Box<String>` matched everything — the silent over-matching of #12998, one level down — and a deployment the specification requires to be rejected validated instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)