### PR TITLE
Iterate the introspections in a stable order again

### DIFF
--- a/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
+++ b/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
@@ -20,11 +20,14 @@ import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.core.util.CollectionUtils;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,7 +49,7 @@ class DefaultBeanIntrospector implements BeanIntrospector {
     private static final String MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER = "micronaut.introspections.use.context.classloader";
 
     @Nullable
-    @SuppressWarnings("java:S3077") // resolveIntrospections returns an immutable Map.copyOf, published once under double checked locking
+    @SuppressWarnings("java:S3077") // resolveIntrospections returns an unmodifiable map, published once under double checked locking
     private volatile Map<String, BeanIntrospectionReference<Object>> introspectionMap;
     @Nullable
     @SuppressWarnings("java:S3077") // resolveFallbacks returns an immutable List.copyOf, published once under double checked locking
@@ -100,7 +103,7 @@ class DefaultBeanIntrospector implements BeanIntrospector {
                 .stream()
                 .filter(filter)
                 .map(BeanIntrospectionReference::getBeanType)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @Override
@@ -237,12 +240,18 @@ class DefaultBeanIntrospector implements BeanIntrospector {
         return classLoader;
     }
 
+    /**
+     * The introspections keyed by name, in a {@link HashMap}. {@link #findIntrospections(Predicate)} and
+     * {@link #findIntrospectedTypes(Predicate)} iterate this map, so its order is what they return: a {@code HashMap}
+     * of names iterates the same way on every run, where a {@code Map.copyOf} is randomized per JVM. The order is
+     * kept as it was before the map was made immutable, since consumers came to depend on it.
+     */
     private Map<String, BeanIntrospectionReference<Object>> resolveIntrospections(ClassLoader classLoader) {
-        Map<String, BeanIntrospectionReference<Object>> resolvedIntrospectionMap = new HashMap<>(30);
         List<BeanIntrospectionReference<Object>> beanIntrospectionReferences = BeanIntrospectionProviders.get().provide(classLoader);
+        Map<String, BeanIntrospectionReference<Object>> resolvedIntrospectionMap = CollectionUtils.newHashMap(beanIntrospectionReferences.size());
         for (BeanIntrospectionReference<Object> reference : beanIntrospectionReferences) {
             resolvedIntrospectionMap.put(reference.getName(), reference);
         }
-        return Map.copyOf(resolvedIntrospectionMap);
+        return Collections.unmodifiableMap(resolvedIntrospectionMap);
     }
 }

--- a/core/src/test/java/io/micronaut/core/beans/DefaultBeanIntrospectorTest.java
+++ b/core/src/test/java/io/micronaut/core/beans/DefaultBeanIntrospectorTest.java
@@ -8,13 +8,19 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
+import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,6 +55,94 @@ class DefaultBeanIntrospectorTest {
             } else {
                 System.setProperty(CONTEXT_CLASSLOADER_PROPERTY, previousProperty);
             }
+        }
+    }
+
+    @Test
+    void findIntrospectionsIteratesInAStableOrder() {
+        // enough types that an order randomized per JVM, as Map.copyOf is, cannot come out equal to the order
+        // of a HashMap of the names, which is the same on every run and the order consumers came to depend on
+        List<Class<?>> beanTypes = List.of(
+            java.util.zip.CRC32.class, String.class, java.time.ZonedDateTime.class, Integer.class,
+            java.util.concurrent.atomic.AtomicLong.class, Long.class, java.util.UUID.class, Short.class,
+            java.net.URI.class, Byte.class, java.math.BigDecimal.class, Character.class,
+            java.time.Duration.class, Boolean.class, java.util.BitSet.class, Double.class,
+            java.util.Locale.class, Float.class, java.time.Instant.class, StringBuilder.class,
+            java.math.BigInteger.class, Thread.class, java.util.Date.class, Object.class,
+            java.time.LocalDate.class, Number.class, java.util.Optional.class, Runtime.class,
+            java.nio.file.Path.class, Math.class, java.time.LocalTime.class, System.class
+        );
+        List<BeanIntrospectionReference<Object>> references = beanTypes.stream()
+            .<BeanIntrospectionReference<Object>>map(StubReference::new)
+            .toList();
+        Map<String, BeanIntrospectionReference<Object>> byName = new HashMap<>();
+        for (BeanIntrospectionReference<Object> reference : references) {
+            byName.put(reference.getName(), reference);
+        }
+        List<BeanIntrospectionReference<Object>> expectedOrder = List.copyOf(byName.values());
+        assertNotEquals(references, expectedOrder, "the hash order must differ from the provider order to prove anything");
+
+        BeanIntrospectionsProvider previous = BeanIntrospectionProviders.set(classLoader -> references);
+        try {
+            DefaultBeanIntrospector introspector = new DefaultBeanIntrospector(getClass().getClassLoader());
+
+            assertEquals(
+                expectedOrder.stream().map(BeanIntrospectionReference::load).toList(),
+                List.copyOf(introspector.findIntrospections(ref -> true))
+            );
+            assertEquals(
+                expectedOrder.stream().map(BeanIntrospectionReference::getBeanType).toList(),
+                List.copyOf(introspector.findIntrospectedTypes(ref -> true))
+            );
+            Predicate<BeanIntrospectionReference<?>> secondHalf = ref -> beanTypes.indexOf(ref.getBeanType()) >= 16;
+            assertEquals(
+                expectedOrder.stream().filter(secondHalf).map(BeanIntrospectionReference::load).toList(),
+                List.copyOf(introspector.findIntrospections(secondHalf))
+            );
+        } finally {
+            BeanIntrospectionProviders.set(previous);
+        }
+    }
+
+    private static final class StubReference implements BeanIntrospectionReference<Object> {
+
+        private final Class<Object> beanType;
+        private final BeanIntrospection<Object> introspection;
+
+        @SuppressWarnings("unchecked")
+        StubReference(Class<?> beanType) {
+            this.beanType = (Class<Object>) beanType;
+            this.introspection = (BeanIntrospection<Object>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {BeanIntrospection.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getBeanType" -> beanType;
+                    case "equals" -> proxy == args[0];
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "toString" -> "BeanIntrospection(" + beanType.getName() + ")";
+                    default -> throw new UnsupportedOperationException(method.getName());
+                }
+            );
+        }
+
+        @Override
+        public boolean isPresent() {
+            return true;
+        }
+
+        @Override
+        public Class<Object> getBeanType() {
+            return beanType;
+        }
+
+        @Override
+        public BeanIntrospection<Object> load() {
+            return introspection;
+        }
+
+        @Override
+        public String getName() {
+            return beanType.getName();
         }
     }
 


