### PR TITLE
Send a streamed element and its separator as one message

### DIFF
--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/StreamingResponseBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/StreamingResponseBenchmark.java
@@ -1,0 +1,204 @@
+package io.micronaut.http.server.stack;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.server.netty.NettyHttpServer;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import reactor.core.publisher.Flux;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark for streaming a {@link Flux} of many small records out of the server, both as a JSON
+ * array and as a JSON stream.
+ */
+public class StreamingResponseBenchmark {
+    private static final int COUNT = 200;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .include(StreamingResponseBenchmark.class.getName() + ".*")
+            .warmupIterations(5)
+            .measurementIterations(5)
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.MICROSECONDS)
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void test(Holder holder) {
+        ByteBuf response = holder.exchange();
+        if (!holder.responseBytes.equals(response)) {
+            throw new AssertionError("Response did not match");
+        }
+        response.release();
+    }
+
+    @State(Scope.Thread)
+    public static class Holder {
+        @Param
+        Request request;
+
+        ApplicationContext ctx;
+        EmbeddedChannel channel;
+        ByteBuf requestBytes;
+        ByteBuf responseBytes;
+
+        @Setup
+        public void setUp(Blackhole blackhole) {
+            ctx = ApplicationContext.run(Map.of(
+                "spec.name", "StreamingResponseBenchmark",
+                "micronaut.server.date-header", false // disabling this makes the response identical each time
+            ));
+            ctx.registerSingleton(Blackhole.class, blackhole);
+            EmbeddedServer server = ctx.getBean(EmbeddedServer.class);
+            channel = ((NettyHttpServer) server).buildEmbeddedChannel(false);
+
+            EmbeddedChannel clientChannel = new EmbeddedChannel();
+            clientChannel.pipeline().addLast(new HttpClientCodec());
+            clientChannel.pipeline().addLast(new HttpObjectAggregator(1024 * 1024));
+
+            clientChannel.writeOutbound(request.request());
+            clientChannel.flushOutbound();
+
+            requestBytes = NettyUtil.readAllOutboundContiguous(clientChannel);
+
+            // sanity check: run req/resp once and see that the response is correct
+            responseBytes = exchange();
+            clientChannel.writeInbound(responseBytes.retainedDuplicate());
+            FullHttpResponse response = clientChannel.readInbound();
+            request.verifyResponse(response);
+            response.release();
+        }
+
+        ByteBuf exchange() {
+            channel.writeInbound(requestBytes.retainedDuplicate());
+            channel.runPendingTasks();
+            return NettyUtil.readAllOutboundComposite(channel);
+        }
+
+        @TearDown
+        public void tearDown() {
+            ctx.close();
+            requestBytes.release();
+            responseBytes.release();
+        }
+    }
+
+    public enum Request {
+        /**
+         * A {@link Flux} of {@value COUNT} records rendered as a single JSON array.
+         */
+        JSON_STREAM_RESPONSE {
+            @Override
+            FullHttpRequest request() {
+                FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/streaming-benchmark/records");
+                request.headers().add(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON);
+                return request;
+            }
+
+            @Override
+            void verifyResponse(FullHttpResponse response) {
+                Assertions.assertEquals(HttpResponseStatus.OK, response.status());
+                String body = response.content().toString(StandardCharsets.UTF_8);
+                Assertions.assertTrue(body.startsWith("[{\"id\":0,"), body.substring(0, Math.min(64, body.length())));
+                Assertions.assertTrue(body.endsWith("}]"), body.substring(Math.max(0, body.length() - 64)));
+            }
+        },
+        /**
+         * A {@link Flux} of {@value COUNT} records rendered as a JSON stream.
+         */
+        JSON_STREAM_RESPONSE_NDJSON {
+            @Override
+            FullHttpRequest request() {
+                FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/streaming-benchmark/records-stream");
+                request.headers().add(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON_STREAM);
+                return request;
+            }
+
+            @Override
+            void verifyResponse(FullHttpResponse response) {
+                Assertions.assertEquals(HttpResponseStatus.OK, response.status());
+                String body = response.content().toString(StandardCharsets.UTF_8);
+                Assertions.assertTrue(body.startsWith("{\"id\":0,"), body.substring(0, Math.min(64, body.length())));
+            }
+        };
+
+        abstract FullHttpRequest request();
+
+        abstract void verifyResponse(FullHttpResponse response);
+    }
+
+    /**
+     * A small record, as would be returned from a paged database query.
+     *
+     * @param id      The id
+     * @param message The message
+     * @param value   The value
+     */
+    public record Rec(int id, String message, long value) {
+    }
+
+    @Singleton
+    @Controller("/streaming-benchmark")
+    @Requires(property = "spec.name", value = "StreamingResponseBenchmark")
+    public static class StreamController {
+        private final List<Rec> records;
+
+        StreamController() {
+            List<Rec> list = new ArrayList<>(COUNT);
+            for (int i = 0; i < COUNT; i++) {
+                list.add(new Rec(i, "message-" + i, i * 31L));
+            }
+            this.records = List.copyOf(list);
+        }
+
+        @Get("/records")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Flux<Rec> records() {
+            return Flux.fromIterable(records);
+        }
+
+        @Get("/records-stream")
+        @Produces(MediaType.APPLICATION_JSON_STREAM)
+        public Flux<Rec> recordsStream() {
+            return Flux.fromIterable(records);
+        }
+    }
+}

