### PR TITLE
Find beans compiled before their annotation was self-indexed

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -144,6 +144,7 @@ import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -220,9 +221,15 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     private final Map<Argument, Collection<BeanDefinition>> beanCandidateCache = new ConcurrentLinkedHashMap.Builder<Argument, Collection<BeanDefinition>>().maximumWeightedCapacity(30).build();
 
     /**
-     * Whether the compile-time index of a self-indexed annotation holds every bean carrying it, by annotation type.
+     * Whether the compile-time index of a self-indexed annotation holds every bean carrying it, by annotation type,
+     * with the {@link #beanDefinitionsEpoch} it was computed at.
      */
-    private final Map<Argument<?>, Boolean> indexExhaustiveCache = new ConcurrentHashMap<>(5);
+    private final Map<Argument<?>, IndexExhaustiveness> indexExhaustiveCache = new ConcurrentHashMap<>(5);
+
+    /**
+     * Advanced after bean definitions are added, so that an index exhaustiveness computed before is not used.
+     */
+    private final AtomicLong beanDefinitionsEpoch = new AtomicLong();
 
     private final ClassLoader classLoader;
     private final Set<Class<?>> thisInterfaces = CollectionUtils.setOf(
@@ -1757,18 +1764,23 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
      * @return True if the index holds every bean the qualifier selects
      */
     private boolean isIndexExhaustive(Argument<?> indexedArgument, FilteringQualifier<Object> qualifier) {
-        Boolean exhaustive = indexExhaustiveCache.get(indexedArgument);
-        if (exhaustive == null) {
-            exhaustive = Boolean.TRUE;
-            Class<?> indexedType = indexedArgument.getType();
-            for (BeanDefinitionReference<Object> reference : beanDefinitionProvider.getBeanReferences()) {
-                if (!isIndexedBy(reference, indexedType) && qualifier.doesQualify(Object.class, reference)) {
-                    exhaustive = Boolean.FALSE;
-                    break;
-                }
-            }
-            indexExhaustiveCache.put(indexedArgument, exhaustive);
+        long epoch = beanDefinitionsEpoch.get();
+        IndexExhaustiveness cached = indexExhaustiveCache.get(indexedArgument);
+        if (cached != null && cached.epoch() == epoch) {
+            return cached.exhaustive();
         }
+        boolean exhaustive = true;
+        Class<?> indexedType = indexedArgument.getType();
+        for (BeanDefinitionReference<Object> reference : beanDefinitionProvider.getBeanReferences()) {
+            // the qualifier first: few references match it, and getIndexes() reads the annotation metadata of
+            // any reference that was compiled without indexes
+            if (qualifier.doesQualify(Object.class, reference) && !isIndexedBy(reference, indexedType)) {
+                exhaustive = false;
+                break;
+            }
+        }
+        // stored with the epoch read before computing, so a result that raced a registration is never used
+        indexExhaustiveCache.put(indexedArgument, new IndexExhaustiveness(epoch, exhaustive));
         return exhaustive;
     }
 
@@ -1779,6 +1791,15 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             }
         }
         return false;
+    }
+
+    /**
+     * Whether the compile-time index of an annotation holds every bean carrying it.
+     *
+     * @param epoch      The {@link #beanDefinitionsEpoch} it was computed at
+     * @param exhaustive True if the index holds every bean carrying the annotation
+     */
+    private record IndexExhaustiveness(long epoch, boolean exhaustive) {
     }
 
     @Override
