### PR TITLE
Handle absent optional HTTP/2 client configuration

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -666,7 +666,10 @@ public class ConnectionManager {
     private Http2FrameCodec makeFrameCodec() {
         Http2Settings defaultSettings = Http2Settings.defaultSettings();
 
-        defaultSettings.maxHeaderListSize(Objects.requireNonNull(configuration.getHttp2Configuration()).getMaxHeaderListSize());
+        HttpClientConfiguration.Http2ClientConfiguration http2Configuration = configuration.getHttp2Configuration();
+        defaultSettings.maxHeaderListSize(http2Configuration == null
+            ? HttpClientConfiguration.Http2ClientConfiguration.DEFAULT_MAX_HEADER_LIST_SIZE
+            : http2Configuration.getMaxHeaderListSize());
 
         Http2FrameCodecBuilder builder = Http2FrameCodecBuilder.forClient()
             .initialSettings(defaultSettings);

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/Http2Spec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/Http2Spec.groovy
@@ -11,9 +11,12 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Produces
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.DefaultHttpClientConfiguration
+import io.micronaut.http.client.HttpClientConfiguration
 import io.micronaut.http.client.HttpVersionSelection
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.runtime.server.EmbeddedServer
 import jakarta.inject.Inject
 import spock.lang.Specification
 
@@ -30,6 +33,28 @@ class Http2Spec extends Specification {
     @Inject
     @Client(value = "/", alpnModes = HttpVersionSelection.ALPN_HTTP_2)
     HttpClient client
+
+    @Inject
+    EmbeddedServer server
+
+    def "test http2 with absent optional configuration"() {
+        given:
+        def configuration = new DefaultHttpClientConfiguration() {
+            @Override
+            HttpClientConfiguration.Http2ClientConfiguration getHttp2Configuration() {
+                return null
+            }
+        }
+        configuration.alpnModes = [HttpVersionSelection.ALPN_HTTP_2]
+        configuration.sslConfiguration.insecureTrustAllCertificates = true
+        def customClient = HttpClient.create(server.URL, configuration)
+
+        expect:
+        customClient.toBlocking().retrieve(HttpRequest.GET("/http2")) == "hello"
+
+        cleanup:
+        customClient.close()
+    }
 
     def "test http2"() {
         when:


### PR DESCRIPTION
A custom HttpClientConfiguration can return null from the nullable getHttp2Configuration() method. Starting an HTTP/2 connection then fails while constructing the frame codec. Fall back to the existing default maximum header list size when that configuration is absent, while preserving an explicitly configured value.

Fixes #12619.

The new HTTP/2 request regression fails before the fix and passes afterward. On Liberica JDK 25, the following passed (3 tests and Checkstyle):

```sh
./gradlew :micronaut-http-client:test --tests io.micronaut.http.client.netty.Http2Spec :micronaut-http-client:checkstyleMain --max-workers=2
```

The full `check` task and GraalVM/native tests have not been run locally; this PR is a draft.

