### PR TITLE
HTTP/2 specification conformance and h2c pipeline wiring

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -580,9 +580,7 @@ final class HttpPipelineBuilder {
                         public void upgradeTo(ChannelHandlerContext ctx, FullHttpRequest upgradeRequest) {
                             super.upgradeTo(ctx, upgradeRequest);
                             pipeline.remove(fallbackHandlerName);
-                            new StreamPipeline(channel, sslHandler, connectionCustomizer).afterHttp2ServerHandlerSetUp();
-                            specificGracefulShutdown = new Http2GracefulShutdown(ctx.pipeline().context(connectionHandler), connectionHandler);
-                            onRequestPipelineBuilt();
+                            afterH2cEstablished(connectionHandler);
                         }
                     }
 
@@ -614,6 +612,18 @@ final class HttpPipelineBuilder {
             pipeline.addLast(cleartextHttp2ServerUpgradeHandler);
             pipeline.addLast(fallbackHandlerName, new SimpleChannelInboundHandler<HttpMessage>() {
                 @Override
+                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                    if (evt instanceof CleartextHttp2ServerUpgradeHandler.PriorKnowledgeUpgradeEvent) {
+                        // the client spoke HTTP/2 straight away, so this fallback is not needed.
+                        // The connection handler is already in the pipeline, but the rest of the
+                        // set-up still has to run, same as for the h2c upgrade above.
+                        ctx.pipeline().remove(this);
+                        afterH2cEstablished(connectionHandler);
+                    }
+                    super.userEventTriggered(ctx, evt);
+                }
+
+                @Override
                 protected void channelRead0(ChannelHandlerContext ctx, HttpMessage msg) {
                     // If this handler is hit then no upgrade has been attempted and the client is just talking HTTP.
                     ChannelPipeline cp = ctx.pipeline();
@@ -638,6 +648,18 @@ final class HttpPipelineBuilder {
                 }
             });
             connectionCustomizer.onInitialPipelineBuilt();
+        }
+
+        /**
+         * Complete the pipeline set-up for an established h2c connection. Called both for the
+         * HTTP/1.1 upgrade path and for prior-knowledge connections.
+         *
+         * @param connectionHandler The HTTP/2 connection handler that is now in the pipeline
+         */
+        private void afterH2cEstablished(Http2ConnectionHandler connectionHandler) {
+            new StreamPipeline(channel, sslHandler, connectionCustomizer).afterHttp2ServerHandlerSetUp();
+            specificGracefulShutdown = new Http2GracefulShutdown(pipeline.context(connectionHandler), connectionHandler);
+            onRequestPipelineBuilt();
         }
 
         private Http2MultiplexHandler makeHttp2Handler() {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
@@ -259,10 +259,14 @@ public final class Http2ServerHandler extends MultiplexedServerHandler implement
                 }
                 io.netty.handler.codec.http2.Http2Stream cs = connection().stream(1);
                 handleFakeRequest(cs, fhr);