@@ -1811,7 +1832,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     public <B> BeanContext registerBeanDefinition(RuntimeBeanDefinition<B> definition) {
         beanDefinitionProvider.addBeanDefinition(definition);
         purgeCacheForBeanDefinition(definition);
-        indexExhaustiveCache.clear();
+        beanDefinitionsEpoch.incrementAndGet();
         if (CustomScope.class.isAssignableFrom(definition.getBeanType())) {
             // a bean of this scope resolved earlier left the scope's absence recorded in the registry
             customScopeRegistry.invalidate();
@@ -4123,6 +4144,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (configured.compareAndSet(false, true)) {
             readAllBeanConfigurations();
             beanDefinitionProvider.initialize(this);
+            // an index exhaustiveness computed before the bean definitions were read does not hold for them
+            beanDefinitionsEpoch.incrementAndGet();
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -219,6 +219,11 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     private final Map<Argument, Collection<BeanDefinition>> beanCandidateCache = new ConcurrentLinkedHashMap.Builder<Argument, Collection<BeanDefinition>>().maximumWeightedCapacity(30).build();
 
+    /**
+     * Whether the compile-time index of a self-indexed annotation holds every bean carrying it, by annotation type.
+     */
+    private final Map<Argument<?>, Boolean> indexExhaustiveCache = new ConcurrentHashMap<>(5);
+
     private final ClassLoader classLoader;
     private final Set<Class<?>> thisInterfaces = CollectionUtils.setOf(
         BeanDefinitionRegistry.class,
@@ -487,6 +492,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             beanCandidateCache.clear();
             beanProxyTargetCache.clear();
             containsBeanCache.clear();
+            indexExhaustiveCache.clear();
             beanConfigurations.clear();
             disabledConfigurations.clear();
             singletonScope.clear();
@@ -1716,7 +1722,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (qualifier instanceof FilteringQualifier<Object> filteringQualifier) {
             @SuppressWarnings("unchecked")
             Argument<Object> indexedArgument = (Argument<Object>) filteringQualifier.getIndexedArgument();
-            if (indexedArgument != null) {
+            if (indexedArgument != null && isIndexExhaustive(indexedArgument, filteringQualifier)) {
                 // the compile-time index holds every bean this qualifier selects, so there is nothing to filter
                 return getBeanDefinitions(indexedArgument);
             }
@@ -1738,6 +1744,41 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
         filterReplacedBeans(candidates);
         return candidates;
+    }
+
+    /**
+     * Whether every bean the qualifier selects is indexed by the annotation type it reports. A bean compiled
+     * before that annotation was indexed by itself carries the annotation without the index, as every module
+     * released against an earlier version does, so only filtering every reference finds it. That is checked
+     * once per annotation type, and the index is taken only when no such bean is present.
+     *
+     * @param indexedArgument The type the qualifier reports the beans it selects are indexed by
+     * @param qualifier       The qualifier
+     * @return True if the index holds every bean the qualifier selects
+     */
+    private boolean isIndexExhaustive(Argument<?> indexedArgument, FilteringQualifier<Object> qualifier) {
+        Boolean exhaustive = indexExhaustiveCache.get(indexedArgument);
+        if (exhaustive == null) {
+            exhaustive = Boolean.TRUE;
+            Class<?> indexedType = indexedArgument.getType();
+            for (BeanDefinitionReference<Object> reference : beanDefinitionProvider.getBeanReferences()) {
+                if (!isIndexedBy(reference, indexedType) && qualifier.doesQualify(Object.class, reference)) {
+                    exhaustive = Boolean.FALSE;
+                    break;
+                }
+            }
+            indexExhaustiveCache.put(indexedArgument, exhaustive);
+        }
+        return exhaustive;
+    }
+
+    private static boolean isIndexedBy(BeanDefinitionReference<?> reference, Class<?> indexedType) {
+        for (Class<?> index : reference.getIndexes()) {
+            if (index == indexedType) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -1770,6 +1811,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     public <B> BeanContext registerBeanDefinition(RuntimeBeanDefinition<B> definition) {
         beanDefinitionProvider.addBeanDefinition(definition);
         purgeCacheForBeanDefinition(definition);
+        indexExhaustiveCache.clear();
         if (CustomScope.class.isAssignableFrom(definition.getBeanType())) {
             // a bean of this scope resolved earlier left the scope's absence recorded in the registry
             customScopeRegistry.invalidate();
@@ -1973,6 +2015,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         beanCandidateCache.clear();
         beanConcreteCandidateCache.clear();
         singletonBeanRegistrations.clear();
+        indexExhaustiveCache.clear();
     }
 
     /**

--- a/management/src/test/groovy/io/micronaut/management/endpoint/NotRecompiledEndpointSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/NotRecompiledEndpointSpec.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultBeanDefinitionsProvider
+import io.micronaut.context.env.Environment
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.management.endpoint.annotation.Endpoint
+import io.micronaut.management.endpoint.annotation.Read
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * {@code @Endpoint} became {@code @Indexed(Endpoint)} in 5.2, so an endpoint compiled against an earlier
+ * version has no {@code Endpoint} index in its bean definition reference. Every released module that
+ * ships an endpoint, such as the metrics endpoint of micronaut-micrometer, is compiled that way, and
+ * resolving endpoints from the index alone lost them: their routes answered 404.
+ */
+class NotRecompiledEndpointSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer server = startServer()
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = server.applicationContext.createBean(HttpClient, server.URL)
+
+    void "test the reference is shaped like one compiled before @Endpoint was indexed"() {
+        expect:
+        BeanDefinitionReference reference = server.applicationContext.beanDefinitionReferences.find { it instanceof NotIndexedReference }
+        reference.beanType == NotRecompiled
+        !(Endpoint in reference.indexes)
+    }
+
+    void "test an endpoint without the index is still enumerated by its stereotype"() {
+        expect:
+        NotRecompiled in server.applicationContext.getBeanDefinitions(Qualifiers.byStereotype(Endpoint))*.beanType
+    }
+
+    void "test an endpoint without the index still has its route"() {
+        when:
+        def response = client.toBlocking().exchange("/not-recompiled", String)
+
+        then:
+        response.code() == HttpStatus.OK.code
+        response.body() == 'not recompiled'
+    }
+
+    private static EmbeddedServer startServer() {
+        ApplicationContext context = ApplicationContext.builder(Environment.TEST)
+                .beanDefinitionsProvider { ClassLoader classLoader ->
+                    NotIndexedReference.wrap(new DefaultBeanDefinitionsProvider().provide(classLoader), NotRecompiled, Endpoint)
+                }
+                .start()
+        return context.getBean(EmbeddedServer).start()
+    }
+}
+
+@Endpoint(id = 'notRecompiled', defaultSensitive = false)
+class NotRecompiled {
+
+    @Read
+    String value() {
+        'not recompiled'
+    }
+}

--- a/management/src/test/groovy/io/micronaut/management/endpoint/RuntimeRegisteredEndpointLookupSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/RuntimeRegisteredEndpointLookupSpec.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.RuntimeBeanDefinition
+import io.micronaut.context.env.Environment
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.annotation.MutableAnnotationMetadata
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.management.endpoint.annotation.Endpoint
+import spock.lang.Specification
+
+import java.util.function.Supplier
+
+/**
+ * Whether the compile-time index holds every endpoint is remembered once it is known, so a bean definition
+ * registered afterwards that carries {@code @Endpoint} without the index has to invalidate it.
+ */
+class RuntimeRegisteredEndpointLookupSpec extends Specification {
+
+    void "test an endpoint registered without the index after the index answered is still found"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(Environment.TEST)
+
+        when: 'every endpoint is indexed, so the index answers and that is remembered'
+        Collection<BeanDefinition<?>> before = context.getBeanDefinitions(Qualifiers.byStereotype(Endpoint))
+
+        then:
+        !before.isEmpty()
+        !(RuntimeEndpoint in before*.beanType)
+
+        when: 'a definition that carries @Endpoint but not its index is registered'
+        MutableAnnotationMetadata metadata = new MutableAnnotationMetadata()
+        metadata.addDeclaredAnnotation(Endpoint.name, [id: 'runtime'])
+        RuntimeBeanDefinition<RuntimeEndpoint> definition = RuntimeBeanDefinition.builder(RuntimeEndpoint, { new RuntimeEndpoint() } as Supplier<RuntimeEndpoint>)
+                .annotationMetadata(metadata)
+                .build()
+        context.registerBeanDefinition(definition)
+        Collection<BeanDefinition<?>> after = context.getBeanDefinitions(Qualifiers.byStereotype(Endpoint))
+
+        then: 'it carries no index, so it is only found by filtering every definition'
+        definition.annotationMetadata.hasStereotype(Endpoint)
+        !(Endpoint in definition.indexes)
+        RuntimeEndpoint in after*.beanType
+
+        and: 'every endpoint found before is still found'
+        after*.beanType.containsAll(before*.beanType)
+
+        cleanup:
+        context.close()
+    }
+}
+
+class RuntimeEndpoint {
+}

--- a/management/src/test/java/io/micronaut/management/endpoint/NotIndexedReference.java
+++ b/management/src/test/java/io/micronaut/management/endpoint/NotIndexedReference.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanDefinitionReference;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A bean definition reference as the processor emitted it before an annotation the bean carries was
+ * indexed by itself: the same reference, without that index.
+ *
+ * @param <T> The bean type
+ */
+public final class NotIndexedReference<T> implements BeanDefinitionReference<T> {
+
+    private final BeanDefinitionReference<T> delegate;
+    private final Class<?> withoutIndex;
+
+    public NotIndexedReference(BeanDefinitionReference<T> delegate, Class<?> withoutIndex) {
+        this.delegate = delegate;
+        this.withoutIndex = withoutIndex;
+    }
+
+    /**
+     * Replaces the reference of the given bean with one that is not indexed by the given type. Matched by
+     * definition name, so the other references are not introspected.
+     *
+     * @param references The references
+     * @param beanType The bean whose reference to replace
+     * @param withoutIndex The index to drop
+     * @return The references
+     */
+    public static List<BeanDefinitionReference<?>> wrap(List<BeanDefinitionReference<?>> references, Class<?> beanType, Class<?> withoutIndex) {
+        String definitionName = beanType.getPackageName() + ".$" + beanType.getSimpleName() + "$Definition";
+        List<BeanDefinitionReference<?>> result = new ArrayList<>(references.size());
+        for (BeanDefinitionReference<?> reference : references) {
+            result.add(reference.getBeanDefinitionName().equals(definitionName) ? new NotIndexedReference<>(reference, withoutIndex) : reference);
+        }
+        return result;
+    }
+
+    @Override
+    public Class<?>[] getIndexes() {
+        return Arrays.stream(delegate.getIndexes()).filter(type -> type != withoutIndex).toArray(Class<?>[]::new);
+    }
+
+    @Override
+    public String getBeanDefinitionName() {
+        return delegate.getBeanDefinitionName();
+    }
+
+    @Override
+    public BeanDefinition<T> load() {
+        return delegate.load();
+    }
+
+    @Override
+    public BeanDefinition<T> load(BeanContext context) {
+        return delegate.load(context);
+    }
+
+    @Override
+    public boolean isPresent() {
+        return delegate.isPresent();
+    }
+
+    @Override
+    public boolean isContextScope() {
+        return delegate.isContextScope();
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return delegate.isSingleton();
+    }
+
+    @Override
+    public boolean isConfigurationProperties() {
+        return delegate.isConfigurationProperties();
+    }
+
+    @Override
+    public boolean isProxiedBean() {
+        return delegate.isProxiedBean();
+    }
+
+    @Override
+    public boolean isProxyTarget() {
+        return delegate.isProxyTarget();
+    }
+
+    @Override
+    public boolean isParallel() {
+        return delegate.isParallel();
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return delegate.isPrimary();
+    }
+
+    @Override
+    public boolean requiresMethodProcessing() {
+        return delegate.requiresMethodProcessing();
+    }
+
+    @Override
+    public Class<T> getBeanType() {
+        return delegate.getBeanType();
+    }
+
+    @Override
+    public Set<Class<?>> getExposedTypes() {
+        return delegate.getExposedTypes();
+    }
+
+    @Override
+    public boolean isEnabled(BeanContext context, BeanResolutionContext resolutionContext) {
+        return delegate.isEnabled(context, resolutionContext);
+    }
+
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        return delegate.getAnnotationMetadata();
+    }
+}


### PR DESCRIPTION
Part of #13110.

## Problem

Since #12960, `@Endpoint`, `@ServerWebSocket`, `@FunctionBean` and `@MessageListener` are `@Indexed` by themselves, and `getBeanDefinitions(Qualifiers.byStereotype(X))` answers from that compile-time index instead of filtering every bean definition reference.

The index is only complete for beans compiled after the annotation became self-indexed. A bean compiled against 5.1 carries `@Endpoint` in its annotation metadata but has no `Endpoint` in `getIndexes()`. Every released module that ships an endpoint is built that way, so on 5.2 those beans are dropped from the lookup. `AbstractEndpointRouteBuilder` never registers their routes.

micronaut-micrometer 6.0.2's `MetricsEndpoint` is one of them (its `$MetricsEndpoint$Definition` has no `$INDEXES` field). With micronaut-sql 7.2.x on core 5.2.x, `GET /metrics` returns `404 Not Found`, which fails every feature of `DataSourcePoolMetadataSpec` in jdbc-hikari, jdbc-tomcat, jdbc-dbcp and jdbc-ucp. `git bisect` points at d44e268e3b (#12960).

## Fix

`DefaultBeanContext` takes the index for a self-indexed qualifier only when it is exhaustive: no bean definition reference carries the stereotype without the index. That is checked once per annotation type, on the first lookup, and cached. The cache is cleared when a bean definition is registered at runtime and when the context closes. If a not-recompiled bean is present, the lookup falls back to the scan it used before #12960, which answers in the same reference order.

A context where everything is recompiled keeps the index for every lookup after the first. Enumeration by `@Indexed` marker for beans that do not implement it, and the `isInjectableCandidate` filtering, are unchanged.

## Tests

`NotRecompiledEndpointSpec` (management) wraps the reference of a test `@Endpoint` so it reports no `Endpoint` index, as a 5.1-compiled reference does, and asserts the endpoint is still enumerated by its stereotype and its route answers.

- origin/5.2.x without the fix: fails (stereotype lookup misses the bean, route answers 404)
- 0a7c9cfdb1 (before #12960): passes
- with the fix: passes

Also run with the fix, all passing: every spec #12960 added (`FunctionBeanIndexedLookupSpec`, `CustomScopeReentrancySpec`, `FactoryIndexLeakSpec`, `IndexedByVisitorSpec`, `NonIndexedStereotypeLookupSpec`, `SelfIndexedAnnotationSpec`, `SelfIndexedInheritanceSpec`, `EndpointIndexedLookupSpec`, `MessageListenerIndexedLookupSpec`), plus the full `:micronaut-inject-java:test` (5278 tests, 0 failures, 9 skipped) and `:micronaut-management:test` (162 tests, 0 failures).

## Verified against micronaut-sql

micronaut-sql 7.2.x (1e2569c97) was built against this branch published as `5.2.1-metricsfix-SNAPSHOT`, with the released micronaut-micrometer-core 6.0.2 on the classpath:

- `:micronaut-jdbc-hikari:test --tests '*DataSourcePoolMetadataSpec'`: 20/20 (was 0/20)
- `:micronaut-jdbc-tomcat:test`: 36 tests, 0 failures
- `:micronaut-jdbc-dbcp:test`: 32 tests, 0 failures
- `:micronaut-jdbc-ucp:test`: 43 tests, 0 failures, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
