### PR TITLE
Let a consumer read which super types a bean records type arguments for

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/IntermediateTypeArgumentSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/IntermediateTypeArgumentSpec.groovy
@@ -63,6 +63,18 @@ class RawRepo implements Repo {}
         definition.getTypeArguments(repo)*.type == [Integer]
     }
 
+    void "test the recorded keys name the whole hierarchy of the intermediate case"() {
+        given:
+        def definition = buildBeanDefinition('intermediate.IntRepo', HIERARCHY)
+
+        expect: 'the reference key set that a runtime definition of the same classes has to match'
+        definition.typeArgumentKeys.collect { it.substring(it.lastIndexOf('.') + 1) }.toSet() ==
+                ['IntRepo', 'NumberRepo', 'Repo'].toSet()
+        definition.getTypeArguments('intermediate.NumberRepo')*.type == [Integer]
+        definition.getTypeArguments('intermediate.Repo')*.type == [Integer]
+        definition.getTypeArguments('intermediate.IntRepo').isEmpty()
+    }
+
     void "test a raw implementation binds nothing"() {
         given:
         def definition = buildBeanDefinition('intermediate.RawRepo', HIERARCHY)

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/IntermediateTypeArgumentSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/IntermediateTypeArgumentSpec.groovy
@@ -75,6 +75,15 @@ class RawRepo implements Repo {}
         definition.getTypeArguments('intermediate.IntRepo').isEmpty()
     }
 