### PR DESCRIPTION
## What

`DefaultBeanIntrospector.resolveIntrospections` publishes an unmodifiable view of a `HashMap` again, instead of `Map.copyOf`. `findIntrospectedTypes` collects into a `LinkedHashSet`, so it follows the same order.

## Why

#13004 switched the published introspection map to `Map.copyOf` for safe publication. A JDK immutable map iterates in an order randomized per JVM (`ImmutableCollections.SALT`), and `findIntrospections` / `findIntrospectedTypes` stream that map's values, so their result order changed between runs.

micronaut-data hit this: `SchemaGenerator` creates tables in `findIntrospections` order, two test `@MappedEntity` classes map to table `client` (the TCK `Client` with a `tier` column, and the one in `EmbeddedAssociationJoinSpec`), and a failed second `CREATE TABLE` only logs a warning. `io.micronaut.data.jdbc.h2.JdbcRepositorySpec` failed intermittently with `Column "TIER" not found`.

## What reviewers should know

- **Safe publication is unchanged.** The map is still built in full before the volatile field is assigned under the double-checked lock, and readers only get an unmodifiable view.
- **HashMap order, not provider order, on purpose.** I first kept the order the providers return (`LinkedHashMap`). The order was then stable, but data's `JdbcRepositorySpec` failed on **every** run: the embedded-association `Client` comes first on the classpath and creates `client` without `tier`. Consumers depend on the pre-#13004 order, so this restores exactly that. `HashMap` iteration over `String` keys is the same on every JVM.
- **`findIntrospectedTypes`** used `Collectors.toSet()`, whose order follows `Class` identity hashes and so also varied between runs. It now follows the map order.
- **The rest of #13004 is unaffected.** `List.copyOf` preserves order (`DefaultEnvironment`, `DefaultPropertyPlaceholderResolver`), and `MediaType`'s extension map is only used through `get`.

## Tests

- New `DefaultBeanIntrospectorTest.findIntrospectionsIteratesInAStableOrder`: a provider returns 32 references, and the test asserts `findIntrospections` (with and without a filter) and `findIntrospectedTypes` return exactly the iteration order of a `HashMap` of their names, and that this order differs from the provider order. It passes with the fix and fails on the `Map.copyOf` code.
- `BeanIntrospectorSpec` (inject-java-test) and the `reflection` module tests pass; `:micronaut-core:checkstyleMain` is clean.
- micronaut-data 5.2.x (06fe8c7cba) against a local snapshot of this branch: `JdbcRepositorySpec` passed 4 of 4 runs (27 tests each). With provider order it failed 4 of 4, and on core 359bee6a6e it failed 1 of 3. To build, data needed NullAway set to WARN because of the unrelated Reactor 3.8 nullability break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
