### PR TITLE
Only look up introspections in a class loader that shares the core types

### DIFF
--- a/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
+++ b/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
@@ -233,7 +233,8 @@ class DefaultBeanIntrospector implements BeanIntrospector {
 
     /**
      * Whether the given class loader resolves {@link BeanIntrospectionReference} to this class' own, so that the
-     * introspections and fallbacks it lists as services can be used here.
+     * introspections and fallbacks it lists as services can be used here. A class loader that fails to answer, as a
+     * restricted or custom class loader may with any runtime exception, is taken as not sharing them.
      *
      * @param otherClassLoader The class loader
      * @return Whether it shares the introspection types of this class
@@ -241,7 +242,7 @@ class DefaultBeanIntrospector implements BeanIntrospector {
     private static boolean sharesBeanIntrospectionReference(ClassLoader otherClassLoader) {
         try {
             return Class.forName(BeanIntrospectionReference.class.getName(), false, otherClassLoader) == BeanIntrospectionReference.class;
-        } catch (ClassNotFoundException | LinkageError e) {
+        } catch (ClassNotFoundException | RuntimeException | LinkageError e) {
             return false;
         }
     }

--- a/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
+++ b/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
@@ -112,7 +112,7 @@ class DefaultBeanIntrospector implements BeanIntrospector {
         ArgumentUtils.requireNonNull("beanType", beanType);
         ClassLoader effectiveClassLoader = resolveClassLoader();
         @SuppressWarnings("unchecked") final BeanIntrospectionReference<T> reference =
-                (BeanIntrospectionReference<T>) findIntrospectionReference(beanType);
+                (BeanIntrospectionReference<T>) findIntrospectionReference(beanType, effectiveClassLoader);
         try {
             if (reference != null) {
                 return Optional.of(reference).map((Function<BeanIntrospectionReference<T>, BeanIntrospection<T>>) ref -> {
@@ -121,21 +121,6 @@ class DefaultBeanIntrospector implements BeanIntrospector {
                     }
                     return ref.load();
                 });
-            }
-            if (useContextClassLoader && Boolean.getBoolean(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER)) {
-                ClassLoader beanClassLoader = beanType.getClassLoader();
-                if (beanClassLoader != null && beanClassLoader != effectiveClassLoader) {
-                    @SuppressWarnings("unchecked") final BeanIntrospectionReference<T> beanClassLoaderReference =
-                            (BeanIntrospectionReference<T>) getIntrospections(beanClassLoader).get(beanType.getName());
-                    if (beanClassLoaderReference != null) {
-                        return Optional.of(beanClassLoaderReference).map((Function<BeanIntrospectionReference<T>, BeanIntrospection<T>>) ref -> {
-                            if (LOG.isDebugEnabled()) {
-                                LOG.debug("Found BeanIntrospection for type: {},", ref.getBeanType());
-                            }
-                            return ref.load();
-                        });
-                    }
-                }
             }
         } catch (Throwable e) {
             throw new IntrospectionException("Error loading BeanIntrospection for type [" + beanType + "]: " + e.getMessage(), e);
@@ -165,16 +150,22 @@ class DefaultBeanIntrospector implements BeanIntrospector {
         return Optional.empty();
     }
 
+    /**
+     * The introspection reference of the class loader the introspections are resolved with, or else of the class loader
+     * of the bean type, which may be a child class loader that the introspector cannot see.
+     * The class loader of the bean type is only asked when it shares this class' {@link BeanIntrospectionReference}:
+     * one that loads Micronaut on its own, as the application class loader does under a test harness that runs Micronaut
+     * in a class loader of its own, has introspections that cannot be cast to it, and a type from there is a lookup miss.
+     */
     @Nullable
-    private BeanIntrospectionReference<Object> findIntrospectionReference(Class<?> beanType) {
+    private BeanIntrospectionReference<Object> findIntrospectionReference(Class<?> beanType, ClassLoader effectiveClassLoader) {
         String beanTypeName = beanType.getName();
-        BeanIntrospectionReference<Object> reference = getIntrospections().get(beanTypeName);
+        BeanIntrospectionReference<Object> reference = getIntrospections(effectiveClassLoader).get(beanTypeName);
         if (reference != null) {
             return reference;
         }
         ClassLoader beanClassLoader = beanType.getClassLoader();
-        ClassLoader effectiveClassLoader = resolveClassLoader();
-        if (beanClassLoader != null && beanClassLoader != effectiveClassLoader) {
+        if (beanClassLoader != null && beanClassLoader != effectiveClassLoader && sharesBeanIntrospectionReference(beanClassLoader)) {
             return resolveIntrospections(beanClassLoader).get(beanTypeName);
         }
         return null;
@@ -233,11 +224,26 @@ class DefaultBeanIntrospector implements BeanIntrospector {
     private ClassLoader resolveClassLoader() {
         if (useContextClassLoader && Boolean.getBoolean(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER)) {
             ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-            if (contextClassLoader != null) {
+            if (contextClassLoader != null && (contextClassLoader == classLoader || sharesBeanIntrospectionReference(contextClassLoader))) {
                 return contextClassLoader;
             }
         }
         return classLoader;
+    }
+
+    /**
+     * Whether the given class loader resolves {@link BeanIntrospectionReference} to this class' own, so that the
+     * introspections and fallbacks it lists as services can be used here.
+     *
+     * @param otherClassLoader The class loader
+     * @return Whether it shares the introspection types of this class
+     */
+    private static boolean sharesBeanIntrospectionReference(ClassLoader otherClassLoader) {
+        try {
+            return Class.forName(BeanIntrospectionReference.class.getName(), false, otherClassLoader) == BeanIntrospectionReference.class;
+        } catch (ClassNotFoundException | LinkageError e) {
+            return false;
+        }
     }
 
     /**

--- a/core/src/test/java/io/micronaut/core/beans/DefaultBeanIntrospectorTest.java
+++ b/core/src/test/java/io/micronaut/core/beans/DefaultBeanIntrospectorTest.java
@@ -8,18 +8,22 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
+import java.io.File;
 import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,6 +59,91 @@ class DefaultBeanIntrospectorTest {
             } else {
                 System.setProperty(CONTEXT_CLASSLOADER_PROPERTY, previousProperty);
             }
+        }
+    }
+
+    @Test
+    void beanClassLoaderWithItsOwnCoreIsALookupMiss() throws Exception {
+        // the Fn testing harness runs Micronaut in its own class loader while the test types come from the application
+        // class loader, whose introspections implement a BeanIntrospectionReference that is not the one of the introspector
+        Path classesDir = tempDir.resolve("classes");
+        compileChildLoaderIntrospection(classesDir);
+        writeMicronautServiceEntry(classesDir);
+
+        String previousProperty = System.getProperty(CONTEXT_CLASSLOADER_PROPERTY);
+        try (URLClassLoader isolatedCoreClassLoader = isolatedCoreClassLoader();
+             URLClassLoader childClassLoader = new URLClassLoader(new URL[] { classesDir.toUri().toURL() }, getClass().getClassLoader())) {
+            System.clearProperty(CONTEXT_CLASSLOADER_PROPERTY);
+            Class<?> isolatedIntrospector = isolatedCoreClassLoader.loadClass(BeanIntrospector.class.getName());
+            assertNotEquals(BeanIntrospector.class, isolatedIntrospector);
+            Object shared = isolatedIntrospector.getField("SHARED").get(null);
+
+            Class<?> beanType = childClassLoader.loadClass("example.ChildBean");
+            Optional<?> introspection = (Optional<?>) isolatedIntrospector.getMethod("findIntrospection", Class.class).invoke(shared, beanType);
+
+            assertTrue(introspection.isEmpty());
+        } finally {
+            restoreProperty(previousProperty);
+        }
+    }
+
+    @Test
+    void contextClassLoaderWithItsOwnCoreIsIgnored() throws Exception {
+        Path classesDir = tempDir.resolve("classes");
+        compileChildLoaderIntrospection(classesDir);
+        writeMicronautServiceEntry(classesDir);
+
+        Thread thread = Thread.currentThread();
+        ClassLoader previousContextClassLoader = thread.getContextClassLoader();
+        String previousProperty = System.getProperty(CONTEXT_CLASSLOADER_PROPERTY);
+        try (URLClassLoader isolatedCoreClassLoader = isolatedCoreClassLoader();
+             URLClassLoader childClassLoader = new URLClassLoader(new URL[] { classesDir.toUri().toURL() }, getClass().getClassLoader())) {
+            System.setProperty(CONTEXT_CLASSLOADER_PROPERTY, "true");
+            thread.setContextClassLoader(childClassLoader);
+            Class<?> isolatedIntrospector = isolatedCoreClassLoader.loadClass(BeanIntrospector.class.getName());
+            Object shared = isolatedIntrospector.getField("SHARED").get(null);
+
+            Class<?> beanType = childClassLoader.loadClass("example.ChildBean");
+            Optional<?> introspection = (Optional<?>) isolatedIntrospector.getMethod("findIntrospection", Class.class).invoke(shared, beanType);
+            Collection<?> introspectedTypes = (Collection<?>) isolatedIntrospector.getMethod("findIntrospectedTypes", Predicate.class)
+                .invoke(shared, (Predicate<Object>) ref -> true);
+
+            assertTrue(introspection.isEmpty());
+            assertFalse(introspectedTypes.contains(beanType));
+        } finally {
+            thread.setContextClassLoader(previousContextClassLoader);
+            restoreProperty(previousProperty);
+        }
+    }
+
+    /**
+     * A class loader that loads Micronaut core again, from the test class path, apart from the class loader of this test.
+     * Its {@link BeanIntrospector} is initialized with the class loader as the context class loader, since the static
+     * optimizations it initializes are service loaded through the context class loader.
+     */
+    private static URLClassLoader isolatedCoreClassLoader() throws Exception {
+        String[] entries = System.getProperty("java.class.path").split(File.pathSeparator);
+        URL[] urls = new URL[entries.length];
+        for (int i = 0; i < entries.length; i++) {
+            urls[i] = Path.of(entries[i]).toUri().toURL();
+        }
+        URLClassLoader classLoader = new URLClassLoader(urls, ClassLoader.getPlatformClassLoader());
+        Thread thread = Thread.currentThread();
+        ClassLoader previousContextClassLoader = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(classLoader);
+            Class.forName(BeanIntrospector.class.getName(), true, classLoader);
+        } finally {
+            thread.setContextClassLoader(previousContextClassLoader);
+        }
+        return classLoader;
+    }
+
+    private static void restoreProperty(String previousProperty) {
+        if (previousProperty == null) {
+            System.clearProperty(CONTEXT_CLASSLOADER_PROPERTY);
+        } else {
+            System.setProperty(CONTEXT_CLASSLOADER_PROPERTY, previousProperty);
         }
     }
 


### PR DESCRIPTION
Fixes a 5.2.x regression that breaks `micronaut-oracle-cloud`'s `oraclecloud-function-http` module: 15 of its 27 tests fail against core 5.2.1-SNAPSHOT, and all 27 pass against 5.1.11.

## Cause

91da3d2bda ("Use bean classloader for missing introspections") made `DefaultBeanIntrospector.findIntrospectionReference` fall back to service loading every `BeanIntrospectionReference` of the bean type's class loader when the introspector's own class loader has no entry for the type.

The Fn testing harness runs Micronaut in `FnTestingClassLoader`, while test types such as `Person` come from the application class loader. That class loader has its own copy of core. Its `$Person$Introspection` implements a different `BeanIntrospectionReference`, so the cast in `SoftServiceLoader` throws a `ClassCastException`. The exception escapes `findIntrospection`, whose callers expect an empty `Optional` on a miss, and `DefaultRouter` fails to start:

```
SoftServiceLoader$ServiceLoadingException: Failed to load a service: java.lang.ClassCastException: class ...$Person$Introspection cannot be cast to class io.micronaut.core.beans.BeanIntrospectionReference (... loader 'app'; ... loader FnTestingClassLoader)
  at io.micronaut.core.beans.DefaultBeanIntrospector.findIntrospectionReference(DefaultBeanIntrospector.java:178)
  at io.micronaut.web.router.DefaultRouteInfo.<init>(DefaultRouteInfo.java:157)
```

The context class loader under `micronaut.introspections.use.context.classloader` (7fd5b67443) has the same exposure: a context class loader with its own copy of core makes `findIntrospections`, `findIntrospectedTypes` and `findIntrospection` throw.

## Fix

- The bean type's class loader, and the context class loader, are used only when they resolve `BeanIntrospectionReference` to the introspector's own class. Otherwise a type from there is a lookup miss, as it was in 5.1.
- The class loaders the two commits serve still pass that check. Child class loaders like the one in `sharedIntrospectorFallsBackToBeanTypeClassLoader`, and Pyronaut's `AnnotationProcessorClassLoader`, which is child-first only for `io.micronaut.data` processor packages, both delegate core to their parent.
- A system property gate was not an option: the test of 91da3d2bda clears the property.
- The property-gated bean class loader lookup inside `findIntrospection` repeated the one `findIntrospectionReference` already does, so it is removed.
- The iteration order from #13096, safe publication and `BeanIntrospectionFallback` handling are unchanged.

## Tests

`DefaultBeanIntrospectorTest` gains two tests. Each loads core a second time in a separate `URLClassLoader`, which mimics `FnTestingClassLoader`, and uses a bean type whose class loader lists its own introspection:

- `beanClassLoaderWithItsOwnCoreIsALookupMiss`
- `contextClassLoaderWithItsOwnCoreIsIgnored`

Both failed before the fix with the same `ClassCastException` oracle-cloud shows.

Run locally:
- `:micronaut-core:test --tests 'io.micronaut.core.beans.*'`: 4/4, plus `checkstyleMain`
- `:micronaut-inject-groovy:test --tests BeanIntrospectionSpec`: 63/63
- `:micronaut-inject-java-test:test --tests 'io.micronaut.inject.visitor.beans.*'`: 232, 2 skipped
- With `-Ppython-ci`, `:micronaut-inject-python:test`: 125/125
- With `-Ppython-ci`, `:micronaut-inject-python-test:test --tests BeanIntrospectionSpec`: 19/19
- micronaut-oracle-cloud 6.2.x (88f2614e6) against this branch, published as `5.2.1-clfix-SNAPSHOT`: `:micronaut-oraclecloud-function-http:test` runs 27 tests with 0 failures. It had 15 failures on 5.2.x before the fix. The one skipped test is a `@PendingFeature` in `ParameterBindingSpec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
