### PR TITLE
Compare nested type arguments by type in equalsType and typeHashCode

### DIFF
--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -289,7 +289,7 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
             return false;
         }
         return Objects.equals(type, o.getType()) &&
-            Objects.equals(typeParameters, o.getTypeVariables());
+            equalsTypeVariables(typeParameters, o.getTypeVariables());
     }
 
     @Override
@@ -301,14 +301,44 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
             return false;
         }
         DefaultArgument<?> that = (DefaultArgument<?>) o;
-        return Objects.equals(type, that.type) &&
+        // A wildcard only equals a wildcard with the same bounds, so a plain argument must not equal one either
+        return (this instanceof WildcardArgument<?>) == (that instanceof WildcardArgument<?>) &&
+            Objects.equals(type, that.type) &&
             Objects.equals(getName(), that.getName()) &&
             Objects.equals(typeParameters, that.typeParameters);
     }
 
     @Override
     public int typeHashCode() {
-        return ObjectUtils.hash(type, typeParameters);
+        // Summed the way Map.hashCode sums its entries, but over the type hash codes, to agree with equalsType
+        int typeParametersHash = 0;
+        for (Map.Entry<String, Argument<?>> entry : typeParameters.entrySet()) {
+            typeParametersHash += entry.getKey().hashCode() ^ entry.getValue().typeHashCode();
+        }
+        return 31 * (31 + Objects.hashCode(type)) + typeParametersHash;
+    }
+
+    /**
+     * Compares type variables by their types at every depth, so that a type argument compiled to a
+     * {@link WildcardArgument} has the same type as a plain argument of the type the wildcard is bounded by, as
+     * it had before the bounds were kept: {@code Map<String, ? extends Object>}, which is what a Kotlin
+     * {@code Map<String, Any>} compiles to, has the type of {@code Map<String, Object>}.
+     *
+     * @param typeParameters The type variables of this argument
+     * @param other          The type variables of the other argument
+     * @return Whether they have the same types
+     */
+    private static boolean equalsTypeVariables(Map<String, Argument<?>> typeParameters, Map<String, Argument<?>> other) {
+        if (typeParameters.size() != other.size()) {
+            return false;
+        }
+        for (Map.Entry<String, Argument<?>> entry : typeParameters.entrySet()) {
+            Argument<?> otherTypeParameter = other.get(entry.getKey());
+            if (otherTypeParameter == null || !entry.getValue().equalsType(otherTypeParameter)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/core/src/main/java/io/micronaut/core/type/WildcardArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/WildcardArgument.java
@@ -34,7 +34,8 @@ import java.util.List;
  * <p>For compatibility with what the processors have always emitted, a wildcard argument also reports
  * {@link #isTypeVariable()} as {@code true} and may implement {@link GenericPlaceholder}, named after the type
  * parameter it stands for; a consumer that needs to tell a wildcard from a type variable should test for this
- * interface first. {@link #equalsType(Argument)} and {@link #typeHashCode()} do not consider the bounds.</p>
+ * interface first. {@link #equalsType(Argument)} and {@link #typeHashCode()} do not consider the bounds, at any
+ * depth: {@code Map<String, ? extends Object>} has the type of {@code Map<String, Object>}.</p>
  *
  * @param <T> The type the wildcard is bounded by
  * @author Denis Stepanov

--- a/core/src/test/groovy/io/micronaut/core/type/ArgumentSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/type/ArgumentSpec.groovy
@@ -216,6 +216,40 @@ class ArgumentSpec extends Specification {
             field << ["justString", "stringList", "mapStringInteger", "objectMap", "noTypeMap"]
     }
 
+    void 'a nested wildcard is compared by the type it is bounded by in equalsType and typeHashCode'() {
+        given: 'the JVM signature of a Kotlin Map<String, Any>: Map<String, ? extends Object>'
+        def wildcard = Argument.ofWildcard(Object, 'V', null, null, null, null)
+        def kotlinMap = Argument.of(Map, 'headers', Argument.of(String, 'K'), wildcard)
+        def map = Argument.mapOf(String, Object)
+        def upperBounded = Argument.of(List, 'numbers', Argument.ofWildcard(Number, 'E', null, null, [Argument.of(Number)] as Argument[], null))
+        def lowerBounded = Argument.of(List, 'numbers', Argument.ofWildcard(Number, 'E', null, null, null, [Argument.of(Number)] as Argument[]))
+        def nested = Argument.of(List, 'nested', Argument.of(Map, 'E', Argument.of(String, 'K'), wildcard))
+
+        expect:
+        kotlinMap.equalsType(map)
+        map.equalsType(kotlinMap)
+        kotlinMap.typeHashCode() == map.typeHashCode()
+        !kotlinMap.equalsType(Argument.mapOf(String, String))
+
+        and: 'whichever way the wildcard is bounded, as the processors compiled it before the bounds were kept'
+        upperBounded.equalsType(Argument.listOf(Number))
+        upperBounded.typeHashCode() == Argument.listOf(Number).typeHashCode()
+        lowerBounded.equalsType(Argument.listOf(Number))
+        lowerBounded.typeHashCode() == Argument.listOf(Number).typeHashCode()
+
+        and: 'at any depth, a type argument being matched by the name of the type parameter it stands for'
+        nested.equalsType(Argument.listOf(map.withName('E')))
+        Argument.listOf(map.withName('E')).equalsType(nested)
+        nested.typeHashCode() == Argument.listOf(map.withName('E')).typeHashCode()
+        !nested.equalsType(Argument.listOf(Argument.mapOf(String, String).withName('E')))
+
+        and: 'equals keeps telling a wildcard from a plain argument, in both directions'
+        wildcard != Argument.of(Object, 'V')
+        Argument.of(Object, 'V') != wildcard
+        kotlinMap != Argument.of(Map, 'headers', Argument.of(String, 'K'), Argument.of(Object, 'V'))
+        Argument.of(Map, 'headers', Argument.of(String, 'K'), Argument.of(Object, 'V')) != kotlinMap
+    }
+
 /*
     void "test inner class"() {
         def arg = new Test<String>() {}.get();

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/WildcardTypeArgumentSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/WildcardTypeArgumentSpec.groovy
@@ -278,6 +278,43 @@ class FooFactory {
         context.close()
     }
 
+    void "an argument with a nested wildcard has the same type as the argument with the type it is bounded by"() {
+        given:
+        BeanDefinition<?> client = buildBeanDefinition('test.HeadersClient', '''
+package test
+
+import io.micronaut.context.annotation.Executable
+import jakarta.inject.Singleton
+
+@Singleton
+class HeadersClient {
+    @Executable
+    void send(Map<String, ? extends Object> headers, List<Map<String, ? extends Number>> nested, Map<String, Object> plain) {}
+}
+''')
+        Argument<?>[] arguments = client.executableMethods.find { it.methodName == 'send' }.arguments
+        Argument<?> headers = arguments[0]
+        Argument<?> nested = arguments[1]
+        Argument<?> plain = arguments[2]
+
+        expect:
+        headers.typeParameters[1] instanceof WildcardArgument
+        headers.equalsType(Argument.mapOf(String, Object))
+        Argument.mapOf(String, Object).equalsType(headers)
+        headers.typeHashCode() == Argument.mapOf(String, Object).typeHashCode()
+        headers.equalsType(plain) && plain.equalsType(headers)
+        headers.typeHashCode() == plain.typeHashCode()
+        !headers.equalsType(Argument.mapOf(String, String))
+
+        and: 'at any depth, the map named after the type parameter of List it stands for'
+        nested.equalsType(Argument.listOf(Argument.mapOf(String, Number).withName('E')))
+        nested.typeHashCode() == Argument.listOf(Argument.mapOf(String, Number).withName('E')).typeHashCode()
+
+        and: 'equals still tells the wildcard apart'
+        headers.typeParameters[1] != plain.typeParameters[1]
+        plain.typeParameters[1] != headers.typeParameters[1]
+    }
+
     void "a wildcard is recorded for introspected properties"() {
         given:
         BeanIntrospection<?> bean = buildBeanIntrospection('test.Bean', '''

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/WildcardTypeArgumentSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/WildcardTypeArgumentSpec.groovy
@@ -237,6 +237,45 @@ class Bean<B extends Book> extends Base<Foo<?>, List<? super Book>> implements F
         lowerBounded != renamed
     }
 
+    void "an argument with a nested wildcard has the same type as the argument with the type it is bounded by"() {
+        given: 'the signature kapt writes for a Kotlin Map<String, Any> parameter'
+        BeanDefinition<?> client = buildBeanDefinition('test.HeadersClient', '''
+package test;
+
+import io.micronaut.context.annotation.Executable;
+import jakarta.inject.Singleton;
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+class HeadersClient {
+    @Executable
+    void send(Map<String, ? extends Object> headers, List<Map<String, ? extends Number>> nested, Map<String, Object> plain) {}
+}
+''')
+        Argument<?>[] arguments = client.executableMethods.find { it.methodName == 'send' }.arguments
+        Argument<?> headers = arguments[0]
+        Argument<?> nested = arguments[1]
+        Argument<?> plain = arguments[2]
+
+        expect:
+        headers.typeParameters[1] instanceof WildcardArgument
+        headers.equalsType(Argument.mapOf(String, Object))
+        Argument.mapOf(String, Object).equalsType(headers)
+        headers.typeHashCode() == Argument.mapOf(String, Object).typeHashCode()
+        headers.equalsType(plain) && plain.equalsType(headers)
+        headers.typeHashCode() == plain.typeHashCode()
+        !headers.equalsType(Argument.mapOf(String, String))
+
+        and: 'at any depth, the map named after the type parameter of List it stands for'
+        nested.equalsType(Argument.listOf(Argument.mapOf(String, Number).withName('E')))
+        nested.typeHashCode() == Argument.listOf(Argument.mapOf(String, Number).withName('E')).typeHashCode()
+
+        and: 'equals still tells the wildcard apart'
+        headers.typeParameters[1] != plain.typeParameters[1]
+        plain.typeParameters[1] != headers.typeParameters[1]
+    }
+
     void "a wildcard is recorded for an injected field"() {
         given:
         def field = definition.injectedFields.find { it.name == 'field' }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/WildcardTypeArgumentSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/WildcardTypeArgumentSpec.groovy
@@ -290,6 +290,41 @@ class FooFactory {
         context.close()
     }
 
+    void "an argument with a nested projection has the same type as the argument with the type it is bounded by"() {
+        given: 'a Kotlin Map<String, Any>, whose value parameter is declared out'
+        BeanDefinition<?> client = buildBeanDefinition('test.HeadersClient', '''
+package test
+
+import io.micronaut.context.annotation.Executable
+import jakarta.inject.Singleton
+
+@Singleton
+open class HeadersClient {
+    @Executable
+    open fun send(headers: Map<String, Any>, nested: java.util.List<java.util.Map<String, out Number>>, projected: java.util.Map<String, out Any>) {}
+}
+''')
+        Argument<?>[] arguments = client.executableMethods.find { it.methodName == 'send' }.arguments
+        Argument<?> headers = arguments[0]
+        Argument<?> nested = arguments[1]
+        Argument<?> projected = arguments[2]
+
+        expect:
+        headers.equalsType(Argument.mapOf(String, Object))
+        Argument.mapOf(String, Object).equalsType(headers)
+        headers.typeHashCode() == Argument.mapOf(String, Object).typeHashCode()
+
+        and: 'an explicit projection'
+        projected.typeParameters[1] instanceof WildcardArgument
+        projected.equalsType(Argument.mapOf(String, Object))
+        projected.typeHashCode() == Argument.mapOf(String, Object).typeHashCode()
+        !projected.equalsType(Argument.mapOf(String, String))
+
+        and: 'at any depth, the map named after the type parameter of List it stands for'
+        nested.equalsType(Argument.listOf(Argument.mapOf(String, Number).withName('E')))
+        nested.typeHashCode() == Argument.listOf(Argument.mapOf(String, Number).withName('E')).typeHashCode()
+    }
+
     void "a projection is recorded for introspected properties of a class and a data class"() {
         given:
         BeanIntrospection<?> bean = buildBeanIntrospection('test.Bean', '''


### PR DESCRIPTION
Fixes a 5.2 regression found while testing modules against core 5.2 (micronaut-projects/micronaut-core#13110).

## Symptom

micronaut-rabbitmq's Kotlin docs example `HeadersSpec.testBasicProducerAndConsumer` passes on core 5.1.11 and fails on 5.2.x:

```
RabbitClientException: The @RabbitHeaders annotation is applied to an argument that is not java.util.Map<String, ?>.
```

The client declares `fun send(@RabbitHeaders headers: Map<String, Any>, ...)` and `RabbitMQIntroductionAdvice` checks `argument.equalsType(Argument.mapOf(String.class, Object.class))`.

## Cause

Kotlin's `Map<String, Any>` has the JVM signature `Map<String, ? extends Object>` (`Map<K, out V>`), which is what kapt hands the Java processor. Since #13023 that nested wildcard compiles to a `WildcardArgument` instead of a plain `Object` argument.

`DefaultArgument.equalsType` compared the type parameters with `Map.equals`, so the nested arguments were compared with `equals`. `DefaultWildcardArgument.equals` only matches another wildcard with the same bounds, so `Map<String, ? extends Object>` no longer had the type of `Map<String, Object>`. #13023 meant `equalsType` and `typeHashCode` to ignore the bounds; that held only at the top level.

The comparison was also asymmetric: a plain argument's `equals` accepted a wildcard, so the outcome depended on which side the wildcard was on.

## Fix

- `equalsType` compares the type parameters by name with a recursive `equalsType`. A wildcard's type is already the bound the processor resolved (`? extends X` → `X`, `? super X` → `X`, `?` → `Object`), so the result is the same as before #13023.
- `typeHashCode` is computed the same way, from each type parameter's `typeHashCode`, so the bean context's `BeanKey` and `BeanCandidateKey` caches stay consistent with `equalsType`.
- `equals` and `hashCode` stay strict. `equals` is now symmetric: a plain argument no longer equals a wildcard. `Foo<?>` and `Foo<Object>` still differ under `equals`.

Nested type parameters still match by name, as before; only the value comparison changed.

## Tests

- `ArgumentSpec`: hand-built `Map<String, ? extends Object>`, upper- and lower-bounded wildcards, and a wildcard two levels deep, for `equalsType` and `typeHashCode` in both directions; `equals` stays symmetric and strict.
- `WildcardTypeArgumentSpec` (Java, Groovy, Kotlin): a compiled method argument with a nested wildcard (Kotlin: `Map<String, Any>` and an explicit `out` projection) has the type of `Map<String, Object>`.

The new tests fail on 5.2.x without this change, in all four modules. The Java one passes on d6faeb1347^, the commit before #13023.

Nested type arguments are still matched by the name of the type parameter they stand for, as before. So `Argument.listOf(Argument.mapOf(String, Number))` still does not have the type of a compiled `List<Map<String, Number>>`, because `mapOf` names the argument `map` rather than `E`. That predates #13023 and is left alone here.

## Verification

Local runs with this change:

| project | tests | failures |
|---|---|---|
| `:micronaut-core:test` | 7409 | 0 |
| `:micronaut-inject:test` | 405 | 0 |
| `:micronaut-http:test` | 1857 | 0 |
| `:micronaut-inject-java:test` | 5279 | 0 |
| `:micronaut-inject-kotlin:test` | 866 | 0 |
| `:micronaut-inject-groovy:test` | 1127 | 10 |

The ten inject-groovy failures are `GroovyReconstructionSpec` "super type is AbstractList…", all `StackOverflowError` in `AbstractGroovyElement.resolvePlaceholder`. That is compile-time AST code that uses neither `Argument` nor `equalsType`. The spec fails the same way locally without this change: with the previous `DefaultArgument` and `WildcardArgument` it runs 121 tests with 10 `StackOverflowError` failures. It passes in the 5.2.x CI run for c6158f9e0e, so the failure is specific to the local environment; the tests here ran on JDK 26.0.2.1.

### micronaut-rabbitmq

I built micronaut-rabbitmq 5.1.x (7f86b4fa) against this branch, published locally as `5.2.1-eqtype-SNAPSHOT`. `:micronaut-docs-examples:micronaut-example-kotlin:test --tests 'io.micronaut.rabbitmq.docs.headers.HeadersSpec'` passes: 1 test, 0 failures. On c6158f9e0e it fails with the `RabbitClientException` above.

Under the local machine's load, the RabbitMQ container took about 55s to start, which is past the Testcontainers wait. For this run I pointed `test-suite-utils`' `RabbitMQ.getProperties()` at a broker started beforehand. The spec and its `@RabbitHeaders` client were unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
