### PR TITLE
Serve the registered annotation type to a caller naming no class loader

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -342,14 +342,48 @@ public final class AnnotationMetadataSupport {
      * @return The annotation
      */
     static Optional<Class<? extends Annotation>> getAnnotationType(String name) {
-        // a caller naming no loader has no copy of its own to be served: the registered type is the one the
-        // generated metadata of its deployment registered, and resolving the name again through the loader of
-        // this class would answer the application's copy where a child-first deployment loader defines another
+        // a caller naming no loader is answered for the thread context loader, the loader of the deployment it
+        // runs in, never for the loader of this class: that one sees the application's copy of a type where a
+        // child-first deployment loader defines another
+        final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
         final Class<? extends Annotation> type = ANNOTATION_TYPES.get(name);
         if (type != null) {
-            return Optional.of(type);
+            // the registered type is kept for a context that defines it or sits above the loader defining it,
+            // a thread of the container a deployment runs in; only a context loader apart from it - another
+            // deployment, which may define a copy of its own - resolves the name again
+            if (contextLoader == null || isSelfOrAncestor(contextLoader, type.getClassLoader())) {
+                return Optional.of(type);
+            }
+            return getAnnotationType(name, contextLoader);
         }
-        return getAnnotationType(name, AnnotationMetadataSupport.class.getClassLoader());
+        final ClassLoader ownLoader = AnnotationMetadataSupport.class.getClassLoader();
+        if (contextLoader != null && contextLoader != ownLoader) {
+            final Optional<Class<? extends Annotation>> fromContext = getAnnotationType(name, contextLoader);
+            if (fromContext.isPresent()) {
+                return fromContext;
+            }
+        }
+        return getAnnotationType(name, ownLoader);
+    }
+
+    /**
+     * Whether a loader is the given one or one of the parents it delegates to.
+     *
+     * @param candidate The loader that may be the given one or one of its parents
+     * @param loader    The loader whose parents are walked, {@code null} for the bootstrap loader
+     * @return True if it is
+     */
+    private static boolean isSelfOrAncestor(ClassLoader candidate, @Nullable ClassLoader loader) {
+        if (loader == null) {
+            // the bootstrap loader defines a type no other loader can shadow
+            return true;
+        }
+        for (ClassLoader current = loader; current != null; current = current.getParent()) {
+            if (current == candidate) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -342,6 +342,13 @@ public final class AnnotationMetadataSupport {
      * @return The annotation
      */
     static Optional<Class<? extends Annotation>> getAnnotationType(String name) {
+        // a caller naming no loader has no copy of its own to be served: the registered type is the one the
+        // generated metadata of its deployment registered, and resolving the name again through the loader of
+        // this class would answer the application's copy where a child-first deployment loader defines another
+        final Class<? extends Annotation> type = ANNOTATION_TYPES.get(name);
+        if (type != null) {
+            return Optional.of(type);
+        }
         return getAnnotationType(name, AnnotationMetadataSupport.class.getClassLoader());
     }
 

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationTypeClassLoaderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationTypeClassLoaderSpec.groovy
@@ -39,10 +39,10 @@ class AnnotationTypeClassLoaderSpec extends Specification {
         AnnotationMetadataSupport.getAnnotationType(Portable.name, null).get().is(Portable)
     }
 
-    void "a caller naming no loader is served the type a deployment loader registered"() {
-        given: "a child-first deployment loader defining its own copy of an annotation the application loader also sees"
-        def child = new OwnCopy()
-        def own = child.define(Deployed.name)
+    void "a caller naming no loader is served for the thread context loader"() {
+        given: "a child-first deployment loader under the application loader, defining its own copy of an annotation the application loader also sees"
+        def deployment = new OwnCopy(Deployed.classLoader)
+        def own = deployment.define(Deployed.name)
 
         and: "the generated metadata of that deployment registering its copy"
         AnnotationMetadataSupport.registerAnnotationType(new AnnotationClassValue<>(own))
@@ -51,10 +51,45 @@ class AnnotationTypeClassLoaderSpec extends Specification {
         def metadata = new MutableAnnotationMetadata()
         metadata.addAnnotation(Deployed.name, [:])
 
-        expect: "the registered copy is answered, not the one the loader of the support class resolves again"
+        and: "another deployment defining a copy of its own, which the registry does not hold"
+        def other = new OwnCopy(Deployed.classLoader)
+        def otherOwn = other.define(Deployed.name)
+
+        expect: "the deployment that registered its copy is served that copy, not the one the loader of the support class resolves again"
         !own.is(Deployed)
-        AnnotationMetadataSupport.getAnnotationType(Deployed.name).get().is(own)
-        metadata.getAnnotationType(Deployed.name).get().is(own)
+        withContext(deployment) { AnnotationMetadataSupport.getAnnotationType(Deployed.name).get() }.is(own)
+        withContext(deployment) { metadata.getAnnotationType(Deployed.name).get() }.is(own)
+
+        and: "so is a thread of the application the deployment runs in, whose context loader is a parent of the deployment"
+        withContext(Deployed.classLoader) { AnnotationMetadataSupport.getAnnotationType(Deployed.name).get() }.is(own)
+
+        and: "so is a thread with no context loader"
+        withContext(null) { AnnotationMetadataSupport.getAnnotationType(Deployed.name).get() }.is(own)
+
+        and: "another deployment is served its own copy"
+        withContext(other) { AnnotationMetadataSupport.getAnnotationType(Deployed.name).get() }.is(otherOwn)
+        withContext(other) { metadata.getAnnotationType(Deployed.name).get() }.is(otherOwn)
+    }
+
+    void "a name nothing registered is loaded through the thread context loader first"() {
+        given: "a deployment loader defining its own copy of an annotation nothing registered"
+        def deployment = new OwnCopy()
+        def own = deployment.define(Unregistered.name)
+
+        expect:
+        !own.is(Unregistered)
+        withContext(deployment) { AnnotationMetadataSupport.getAnnotationType(Unregistered.name).get() }.is(own)
+    }
+
+    private static <T> T withContext(ClassLoader loader, Closure<T> action) {
+        def thread = Thread.currentThread()
+        def previous = thread.contextClassLoader
+        thread.contextClassLoader = loader
+        try {
+            return action.call()
+        } finally {
+            thread.contextClassLoader = previous
+        }
     }
 
     void "an annotation type of the JDK is served whatever the loader asks"() {
@@ -70,8 +105,8 @@ class AnnotationTypeClassLoaderSpec extends Specification {
      */
     static class OwnCopy extends ClassLoader {
 
-        OwnCopy() {
-            super(ClassLoader.platformClassLoader)
+        OwnCopy(ClassLoader parent = ClassLoader.platformClassLoader) {
+            super(parent)
         }
 
         Class<?> define(String name) {

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationTypeClassLoaderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationTypeClassLoaderSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.inject.annotation
 
+import io.micronaut.core.annotation.AnnotationClassValue
 import spock.lang.Specification
 
 class AnnotationTypeClassLoaderSpec extends Specification {
@@ -36,6 +37,24 @@ class AnnotationTypeClassLoaderSpec extends Specification {
         expect: "the bootstrap loader defines no copy of an application annotation, so resolving again would only\
  answer from whatever loader the fallback picks"
         AnnotationMetadataSupport.getAnnotationType(Portable.name, null).get().is(Portable)
+    }
+
+    void "a caller naming no loader is served the type a deployment loader registered"() {
+        given: "a child-first deployment loader defining its own copy of an annotation the application loader also sees"
+        def child = new OwnCopy()
+        def own = child.define(Deployed.name)
+
+        and: "the generated metadata of that deployment registering its copy"
+        AnnotationMetadataSupport.registerAnnotationType(new AnnotationClassValue<>(own))
+
+        and: "metadata of that deployment carrying the annotation"
+        def metadata = new MutableAnnotationMetadata()
+        metadata.addAnnotation(Deployed.name, [:])
+
+        expect: "the registered copy is answered, not the one the loader of the support class resolves again"
+        !own.is(Deployed)
+        AnnotationMetadataSupport.getAnnotationType(Deployed.name).get().is(own)
+        metadata.getAnnotationType(Deployed.name).get().is(own)
     }
 
     void "an annotation type of the JDK is served whatever the loader asks"() {

--- a/inject/src/test/java/io/micronaut/inject/annotation/Deployed.java
+++ b/inject/src/test/java/io/micronaut/inject/annotation/Deployed.java
@@ -1,0 +1,15 @@
+package io.micronaut.inject.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation with no member that nothing else registers, so that a copy another class loader defines can be
+ * the registered one.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+public @interface Deployed {
+}

--- a/inject/src/test/java/io/micronaut/inject/annotation/Unregistered.java
+++ b/inject/src/test/java/io/micronaut/inject/annotation/Unregistered.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation with no member that no generated metadata registers, so that its first resolution is a load.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+public @interface Unregistered {
+}


### PR DESCRIPTION
Fixes the 32 Jakarta Validation TCK failures micronaut-validation hits on 5.2.x, tracked in #13110.

## Cause

`AnnotationMetadata.getAnnotationType(name)` names no class loader, and `AnnotationMetadataSupport` answered it with the loader of the support class itself. Since #12977, a registered annotation type defined by another loader is resolved again through the loader asked with. So a type registered by the generated metadata of a child-first deployment was answered with the application loader's copy of the same name.

The validation TCK runs each test in such a deployment loader, with the TCK classes on the application classpath as well. `DefaultValidator` reads constraint types through `getAnnotationTypesByStereotype(Constraint.class)`, which reaches the one-arg lookup. It got the application's copies, so violations carried a constraint type that is not the class the test compares with. The assertions print identical types, e.g. `expected [interface ...$ValidTestBean] but found [interface ...$ValidTestBean]`. Class-level and cross-parameter constraints are the ones read that way.

A first-parent bisect over the validation TCK names 2c9161c43f (#12977) as the first bad commit: its predecessor d106b03832 (#13019) passes 384/384, and 2c9161c43f fails all 32.

## Fix

A caller naming no loader is answered for the thread context loader, the loader of the deployment it runs in, never for the loader of the support class:

- the registered type is kept when the context loader defines it, is one of its parents (a thread of the container a deployment runs in), or is absent;
- a context loader apart from it resolves the name again, as a loader the caller names does, so another deployment defining its own copy is served that copy rather than the first registration;
- a name nothing registered is loaded through the context loader before the loader of the support class.

The two-arg lookup is unchanged. The validation TCK sets the deployment loader as the context loader around each test, which is the loader that registered its constraint types.

## Verification

- `AnnotationTypeClassLoaderSpec`: two new cases (the context loader being the registering deployment, its parent, absent, or another deployment; and an unregistered name). Both fail on 5.2.x and pass here; the existing cases pass both ways.
- micronaut-validation e65b135f against core published from this branch: `:micronaut-tests:micronaut-jakarta-validation-tck:test` 384 tests, 0 failed (32 failed against c6158f9e0e, exactly the known set).
- `:micronaut-validation:test` 500 tests, 1 failed: `ValidatorSpec` "test @Introspected is required to validate the bean". It is a separate, already known 5.2 change and fails without this PR too.
- `:micronaut-inject:test` 407/0, `:micronaut-reflection:test` 397/0, `:micronaut-inject-java:test --tests 'io.micronaut.inject.annotation.*'` 195/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


