### PR TITLE
Keep a property's annotations to the type it is read through

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -347,6 +347,42 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     /**
+     * Build the metadata for the given field element read through the given owning type, excluding any class
+     * metadata. A mutation made on the field itself is keyed by the declaring type, as with
+     * {@link #lookupOrBuildForField(Object, Object)}, and is visible through every type the field is read through.
+     * A mutation made on the field as a component of a bean property belongs to the owning type: a bean property is
+     * resolved for the type it is read through, as its accessor methods are, so annotating the property of a super
+     * type must not annotate the same property read through a subclass. Once the owning type holds such a mutation,
+     * the field read or mutated through the owning type uses it.
+     *
+     * @param owningType        The type the field is read through
+     * @param declaringType     The type declaring the field
+     * @param element           The element
+     * @param propertyComponent Whether a mutation is made on the field as a component of a bean property
+     * @return The {@link CachedAnnotationMetadata}
+     * @since 5.2.1
+     */
+    public CachedAnnotationMetadata lookupOrBuildForField(T owningType, T declaringType, T element, boolean propertyComponent) {
+        return lookupOrBuildForOwner(new Key2<>(declaringType, element), new OwnerKey2<>(owningType, element), element, propertyComponent);
+    }
+
+    /**
+     * Lookup or build the metadata of a member shared by the types it is read through, keeping the mutations made
+     * for one owning type apart from the shared metadata.
+     *
+     * @param sharedKey     The cache key of the metadata shared by every owning type
+     * @param ownerKey      The cache key of the metadata mutated for the owning type
+     * @param element       The element
+     * @param ownerMutation Whether a mutation belongs to the owning type
+     * @return The {@link CachedAnnotationMetadata}
+     * @see #lookupOrBuildForField(Object, Object, Object, boolean)
+     * @since 5.2.1
+     */
+    public CachedAnnotationMetadata lookupOrBuildForOwner(Object sharedKey, Object ownerKey, T element, boolean ownerMutation) {
+        return new OwnerCachedAnnotationMetadata(sharedKey, ownerKey, element, ownerMutation);
+    }
+
+    /**
      * Lookup or build new annotation metadata.
      *
      * @param key     The cache key
@@ -2326,6 +2362,78 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         @Override
         public Iterator<T> iterator() {
             return List.of(type, e2, e3).iterator();
+        }
+    }
+
+    /**
+     * Key used to reference the metadata a member is mutated with for one owning type. The first element is the
+     * owning type so that {@link #clearMutated(Object)} can drop the entry when that type is cleared.
+     *
+     * @param owningType The owning type
+     * @param e2         The element 2
+     * @param <T>        the element type
+     */
+    @Internal
+    private record OwnerKey2<T>(T owningType, T e2) implements Iterable<T> {
+        @Override
+        public Iterator<T> iterator() {
+            return List.of(owningType, e2).iterator();
+        }
+    }
+
+    /**
+     * The metadata of a member read through one owning type: the metadata mutated for the owning type when there
+     * is one, otherwise the metadata shared by every owning type. The shared metadata is built when the entry is
+     * looked up, while the element can still be read, and the metadata of the owning type is looked for until it
+     * is found, as a mutation for the owning type can be made after the entry was looked up.
+     */
+    private final class OwnerCachedAnnotationMetadata implements CachedAnnotationMetadata {
+
+        private final CachedAnnotationMetadata shared;
+        private final Object ownerKey;
+        private final boolean ownerMutation;
+        @Nullable
+        private CachedAnnotationMetadata owned;
+
+        OwnerCachedAnnotationMetadata(Object sharedKey, Object ownerKey, T element, boolean ownerMutation) {
+            this.shared = lookupOrBuild(sharedKey, element);
+            this.ownerKey = ownerKey;
+            this.ownerMutation = ownerMutation;
+        }
+
+        private CachedAnnotationMetadata current() {
+            if (owned == null) {
+                owned = MUTATED_ANNOTATION_METADATA.get(ownerKey);
+            }
+            return owned != null ? owned : shared;
+        }
+
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return current().getAnnotationMetadata();
+        }
+
+        @Override
+        public boolean isMutated() {
+            return current().isMutated();
+        }
+
+        @Override
+        public void update(AnnotationMetadata annotationMetadata) {
+            if (ownerMutation && !MUTATED_ANNOTATION_METADATA.containsKey(ownerKey)) {
+                MUTATED_ANNOTATION_METADATA.put(ownerKey, new DefaultCachedAnnotationMetadata(annotationMetadata));
+            }
+            current().update(annotationMetadata);
+        }
+
+        @Override
+        public boolean wasCleared() {
+            return current().wasCleared();
+        }
+
+        @Override
+        public void markCleared() {
+            current().markCleared();
         }
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
@@ -178,10 +178,48 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
      * @return The annotation metadata
      */
     protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForField(FieldElement fieldElement) {
+        return lookupForField(fieldElement, false);
+    }
+
+    /**
+     * Lookup annotation metadata for the field read through its owning type. A mutation made on the field is keyed
+     * by the declaring type, a mutation made on the field as a component of a bean property belongs to the owning
+     * type.
+     *
+     * @param fieldElement      The element
+     * @param propertyComponent Whether a mutation is made on the field as a component of a bean property
+     * @return The annotation metadata
+     * @see AbstractAnnotationMetadataBuilder#lookupOrBuildForField(Object, Object, Object, boolean)
+     * @since 5.2.1
+     */
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForField(FieldElement fieldElement, boolean propertyComponent) {
         return metadataBuilder.lookupOrBuildForField(
+            getNativeElement(fieldElement.getOwningType()),
             getNativeElement(fieldElement.getDeclaringType()),
-            getNativeElement(fieldElement)
+            getNativeElement(fieldElement),
+            propertyComponent
         );
+    }
+
+    /**
+     * Build the annotation metadata of a field as a component of a bean property of the field's owning type.
+     *
+     * @param fieldElement The field element
+     * @return The element annotation metadata
+     */
+    ElementAnnotationMetadata buildForPropertyField(FieldElement fieldElement) {
+        return new AbstractElementAnnotationMetadata() {
+
+            @Override
+            protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookup() {
+                return lookupForField(fieldElement, true);
+            }
+
+            @Override
+            public String toString() {
+                return fieldElement.toString();
+            }
+        };
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/PropertyElementAnnotationMetadata.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/PropertyElementAnnotationMetadata.java
@@ -103,8 +103,9 @@ public final class PropertyElementAnnotationMetadata implements ElementAnnotatio
                     }
                 }
             } else {
-                writeElements.add(field);
-                readElements.add(field);
+                MutableAnnotationMetadataDelegate<?> fieldAnnotationMetadata = propertyFieldAnnotationMetadata(field);
+                writeElements.add(fieldAnnotationMetadata);
+                readElements.add(fieldAnnotationMetadata);
                 MutableAnnotationMetadataDelegate<?> typeAnnotationMetadata = field.getType().getTypeAnnotationMetadata();
                 if (!typeAnnotationMetadata.isEmpty()) {
                     writeElements.add(typeAnnotationMetadata);
@@ -132,6 +133,23 @@ public final class PropertyElementAnnotationMetadata implements ElementAnnotatio
         this.propertyWriteAnnotationMetadata =
             writeHierarchy.length == 1 ? writeHierarchy[0] : new AnnotationMetadataHierarchy(true, writeHierarchy);
         this.writeElements = writeElements;
+    }
+
+    /**
+     * The annotation metadata of the field as a component of the property. A property is resolved for the type it is
+     * read through, so annotating it annotates the field for that type only, not for the other types the field is
+     * inherited by.
+     *
+     * @param field The field
+     * @return The annotation metadata to read and write
+     */
+    private static MutableAnnotationMetadataDelegate<?> propertyFieldAnnotationMetadata(FieldElement field) {
+        if (field instanceof AbstractAnnotationElement element
+            && element.presetAnnotationMetadata == null
+            && element.getElementAnnotationMetadataFactory() instanceof AbstractElementAnnotationMetadataFactory<?, ?> factory) {
+            return factory.buildForPropertyField(field);
+        }
+        return field;
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/visitors/InheritedPropertyAnnotationMutationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/InheritedPropertyAnnotationMutationSpec.groovy
@@ -1,0 +1,131 @@
+package io.micronaut.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ElementQuery
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+/**
+ * A bean property is resolved for the type it is read through, so an annotation a visitor adds to a property
+ * belongs to that type: a property of a super type annotated while visiting the super type must not carry the
+ * annotation when the same property is read through a subclass. This is what micronaut-serialization relies on
+ * to apply only the nearest {@code @JsonIgnoreProperties}.
+ */
+class InheritedPropertyAnnotationMutationSpec extends AbstractTypeElementSpec {
+
+    void 'a property annotated through a super type is not annotated through the subclass'() {
+        given:
+        RecordingVisitor.reset()
+
+        when:
+        buildClassLoader('test.A', '''
+package test;
+
+import java.lang.annotation.*;
+
+@IgnoreProps("p2")
+class A extends B {
+    private String p1;
+    private String p2;
+    public String getP1() { return p1; }
+    public void setP1(String p1) { this.p1 = p1; }
+    public String getP2() { return p2; }
+    public void setP2(String p2) { this.p2 = p2; }
+}
+
+@IgnoreProps("a2")
+class B extends C {
+    private String a1;
+    private String a2;
+    public String getA1() { return a1; }
+    public void setA1(String a1) { this.a1 = a1; }
+    public String getA2() { return a2; }
+    public void setA2(String a2) { this.a2 = a2; }
+}
+
+@IgnoreProps("f2")
+class C {
+    private String f1;
+    private String f2;
+    public String getF1() { return f1; }
+    public void setF1(String f1) { this.f1 = f1; }
+    public String getF2() { return f2; }
+    public void setF2(String f2) { this.f2 = f2; }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface IgnoreProps {
+    String[] value();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Ignored {
+}
+''')
+
+        then: 'each type only carries the annotations added through it'
+        RecordingVisitor.ignoredProperties['test.C'] == ['f2']
+        RecordingVisitor.ignoredProperties['test.B'] == ['a2']
+        RecordingVisitor.ignoredProperties['test.A'] == ['p2']
+
+        and: 'a field read through the type whose property was annotated carries the annotation'
+        RecordingVisitor.ignoredFields['test.C'] == ['f2']
+        RecordingVisitor.ignoredFields['test.B'] == ['a2']
+        RecordingVisitor.ignoredFields['test.A'] == ['p2']
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        return [new IgnorePropsVisitor(), new RecordingVisitor()]
+    }
+
+    /**
+     * Annotates the properties a type names in its own {@code @IgnoreProps}, like micronaut-serialization does
+     * for {@code @JsonIgnoreProperties}.
+     */
+    static class IgnorePropsVisitor implements TypeElementVisitor<Object, Object> {
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            def ignored = element.stringValues('test.IgnoreProps') as Set
+            element.beanProperties
+                .findAll { ignored.contains(it.name) }
+                .each { it.annotate('test.Ignored') }
+        }
+    }
+
+    /**
+     * Records, once every type was visited, the properties and the fields that carry the annotation when read
+     * through each type.
+     */
+    static class RecordingVisitor implements TypeElementVisitor<Object, Object> {
+
+        static List<ClassElement> elements
+        static Map<String, List<String>> ignoredProperties
+        static Map<String, List<String>> ignoredFields
+
+        static void reset() {
+            elements = []
+            ignoredProperties = [:]
+            ignoredFields = [:]
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.hasAnnotation('test.IgnoreProps')) {
+                elements << element
+            }
+        }
+
+        @Override
+        void finish(VisitorContext visitorContext) {
+            for (ClassElement element : elements) {
+                ignoredProperties[element.name] = element.beanProperties
+                    .findAll { it.hasAnnotation('test.Ignored') }*.name.sort()
+                ignoredFields[element.name] = element.getEnclosedElements(ElementQuery.ALL_FIELDS)
+                    .findAll { it.hasAnnotation('test.Ignored') }*.name.sort()
+            }
+        }
+    }
+}

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinElementAnnotationMetadataFactory.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinElementAnnotationMetadataFactory.kt
@@ -154,24 +154,27 @@ internal class KotlinElementAnnotationMetadataFactory(
         )
     }
 