--- a/core/src/main/java/io/micronaut/core/io/buffer/LeakTracker.java
+++ b/core/src/main/java/io/micronaut/core/io/buffer/LeakTracker.java
@@ -83,10 +83,15 @@ public interface LeakTracker<T> {
          */
         static <R> R staticInitializer(Supplier<R> supplier) {
             if (LeakTrackerFactoryHolder.nettyAvailable) {
-                return LeakPresenceDetector.staticInitializer(supplier);
-            } else {
-                return supplier.get();
+                try {
+                    return LeakPresenceDetector.staticInitializer(supplier);
+                } catch (LinkageError err) {
+                    // netty is not on the class path. forClass(Class) discovers the same thing, but
+                    // whichever of the two runs first has to survive it.
+                    LeakTrackerFactoryHolder.nettyAvailable = false;
+                }
             }
+            return supplier.get();
         }
     }
 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/body/StreamingNettyByteBody.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/StreamingNettyByteBody.java
@@ -243,13 +243,13 @@ public final class StreamingNettyByteBody extends BaseStreamingByteBody<Streamin
         }
 
         @Override
-        public void add(ReadBuffer rb) {
+        protected boolean addGuarded(ReadBuffer rb, boolean completeAfter) {
             if (!eventLoop.inEventLoop()) {
                 throw new IllegalStateException("Must only be called on event loop");
             }
             adding = true;
             try {
-                super.add(rb);
+                return super.addGuarded(rb, completeAfter);
             } finally {
                 adding = false;
             }

--- a/http-netty/src/main/java/io/micronaut/http/netty/body/StreamingNettyByteBody.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/StreamingNettyByteBody.java
@@ -35,6 +35,7 @@ import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.ResourceLeakTracker;
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -243,7 +244,7 @@ public final class StreamingNettyByteBody extends BaseStreamingByteBody<Streamin
         }
 
         @Override
-        protected boolean addGuarded(ReadBuffer rb, boolean completeAfter) {
+        protected @Nullable List<ReadBuffer> addGuarded(ReadBuffer rb, boolean completeAfter) {
             if (!eventLoop.inEventLoop()) {
                 throw new IllegalStateException("Must only be called on event loop");
             }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyResponseLifecycle.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyResponseLifecycle.java
@@ -36,6 +36,7 @@ import io.micronaut.http.server.ResponseLifecycle;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.util.LeakPresenceDetector;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
@@ -120,9 +121,9 @@ final class NettyResponseLifecycle extends ResponseLifecycle {
         }
 
         @Override
-        protected void forwardComplete() {
-            if (flow.executeNow(super::forwardComplete)) {
-                super.forwardComplete();
+        protected void forwardComplete(@Nullable ReadBuffer trailing) {
+            if (flow.executeNow(() -> super.forwardComplete(trailing))) {
+                super.forwardComplete(trailing);
             }
         }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -1317,6 +1317,31 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
         }
 
         @Override
+        public void addAndComplete(ReadBuffer buf) {
+            if (flow.executeNow(() -> addAndComplete0(buf))) {
+                addAndComplete0(buf);
+            }
+        }
+
+        private void addAndComplete0(ReadBuffer buf) {
+            if (outboundHandler != this || writtenLast || removed) {
+                // not the normal steady state (e.g. the response has not started yet, or the
+                // connection is already gone). those cases are handled by the separate paths.
+                add0(buf);
+                complete0();
+                return;
+            }
+
+            // the final bytes go out as the LastHttpContent that terminates the response, instead
+            // of a content message of their own followed by an empty terminator
+            outboundHandler = null;
+            writeCompressing(new DefaultLastHttpContent(NettyReadBufferFactory.toByteBuf(buf)), true, true);
+            writtenLast = true;
+            requestHandler.responseWritten(outboundAccess.attachment);
+            PipeliningServerHandler.this.writeSome();
+        }
+
+        @Override
         public void error(Throwable t) {
             if (flow.executeNow(() -> error0(t))) {
                 error0(t);

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/StreamingResponseChunkSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/StreamingResponseChunkSpec.groovy
@@ -1,0 +1,239 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.netty.channel.ChannelPipelineCustomizer
+import io.micronaut.http.sse.Event
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.buffer.Unpooled
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelOutboundHandlerAdapter
+import io.netty.channel.ChannelPromise
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.http.HttpContent
+import io.netty.handler.codec.http.LastHttpContent
+import jakarta.inject.Singleton
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Sinks
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+/**
+ * Tests for how a streaming response is split into outbound messages: an element and the separator
+ * in front of it belong in the same message, but an element must never wait for the next one.
+ */
+class StreamingResponseChunkSpec extends Specification {
+
+    private static EmbeddedChannel channel(ApplicationContext ctx, Monitor mon) {
+        def server = (NettyHttpServer) ctx.getBean(EmbeddedServer)
+        def channel = server.buildEmbeddedChannel(false)
+        // outbound messages travel from PipeliningServerHandler towards the head of the pipeline,
+        // so a handler placed before it sees the HttpContents before they are encoded
+        channel.pipeline().addBefore(ChannelPipelineCustomizer.HANDLER_MICRONAUT_INBOUND, "monitor", mon)
+        return channel
+    }
+
+    private static void request(EmbeddedChannel channel, String uri, String accept) {
+        channel.writeInbound(Unpooled.wrappedBuffer(
+                ("GET " + uri + " HTTP/1.1\r\nhost: example.com\r\naccept: " + accept + "\r\n\r\n")
+                        .getBytes(StandardCharsets.UTF_8)))
+        channel.runPendingTasks()
+    }
+
+    def 'a streamed json array sends one content message per element'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'StreamingResponseChunkSpec'])
+        def mon = new Monitor()
+        def channel = channel(ctx, mon)
+
+        when:
+        request(channel, '/streaming-chunks/json', 'application/json')
+
+        then: 'the bytes on the wire are unchanged'
+        mon.contents.join('') == '[1,2,3]'
+
+        and: 'each element travels with the separator in front of it, and the array is closed by the terminating message'
+        mon.contents == ['[1', ',2', ',3', ']']
+        mon.lastContentIndex == 3
+
+        and: 'writes inside a single read cycle share one flush'
+        mon.flushes == 1
+
+        cleanup:
+        channel.finishAndReleaseAll()
+        ctx.close()
+    }
+
+    def 'an asynchronously produced json array element is written and flushed as one message'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'StreamingResponseChunkSpec'])
+        def sink = ctx.getBean(JsonSink).sink
+        def mon = new Monitor()
+        def channel = channel(ctx, mon)
+
+        when:
+        request(channel, '/streaming-chunks/json-async', 'application/json')
+        then: 'nothing is written before the first element'
+        mon.contents.isEmpty()
+
+        when:
+        sink.tryEmitNext(1)
+        channel.runPendingTasks()
+        then: 'the opening bracket and the element are one message and one flush'
+        mon.contents == ['[1']
+        mon.flushes == 1
+
+        when:
+        sink.tryEmitNext(2)
+        channel.runPendingTasks()
+        then: 'the separator and the element are one message and one flush'
+        mon.contents == ['[1', ',2']
+        mon.flushes == 2
+
+        when:
+        sink.tryEmitComplete()
+        channel.runPendingTasks()
+        then: 'the closing bracket is the terminating message'
+        mon.contents == ['[1', ',2', ']']
+        mon.lastContentIndex == 2
+        mon.flushes == 3
+
+        cleanup:
+        channel.finishAndReleaseAll()
+        ctx.close()
+    }
+
+    def 'an empty streamed json array sends a single content message'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'StreamingResponseChunkSpec'])
+        def mon = new Monitor()
+        def channel = channel(ctx, mon)
+
+        when:
+        request(channel, '/streaming-chunks/json-empty', 'application/json')
+
+        then:
+        mon.contents.join('') == '[]'
+        mon.contents == ['[]']
+        mon.lastContentIndex == 0
+
+        cleanup:
+        channel.finishAndReleaseAll()
+        ctx.close()
+    }
+
+    def 'server sent events are not held back waiting for the next one'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'StreamingResponseChunkSpec'])
+        def sink = ctx.getBean(SseSink).sink
+        def mon = new Monitor()
+        def channel = channel(ctx, mon)
+
+        when:
+        request(channel, '/streaming-chunks/sse', MediaType.TEXT_EVENT_STREAM)
+        then: 'nothing is written before the first event'
+        mon.contents.isEmpty()
+
+        when: 'a single event is produced'
+        sink.tryEmitNext(Event.of('one'))
+        channel.runPendingTasks()
+        then: 'it is on the wire and flushed immediately, without waiting for a second event'
+        mon.contents == ['data: one\n\n']
+        mon.flushes == 1
+
+        when:
+        sink.tryEmitNext(Event.of('two'))
+        channel.runPendingTasks()
+        then:
+        mon.contents == ['data: one\n\n', 'data: two\n\n']
+        mon.flushes == 2
+
+        when:
+        sink.tryEmitComplete()
+        channel.runPendingTasks()
+        then:
+        mon.contents == ['data: one\n\n', 'data: two\n\n', '']
+        mon.lastContentIndex == 2
+
+        cleanup:
+        channel.finishAndReleaseAll()
+        ctx.close()
+    }
+
+    static class Monitor extends ChannelOutboundHandlerAdapter {
+        final List<String> contents = []
+        int flushes = 0
+        int lastContentIndex = -1
+
+        @Override
+        void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (msg instanceof HttpContent) {
+                if (msg instanceof LastHttpContent) {
+                    lastContentIndex = contents.size()
+                }
+                contents.add(((HttpContent) msg).content().toString(StandardCharsets.UTF_8))
+            }
+            super.write(ctx, msg, promise)
+        }
+
+        @Override
+        void flush(ChannelHandlerContext ctx) throws Exception {
+            flushes++
+            super.flush(ctx)
+        }
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'StreamingResponseChunkSpec')
+    static class SseSink {
+        final Sinks.Many<Event<String>> sink = Sinks.many().unicast().onBackpressureBuffer()
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'StreamingResponseChunkSpec')
+    static class JsonSink {
+        final Sinks.Many<Integer> sink = Sinks.many().unicast().onBackpressureBuffer()
+    }
+
+    @Singleton
+    @Controller('/streaming-chunks')
+    @Requires(property = 'spec.name', value = 'StreamingResponseChunkSpec')
+    static class StreamController {
+        final SseSink sseSink
+        final JsonSink jsonSink
+
+        StreamController(SseSink sseSink, JsonSink jsonSink) {
+            this.sseSink = sseSink
+            this.jsonSink = jsonSink
+        }
+
+        @Get('/json')
+        @Produces(MediaType.APPLICATION_JSON)
+        Flux<Integer> json() {
+            return Flux.just(1, 2, 3)
+        }
+
+        @Get('/json-async')
+        @Produces(MediaType.APPLICATION_JSON)
+        Flux<Integer> jsonAsync() {
+            return jsonSink.sink.asFlux()
+        }
+
+        @Get('/json-empty')
+        @Produces(MediaType.APPLICATION_JSON)
+        Flux<Integer> jsonEmpty() {
+            return Flux.empty()
+        }
+
+        @Get('/sse')
+        @Produces(MediaType.TEXT_EVENT_STREAM)
+        Flux<Event<String>> sse() {
+            return sseSink.sink.asFlux()
+        }
+    }
+}