-            } else if (evt instanceof IdleStateEvent idle) {
-                if (idle.state() == IdleState.ALL_IDLE) {
+            } else {
+                if (evt instanceof IdleStateEvent idle && idle.state() == IdleState.ALL_IDLE) {
                     ctx.close();
                 }
+                // forward everything we do not consume ourselves. Our superclass
+                // ByteToMessageDecoder needs ChannelInputShutdownEvent, and handlers further down
+                // the pipeline may be interested in other events, e.g. SslCloseCompletionEvent or
+                // CleartextHttp2ServerUpgradeHandler.PriorKnowledgeUpgradeEvent.
                 super.userEventTriggered(ctx, evt);
             }
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
@@ -261,7 +261,11 @@ public final class Http2ServerHandler extends MultiplexedServerHandler implement
                 handleFakeRequest(cs, fhr);
             } else {
                 if (evt instanceof IdleStateEvent idle && idle.state() == IdleState.ALL_IDLE) {
+                    // consumed: the connection is going away. On a real channel close() only
+                    // schedules the teardown, so without the return the event would still be
+                    // forwarded to whatever is behind us.
                     ctx.close();
+                    return;
                 }
                 // forward everything we do not consume ourselves. Our superclass
                 // ByteToMessageDecoder needs ChannelInputShutdownEvent, and handlers further down

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
@@ -402,7 +402,11 @@ public final class Http2ServerHandler extends MultiplexedServerHandler implement
         void closeInput() {
             closeInput = true;
             if (stream.state() == io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL) {
-                requiredConnectionHandler().encoder().writeRstStream(requiredCtx(), stream.id(), Http2Error.CANCEL.code(), requiredCtx().voidPromise());
+                // We have sent a complete response, but the peer is still sending the request body.
+                // RFC 9113 §8.1 allows us to stop reading it, but the response was delivered in
+                // full, so this is not an error: NO_ERROR keeps clients from reporting the request
+                // as failed. Genuine cancellation is signalled with CANCEL in reset(Throwable).
+                requiredConnectionHandler().encoder().writeRstStream(requiredCtx(), stream.id(), Http2Error.NO_ERROR.code(), requiredCtx().voidPromise());
                 flush();
             }
         }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/GracefulShutdownSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/GracefulShutdownSpec.groovy
@@ -59,6 +59,7 @@ import spock.util.concurrent.PollingConditions
 
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.BlockingQueue
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
@@ -463,7 +464,10 @@ class GracefulShutdownSpec extends Specification {
                 .connect(server.host, server.port).sync().channel()
 
         def sink = Sinks.<String> one()
-        server.applicationContext.getBean(MyCtrl).publisher = sink.asMono()
+        // the controller subscribes to this publisher while it is producing the response, so the
+        // latch tells us the request has actually reached the server and is still in flight
+        def requestInFlight = new CountDownLatch(1)
+        server.applicationContext.getBean(MyCtrl).publisher = sink.asMono().doOnSubscribe(s -> requestInFlight.countDown())
 
         expect:
         inbound.take() instanceof Http2SettingsFrame
@@ -477,7 +481,7 @@ class GracefulShutdownSpec extends Specification {
                 .authority("localhost")
                 .scheme("http"), true
         ).stream(stream1), ch.newPromise().addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE))
-        TimeUnit.SECONDS.sleep(1)
+        assert requestInFlight.await(10, TimeUnit.SECONDS)
         def shFuture = gracefulShutdown.shutdownGracefully().toCompletableFuture()
 
         then: "the client gets a GOAWAY and the connection stays up for the in-flight request"
@@ -501,6 +505,7 @@ class GracefulShutdownSpec extends Specification {
         cleanup:
         data?.release()
         goAway?.release()
+        ch?.close()?.await(10, TimeUnit.SECONDS)
         loop.shutdownGracefully()
         server.close()
     }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/GracefulShutdownSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/GracefulShutdownSpec.groovy
@@ -433,6 +433,78 @@ class GracefulShutdownSpec extends Specification {
         server.close()
     }
 
