### PR TITLE
Update managed-netty version in Micronaut 3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -126,7 +126,7 @@ managed-micronaut-views = "3.8.2"
 managed-micronaut-xml = "3.2.0"
 managed-neo4j = "3.5.35"
 managed-neo4j-java-driver = "4.4.9"
-managed-netty = "4.1.136.Final"
+managed-netty = "4.1.138.Final"
 managed-reactive-pg-client = "0.11.4"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM


### PR DESCRIPTION
Updated managed-netty version from 4.1.136.Final to 4.1.138.Final.

https://github.com/netty/netty/releases#release-netty-4.1.138.Final