--- a/http/src/main/java/io/micronaut/http/body/ConcatenatingSubscriber.java
+++ b/http/src/main/java/io/micronaut/http/body/ConcatenatingSubscriber.java
@@ -155,10 +155,10 @@ public class ConcatenatingSubscriber implements BufferConsumer.Upstream, CoreSub
 
     @Override
     public final void onNext(ByteBody body) {
-        boolean first = this.first;
+        boolean isFirst = this.first;
         this.first = false;
 
-        BufferConsumer.Upstream component = forward(body, first ? separators.beforeFirst : separators.between);
+        BufferConsumer.Upstream component = forward(body, isFirst ? separators.beforeFirst : separators.between);
         if (component == null) {
             return;
         }

--- a/http/src/main/java/io/micronaut/http/body/ConcatenatingSubscriber.java
+++ b/http/src/main/java/io/micronaut/http/body/ConcatenatingSubscriber.java
@@ -29,6 +29,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 /**
  * This is a reactive subscriber that accepts {@link ByteBody}s and concatenates them into a single
@@ -87,30 +88,6 @@ public class ConcatenatingSubscriber implements BufferConsumer.Upstream, CoreSub
         }
     }
 
-    /**
-     * Called before any new {@link ByteBody} component to emit an additional separator.
-     *
-     * @param first {@code true} iff this is the first element (i.e. the start of the output)
-     */
-    private void emitLeadingSeparator(boolean first) {
-        ReadBuffer rb = first ? separators.beforeFirst : separators.between;
-        if (rb != null) {
-            add(rb.duplicate());
-        }
-    }
-
-    /**
-     * Called before after all {@link ByteBody} components to emit additional trailing bytes.
-     *
-     * @param first {@code true} iff this is the first element, i.e. there were no component {@link ByteBody}s
-     */
-    private void emitFinalSeparator(boolean first) {
-        ReadBuffer rb = first ? separators.empty : separators.afterLast;
-        if (rb != null) {
-            add(rb.duplicate());
-        }
-    }
-
     @Override
     public final void onComplete() {
         synchronized (this) {
@@ -120,8 +97,16 @@ public class ConcatenatingSubscriber implements BufferConsumer.Upstream, CoreSub
             }
         }
 
-        emitFinalSeparator(first);
-        forwardComplete();
+        // the trailing separator travels with the completion signal, so that it can be written as
+        // part of the message that terminates the response instead of as a message of its own
+        ReadBuffer trailing = first ? separators.empty : separators.afterLast;
+        if (trailing == null) {
+            forwardComplete(null);
+        } else {
+            ReadBuffer duplicate = trailing.duplicate();
+            onForward(duplicate.readable());
+            forwardComplete(duplicate);
+        }
     }
 
     @Override