+    void "test a raw implementation still names its hierarchy in the recorded keys"() {
+        given:
+        def definition = buildBeanDefinition('intermediate.RawRepo', HIERARCHY)
+
+        expect: 'the reference for the runtime definition: the key is there even though the argument is unbound'
+        definition.typeArgumentKeys.collect { it.substring(it.lastIndexOf('.') + 1) }.toSet() ==
+                ['RawRepo', 'Repo'].toSet()
+    }
+
     void "test a raw implementation binds nothing"() {
         given:
         def definition = buildBeanDefinition('intermediate.RawRepo', HIERARCHY)

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeArgumentKeysSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/TypeArgumentKeysSpec.groovy
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.generics
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+/**
+ * {@code BeanDefinition#getTypeArgumentKeys()} names the types a definition can answer
+ * {@code getTypeArguments} for, so that a consumer that needs every super type a bean carries arguments into can
+ * read what the compiler recorded instead of walking the hierarchy reflectively.
+ */
+class TypeArgumentKeysSpec extends AbstractTypeElementSpec {
+
+    void "test the keys name the whole recorded hierarchy and answer the same arguments as the lookups"() {
+        given:
+        def definition = buildBeanDefinition('keys.BothRepo', '''
+package keys;
+
+import jakarta.inject.Singleton;
+
+interface Repo<T> {}
+
+interface Marker {}
+
+abstract class Base<X> implements Marker {}
+
+@Singleton
+class BothRepo extends Base<Long> implements Repo<String> {}
+''')
+
+        expect: 'the parameterized interface, the parameterized super class and the bean type itself are all named'
+        definition.typeArgumentKeys.toSet() == ['keys.BothRepo', 'keys.Base', 'keys.Marker', 'keys.Repo'].toSet()
+
+        and: 'every key answers the lookup, a super type carrying no arguments of its own with an empty list'
+        definition.getTypeArguments('keys.Repo')*.type == [String]
+        definition.getTypeArguments('keys.Base')*.type == [Long]
+        definition.getTypeArguments('keys.Marker').isEmpty()
+        definition.getTypeArguments('keys.BothRepo').isEmpty()
+
+        and: 'the name lookup and the class lookup agree for every key'
+        definition.typeArgumentKeys.every {
+            def type = definition.beanType.classLoader.loadClass(it)
+            definition.getTypeArguments(type) == definition.getTypeArguments(it)
+        }
+    }
+
+    void "test a bean that records no type argument anywhere answers no keys"() {
+        given:
+        def definition = buildBeanDefinition('keys.Plain', '''
+package keys;
+
+import jakarta.inject.Singleton;
+
+interface Marker {}
+
+@Singleton
+class Plain implements Marker {}
+''')
+
+        expect: 'nothing was recorded, so nothing is named - not even the bean type'
+        definition.typeArgumentKeys.isEmpty()
+        definition.typeArguments.isEmpty()
+    }
+
+    void "test a proxy definition answers for the hierarchy of the type it proxies"() {
+        given:
+        def context = buildContext('''
+package keys;
+
+import jakarta.inject.Singleton;
+import io.micronaut.aop.simple.Mutating;
+
+interface Repo<T> {}
+
+@Singleton
+class ProxiedRepo implements Repo<Integer> {
+    @Mutating("name")
+    public String hello(String name) {
+        return name;
+    }
+}
+''')
+        def proxied = context.classLoader.loadClass('keys.ProxiedRepo')
+        def definition = context.getBeanDefinitions(proxied).find { it.isProxy() }
+
+        expect: 'the keys are the target type and its super types, not the generated proxy class'
+        definition != null
+        definition.typeArgumentKeys.toSet() == ['keys.ProxiedRepo', 'keys.Repo'].toSet()
+        definition.getTypeArguments('keys.Repo')*.type == [Integer]
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -238,6 +238,14 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
     }
 
     @Override
+    public final Collection<String> getTypeArgumentKeys() {
+        if (typeArgumentsMap == null) {
+            return Collections.emptySet();
+        }
+        return Collections.unmodifiableSet(typeArgumentsMap.keySet());
+    }
+
+    @Override
     public AnnotationMetadata getAnnotationMetadata() {
         return annotationMetadata;
     }

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
@@ -38,12 +38,15 @@ import io.micronaut.inject.qualifiers.EachBeanQualifier;
 import io.micronaut.inject.qualifiers.PrimaryQualifier;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A delegate bean definition.
@@ -99,6 +102,17 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
     public List<Argument<?>> getTypeArguments(String type) {
         List<Argument<?>> arguments = typeArgumentsMap.get(type);
         return arguments == null ? getTarget().getTypeArguments(type) : arguments;
+    }
+
+    @Override
+    public Collection<String> getTypeArgumentKeys() {
+        Collection<String> targetKeys = getTarget().getTypeArgumentKeys();
+        if (typeArgumentsMap.isEmpty()) {
+            return targetKeys;
+        }
+        Set<String> keys = new LinkedHashSet<>(typeArgumentsMap.keySet());
+        keys.addAll(targetKeys);
+        return Collections.unmodifiableSet(keys);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Experimental;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.reflect.GenericTypeUtils;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanContextConditional;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
@@ -32,9 +33,11 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -79,6 +82,75 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
         } else {
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>A runtime definition has no recorded arguments to look the name up in, so it resolves the name against the
+     * bean type's own hierarchy and then answers as {@link #getTypeArguments(Class)} does, which keeps the two
+     * lookups in agreement. A name that is not a super type of the bean answers empty.</p>
+     */
+    @Override
+    default List<Argument<?>> getTypeArguments(@Nullable String type) {
+        if (type == null) {
+            return Collections.emptyList();
+        }
+        for (Class<?> superType : superTypeClosure(getBeanType())) {
+            if (superType.getName().equals(type)) {
+                return getTypeArguments(superType);
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Nothing is recorded for a runtime definition, so this is the bean type and every super class and interface
+     * above it, which is the hierarchy a build time definition records for the same classes. It answers empty when
+     * none of them carries a type argument, again as a build time definition does.</p>
+     */
+    @Override
+    default Collection<String> getTypeArgumentKeys() {
+        Collection<Class<?>> superTypes = superTypeClosure(getBeanType());
+        boolean anyArguments = false;
+        for (Class<?> superType : superTypes) {
+            if (!getTypeArguments(superType).isEmpty()) {
+                anyArguments = true;
+                break;
+            }
+        }
+        if (!anyArguments) {
+            return Collections.emptySet();
+        }
+        Set<String> keys = CollectionUtils.newLinkedHashSet(superTypes.size());
+        for (Class<?> superType : superTypes) {
+            keys.add(superType.getName());
+        }
+        return Collections.unmodifiableSet(keys);
+    }
+
+    /**
+     * The given type and every super class and interface above it, excluding {@link Object}.
+     *
+     * @param beanType The type to walk
+     * @return The types, the given one first
+     */
+    private static Collection<Class<?>> superTypeClosure(Class<?> beanType) {
+        Set<Class<?>> collected = new LinkedHashSet<>();
+        collectSuperTypes(beanType, collected);
+        return collected;
+    }
+
+    private static void collectSuperTypes(@Nullable Class<?> type, Set<Class<?>> collected) {
+        if (type == null || type == Object.class || !collected.add(type)) {
+            return;
+        }
+        for (Class<?> anInterface : type.getInterfaces()) {
+            collectSuperTypes(anInterface, collected);
+        }
+        collectSuperTypes(type.getSuperclass(), collected);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
@@ -109,19 +109,25 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, In
      *
      * <p>Nothing is recorded for a runtime definition, so this is the bean type and every super class and interface
      * above it, which is the hierarchy a build time definition records for the same classes. It answers empty when
-     * none of them carries a type argument, again as a build time definition does.</p>
+     * none of them <em>declares</em> a type parameter, again as a build time definition does.</p>
+     *
+     * <p>The test is what the hierarchy declares rather than what resolves, so that the keys do not depend on
+     * whether an argument could be resolved. A bean implementing a raw or unbound super type - {@code RawRepo
+     * implements Repo} - names {@code Repo} here exactly as a build time definition does, even though
+     * {@link #getTypeArguments(Class)} answers nothing for it where a build time definition answers the erased
+     * variable.</p>
      */
     @Override
     default Collection<String> getTypeArgumentKeys() {
         Collection<Class<?>> superTypes = superTypeClosure(getBeanType());
-        boolean anyArguments = false;
+        boolean anyDeclared = false;
         for (Class<?> superType : superTypes) {
-            if (!getTypeArguments(superType).isEmpty()) {
-                anyArguments = true;
+            if (superType.getTypeParameters().length > 0) {
+                anyDeclared = true;
                 break;
             }
         }
-        if (!anyArguments) {
+        if (!anyDeclared) {
             return Collections.emptySet();
         }
         Set<String> keys = CollectionUtils.newLinkedHashSet(superTypes.size());

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -450,6 +450,34 @@ public interface BeanDefinition<T> extends QualifiedBeanType<T>, Named, BeanType
     }
 
     /**
+     * The types this definition can answer {@link #getTypeArguments(String)} for.
+     *
+     * <p>A definition computed at build time records the type arguments the compiler resolved for the bean type
+     * and for every super class and interface above it, keyed by type. This returns those keys, so a consumer that
+     * needs every super type the bean supplies arguments to can read what was recorded instead of rediscovering
+     * the hierarchy reflectively.</p>
+     *
+     * <p>A key is a class <em>name</em> in the form {@link Class#getName()} returns, which is what the definition
+     * stores; nothing here loads it. A caller that only needs the arguments passes the key straight back to
+     * {@link #getTypeArguments(String)}, and one that needs a {@link Class} loads the name itself. Every key answers
+     * that lookup, though the answer may be an empty list: a super type that carries no arguments of its own is
+     * still part of what was recorded.</p>
+     *
+     * <p>The iteration order is unspecified and is not the order of the hierarchy. A definition that records nothing
+     * answers empty - including for its own {@link #getBeanType()}, which {@link #getTypeArguments()} then answers
+     * empty for as well.</p>
+     *
+     * <p>A {@link ProxyBeanDefinition} answers for the hierarchy of the type it proxies rather than for the generated
+     * proxy class, so its keys name {@link ProxyBeanDefinition#getTargetType()} and the super types above it.</p>
+     *
+     * @return The recorded type keys, never {@code null}
+     * @since 5.2.0
+     */
+    default Collection<String> getTypeArgumentKeys() {
+        return Collections.emptySet();
+    }
+
+    /**
      * Finds a single {@link ExecutableMethod} for the given name and argument types.
      *
      * @param name          The method name

--- a/inject/src/main/java/io/micronaut/inject/DelegatingBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/DelegatingBeanDefinition.java
@@ -160,4 +160,9 @@ public interface DelegatingBeanDefinition<T> extends BeanDefinition<T> {
     default List<Argument<?>> getTypeArguments(String type) {
         return getTarget().getTypeArguments(type);
     }
+
+    @Override
+    default Collection<String> getTypeArgumentKeys() {
+        return getTarget().getTypeArgumentKeys();
+    }
 }

--- a/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionTypeArgumentKeysSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionTypeArgumentKeysSpec.groovy
@@ -3,7 +3,9 @@ package io.micronaut.context
 import io.micronaut.context.generics.IntRepo
 import io.micronaut.context.generics.Marker
 import io.micronaut.context.generics.NumberRepo
+import io.micronaut.context.generics.OpenRepo
 import io.micronaut.context.generics.Plain
+import io.micronaut.context.generics.RawRepo
 import io.micronaut.context.generics.Repo
 import spock.lang.Specification
 
@@ -52,5 +54,15 @@ class RuntimeBeanDefinitionTypeArgumentKeysSpec extends Specification {
     void 'a bean with no type argument anywhere in its hierarchy answers no keys'() {
         expect:
         definitionOf(Plain).typeArgumentKeys.isEmpty()
+    }
+
+    void 'a raw or unbound super type is still named, as the compiled definition names it'() {
+        expect: 'the keys follow what the hierarchy declares, not what resolves'
+        definitionOf(RawRepo).typeArgumentKeys.toSet() == [RawRepo.name, Repo.name].toSet()
+        definitionOf(OpenRepo).typeArgumentKeys.toSet() == [OpenRepo.name, Repo.name].toSet()
+
+        and: 'the argument itself is the one place the two still differ - a compiled definition answers the erased\n         variable where a runtime definition answers nothing, which is what makes the bean match any parameterization'
+        definitionOf(RawRepo).getTypeArguments(Repo.name).isEmpty()
+        definitionOf(OpenRepo).getTypeArguments(Repo.name).isEmpty()
     }
 }

--- a/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionTypeArgumentKeysSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/RuntimeBeanDefinitionTypeArgumentKeysSpec.groovy
@@ -1,0 +1,56 @@
+package io.micronaut.context
+
+import io.micronaut.context.generics.IntRepo
+import io.micronaut.context.generics.Marker
+import io.micronaut.context.generics.NumberRepo
+import io.micronaut.context.generics.Plain
+import io.micronaut.context.generics.Repo
+import spock.lang.Specification
+
+import java.util.function.Supplier
+
+/**
+ * A runtime definition records nothing, so it derives {@code getTypeArgumentKeys()} from the bean type's own
+ * hierarchy. The answer has to be the one a build time definition of the same classes gives, which
+ * {@code io.micronaut.inject.generics.IntermediateTypeArgumentSpec} holds as the reference.
+ */
+class RuntimeBeanDefinitionTypeArgumentKeysSpec extends Specification {
+
+    private static <B> RuntimeBeanDefinition<B> definitionOf(Class<B> type) {
+        RuntimeBeanDefinition.builder(type, { type.getDeclaredConstructor().newInstance() } as Supplier)
+                .singleton(true)
+                .build()
+    }
+
+    void 'the keys name the hierarchy the compiled definition records for the same classes'() {
+        given:
+        def definition = definitionOf(IntRepo)
+
+        expect: 'the bean type, the intermediate super class and the interface, as the compiled definition names them'
+        definition.typeArgumentKeys.toSet() == [IntRepo.name, NumberRepo.name, Repo.name].toSet()
+
+        and: 'each key answers the argument resolved through the intermediate super type'
+        definition.getTypeArguments(Repo.name)*.type == [Integer]
+        definition.getTypeArguments(NumberRepo.name)*.type == [Integer]
+        definition.getTypeArguments(IntRepo.name).isEmpty()
+    }
+
+    void 'the name lookup answers what the class lookup answers'() {
+        given:
+        def definition = definitionOf(IntRepo)
+
+        expect:
+        definition.typeArgumentKeys.every {
+            definition.getTypeArguments(Class.forName(it)) == definition.getTypeArguments(it)
+        }
+
+        and: 'a name that is not a super type of the bean answers nothing'
+        definition.getTypeArguments(Marker.name).isEmpty()
+        definition.getTypeArguments((String) null).isEmpty()
+    }
+
+    void 'a bean with no type argument anywhere in its hierarchy answers no keys'() {
+        expect:
+        definitionOf(Plain).typeArgumentKeys.isEmpty()
+    }
+}

--- a/inject/src/test/java/io/micronaut/context/generics/IntRepo.java
+++ b/inject/src/test/java/io/micronaut/context/generics/IntRepo.java
@@ -1,0 +1,7 @@
+package io.micronaut.context.generics;
+
+/**
+ * Binds the argument at the intermediate super class.
+ */
+public class IntRepo extends NumberRepo<Integer> {
+}

--- a/inject/src/test/java/io/micronaut/context/generics/Marker.java
+++ b/inject/src/test/java/io/micronaut/context/generics/Marker.java
@@ -1,0 +1,7 @@
+package io.micronaut.context.generics;
+
+/**
+ * A super type that carries no type argument.
+ */
+public interface Marker {
+}

--- a/inject/src/test/java/io/micronaut/context/generics/NumberRepo.java
+++ b/inject/src/test/java/io/micronaut/context/generics/NumberRepo.java
@@ -1,0 +1,9 @@
+package io.micronaut.context.generics;
+
+/**
+ * A generic super class that binds the interface's argument to its own variable.
+ *
+ * @param <X> The number type
+ */
+public abstract class NumberRepo<X extends Number> implements Repo<X> {
+}

--- a/inject/src/test/java/io/micronaut/context/generics/OpenRepo.java
+++ b/inject/src/test/java/io/micronaut/context/generics/OpenRepo.java
@@ -1,0 +1,9 @@
+package io.micronaut.context.generics;
+
+/**
+ * Passes its own unbound variable to the super type.
+ *
+ * @param <T> The repository type
+ */
+public class OpenRepo<T> implements Repo<T> {
+}

--- a/inject/src/test/java/io/micronaut/context/generics/Plain.java
+++ b/inject/src/test/java/io/micronaut/context/generics/Plain.java
@@ -1,0 +1,7 @@
+package io.micronaut.context.generics;
+
+/**
+ * A type with no type argument anywhere in its hierarchy.
+ */
+public class Plain implements Marker {
+}

--- a/inject/src/test/java/io/micronaut/context/generics/RawRepo.java
+++ b/inject/src/test/java/io/micronaut/context/generics/RawRepo.java
@@ -1,0 +1,8 @@
+package io.micronaut.context.generics;
+
+/**
+ * A raw implementation: the super type declares a type parameter that this type leaves unbound.
+ */
+@SuppressWarnings("rawtypes")
+public class RawRepo implements Repo {
+}

--- a/inject/src/test/java/io/micronaut/context/generics/Repo.java
+++ b/inject/src/test/java/io/micronaut/context/generics/Repo.java
@@ -1,0 +1,10 @@
+package io.micronaut.context.generics;
+
+/**
+ * The same hierarchy as {@code io.micronaut.inject.generics.IntermediateTypeArgumentSpec} compiles, in Java so that a
+ * runtime definition of these classes can be compared against that compiled reference name for name.
+ *
+ * @param <T> The repository type
+ */
+public interface Repo<T> {
+}


### PR DESCRIPTION
There is no issue for this, so the problem is described in full below.

## The problem

`AbstractInitializableBeanDefinition` holds the type arguments the processors resolved, keyed by class name:

```java
private final Map<String, Argument<?> @Nullable []> typeArgumentsMap;
```

The compiler fills it from `ClassElement#getAllTypeArguments()`, so it covers the bean type *and every super class and interface above it*. But `BeanDefinition` exposes only lookups **into** that map — `getTypeArguments()`, `getTypeArguments(Class)`, `getTypeArguments(String)`. Every one of them requires the caller to already know the type it is asking about. Nothing enumerates the keys.

So a consumer that wants **every** super type a bean supplies arguments to cannot ask. It has to rediscover the hierarchy itself, walking `getGenericInterfaces()` and `getGenericSuperclass()` reflectively, and then look each type up — re-deriving, at runtime and worse, something the compiler already wrote into the definition.

That reflective walk is not merely redundant, it is less correct. It is the walk that #13081 just fixed on the runtime side: matching a super type by its raw type without substituting the type variables of the levels between loses an argument bound at an intermediate generic super type. A consumer doing its own walk reproduces that bug locally.

## The change

Adds a read-only view of what was recorded:

```java
default Collection<String> getTypeArgumentKeys();
```

defaulting to empty on `BeanDefinition`, answered by `AbstractInitializableBeanDefinition` as an unmodifiable view of the key set it already holds, and forwarded by `DelegatingBeanDefinition` / unioned with its own overlay by `BeanDefinitionDelegate`.

### Keys, not a map

The alternative shape was `Map<String, List<Argument<?>>>`. The keys won:

- the map's only gain is one call instead of two;
- it pays for that by duplicating the accessor that has to produce every value anyway, creating a second source of truth that can drift from `getTypeArguments(String)`;
- it has to wrap the internal `Argument<?>[]` per call, and take a position on the recorded nullability, where the key set is a free `keySet()` view;
- adding the map later is still possible; removing it would not be.

### `RuntimeBeanDefinition`

A runtime definition records nothing, so it derives the same view from the bean type's own hierarchy — the bean type and every super class and interface above it — and answers empty when none of them *declares* a type parameter, which is what a build time definition does (the compiler omits the map entirely in that case). The test is what the hierarchy declares rather than what resolves, so the key set does not depend on whether an argument could be resolved.

It also now implements `getTypeArguments(String)`. **This is a fix in its own right:** until now the name lookup silently answered empty on a runtime definition while `getTypeArguments(Class)` answered correctly, so anything holding a type *name* got the wrong answer. The name is now resolved against that same hierarchy and delegated to the class lookup, so both go through `GenericTypeUtils.resolveTypeArguments` and the intermediate-super-type case from #13081 is answered either way. It agrees with that fix rather than bypassing it.

## Points settled, and stated in the javadoc

- **What a key is.** A class *name* in `Class#getName()` form, which is what the definition stores; nothing here loads it. A caller that only needs the arguments passes the key straight back to `getTypeArguments(String)`; one that needs a `Class` loads the name itself. Every key answers that lookup, though the answer may be an empty list — a super type carrying no arguments of its own (a marker interface, `Serializable`) is still part of what was recorded.
- **A definition with nothing recorded answers empty**, rather than including the bean type. The compiler omits the whole map when no super type carries an argument, so there is nothing to name; a synthesized bean-type key would answer empty anyway, and `getTypeArguments()` — itself a lookup into the same map — already answers empty there.
- **`ProxyBeanDefinition` needed no special case.** It already records the *target*'s hierarchy: for a proxied `ProxiedRepo implements Repo<Integer>` the keys are `[ProxiedRepo, Repo]` — the generated proxy class is not among them. That is what a caller wants, and it is now covered by a test and documented on the method.
- **Iteration order is unspecified**, and documented as such. The generated map is a `Map.of`, whose order is neither the hierarchy's nor stable across runs.

## Tests

`:micronaut-inject:test`, `:micronaut-inject-java:test` and `:micronaut-core:test` all pass; checkstyle clean.

- `inject-java` — `TypeArgumentKeysSpec`: a bean extending `Base<Long>` and implementing `Repo<String>` names both, plus the marker interface and itself; `getTypeArguments(key)` for every key equals what the `Class` lookup already answers; a bean with no arguments anywhere answers empty; and the proxy case above.
- `inject-java` — `IntermediateTypeArgumentSpec` gains the compiled reference key set for the #13081 hierarchy.
- `inject` — `RuntimeBeanDefinitionTypeArgumentKeysSpec`: the runtime definition of that same hierarchy agrees with the compiled reference, key for key and argument for argument, including the intermediate-super-type case, plus the raw and unbound cases below. The classes are declared in `inject/src/test/java` rather than as Groovy nested classes so the comparison is name-for-name and does not trip over Groovy's implicit `GroovyObject`.

**The raw case, and where the two still differ.** A [Codex](https://openai.com/codex/) review of the branch caught a divergence in the first version: `getTypeArgumentKeys()` decided whether the hierarchy was worth naming by asking whether any super type *resolved* an argument, so for `class RawRepo implements Repo` the runtime definition answered no keys at all while the compiled definition names `[RawRepo, Repo]`. Two definitions of one class disagreed on the key set — the exact consistency this method exists to provide. Fixed in the second commit by testing what the hierarchy *declares* rather than what resolves, which is also the cheaper test; both specs now pin the raw and unbound-variable cases on both sides.

What remains is confined to the argument, not the keys: for that same raw bean the compiled definition answers `[Object]` (the erased variable) where the runtime one answers nothing. That predates this change — it is the behaviour documented in the #13081 specs, and the empty answer is what makes such a bean match any parameterization — so it is left alone and asserted explicitly rather than papered over.

## Motivation

Jakarta CDI's bean types (CDI 4.0 §2.2) are the closure of a bean's own type and every super type, each with the arguments carried into it. [micronaut-cdi](https://github.com/dstepanov/micronaut-cdi) computes that closure in `CdiTypes.closureOf` by walking the class hierarchy reflectively, purely because the recorded arguments cannot be enumerated. With this it reads what the compiler already wrote, and the last class-walking leaves its bean model — which matters for a compile-time DI framework in general and under GraalVM in particular.

The added surface is one default method returning an immutable view of an existing field: no new state, and no allocation on the build time path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
