### PR TITLE
Netty server pipeline configuration fixes

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -99,6 +99,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -421,10 +422,13 @@ final class HttpPipelineBuilder {
         private void insertIdleStateHandler() {
             final Duration idleTime = server.getServerConfiguration().getIdleTimeout();
             if (idleTime != null && !idleTime.isNegative()) {
+                // millisecond precision: truncating to whole seconds turns a sub-second timeout into 0,
+                // which IdleStateHandler treats as "disabled"
                 pipeline.addLast(ChannelPipelineCustomizer.HANDLER_IDLE_STATE, new IdleStateHandler(
-                        (int) server.getServerConfiguration().getReadIdleTimeout().getSeconds(),
-                        (int) server.getServerConfiguration().getWriteIdleTimeout().getSeconds(),
-                        (int) idleTime.getSeconds()));
+                        server.getServerConfiguration().getReadIdleTimeout().toMillis(),
+                        server.getServerConfiguration().getWriteIdleTimeout().toMillis(),
+                        idleTime.toMillis(),
+                        TimeUnit.MILLISECONDS));
             }
         }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -44,6 +44,7 @@ import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpDecoderConfig;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
@@ -652,12 +653,14 @@ final class HttpPipelineBuilder {
         }
 
         private HttpServerCodec createServerCodec() {
-            return new HttpServerCodec(
-                    server.getServerConfiguration().getMaxInitialLineLength(),
-                    server.getServerConfiguration().getMaxHeaderSize(),
-                    server.getServerConfiguration().getMaxChunkSize(),
-                    server.getServerConfiguration().isValidateHeaders(),
-                    server.getServerConfiguration().getInitialBufferSize()
+            NettyHttpServerConfiguration configuration = server.getServerConfiguration();
+            return new HttpServerCodec(new HttpDecoderConfig()
+                    .setMaxInitialLineLength(configuration.getMaxInitialLineLength())
+                    .setMaxHeaderSize(configuration.getMaxHeaderSize())
+                    .setMaxChunkSize(configuration.getMaxChunkSize())
+                    .setValidateHeaders(configuration.isValidateHeaders())
+                    .setInitialBufferSize(configuration.getInitialBufferSize())
+                    .setChunkedSupported(configuration.isChunkedSupported())
             );
         }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -508,15 +508,11 @@ final class HttpPipelineBuilder {
 
                 @Override
                 public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-                    if (evt instanceof SslHandshakeCompletionEvent event) {
-                        if (!event.isSuccess()) {
-                            final Throwable cause = event.cause();
-                            if (!(cause instanceof ClosedChannelException)) {
-                                super.userEventTriggered(ctx, evt);
-                            } else {
-                                return;
-                            }
-                        }
+                    if (evt instanceof SslHandshakeCompletionEvent event &&
+                        !event.isSuccess() &&
+                        event.cause() instanceof ClosedChannelException) {
+                        // the peer went away before the handshake completed, nothing to report
+                        return;
                     }
                     super.userEventTriggered(ctx, evt);
                 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpToHttpsRedirectHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpToHttpsRedirectHandler.java
@@ -17,6 +17,7 @@ package io.micronaut.http.server.netty;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.body.CloseableByteBody;
 import io.micronaut.http.netty.NettyHttpResponseBuilder;
@@ -29,6 +30,8 @@ import io.micronaut.http.ssl.ServerSslConfiguration;
 import io.micronaut.http.uri.UriBuilder;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
+
+import java.net.URI;
 
 /**
  * Handler to automatically redirect HTTP to HTTPS request when using dual protocol.
@@ -53,6 +56,7 @@ record HttpToHttpsRedirectHandler(
         NettyHttpRequest<?> strippedRequest = new NettyHttpRequest<>(request, body, ctx, conversionService, serverConfiguration);
 
         UriBuilder uriBuilder = UriBuilder.of(hostResolver.resolve(strippedRequest));
+        String rawQuery = strippedRequest.getUri().getRawQuery();
         strippedRequest.release();
         uriBuilder.scheme("https");
         int port = sslConfiguration.getPort();
@@ -63,9 +67,15 @@ record HttpToHttpsRedirectHandler(
         }
         uriBuilder.path(strippedRequest.getPath());
 
+        URI location = uriBuilder.build();
+        if (StringUtils.isNotEmpty(rawQuery)) {
+            // UriBuilder only models decoded query parameters, so append the original query string verbatim
+            location = URI.create(location.toASCIIString() + "?" + rawQuery);
+        }
+
         outboundAccess.closeAfterWrite();
         outboundAccess.write(
-            NettyHttpResponseBuilder.toHttpResponse(HttpResponse.permanentRedirect(uriBuilder.build())),
+            NettyHttpResponseBuilder.toHttpResponse(HttpResponse.permanentRedirect(location)),
                 NettyByteBodyFactory.empty()
         );
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpToHttpsRedirectHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpToHttpsRedirectHandler.java
@@ -18,7 +18,9 @@ package io.micronaut.http.server.netty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.body.CloseableByteBody;
 import io.micronaut.http.netty.NettyHttpResponseBuilder;
 import io.micronaut.http.netty.body.NettyByteBodyFactory;
@@ -30,8 +32,6 @@ import io.micronaut.http.ssl.ServerSslConfiguration;
 import io.micronaut.http.uri.UriBuilder;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
-
-import java.net.URI;
 
 /**
  * Handler to automatically redirect HTTP to HTTPS request when using dual protocol.
@@ -55,9 +55,13 @@ record HttpToHttpsRedirectHandler(
     public void accept(ChannelHandlerContext ctx, HttpRequest request, CloseableByteBody body, OutboundAccess outboundAccess) {
         NettyHttpRequest<?> strippedRequest = new NettyHttpRequest<>(request, body, ctx, conversionService, serverConfiguration);
 
-        UriBuilder uriBuilder = UriBuilder.of(hostResolver.resolve(strippedRequest));
+        // read everything that is needed off the request before releasing it
+        String host = hostResolver.resolve(strippedRequest);
+        String path = strippedRequest.getPath();
         String rawQuery = strippedRequest.getUri().getRawQuery();
         strippedRequest.release();
+
+        UriBuilder uriBuilder = UriBuilder.of(host);
         uriBuilder.scheme("https");
         int port = sslConfiguration.getPort();
         if (port == 443) {
@@ -65,17 +69,19 @@ record HttpToHttpsRedirectHandler(
         } else {
             uriBuilder.port(port);
         }
-        uriBuilder.path(strippedRequest.getPath());
+        uriBuilder.path(path);
 
-        URI location = uriBuilder.build();
+        StringBuilder location = new StringBuilder(uriBuilder.build().toASCIIString());
+        // UriBuilder only models decoded query parameters, so the query string is carried over verbatim
+        // and the header value is assembled directly rather than round-tripped through URI again.
         if (StringUtils.isNotEmpty(rawQuery)) {
-            // UriBuilder only models decoded query parameters, so append the original query string verbatim
-            location = URI.create(location.toASCIIString() + "?" + rawQuery);
+            location.append('?').append(rawQuery);
         }
 
         outboundAccess.closeAfterWrite();
         outboundAccess.write(
-            NettyHttpResponseBuilder.toHttpResponse(HttpResponse.permanentRedirect(location)),
+            NettyHttpResponseBuilder.toHttpResponse(
+                HttpResponse.status(HttpStatus.PERMANENT_REDIRECT).header(HttpHeaders.LOCATION, location.toString())),
                 NettyByteBodyFactory.empty()
         );
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpToHttpsRedirectHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpToHttpsRedirectHandler.java
@@ -17,7 +17,6 @@ package io.micronaut.http.server.netty;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -72,9 +71,11 @@ record HttpToHttpsRedirectHandler(
         uriBuilder.path(path);
 
         StringBuilder location = new StringBuilder(uriBuilder.build().toASCIIString());
+        // a null raw query is the only case that means the request target had no query component. An
+        // empty one means it ended in '?', which is a distinct URI form and is reproduced as such.
         // UriBuilder only models decoded query parameters, so the query string is carried over verbatim
         // and the header value is assembled directly rather than round-tripped through URI again.
-        if (StringUtils.isNotEmpty(rawQuery)) {
+        if (rawQuery != null) {
             location.append('?').append(rawQuery);
         }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpToHttpsRedirectHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpToHttpsRedirectHandler.java
@@ -31,6 +31,7 @@ import io.micronaut.http.ssl.ServerSslConfiguration;
 import io.micronaut.http.uri.UriBuilder;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Handler to automatically redirect HTTP to HTTPS request when using dual protocol.
@@ -50,6 +51,20 @@ record HttpToHttpsRedirectHandler(
     HttpHostResolver hostResolver
 ) implements RequestHandler {
 
+    /**
+     * The query component of a request target, verbatim, or {@code null} if it has none. An empty
+     * string means the target ended in {@code ?}.
+     */
+    @Nullable
+    static String rawQuery(String target) {
+        int query = target.indexOf('?');
+        if (query < 0) {
+            return null;
+        }
+        int fragment = target.indexOf('#', query);
+        return fragment < 0 ? target.substring(query + 1) : target.substring(query + 1, fragment);
+    }
+
     @Override
     public void accept(ChannelHandlerContext ctx, HttpRequest request, CloseableByteBody body, OutboundAccess outboundAccess) {
         NettyHttpRequest<?> strippedRequest = new NettyHttpRequest<>(request, body, ctx, conversionService, serverConfiguration);
@@ -57,7 +72,11 @@ record HttpToHttpsRedirectHandler(
         // read everything that is needed off the request before releasing it
         String host = hostResolver.resolve(strippedRequest);
         String path = strippedRequest.getPath();
-        String rawQuery = strippedRequest.getUri().getRawQuery();
+        // Taken from the request target as received rather than from getUri(): for an
+        // absolute-form target (GET http://host/p?q HTTP/1.1, as a proxy may send) the request
+        // URI is rebuilt from decoded components, which turns a percent-encoded reserved character
+        // such as %26 back into a bare & and changes the structure of the query.
+        String rawQuery = rawQuery(request.uri());
         strippedRequest.release();
 
         UriBuilder uriBuilder = UriBuilder.of(host);

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/AlpnHandshakeFailureSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/AlpnHandshakeFailureSpec.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler
+import io.netty.handler.ssl.SslHandshakeCompletionEvent
+import spock.lang.Specification
+
+import javax.net.ssl.SSLHandshakeException
+import java.nio.channels.ClosedChannelException
+
+class AlpnHandshakeFailureSpec extends Specification {
+
+    private static ApplicationContext newContext() {
+        ApplicationContext.run([
+                'micronaut.server.http-version'         : '2.0',
+                'micronaut.ssl.enabled'                 : true,
+                'micronaut.server.ssl.port'             : -1,
+                'micronaut.server.ssl.build-self-signed': true,
+        ])
+    }
+
+    void 'a failed handshake event is forwarded downstream exactly once'() {
+        given:
+        ApplicationContext ctx = newContext()
+        def server = (NettyHttpServer) ctx.getBean(EmbeddedServer)
+        def channel = server.buildEmbeddedChannel(true)
+        def received = []
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            @Override
+            void userEventTriggered(ChannelHandlerContext context, Object evt) {
+                if (evt instanceof SslHandshakeCompletionEvent) {
+                    received.add(evt)
+                }
+                context.fireUserEventTriggered(evt)
+            }
+        })
+        def alpn = channel.pipeline().get(ApplicationProtocolNegotiationHandler)
+        def event = new SslHandshakeCompletionEvent(new SSLHandshakeException('handshake failed'))
+
+        when:
+        alpn.userEventTriggered(channel.pipeline().context(alpn), event)
+
+        then:
+        received == [event]
+
+        cleanup:
+        channel.close()
+        ctx.close()
+    }
+
+    void 'a handshake aborted by a closed channel is not forwarded downstream'() {
+        given:
+        ApplicationContext ctx = newContext()
+        def server = (NettyHttpServer) ctx.getBean(EmbeddedServer)
+        def channel = server.buildEmbeddedChannel(true)
+        def received = []
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            @Override
+            void userEventTriggered(ChannelHandlerContext context, Object evt) {
+                if (evt instanceof SslHandshakeCompletionEvent) {
+                    received.add(evt)
+                }
+                context.fireUserEventTriggered(evt)
+            }
+        })
+        def alpn = channel.pipeline().get(ApplicationProtocolNegotiationHandler)
+        def event = new SslHandshakeCompletionEvent(new ClosedChannelException())
+
+        when:
+        alpn.userEventTriggered(channel.pipeline().context(alpn), event)
+
+        then:
+        received.isEmpty()
+
+        cleanup:
+        channel.close()
+        ctx.close()
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/ChunkedSupportedSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/ChunkedSupportedSpec.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.configuration
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class ChunkedSupportedSpec extends Specification {
+
+    private static String sendChunkedRequest(EmbeddedServer server) {
+        new Socket(server.host, server.port).withCloseable { Socket socket ->
+            socket.soTimeout = 10_000
+            socket.outputStream.write(("POST /chunked-supported HTTP/1.1\r\n" +
+                    "Host: ${server.host}:${server.port}\r\n" +
+                    "Content-Type: text/plain\r\n" +
+                    "Transfer-Encoding: chunked\r\n" +
+                    "Connection: close\r\n" +
+                    "\r\n" +
+                    "5\r\nhello\r\n" +
+                    "0\r\n\r\n").getBytes(StandardCharsets.US_ASCII))
+            socket.outputStream.flush()
+            return new String(socket.inputStream.readAllBytes(), StandardCharsets.ISO_8859_1)
+        }
+    }
+
+    void "chunked request bodies are accepted by default"() {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': 'ChunkedSupportedSpec'
+        ])
+
+        when:
+        String response = sendChunkedRequest(server)
+
+        then:
+        response.startsWith('HTTP/1.1 200 OK')
+        response.contains('echo:hello')
+
+        cleanup:
+        server.stop()
+    }
+
+    void "chunked request bodies are rejected when chunked support is disabled"() {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name'                               : 'ChunkedSupportedSpec',
+                'micronaut.server.netty.chunked-supported': false
+        ])
+
+        when:
+        String response = sendChunkedRequest(server)
+
+        then:
+        response.startsWith('HTTP/1.1 400 Bad Request')
+        !response.contains('echo:hello')
+
+        cleanup:
+        server.stop()
+    }
+
+    @Requires(property = "spec.name", value = "ChunkedSupportedSpec")
+    @Controller('/chunked-supported')
+    static class TestController {
+        @Post(consumes = "text/plain", produces = "text/plain")
+        String echo(@Body String body) {
+            return "echo:" + body
+        }
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/IdleTimeoutPrecisionSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/IdleTimeoutPrecisionSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.configuration
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class IdleTimeoutPrecisionSpec extends Specification {
+
+    void "a sub-second idle timeout closes the connection"() {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name'                    : 'IdleTimeoutPrecisionSpec',
+                'micronaut.server.idle-timeout': '500ms'
+        ])
+
+        when:
+        String response = new Socket(server.host, server.port).withCloseable { Socket socket ->
+            socket.soTimeout = 5_000
+            socket.outputStream.write(("GET /idle-timeout HTTP/1.1\r\n" +
+                    "Host: ${server.host}:${server.port}\r\n" +
+                    "\r\n").getBytes(StandardCharsets.US_ASCII))
+            socket.outputStream.flush()
+            // the keep-alive connection is left idle, so the server is expected to close
+            // it and we read to EOF rather than hitting the socket read timeout
+            return new String(socket.inputStream.readAllBytes(), StandardCharsets.ISO_8859_1)
+        }
+
+        then:
+        response.startsWith('HTTP/1.1 200 OK')
+        response.endsWith('idle')
+
+        cleanup:
+        server.stop()
+    }
+
+    @Requires(property = "spec.name", value = "IdleTimeoutPrecisionSpec")
+    @Controller('/idle-timeout')
+    static class TestController {
+        @Get(produces = "text/plain")
+        String index() {
+            return "idle"
+        }
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/redirect/HttpToHttpsRedirectSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/redirect/HttpToHttpsRedirectSpec.groovy
@@ -88,6 +88,18 @@ class HttpToHttpsRedirectSpec extends Specification {
         location.endsWith('/hello?a=1%2F2&b=x:y@z&c=p,q$r&d=%7Bjson%7D')
     }
 
+    void 'test http to https redirect reproduces the query string of an absolute-form target verbatim'() {
+        given: 'a proxy-style request line whose target carries the authority'
+        int port = (embeddedServer.boundPorts - embeddedServer.port).first() as int
+
+        when: 'the query holds a percent encoded reserved character'
+        String location = redirectLocationOf("http://localhost:${port}/hello?value=a%26b&x=1")
+
+        then: 'it is neither decoded nor re-encoded on the way to the Location header'
+        location.startsWith('https://localhost')
+        location.endsWith('/hello?value=a%26b&x=1')
+    }
+
     /**
      * Sends a request line verbatim so the request target is not normalised by a client, and returns
      * the value of the Location header of the response.

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/redirect/HttpToHttpsRedirectSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/redirect/HttpToHttpsRedirectSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.http.server.netty.redirect
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.io.socket.SocketUtils
 import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
@@ -55,5 +56,17 @@ class HttpToHttpsRedirectSpec extends Specification {
         response.status == HttpStatus.PERMANENT_REDIRECT
         response.header(HttpHeaders.LOCATION).startsWith("https://localhost")
         response.header(HttpHeaders.CONNECTION) == 'close'
+    }
+
+    void 'test http to https redirect retains the query string'() {
+        when:
+        HttpResponse response = httpClient.toBlocking().exchange(HttpRequest.GET('/hello?foo=bar&baz=a%20b'))
+
+        then:
+        response.status == HttpStatus.PERMANENT_REDIRECT
+        def location = URI.create(response.header(HttpHeaders.LOCATION))
+        location.scheme == 'https'
+        location.rawPath == '/hello'
+        location.rawQuery == 'foo=bar&baz=a%20b'
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/redirect/HttpToHttpsRedirectSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/redirect/HttpToHttpsRedirectSpec.groovy
@@ -69,4 +69,43 @@ class HttpToHttpsRedirectSpec extends Specification {
         location.rawPath == '/hello'
         location.rawQuery == 'foo=bar&baz=a%20b'
     }
+
+    void 'test http to https redirect retains an empty query string'() {
+        when: 'the request target ends in "?", which is a query component that happens to be empty'
+        String location = redirectLocationOf('/hello?')
+
+        then: 'the delimiter is kept, because an empty query and an absent query are distinct URI forms'
+        location.startsWith('https://localhost')
+        location.endsWith('/hello?')
+    }
+
+    void 'test http to https redirect reproduces the query string verbatim'() {
+        when: 'the query uses reserved and percent encoded characters'
+        String location = redirectLocationOf('/hello?a=1%2F2&b=x:y@z&c=p,q$r&d=%7Bjson%7D')
+
+        then: 'the Location header carries the original bytes without a decode or re-encode round trip'
+        location.startsWith('https://localhost')
+        location.endsWith('/hello?a=1%2F2&b=x:y@z&c=p,q$r&d=%7Bjson%7D')
+    }
+
+    /**
+     * Sends a request line verbatim so the request target is not normalised by a client, and returns
+     * the value of the Location header of the response.
+     */
+    private String redirectLocationOf(String requestTarget) {
+        int port = (embeddedServer.boundPorts - embeddedServer.port).first() as int
+        new Socket('localhost', port).withCloseable { Socket socket ->
+            socket.soTimeout = 10_000
+            socket.outputStream.with {
+                write("GET ${requestTarget} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n".getBytes('ISO-8859-1'))
+                flush()
+            }
+            String response = new String(socket.inputStream.readAllBytes(), 'ISO-8859-1')
+            assert response.startsWith('HTTP/1.1 308 Permanent Redirect')
+            return response.readLines()
+                    .find { it.toLowerCase(Locale.ROOT).startsWith('location:') }
+                    .substring('location:'.length())
+                    .trim()
+        }
+    }
 }


