### PR TITLE
Make BinaryWebSocketSpec join ordering deterministic

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatServerWebSocket.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatServerWebSocket.java
@@ -24,10 +24,18 @@ import io.micronaut.websocket.annotation.OnOpen;
 import io.micronaut.websocket.annotation.ServerWebSocket;
 
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Requires(property = "spec.name", value = "BinaryWebSocketSpec")
 @ServerWebSocket("/binary/chat/{topic}/{username}")
 public class BinaryChatServerWebSocket {
+    /**
+     * Usernames whose {@link #onOpen} handler has completed. This handler is blocking and so runs on the
+     * executor, i.e. after the client's connect() has already returned. Tests that need a deterministic
+     * "Joined!" broadcast order should wait for a username to appear here before connecting the next client.
+     */
+    private final Set<String> openedUsernames = ConcurrentHashMap.newKeySet();
+
     @OnOpen
     public void onOpen(String topic, String username, WebSocketSession session) {
         assert ServerRequestContext.currentRequest().isPresent();
@@ -41,6 +49,11 @@ public class BinaryChatServerWebSocket {
                 openSession.sendAsync(msg.getBytes());
             }
         }
+        openedUsernames.add(username);
+    }
+
+    public Set<String> getOpenedUsernames() {
+        return openedUsernames;
     }
 
     @OnMessage(maxPayloadLength = 32)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
@@ -46,11 +46,18 @@ class BinaryWebSocketSpec extends Specification {
     void "test binary websocket exchange"() {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.builder('spec.name': 'BinaryWebSocketSpec', 'micronaut.server.netty.log-level':'TRACE').run(EmbeddedServer)
+        BinaryChatServerWebSocket serverWebSocket = embeddedServer.applicationContext.getBean(BinaryChatServerWebSocket)
         PollingConditions conditions = new PollingConditions(timeout: 15, delay: 0.5)
 
         when: "a websocket connection is established"
         WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient, embeddedServer.getURI())
         BinaryChatClientWebSocket fred = Flux.from(wsClient.connect(BinaryChatClientWebSocket, "/binary/chat/stuff/fred")).blockFirst()
+        // The server's @OnOpen is a blocking handler and runs on the executor, so connect() returning does not
+        // mean it has run yet. If bob connects before fred's @OnOpen executes, fred's handler sees bob in
+        // getOpenSessions() and bob receives a "[fred] Joined!" message, which breaks the exact reply counts below.
+        conditions.eventually {
+            serverWebSocket.openedUsernames.contains('fred')
+        }
         BinaryChatClientWebSocket bob = Flux.from(wsClient.connect(BinaryChatClientWebSocket, [topic:"stuff",username:"bob"])).blockFirst()
 
         then:"The connection is valid"


### PR DESCRIPTION
## What changed

- `BinaryChatServerWebSocket` (test fixture) records each username in a concurrent set once its `@OnOpen` handler has completed and exposes it via `getOpenedUsernames()`. The messages it sends are unchanged.
- `BinaryWebSocketSpec."test binary websocket exchange"` now waits for the server to have processed fred's open before connecting bob. All existing assertions, including the exact reply counts, are unchanged.

Test sources only.

## Why

The feature failed intermittently in full `:micronaut-http-server-netty:test` runs (passes when run alone) with:

```
bob.replies.size() == 1
Condition not satisfied: bob.replies == [[fred] Joined!, [fred] Hello bob!]
```

The server's `@OnOpen` is a void handler, so with the default `ThreadSelection` it is dispatched to the blocking executor. The client's `connect()` returns once the handshake completes, which can be before that handler has run. If bob connected in that window, fred's handler saw bob in `getOpenSessions()` and broadcast `[fred] Joined!` to bob, giving bob two replies. The ordering of the two "Joined!" broadcasts was therefore not deterministic.

Waiting for fred's server-side open to finish before bob connects removes the race without loosening the assertions to `>=`/contains semantics.

## Reviewer notes

- The other features in the spec only use `contains` on bob's replies, so they were not exposed to this race and were left as they are.
- Verified with 10 consecutive forced re-runs of the spec (all 7 features green each time) and a full module run: 1156 tests, 0 failures, 0 errors, 22 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