+    def "h2c prior knowledge"() {
+        given:
+        def server = ApplicationContext.<EmbeddedServer> run(EmbeddedServer, [
+                'spec.name'                    : 'GracefulShutdownSpec',
+                'micronaut.server.ssl.enabled' : false,
+                'micronaut.server.http-version': '2.0'
+        ])
+        def gracefulShutdown = server.applicationContext.getBean(GracefulShutdownManager)
+
+        def loop = new NioEventLoopGroup(1)
+        BlockingQueue<Object> inbound = new LinkedBlockingQueue<>()
+        def duplexHandler = new Http2ChannelDuplexHandler() {
+            @Override
+            void channelRead(@NonNull ChannelHandlerContext ctx, @NonNull Object msg) throws Exception {
+                inbound.add(msg)
+            }
+        }
+        def ch = new Bootstrap()
+                .group(loop)
+                .channel(NioSocketChannel)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(@NonNull Channel c) throws Exception {
+                        // no h2c upgrade: this client speaks HTTP/2 from the first byte
+                        c.pipeline().addLast(Http2FrameCodecBuilder.forClient().build(), duplexHandler)
+                    }
+                })
+                .connect(server.host, server.port).sync().channel()
+
+        def sink = Sinks.<String> one()
+        server.applicationContext.getBean(MyCtrl).publisher = sink.asMono()
+
+        expect:
+        inbound.take() instanceof Http2SettingsFrame
+        inbound.take() instanceof Http2SettingsAckFrame
+
+        when: "the server shuts down while a request is still in flight"
+        def stream1 = duplexHandler.newStream()
+        ch.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()
+                .path("/graceful-shutdown/single")
+                .method("GET")
+                .authority("localhost")
+                .scheme("http"), true
+        ).stream(stream1), ch.newPromise().addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE))
+        TimeUnit.SECONDS.sleep(1)
+        def shFuture = gracefulShutdown.shutdownGracefully().toCompletableFuture()
+
+        then: "the client gets a GOAWAY and the connection stays up for the in-flight request"
+        def goAwayMsg = inbound.poll(10, TimeUnit.SECONDS)
+        goAwayMsg instanceof Http2GoAwayFrame
+        Http2GoAwayFrame goAway = (Http2GoAwayFrame) goAwayMsg
+        goAway.errorCode() == Http2Error.NO_ERROR.code()
+        goAway.lastStreamId() == stream1.id()
+        !shFuture.isDone()
+
+        when: "the in-flight request completes"
+        sink.tryEmitValue("foo")
+
+        then:
+        Http2HeadersFrame resp = inbound.take()
+        !resp.isEndStream()
+        resp.headers().status().toString() == "200"
+        Http2DataFrame data = inbound.take()
+        data.isEndStream()
+
+        cleanup:
+        data?.release()
+        goAway?.release()
+        loop.shutdownGracefully()
+        server.close()
+    }
+
     def "http3"() {
         given:
         def server = ApplicationContext.<EmbeddedServer> run(EmbeddedServer, [

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.http.server.netty.handler
 
+import io.micronaut.http.body.ByteBody
 import io.micronaut.http.body.CloseableByteBody
 import io.micronaut.http.body.InternalByteBody
 import io.micronaut.http.body.stream.InputStreamByteBody
@@ -565,9 +566,10 @@ class Http2ServerHandlerSpec extends Specification {
         EmbeddedTestUtil.advance(client, server)
 
         where:
-        exception                             | expectedCode
-        new Exception()                       | Http2Error.INTERNAL_ERROR
-        new Http2Exception(Http2Error.CANCEL) | Http2Error.CANCEL
+        exception                              | expectedCode
+        new Exception()                        | Http2Error.INTERNAL_ERROR
+        new Http2Exception(Http2Error.CANCEL)  | Http2Error.CANCEL
+        ByteBody.BodyDiscardedException.create() | Http2Error.CANCEL
     }
 
     def "closeIfNoSubscriber"() {
@@ -616,7 +618,53 @@ class Http2ServerHandlerSpec extends Specification {
         AsciiString.contentEquals(response.headers().status(), HttpResponseStatus.OK.codeAsText())
         Http2ResetFrame rst = client.readInbound()
         rst.stream() == stream1
-        rst.errorCode() == Http2Error.CANCEL.code()
+        // the response was delivered in full, so this is not a failure for the client
+        rst.errorCode() == Http2Error.NO_ERROR.code()
+
+        cleanup:
+        data1.release()
+        client.checkException()
+        server.checkException()
+        client.finishAndReleaseAll()
+        server.finishAndReleaseAll()
+        EmbeddedTestUtil.advance(client, server)
+    }
+
+    def "complete response before request body is finished resets with NO_ERROR"() {
+        given: "a handler that answers without reading the request body"
+        def (server, client, duplexHandler) = configure(new RequestHandler() {
+            @Override
+            void accept(ChannelHandlerContext ctx, HttpRequest request, CloseableByteBody body, OutboundAccess outboundAccess) {
+                body.close()
+                outboundAccess.write(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED), NettyByteBodyFactory.empty())
+            }
+
+            @Override
+            void handleUnboundError(Throwable cause) {
+                cause.printStackTrace()
+            }
+        })
+
+        when: "the client starts an upload that it has not finished"
+        def stream1 = duplexHandler.newStream()
+        def req1 = new DefaultHttp2Headers()
+        req1.method(HttpMethod.POST.asciiName())
+        req1.scheme("http")
+        req1.authority("yawk.at")
+        req1.path("/")
+        client.writeOutbound(new DefaultHttp2HeadersFrame(req1, false).stream(stream1))
+        def data1 = randomData(500)
+        client.writeOutbound(new DefaultHttp2DataFrame(data1.retainedSlice(), false).stream(stream1))
+        EmbeddedTestUtil.advance(server, client)
+
+        then: "the complete response is followed by a reset that does not signal an error"
+        client.readInbound() instanceof Http2SettingsFrame
+        client.readInbound() instanceof Http2SettingsAckFrame
+        Http2HeadersFrame response = client.readInbound()
+        AsciiString.contentEquals(response.headers().status(), HttpResponseStatus.UNAUTHORIZED.codeAsText())
+        Http2ResetFrame rst = client.readInbound()
+        rst.stream() == stream1
+        rst.errorCode() == Http2Error.NO_ERROR.code()
 
         cleanup:
         data1.release()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
@@ -42,6 +42,7 @@ import io.netty.handler.codec.http2.Http2ResetFrame
 import io.netty.handler.codec.http2.Http2SettingsAckFrame
 import io.netty.handler.codec.http2.Http2SettingsFrame
 import io.netty.handler.codec.http2.Http2StreamFrame
+import io.netty.handler.timeout.IdleStateEvent
 import io.netty.util.AsciiString
 import org.jspecify.annotations.NonNull
 import org.junit.jupiter.api.Assertions
@@ -751,8 +752,11 @@ class Http2ServerHandlerSpec extends Specification {
         EmbeddedTestUtil.advance(client, server)
     }
 
-    def "unrecognized user events are forwarded down the pipeline"() {
-        given: "a server pipeline with a handler downstream of the http2 connection handler"
+    /**
+     * A bare server channel with the HTTP/2 connection handler and a handler behind it that
+     * records the user events that make it that far.
+     */
+    private static Tuple2<EmbeddedChannel, List<Object>> configureWithEventRecorder() {
         def received = []
         def server = new EmbeddedChannel()
         server.pipeline().addLast(new Http2ServerHandler.ConnectionHandlerBuilder(new RequestHandler() {
@@ -773,13 +777,38 @@ class Http2ServerHandlerSpec extends Specification {
                 super.userEventTriggered(ctx, evt)
             }
         })
+        return new Tuple2<>(server, received)
+    }
+
+    def "unrecognized user events are forwarded down the pipeline"() {
+        given: "a server pipeline with a handler downstream of the http2 connection handler"
+        def (server, received) = configureWithEventRecorder()
 
         when: "an event the connection handler does not consume is fired"
-        def event = new Object()
         server.pipeline().fireUserEventTriggered(event)
 
-        then: "it reaches the next handler"
+        then: "it reaches the next handler and the connection stays up"
         received == [event]
+        server.isOpen()
+
+        cleanup:
+        server.checkException()
+        server.finishAndReleaseAll()
+
+        where:
+        event << [new Object(), IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT]
+    }
+
+    def "an all-idle event closes the connection"() {
+        given:
+        def (server, received) = configureWithEventRecorder()
+
+        when: "the connection has been idle for too long"
+        server.pipeline().fireUserEventTriggered(IdleStateEvent.FIRST_ALL_IDLE_STATE_EVENT)
+
+        then: "it is closed instead of the event being passed on"
+        !server.isOpen()
+        received == []
 
         cleanup:
         server.checkException()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/Http2ServerHandlerSpec.groovy
@@ -11,6 +11,7 @@ import io.netty.buffer.ByteBufAllocator
 import io.netty.buffer.CompositeByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http.DefaultFullHttpResponse
 import io.netty.handler.codec.http.DefaultHttpResponse
@@ -748,6 +749,41 @@ class Http2ServerHandlerSpec extends Specification {
         client.finishAndReleaseAll()
         server.finishAndReleaseAll()
         EmbeddedTestUtil.advance(client, server)
+    }
+
+    def "unrecognized user events are forwarded down the pipeline"() {
+        given: "a server pipeline with a handler downstream of the http2 connection handler"
+        def received = []
+        def server = new EmbeddedChannel()
+        server.pipeline().addLast(new Http2ServerHandler.ConnectionHandlerBuilder(new RequestHandler() {
+            @Override
+            void accept(ChannelHandlerContext ctx, HttpRequest request, CloseableByteBody body, OutboundAccess outboundAccess) {
+                body.close()
+            }
+
+            @Override
+            void handleUnboundError(Throwable cause) {
+                cause.printStackTrace()
+            }
+        }).build())
+        server.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            @Override
+            void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                received.add(evt)
+                super.userEventTriggered(ctx, evt)
+            }
+        })
+
+        when: "an event the connection handler does not consume is fired"
+        def event = new Object()
+        server.pipeline().fireUserEventTriggered(event)
+
+        then: "it reaches the next handler"
+        received == [event]
+
+        cleanup:
+        server.checkException()
+        server.finishAndReleaseAll()
     }
 
     def "ping response"() {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
@@ -236,10 +236,15 @@ class H2cSpec extends Specification {
     }
 
     /**
-     * Send a request over a connection that speaks HTTP/2 straight away, without an upgrade.
+     * Send a request over a connection that speaks HTTP/2 straight away, without an upgrade, and
+     * wait for the response. The connection and its event loop are always torn down before this
+     * method returns, whether the request succeeded or not.
+     *
+     * @param request The request to send
+     * @return The response, which the caller has to release
      */
-    private CompletableFuture requestPriorKnowledge(DefaultFullHttpRequest request) {
-        def responseFuture = new CompletableFuture()
+    private FullHttpResponse requestPriorKnowledge(DefaultFullHttpRequest request) {
+        CompletableFuture<FullHttpResponse> responseFuture = new CompletableFuture<>()
 
         def group = new NioEventLoopGroup(1)
         def bootstrap = new Bootstrap()
@@ -270,7 +275,7 @@ class H2cSpec extends Specification {
                                             if (msg.headers().getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), -1) != 3) {
                                                 responseFuture.completeExceptionally(new AssertionError("Response must be on stream 3"));
                                             }
-                                            responseFuture.complete(ReferenceCountUtil.retain(msg))
+                                            responseFuture.complete((FullHttpResponse) ReferenceCountUtil.retain(msg))
                                         }
                                         super.channelRead(ctx, msg)
                                     }
@@ -286,24 +291,27 @@ class H2cSpec extends Specification {
                     }
                 })
 
-        def channel = (SocketChannel) bootstrap.connect().await().channel()
+        try {
+            def channel = (SocketChannel) bootstrap.connect().await().channel()
+            try {
+                request.headers().set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http")
+                channel.writeAndFlush(request)
+                channel.read()
 
-        request.headers().set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http")
-        channel.writeAndFlush(request)
-        channel.read()
-
-        return responseFuture.whenComplete((r, e) -> {
-            channel.close()
+                return responseFuture.get(10, TimeUnit.SECONDS)
+            } finally {
+                channel.close().await(10, TimeUnit.SECONDS)
+            }
+        } finally {
             group.shutdownGracefully()
-        })
+        }
     }
 
     def 'prior knowledge'() {
-        given:
-        def responseFuture = requestPriorKnowledge(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/h2c/test'))
+        when:
+        def resp = requestPriorKnowledge(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/h2c/test'))
 
-        expect:
-        def resp = responseFuture.get(10, TimeUnit.SECONDS)
+        then:
         resp != null
 
         cleanup:
@@ -320,7 +328,6 @@ class H2cSpec extends Specification {
 
         when:
         def resp = requestPriorKnowledge(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/h2c/test'))
-                .get(10, TimeUnit.SECONDS)
 
         then:
         resp != null

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
@@ -19,6 +19,7 @@ import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.ChannelInitializer
+import io.netty.channel.ChannelPipeline
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioSocketChannel
@@ -46,6 +47,7 @@ import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
 @MicronautTest
@@ -233,8 +235,10 @@ class H2cSpec extends Specification {
         content.release()
     }
 
-    def 'prior knowledge'() {
-        given:
+    /**
+     * Send a request over a connection that speaks HTTP/2 straight away, without an upgrade.
+     */
+    private CompletableFuture requestPriorKnowledge(DefaultFullHttpRequest request) {
         def responseFuture = new CompletableFuture()
 
         def group = new NioEventLoopGroup(1)
@@ -284,19 +288,46 @@ class H2cSpec extends Specification {
 
         def channel = (SocketChannel) bootstrap.connect().await().channel()
 
-        def request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/h2c/test')
         request.headers().set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http")
         channel.writeAndFlush(request)
         channel.read()
+
+        return responseFuture.whenComplete((r, e) -> {
+            channel.close()
+            group.shutdownGracefully()
+        })
+    }
+
+    def 'prior knowledge'() {
+        given:
+        def responseFuture = requestPriorKnowledge(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/h2c/test'))
 
         expect:
         def resp = responseFuture.get(10, TimeUnit.SECONDS)
         resp != null
 
         cleanup:
-        channel.close()
-        resp.release()
-        group.shutdownGracefully()
+        resp?.release()
+    }
+
+    def 'prior knowledge triggers the pipeline listeners'() {
+        given:
+        def pipelines = new LinkedBlockingQueue<ChannelPipeline>()
+        ((ChannelPipelineCustomizer) embeddedServer).doOnConnect(p -> {
+            pipelines.add(p)
+            return p
+        })
+
+        when:
+        def resp = requestPriorKnowledge(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/h2c/test'))
+                .get(10, TimeUnit.SECONDS)
+
+        then:
+        resp != null
+        pipelines.poll(10, TimeUnit.SECONDS) != null
+
+        cleanup:
+        resp?.release()
     }
 
     @Controller("/h2c")


### PR DESCRIPTION
## Summary

- **`RST_STREAM` after a complete response now uses `NO_ERROR` instead of `CANCEL`.**
  `Http2ServerHandler.Http2Stream.closeInput()` resets the stream when the server has written a
  complete response but the peer is still uploading the request body. RFC 9113 §8.1 permits a
  server to stop reading in that situation, but the code sent was `CANCEL`, which clients report
  as a failed request: curl and nghttp2 print `stream was not closed cleanly: CANCEL (err 8)`
  even though the response — a 401 or a 413 answering a large upload, say — was delivered in
  full. The reset now carries `NO_ERROR`. `CANCEL` is kept for the genuinely cancelled case in
  `reset(Throwable)`, where the consumer discards the response body
  (`ByteBody.BodyDiscardedException`).

- **Unhandled user events are forwarded past the HTTP/2 connection handler.**
  `Http2ServerHandler.ConnectionHandler.userEventTriggered` only passed `IdleStateEvent` to
  `super`; everything else stopped there. That included `ChannelInputShutdownEvent`, which the
  superclass `ByteToMessageDecoder` handles on half-closure, plus `SslCloseCompletionEvent`, the
  h2c prior-knowledge upgrade event and any event a customizer's handlers listen for. Anything
  the handler does not consume itself is now passed to `super`.

- **h2c prior-knowledge connections run the same set-up as h2c upgrades.**
  `HttpPipelineBuilder.configureForH2cSupport()` completed the connection set-up only on the
  HTTP/1.1 upgrade path. When a client sends the HTTP/2 preface straight away, Netty's
  `CleartextHttp2ServerUpgradeHandler` swaps in the connection handler and fires
  `PriorKnowledgeUpgradeEvent`, which nothing acted on — so `afterHttp2ServerHandlerSetUp()`
  never ran, no `Http2GracefulShutdown` was installed for the connection, and pipeline-built
  listeners registered through `ChannelPipelineCustomizer.doOnConnect` were never called for
  such connections. The event is now handled where the HTTP/1 fallback handler sits, and both
  paths share a new `afterH2cEstablished()` helper (which also drops the fallback handler that
  is no longer needed). This depends on the event-forwarding change above, so it is the last of
  the three commits.

## Testing

Commands run, in order, all from the worktree:

- `./gradlew :micronaut-http-server-netty:test --tests '*Http2*' -q` — 45 tests, 0 failures.
- `./gradlew :micronaut-http-server-netty:test -q` — 203 classes, 1161 tests, 0 failures,
  0 errors, 22 skipped.
- `./gradlew :test-suite-http2-server-tck-netty:test -q` — 74 classes, 263 tests, 0 failures,
  0 errors, 3 skipped.
- `./gradlew :micronaut-http-server-netty:checkstyleMain -q` and
  `:micronaut-http-server-netty:checkstyleTest -q` — both pass. The pre-existing `FileLength`
  violation in `NettyHttpServerConfiguration.java` is unchanged and unrelated.

### Fail-before evidence

**`NO_ERROR` reset** — `Http2ServerHandlerSpec`, with the main-source change reverted to the
base version of `Http2ServerHandler.java`:

```
### complete response before request body is finished resets with NO_ERROR
Condition not satisfied:
rst.errorCode() == Http2Error.NO_ERROR.code()
|   |           |  |                   |
|   8           |  |                   0
DefaultHttp2ResetFrame(stream=3, errorCode=8)

### closeIfNoSubscriber
(same failure)
```

The existing `closeIfNoSubscriber` case asserted `CANCEL` for this same path; its expectation is
updated to `NO_ERROR`. A third row was added to the `download exception` data table
(`ByteBody.BodyDiscardedException` → `CANCEL`) to pin the distinction; that row passes on the
base code as well, by design — it guards the behaviour that must *not* change.

**Event forwarding** — new `Http2ServerHandlerSpec` case
`"unrecognized user events are forwarded down the pipeline"`, with the change reverted:

```
Condition not satisfied:
received == [event]
|        |   |
[]       |   <java.lang.Object@44ccd75c>
         false
```

**h2c prior knowledge** — new `H2cSpec` case `'prior knowledge triggers the pipeline listeners'`,
with `HttpPipelineBuilder.java` reverted:

```
Condition not satisfied:
pipelines.poll(10, TimeUnit.SECONDS) != null
|         |                          |
[]        null                       false
```

The new `GracefulShutdownSpec` case `"h2c prior knowledge"` covers graceful shutdown over a
prior-knowledge connection, which had no coverage before. To be explicit: **it passes on the
base code too.** With `decoupleCloseAndGoAway` left at its default of `false`, Netty's
`Http2ConnectionHandler.close()` itself emits a `GOAWAY(NO_ERROR, lastStreamCreated)` and defers
the close until the active streams finish, so the bare `channel.close()` the buggy path fell back
to is indistinguishable on the wire from the `Http2GracefulShutdown` the fixed path installs
(verified against `netty-codec-http2-4.2.17.Final` with `javap -c`). The wiring gap is real —
the connection was relying on Netty's implicit close behaviour rather than the server's own
graceful-shutdown object — but the observable regression is the pipeline listeners, which is what
the fail-before test above pins. The shutdown test is kept as coverage for the newly wired path.

### Netty API verification

Checked against the managed version (`managed-netty = "4.2.17.Final"` in
`gradle/libs.versions.toml`), decompiling the jar in `~/.gradle/caches` with `javap -c`:

- `CleartextHttp2ServerUpgradeHandler.decode` adds the HTTP/2 handler immediately after its own
  context, removes itself, and then fires `PriorKnowledgeUpgradeEvent` on that context — so the
  event does reach handlers downstream of the connection handler, and the connection handler is
  already in the pipeline when it arrives.
- `ByteToMessageDecoder.userEventTriggered` handles `ChannelInputShutdownEvent` and then forwards
  via `ChannelInboundHandlerAdapter.userEventTriggered`, confirming that the previous override
  suppressed it. `Http2ConnectionHandler` declares no `userEventTriggered` of its own.

## Out of scope

- The legacy multiplex handler configuration (`isLegacyMultiplexHandlers()`) is left as it is.
  The h2c upgrade path already called `afterHttp2ServerHandlerSetUp()` unconditionally, including
  for legacy handlers, and the prior-knowledge path now matches it, but the ALPN path
  (`configureForHttp2`) still skips that call for legacy handlers. That inconsistency predates
  this change and was not touched.
- `NettyHttpRequest.getHttpVersion()` masks the missing `STREAM_PIPELINE_ATTRIBUTE` on
  prior-knowledge connections through its `findConnectionHandler()` fallback, so no
  version-reporting change was needed; the attribute is now set correctly regardless.
- The `Http3` equivalent of `closeInput()` was not reviewed as part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