### PR DESCRIPTION
Four small, independent correctness fixes in the Netty server pipeline setup. Each is a
separate commit with its own regression test.

## Summary

- **Preserve the query string in the HTTP to HTTPS redirect**
  (`HttpToHttpsRedirectHandler`). The redirect target was built from
  `NettyHttpRequest#getPath()`, which returns only the path portion of the request target,
  so `http://host/a?b=1` redirected to `https://host/a` and the client silently lost every
  query parameter it sent. The original raw query is now carried across to the `Location`
  header. `UriBuilder` has no API for setting a raw query string — it only models decoded
  query parameters — so the raw query is appended to the built URI verbatim rather than
  going through a decode/re-encode round trip that would not be byte-for-byte faithful.

- **Apply the configured `chunked-supported` flag to the HTTP/1 codec**
  (`HttpPipelineBuilder#createServerCodec`). `NettyHttpServerConfiguration` exposes
  `micronaut.server.netty.chunked-supported` and
  `NettyHttpServerConfiguration#isChunkedSupported()`, but the value was never read
  anywhere in the codebase: the `HttpServerCodec` was built with the constructor overload
  that leaves chunked support at Netty's default, so setting the property to `false` had no
  effect whatsoever. The codec is now built from an `HttpDecoderConfig` carrying the
  configured value alongside the other decoder limits, so a request that uses chunked
  transfer encoding is rejected with a 400 when the property is disabled. The other decoder
  settings are passed through unchanged.

