### PR TITLE
Fix the two critical Sonar issues failing the 5.2.x quality gate

### DIFF
--- a/context-python/src/test/java/io/micronaut/context/python/PythonConversionTest.java
+++ b/context-python/src/test/java/io/micronaut/context/python/PythonConversionTest.java
@@ -123,6 +123,7 @@ class PythonConversionTest {
 
                 @Override
                 public void onComplete() {
+                    // the result is asserted once the synchronous publisher has completed
                 }
             });
 

--- a/core-processor/src/main/java/io/micronaut/inject/ast/DefaultMethodAnnotationMetadata.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/DefaultMethodAnnotationMetadata.java
@@ -40,6 +40,9 @@ import java.util.function.Predicate;
 @Internal
 final class DefaultMethodAnnotationMetadata implements MutableAnnotationMetadataDelegate<AnnotationMetadata> {
 
+    private static final String ADDING = "adding";
+    private static final String REMOVING = "removing";
+
     private final MethodElement methodElement;
 
     DefaultMethodAnnotationMetadata(MethodElement methodElement) {
@@ -53,27 +56,27 @@ final class DefaultMethodAnnotationMetadata implements MutableAnnotationMetadata
 
     @Override
     public <T extends Annotation> AnnotationMetadata annotate(String annotationType, Consumer<AnnotationValueBuilder<T>> consumer) {
-        throw unsupported("adding");
+        throw unsupported(ADDING);
     }
 
     @Override
     public <T extends Annotation> AnnotationMetadata annotate(AnnotationValue<T> annotationValue) {
-        throw unsupported("adding");
+        throw unsupported(ADDING);
     }
 
     @Override
     public AnnotationMetadata removeAnnotation(String annotationType) {
-        throw unsupported("removing");
+        throw unsupported(REMOVING);
     }
 
     @Override
     public <T extends Annotation> AnnotationMetadata removeAnnotationIf(Predicate<AnnotationValue<T>> predicate) {
-        throw unsupported("removing");
+        throw unsupported(REMOVING);
     }
 
     @Override
     public AnnotationMetadata removeStereotype(String annotationType) {
-        throw unsupported("removing");
+        throw unsupported(REMOVING);
     }
 
     /**


### PR DESCRIPTION
The 5.2.x SonarCloud quality gate fails on `new_critical_violations = 2`:

- `java:S1192` in `DefaultMethodAnnotationMetadata`: the `"removing"` literal was repeated three times; it and `"adding"` are now constants.
- `java:S1186` in `PythonConversionTest`: the empty `onComplete()` now has a comment saying why it is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)