@@ -130,18 +115,26 @@ public class ConcatenatingSubscriber implements BufferConsumer.Upstream, CoreSub
     }
 
     /**
-     * Forward the given body to the shared buffer.
+     * Forward the given body to the shared buffer, preceded by the given separator.
      *
      * @param body The body
+     * @param leadingSeparator The separator to emit before the body, or {@code null} for none
      * @return The {@link io.micronaut.http.body.stream.BufferConsumer.Upstream} to control
      * component backpressure, or {@code null} if all bytes were written immediately (as is the
      * case for an {@link AvailableByteBody})
      */
-    protected final BufferConsumer.@Nullable Upstream forward(ByteBody body) {
+    protected final BufferConsumer.@Nullable Upstream forward(ByteBody body, @Nullable ReadBuffer leadingSeparator) {
         if (body instanceof AvailableByteBody abb) {
-            add(abb.toReadBuffer());
+            ReadBuffer element = abb.toReadBuffer();
+            // the separator goes into the same buffer as the element it precedes, so that one
+            // element leads to one buffer downstream (and thus, for a netty response, one HTTP
+            // chunk and one flush) instead of two
+            add(leadingSeparator == null ? element : byteBodyFactory.readBufferFactory().compose(List.of(leadingSeparator.duplicate(), element)));
             complete();
             return null;
+        }
+        if (leadingSeparator != null) {
+            add(leadingSeparator.duplicate());
         }
         try (BaseStreamingByteBody<?> s = byteBodyFactory.toStreaming(body)) {
             return s.primary(this);
@@ -162,10 +155,10 @@ public class ConcatenatingSubscriber implements BufferConsumer.Upstream, CoreSub
 
     @Override
     public final void onNext(ByteBody body) {
-        emitLeadingSeparator(first);
-        first = false;
+        boolean first = this.first;
+        this.first = false;
 
-        BufferConsumer.Upstream component = forward(body);
+        BufferConsumer.Upstream component = forward(body, first ? separators.beforeFirst : separators.between);
         if (component == null) {
             return;
         }
@@ -294,10 +287,17 @@ public class ConcatenatingSubscriber implements BufferConsumer.Upstream, CoreSub
     }
 
     /**
-     * Forward completion to the shared buffer.
+     * Forward completion to the shared buffer, optionally together with a final buffer of trailing
+     * bytes.
+     *
+     * @param trailing The trailing bytes to emit with the completion, or {@code null} for none
      */
-    protected void forwardComplete() {
-        sharedBuffer.complete();
+    protected void forwardComplete(@Nullable ReadBuffer trailing) {
+        if (trailing == null) {
+            sharedBuffer.complete();
+        } else {
+            sharedBuffer.addAndComplete(trailing);
+        }
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/body/ReactiveByteBufferByteBody.java
+++ b/http/src/main/java/io/micronaut/http/body/ReactiveByteBufferByteBody.java
@@ -179,6 +179,11 @@ public final class ReactiveByteBufferByteBody extends BaseStreamingByteBody<Reac
         }
 
         @Override
+        public void addAndComplete(ReadBuffer rb) {
+            submit(() -> super.addAndComplete(rb));
+        }
+
+        @Override
         public void error(Throwable e) {
             submit(() -> super.error(e));
         }

--- a/http/src/main/java/io/micronaut/http/body/stream/BaseSharedBuffer.java
+++ b/http/src/main/java/io/micronaut/http/body/stream/BaseSharedBuffer.java
@@ -336,6 +336,36 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
      */
     @Override
     public void add(ReadBuffer rb) {
+        addGuarded(rb, false);
+    }
+
+    /**
+     * Add a given buffer to this {@link BaseSharedBuffer} and complete it, in one operation. This
+     * allows subscribers that implement {@link BufferConsumer#addAndComplete(ReadBuffer)} to
+     * combine the final bytes and the completion signal into a single downstream message.<br>
+     * Not thread safe, caller must handle concurrency.
+     */
+    @Override
+    public void addAndComplete(ReadBuffer rb) {
+        boolean subscribersCompleted = addGuarded(rb, true);
+        complete0(!subscribersCompleted);
+    }
+
+    /**
+     * Hook for subclasses that need to apply a concurrency guard around the {@link #add} portion
+     * of {@link #add(ReadBuffer)} and {@link #addAndComplete(ReadBuffer)}. Subclasses must call
+     * {@code super.addGuarded(rb, completeAfter)} and return its result.
+     *
+     * @param rb           The buffer to add
+     * @param completeAfter Whether the subscribers should be completed together with this buffer
+     * @return {@code true} iff the subscribers have been completed as part of this call
+     */
+    protected boolean addGuarded(ReadBuffer rb, boolean completeAfter) {
+        return add0(rb, completeAfter);
+    }
+
+    private boolean add0(ReadBuffer rb, boolean completeAfter) {
+        boolean subscribersCompleted = false;
         try (rb) {
             assert !working;
 
@@ -349,7 +379,7 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
 
             // drop messages if we're done with all subscribers
             if (complete || error != null) {
-                return;
+                return false;
             }
             if (expectedLength == -1) {
                 Exception totalSizeException = sizeLimitTrackers.totalSize().add(rb.readable());
@@ -357,14 +387,19 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
                     // for maxBodySize, all subscribers get the error
                     error(totalSizeException);
                     rootUpstream.allowDiscard();
-                    return;
+                    return false;
                 }
             } // else, already checked the Content-Length
 
             working = true;
             if (subscribers != null) {
+                subscribersCompleted = completeAfter;
                 for (BufferConsumer consumer : subscribers) {
-                    consumer.add(rb.duplicate());
+                    if (completeAfter) {
+                        consumer.addAndComplete(rb.duplicate());
+                    } else {
+                        consumer.add(rb.duplicate());
+                    }
                 }
             }
             if (reserved > 0 || fullSubscribers != null) {
@@ -391,6 +426,7 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
             }
             working = false;
         }
+        return subscribersCompleted;
     }
 
     /**
@@ -399,12 +435,16 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
      */
     @Override
     public void complete() {
+        complete0(true);
+    }
+
+    private void complete0(boolean notifySubscribers) {
         if (expectedLength > lengthSoFar) {
             throw new IncorrectContentLengthException("Received fewer bytes than specified by Content-Length");
         }
         complete = true;
         expectedLength = lengthSoFar;
-        if (subscribers != null) {
+        if (notifySubscribers && subscribers != null) {
             for (BufferConsumer subscriber : subscribers) {
                 subscriber.complete();
             }

--- a/http/src/main/java/io/micronaut/http/body/stream/BaseSharedBuffer.java
+++ b/http/src/main/java/io/micronaut/http/body/stream/BaseSharedBuffer.java
@@ -347,8 +347,21 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
      */
     @Override
     public void addAndComplete(ReadBuffer rb) {
-        boolean subscribersCompleted = addGuarded(rb, true);
-        complete0(!subscribersCompleted);
+        // The final bytes are stored and this buffer is marked complete before any streaming
+        // subscriber learns of the completion. A subscriber may consume a reserved split from
+        // inside its completion callback (the servlet integration does), and that consumer has
+        // to find the final bytes in the buffer and a completed state, or it would miss them and
+        // then wait for a completion that is never delivered.
+        List<ReadBuffer> deferred = addGuarded(rb, true);
+        complete0(deferred == null);
+        if (deferred != null) {
+            // a snapshot: a subscriber added reentrantly by a callback below is completed by
+            // subscribe0 itself, since the buffer is complete by now
+            List<BufferConsumer> targets = new ArrayList<>(subscribers);
+            for (int i = 0; i < targets.size(); i++) {
+                targets.get(i).addAndComplete(deferred.get(i));
+            }
+        }
     }
 
     /**
@@ -358,14 +371,18 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
      *
      * @param rb           The buffer to add
      * @param completeAfter Whether the subscribers should be completed together with this buffer
-     * @return {@code true} iff the subscribers have been completed as part of this call
+     * @return With {@code completeAfter}, the copies of {@code rb} still to be delivered to the
+     * streaming subscribers together with their completion, one per subscriber in order, or
+     * {@code null} if there are none to deliver. Always {@code null} without {@code completeAfter}.
      */
-    protected boolean addGuarded(ReadBuffer rb, boolean completeAfter) {
+    @Nullable
+    protected List<ReadBuffer> addGuarded(ReadBuffer rb, boolean completeAfter) {
         return add0(rb, completeAfter);
     }
 
-    private boolean add0(ReadBuffer rb, boolean completeAfter) {
-        boolean subscribersCompleted = false;
+    @Nullable
+    private List<ReadBuffer> add0(ReadBuffer rb, boolean completeAfter) {
+        List<ReadBuffer> deferred = null;
         try (rb) {
             assert !working;
 
@@ -379,7 +396,7 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
 
             // drop messages if we're done with all subscribers
             if (complete || error != null) {
-                return false;
+                return null;
             }
             if (expectedLength == -1) {
                 Exception totalSizeException = sizeLimitTrackers.totalSize().add(rb.readable());
@@ -387,17 +404,20 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
                     // for maxBodySize, all subscribers get the error
                     error(totalSizeException);
                     rootUpstream.allowDiscard();
-                    return false;
+                    return null;
                 }
             } // else, already checked the Content-Length
 
             working = true;
             if (subscribers != null) {
-                subscribersCompleted = completeAfter;
-                for (BufferConsumer consumer : subscribers) {
-                    if (completeAfter) {
-                        consumer.addAndComplete(rb.duplicate());
-                    } else {
+                if (completeAfter) {
+                    // delivered by addAndComplete once the state below is final
+                    deferred = new ArrayList<>(subscribers.size());
+                    for (int i = 0; i < subscribers.size(); i++) {
+                        deferred.add(rb.duplicate());
+                    }
+                } else {
+                    for (BufferConsumer consumer : subscribers) {
                         consumer.add(rb.duplicate());
                     }
                 }
@@ -426,7 +446,7 @@ public abstract class BaseSharedBuffer implements BufferConsumer {
             }
             working = false;
         }
-        return subscribersCompleted;
+        return deferred;
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/body/stream/BufferConsumer.java
+++ b/http/src/main/java/io/micronaut/http/body/stream/BufferConsumer.java
@@ -42,6 +42,21 @@ public interface BufferConsumer {
     void complete();
 
     /**
+     * Send a final buffer to this consumer and signal normal completion of the stream, in one
+     * operation. Ownership of the buffer transfers to the consumer.
+     * <p>This is semantically identical to {@link #add(ReadBuffer)} followed by
+     * {@link #complete()}. Implementations may override it to combine the two into a single
+     * downstream message, e.g. to write the trailing bytes of a response as part of the message
+     * that terminates it.
+     *
+     * @param rb The final buffer
+     */
+    default void addAndComplete(ReadBuffer rb) {
+        add(rb);
+        complete();
+    }
+
+    /**
      * Signal that the upstream has discarded the remaining data, as requested by {@link Upstream#allowDiscard()}.
      */
     default void discard() {

--- a/http/src/test/java/io/micronaut/http/body/ConcatenatingSubscriberReentrancyTest.java
+++ b/http/src/test/java/io/micronaut/http/body/ConcatenatingSubscriberReentrancyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.body;
+
+import io.micronaut.core.io.buffer.ByteArrayBufferFactory;
+import io.micronaut.core.io.buffer.ReadBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A subscriber may consume a reserved split of a body from inside its own completion callback (the
+ * servlet integration does this). That has to hold when the final bytes and the completion arrive
+ * together, as they do for the closing bracket of a JSON array: the buffer must have stored those
+ * bytes and be complete before any subscriber learns of the completion, otherwise the reentrant
+ * consumer misses the final piece and then waits for a completion that is never delivered.
+ */
+class ConcatenatingSubscriberReentrancyTest {
+
+    @Test
+    @Timeout(10)
+    void reentrantConsumptionFromAStreamingCompletionCallbackSeesTheTrailingBytes() throws Exception {
+        ByteBodyFactory bbf = ByteBodyFactory.createDefault(ByteArrayBufferFactory.INSTANCE);
+        Sinks.Many<ByteBody> items = Sinks.many().unicast().onBackpressureBuffer();
+        CompletableFuture<String> result = new CompletableFuture<>();
+        try (CloseableByteBody body = ConcatenatingSubscriber.concatenate(bbf, items.asFlux(), ConcatenatingSubscriber.Separators.JDK_JSON)) {
+            // a streaming consumer of a split, which in its completion callback reads the primary
+            Flux.from(body.split(ByteBody.SplitBackpressureMode.FASTEST).toReadBufferPublisher())
+                .doOnNext(ReadBuffer::close)
+                .doOnComplete(() -> {
+                    try {
+                        result.complete(new String(body.toInputStream().readAllBytes(), StandardCharsets.UTF_8));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                })
+                .doOnError(result::completeExceptionally)
+                .subscribe();
+
+            items.tryEmitNext(bbf.adapt("{}".getBytes(StandardCharsets.UTF_8))).orThrow();
+            // completion arrives together with the closing bracket
+            items.tryEmitComplete().orThrow();
+
+            assertEquals("[{}]", result.get());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `ConcatenatingSubscriber` pushed the `[`, `,` and `]` of a streamed JSON array to the shared
  buffer as `ReadBuffer`s of their own, separate from the element bytes. On the netty side every
  buffer that reaches `StreamingOutboundHandler.add0` becomes its own `DefaultHttpContent` and asks
  for a flush, so a stream of N elements produced **2N+2** outbound messages: a separator message
  and an element message per element, then the closing bracket, then an empty `LastHttpContent`.
  Under chunked transfer encoding that is also a five byte `1\r\n,\r\n` chunk on the wire per
  element. `ConcatenatingSubscriber.forward` now takes the leading separator and, when the element
  is an `AvailableByteBody` (the case for anything the message body writers have already
  serialised), composes the two into one buffer via `ReadBufferFactory.compose`. A streaming
  component body still gets its separator as a separate buffer, as before.
- The trailing bytes now travel with the completion signal rather than as a message of their own.
  `BufferConsumer` gains a default `addAndComplete(ReadBuffer)` that is semantically `add` followed
  by `complete`; `BaseSharedBuffer` forwards it to its subscribers, and
  `PipeliningServerHandler.StreamingOutboundHandler` overrides it to write a
  `DefaultLastHttpContent` carrying those bytes instead of a content message plus an empty
  terminator. Every other `BufferConsumer` inherits the default and behaves exactly as before.
  `BaseSharedBuffer.add` was refactored into `add0(rb, completeAfter)` behind a new
  `addGuarded` hook so that the two subclasses that wrap the add in a concurrency guard
  (`StreamingNettyByteBody.SharedBuffer`'s event-loop check and `ReactiveByteBufferByteBody.SharedBuffer`'s
  `submit`) keep exactly the scope they had.
- Net effect: **N+1** outbound messages instead of 2N+2, and the bytes on the wire are byte for
  byte unchanged (a `DefaultLastHttpContent` carrying `]` encodes to the same `1\r\n]\r\n0\r\n\r\n`
  as a content message plus an empty terminator).

### How the flush-per-item behaviour is preserved

Nothing is ever buffered waiting for a later element:

- The separator that is merged is the one *in front* of the element, which is already known the
  moment the element arrives — the element is written in the same call it would have been before,
  just with one byte of prefix. No element waits for its successor.
- The trailing bytes travel with a completion that has *already happened*, so they add no latency
  either.
- Server-sent events use `Separators.NONE`: `beforeFirst`, `between` and `afterLast` are all
  `null`, so the SSE path takes exactly the same code as before — one buffer, one message, one
  flush per event.

`PipeliningServerHandlerSpec`'s `'streaming responses flush after every item'` feature pins the
contract one level below this change: it feeds raw `ByteBuf`s straight into the response body and
asserts one flush per buffer emitted. That intent is unchanged and the assertion is untouched — the
change is about how many buffers a JSON array element turns into, not about whether a buffer is
flushed when it arrives. The new `StreamingResponseChunkSpec` pins the same guarantee at the level
this change does touch: an SSE event and an asynchronously produced array element each still
produce exactly one message and one flush at the moment they are produced.

## Measurement

`ServerScenariosBenchmark` does not exist on `5.2.x`, so the numbers below come from
`StreamingResponseBenchmark`, added in the second commit of this branch: 200 small records
(`{"id":0,"message":"message-0","value":0}`) streamed through the embedded channel, once as a
single JSON array and once as a JSON stream. Absolute values are therefore not comparable with the
recorded baseline for the equivalent scenarios (309830 ns/op / 335437 B/op and 203672 ns/op /
243590 B/op), but they are the same shape and the comparison below is base against branch in one
session on one machine.

JMH: `-f 1 -wi 5 -w 3s -i 5 -r 3s -t 1 -bm avgt -tu us -prof gc`, three runs each, alternating base
and branch. The 1-minute load average was between 2.47 and 2.97 immediately before every run, and
no java process other than the benchmark itself was running.

Time, us/op (median of three runs; each run's own JMH error in brackets):

| scenario | base | branch | change |
|---|---|---|---|
| JSON array, 200 records | **352.5** (352.0 ±14.0, 352.5 ±5.0, 355.4 ±4.2) | **244.8** (247.9 ±3.5, 229.1 ±3.3, 244.8 ±3.8) | −107.7 us/op, −31% |
| JSON stream, 200 records (control, no separators) | **220.3** (216.5 ±2.4, 220.3 ±13.3, 220.8 ±1.1) | **220.2** (222.2 ±1.2, 220.2 ±1.7, 217.8 ±3.1) | no change |

Allocation, `gc.alloc.rate.norm` in B/op (median of three runs):

| scenario | base | branch | change |
|---|---|---|---|
| JSON array, 200 records | **486660** (486660, 493429, 486637) | **395602** (395702, 395447, 395602) | −91058 B/op, −19% |
| JSON stream, 200 records (control) | **302600** (313503, 298938, 302600) | **299720** (318947, 298925, 299720) | no change |

The array improvement is roughly twelve times the sum of the two error bars, so it is a result. The
JSON stream row is the control: it uses `Separators.NONE`, the code path is untouched, and it does
not move — the spread there is run-to-run noise.

Per element that is about 0.54 us and 455 bytes.

### Outbound message and flush counts

More direct than the timings, measured with an `EmbeddedChannel` and a handler sitting between
`PipeliningServerHandler` and the codec (`StreamingResponseChunkSpec`):

| case | base messages | branch messages | base flushes | branch flushes |
|---|---|---|---|---|
| 3-element JSON array, produced inside the read cycle | 8 (`[`, `1`, `,`, `2`, `,`, `3`, `]`, ``) | 4 (`[1`, `,2`, `,3`, `]`) | 1 | 1 |
| empty JSON array | 2 (`[]`, ``) | 1 (`[]`) | 1 | 1 |
| JSON array, first element produced asynchronously | 2 (`[`, `1`) | 1 (`[1`) | 2 | 1 |
| SSE, per event | 1 | 1 | 1 | 1 |

For N elements that is 2N+2 messages before and N+1 after; at the benchmark's N=200, 402 messages
become 201. Flushes only differ when the element is produced outside a read cycle, because
`PipeliningServerHandler` already defers flushes to `channelReadComplete` while reading — but that
asynchronous case is the normal one for a real reactive endpoint, and there the flushes per element
halve too.

## Testing

New: `http-server-netty/src/test/groovy/io/micronaut/http/server/netty/StreamingResponseChunkSpec.groovy`,
four features — the wire form and message split of a streamed JSON array, an asynchronously
produced array (message and flush per element), an empty array, and an SSE stream where events must
arrive one at a time.

Fail-before evidence, with `http/src/main`, `http-netty` and `http-server-netty/src/main` checked
out at `origin/5.2.x` and the new spec in place:

```
a streamed json array sends one content message per element FAILED
  Condition not satisfied:
  mon.contents == ['[1', ',2', ',3', ']']
  |   [[, 1, ,, 2, ,, 3, ], ]

an asynchronously produced json array element is written and flushed as one message FAILED
  Condition not satisfied:
  mon.contents == ['[1']
  |   [[, 1]

an empty streamed json array sends a single content message FAILED
  Condition not satisfied:
  mon.contents == ['[]']
  |   [[], ]

server sent events are not held back waiting for the next one PASSED
```

The SSE feature passing on both the base and the branch is the point: it is there to pin what must
*not* change.

Ran:

- `./gradlew :micronaut-http:test` — green.
- `./gradlew :micronaut-http-netty:test` — green.
- `./gradlew :micronaut-http-server-netty:test --tests '*Json*' --tests '*Sse*' --tests '*ServerSentEvent*' --tests '*PipeliningServerHandlerSpec*' --tests '*StreamingResponseChunkSpec*'` — green.
- `./gradlew :micronaut-http-server-netty:test` (full) — green, 1138 tests.
- `./gradlew :micronaut-http-client:test` — not a module this change touches, but it consumes
  `BaseSharedBuffer` and `ReactiveByteBufferByteBody`, so it was run for confidence. One failure,
  `ProxyBackpressureTest.backpressureLocal[6] ssl=true version=3 endpoint=/proxy`
  (`AssertionFailedError: expected: <true> but was: <false>` at `ProxyBackpressureTest:124`), a
  timing-sensitive backpressure assertion that ran while the machine was loaded. Re-running
  `--tests '*ProxyBackpressureTest*'` alone passes all six parameterisations.
- `./gradlew :micronaut-http:checkstyleMain :micronaut-http-netty:checkstyleMain :micronaut-http-server-netty:checkstyleMain`
  and the matching `checkstyleTest` tasks, plus `:benchmarks:checkstyleJmh` — no new violations. The
  two reported are pre-existing and in files this branch does not touch
  (`NettyWebSocketSession` DesignForExtension, `NettyHttpServerConfiguration` FileLength).

## Out of scope

- **Bounded look-ahead.** `ConcatenatingSubscriber` still requests the next element only once the
  previous one has been written *and* acknowledged as consumed, so serialisation never overlaps
  with the write. A small look-ahead gated on the channel's write-buffer high-water mark would let
  the two overlap, but it changes the back-pressure contract and belongs in its own change.
- **HTTP/2.** `MultiplexedServerHandler` inherits the default `addAndComplete`, so an h2 response
  still sends the trailing bytes as their own DATA frame followed by an empty end-of-stream frame.
  The separator merge does help there, since it happens above the transport; combining the last
  DATA frame with end-of-stream is a separate change.

## Note on the benchmark in this PR

This PR adds a small `StreamingResponseBenchmark` so the change can be measured on its own. A
broader harness covering the same ground, `ServerScenariosBenchmark`, is proposed separately in
#13112. If that one lands first, the benchmark commit here (`Add a JMH benchmark for streaming a
Flux of records`) can be dropped and the measurement repeated with it; the commit is kept separate
for exactly that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