- **Forward a failed ALPN handshake event downstream only once**
  (`HttpPipelineBuilder#configureForAlpn`). The `ApplicationProtocolNegotiationHandler`
  overrode `userEventTriggered` to filter out handshake failures caused by a
  `ClosedChannelException`. For every other failure cause it called
  `super.userEventTriggered(ctx, evt)` inside the branch and then fell through to the
  unconditional `super` call at the end of the method. Netty's implementation always
  finishes with `ctx.fireUserEventTriggered(evt)`, so downstream handlers saw the same
  `SslHandshakeCompletionEvent` twice. The nested conditions are collapsed into a single
  early return for the closed-channel case so the `super` call happens exactly once.

- **Apply idle timeouts with millisecond precision**
  (`HttpPipelineBuilder#insertIdleStateHandler`). The configured durations were converted
  with `(int) Duration#getSeconds()`, so any sub-second value was truncated to `0`, which
  `IdleStateHandler` interprets as "disabled". A configured `micronaut.server.idle-timeout`
  of `500ms` therefore never fired at all, and `1500ms` was silently applied as `1s`. The
  durations are now passed in milliseconds via the `TimeUnit` overload of
  `IdleStateHandler`, so the configured value is honoured as written. Behaviour for the
  existing whole-second and minute-scale defaults is unchanged.