-    override fun lookupForField(fieldElement: FieldElement): CachedAnnotationMetadata {
+    override fun lookupForField(fieldElement: FieldElement, propertyComponent: Boolean): CachedAnnotationMetadata {
         val kotlinFieldElement = fieldElement as AbstractKotlinElement<*>
-        // Keyed by the declaring type, not the owning type: an inherited field is the same field whichever
-        // class it is read through, so a mutation must be visible through all of them
-        val declaringType: KotlinClassElement
-        if (kotlinFieldElement is KotlinFieldElement) {
-            declaringType = kotlinFieldElement.declaringType as KotlinClassElement
-        } else if (kotlinFieldElement is KotlinEnumConstantElement) {
-            declaringType = kotlinFieldElement.declaringType as KotlinClassElement
-        } else {
+        // A mutation of the field is keyed by the declaring type, not the owning type: an inherited field is the
+        // same field whichever class it is read through, so a mutation must be visible through all of them.
+        // A mutation made through a bean property belongs to the owning type the property is resolved for
+        if (kotlinFieldElement !is KotlinFieldElement && kotlinFieldElement !is KotlinEnumConstantElement) {
             throw RuntimeException("Unknown field element type ${fieldElement.javaClass}")
         }
-        return metadataBuilder.lookupOrBuild(
+        val declaringType = fieldElement.declaringType as KotlinClassElement
+        val owningType = fieldElement.owningType as KotlinClassElement
+        return metadataBuilder.lookupOrBuildForOwner(
             Key2(
                 getClassDefinitionCacheKey(declaringType),
                 kotlinFieldElement.nativeType,
             ),
-            kotlinFieldElement.nativeType.element
+            OwnerKey2(
+                getClassDefinitionCacheKey(owningType),
+                kotlinFieldElement.nativeType,
+            ),
+            kotlinFieldElement.nativeType.element,
+            propertyComponent
         )
     }
 
@@ -194,6 +197,8 @@ internal class KotlinElementAnnotationMetadataFactory(
         )
 
     data class Key2(private val v1: Any, private val v2: Any)
+
+    data class OwnerKey2(private val v1: Any, private val v2: Any)
 
     data class Key3(private val v1: Any, private val v2: Any, private val v3: Any)
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/InheritedPropertyAnnotationMutationSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/InheritedPropertyAnnotationMutationSpec.groovy
@@ -1,0 +1,100 @@
+package io.micronaut.kotlin.processing.annotations
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+/**
+ * A bean property is resolved for the type it is read through, so an annotation a visitor adds to a property
+ * belongs to that type: a property of a super type annotated while visiting the super type must not carry the
+ * annotation when the same property is read through a subclass.
+ */
+class InheritedPropertyAnnotationMutationSpec extends AbstractKotlinCompilerSpec {
+
+    void 'a property annotated through a super type is not annotated through the subclass'() {
+        given:
+        IgnorePropsRecordingVisitor.reset()
+
+        when:
+        buildClassLoader('ignprops.A', '''
+package ignprops
+
+@IgnoreProps("p2")
+open class A : B() {
+    var p1: String? = null
+    var p2: String? = null
+}
+
+@IgnoreProps("a2")
+open class B : C() {
+    var a1: String? = null
+    var a2: String? = null
+}
+
+@IgnoreProps("f2")
+open class C {
+    var f1: String? = null
+    var f2: String? = null
+}
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class IgnoreProps(vararg val value: String)
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Ignored
+''')
+
+        then: 'each type only carries the annotations added through it'
+        IgnorePropsRecordingVisitor.ignoredProperties['ignprops.C'] == ['f2']
+        IgnorePropsRecordingVisitor.ignoredProperties['ignprops.B'] == ['a2']
+        IgnorePropsRecordingVisitor.ignoredProperties['ignprops.A'] == ['p2']
+    }
+
+    /**
+     * Annotates the properties a type names in its own {@code @IgnoreProps}, like micronaut-serialization does
+     * for {@code @JsonIgnoreProperties}.
+     */
+    static class IgnorePropsVisitor implements TypeElementVisitor<Object, Object> {
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            def ignored = element.stringValues('ignprops.IgnoreProps') as Set
+            if (ignored.isEmpty()) {
+                return
+            }
+            element.beanProperties
+                .findAll { ignored.contains(it.name) }
+                .each { it.annotate('ignprops.Ignored') }
+        }
+    }
+
+    /**
+     * Records, once every type was visited, the properties that carry the annotation when read through each type.
+     */
+    static class IgnorePropsRecordingVisitor implements TypeElementVisitor<Object, Object> {
+
+        static List<ClassElement> elements = []
+        static Map<String, List<String>> ignoredProperties = [:]
+
+        static void reset() {
+            elements = []
+            ignoredProperties = [:]
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.hasAnnotation('ignprops.IgnoreProps')) {
+                elements << element
+            }
+        }
+
+        @Override
+        void finish(VisitorContext visitorContext) {
+            for (ClassElement element : elements) {
+                ignoredProperties[element.name] = element.beanProperties
+                    .findAll { it.hasAnnotation('ignprops.Ignored') }*.name.sort()
+            }
+        }
+    }
+}

--- a/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -14,3 +14,5 @@ io.micronaut.kotlin.processing.annotations.AddsUnseenRepeatableAnnotationSpec$Ad
 io.micronaut.kotlin.processing.aop.introduction.MyRepo3Spec$MyRepositoryVisitor
 io.micronaut.kotlin.processing.aop.introduction.MyIsEnumInTypeArgumentSpec$MyControllerVisitor
 io.micronaut.kotlin.processing.ast.visitor.KotlinAnnotationElementSpec$InheritedVisitor
+io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsVisitor
+io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsRecordingVisitor


### PR DESCRIPTION
## Summary

Since #12971, core keys a field's mutated annotation metadata by the type that declares the field, so a change a visitor makes through the declaring class is also visible through a subclass.

That also caught property annotations. `PropertyElementAnnotationMetadata` writes an annotation on a bean property to the property's field as well. So annotating B's property `a2` while visiting B now annotated `a2` when it is read through subclass A too.

micronaut-serialization depends on the old behaviour. It maps `@JsonIgnoreProperties` to per-property ignore annotations for each type it visits. With three classes `A extends B extends C`, each with its own `@JsonIgnoreProperties`, A now ignored `a2` and `f2` as well as `p2`. `SerdeJsonIgnoreAllowSpec` "test @JsonIgnoreProperties inheritance" passes on 5.1.3 and fails on 5.2.0. A bisect of core points at 0b4415abee (#12971).

A bean property is resolved for the type it is read through, like its getter and setter, whose metadata is keyed by the owning type. So an annotation added through the property should belong to that type only.

- `AbstractAnnotationMetadataBuilder#lookupOrBuildForField(owningType, declaringType, element, propertyComponent)` returns a view that resolves on every access:
  - Through a property, the first write creates an entry for the owning type, starting from the shared metadata.
  - Any read or write through that owning type then uses its entry.
  - Otherwise the shared entry keyed by the declaring type is used, as #12971 introduced.
- `PropertyElementAnnotationMetadata` reads and writes the field through the property view.
- `lookupForField(FieldElement)` keeps the shared behaviour, so a direct field mutation through the declaring type is still visible through subclasses.
- The Kotlin factory gets the same change.

## Tests

- `InheritedPropertyAnnotationMutationSpec` (inject-java and inject-kotlin) visits A, B and C, annotating each type's own ignored property the way serde does. It checks each type only sees its own. The Java spec also checks the field read through that type. Both fail without the fix: B reports `[a2, f2]` and A `[a2, f2, p2]`.
- `InheritedMemberAnnotationMutationSpec` from #12971 still passes.
- The view builds the shared entry when it is looked up, as the previous lookup did, so metadata that is read after compilation ends still resolves (`PropertyElementSpec`, Kotlin `ClassElementSpec`).
- The core-processor, inject-java, inject-kotlin and inject-groovy test suites pass.
- micronaut-serialization 3.2.x against a snapshot of this branch: `SerdeJsonIgnoreAllowSpec` passes (29 tests, 1 skipped), including "test @JsonIgnoreProperties inheritance".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