## Testing

Everything below was run in the foreground on JDK 25.

### New / extended specs

`./gradlew :micronaut-http-server-netty:test --tests '<spec>' -q` for each of:

- `io.micronaut.http.server.netty.redirect.HttpToHttpsRedirectSpec` (extended)
- `io.micronaut.http.server.netty.configuration.ChunkedSupportedSpec` (new)
- `io.micronaut.http.server.netty.AlpnHandshakeFailureSpec` (new)
- `io.micronaut.http.server.netty.configuration.IdleTimeoutPrecisionSpec` (new)

All pass.

### Fail-before evidence

Each test was run against the unmodified base version of the main-source file it covers.

1. `HttpToHttpsRedirectSpec > test http to https redirect retains the query string`:

   ```
   Condition not satisfied:

   location.rawQuery == 'foo=bar&baz=a%20b'
   |        |        |
   |        null     false
   https://localhost/hello
   ```

2. `ChunkedSupportedSpec > chunked request bodies are rejected when chunked support is disabled`:

   ```
   Condition not satisfied:

   response.startsWith('HTTP/1.1 400 Bad Request')
   |        |
   |        false
   HTTP/1.1 200 OK
   date: ...
   content-type: text/plain
   content-length: 10
   connection: close

   echo:hello
   ```

   The companion case (`chunked request bodies are accepted by default`) passes both before
   and after, confirming the default is not changed.

3. `AlpnHandshakeFailureSpec > a failed handshake event is forwarded downstream exactly once`:

   ```
   Condition not satisfied:

   received == [event]
   |        |   |
   |        |   SslHandshakeCompletionEvent(javax.net.ssl.SSLHandshakeException: handshake failed)
   |        false
   [SslHandshakeCompletionEvent(...), SslHandshakeCompletionEvent(...)]
   ```

   The companion case (`a handshake aborted by a closed channel is not forwarded
   downstream`) passes both before and after, confirming the existing filter still works.

4. `IdleTimeoutPrecisionSpec > a sub-second idle timeout closes the connection`: fails with

   ```
   java.net.SocketTimeoutException: Read timed out
       at java.base/java.io.InputStream.readAllBytes(InputStream.java:...)
   ```

   i.e. with `micronaut.server.idle-timeout: 500ms` the idle keep-alive connection was still
   open after the 5s socket read timeout. With the fix the server closes it and the read
   reaches EOF, the whole spec completing in ~2s.

### Full module suite

`./gradlew :micronaut-http-server-netty:test` — **SUCCESS: Executed 1159 tests (19 skipped)**.

Two earlier runs of the full suite on this branch each hit one failure, but a different one
each time, and both passed when re-run in isolation:

- `io.micronaut.http.server.netty.ssl.FileCertificateProviderTest > mtlsRefresh [3] format = PEM`
  (`TLSV1_ALERT_CERTIFICATE_REQUIRED`) — this is a file-watcher-driven certificate reload
  test. It **also fails on the unmodified base**: a full-suite run with both main-source
  files reverted to `origin/5.2.x` and the new specs removed produced
  `1153 tests completed, 1 failed` with exactly this failure. Pre-existing flake, unrelated
  to this PR.
- `io.micronaut.http.server.netty.websocket.BinaryWebSocketSpec > test binary websocket exchange`
  (`PollingConditions` timeout after 15s) — passes in isolation and did not recur.

### Checkstyle

`./gradlew :micronaut-http-server-netty:checkstyleMain :micronaut-http-server-netty:checkstyleTest -q`
reports only the pre-existing `NettyHttpServerConfiguration.java` `FileLength` violation
(2,021 lines, max 2,000), which this PR does not touch. No new violations.

## Out of scope

- `HttpToHttpsRedirectHandler` still constructs a full `NettyHttpRequest` purely so it can
  call `HttpHostResolver#resolve`. Avoiding it is not a small change: `HttpHostResolver`
  takes a `io.micronaut.http.HttpRequest` and `DefaultHttpHostResolver` reads both
  `getHeaders()` (for `Host`, forwarded-proto/host/port and the configured host-resolution
  headers) and `getUri()` off it, so removing the construction would mean introducing a
  separate lightweight `HttpRequest` adapter over the raw Netty request. Left as is
  deliberately, to keep this PR to the redirect-target bug.

- `insertIdleStateHandler` schedules all three `IdleStateHandler` timers, but the HTTP
  connection handlers (`PipeliningServerHandler`, `Http2ServerHandler`) only act on
  `IdleState.ALL_IDLE`; `READ_IDLE` and `WRITE_IDLE` events are ignored there. They are not
  entirely unconsumed — `NettyServerWebSocketHandler` reacts to *any* `IdleStateEvent` by
  sending a `GOING_AWAY` close frame — so `micronaut.server.read-idle-timeout` and
  `write-idle-timeout` do have an effect on WebSocket connections and none on plain HTTP
  ones. That asymmetry is left alone here; this PR only changes the precision with which all
  three configured values are applied.

- `micronaut.server.netty.chunked-supported` only affects the HTTP/1 request decoder, since
  chunked transfer encoding is an HTTP/1-only framing. No attempt was made to give it an
  HTTP/2 or HTTP/3 meaning, and its javadoc was not expanded because
  `NettyHttpServerConfiguration.java` is already over the checkstyle `FileLength` limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
