### PR TITLE
Share one NettyByteBodyFactory per channel

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/body/NettyByteBodyFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/NettyByteBodyFactory.java
@@ -35,6 +35,8 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -47,6 +49,8 @@ import reactor.core.publisher.Flux;
  */
 @Internal
 public final class NettyByteBodyFactory extends ByteBodyFactory {
+    private static final AttributeKey<NettyByteBodyFactory> CHANNEL_FACTORY = AttributeKey.valueOf(NettyByteBodyFactory.class, "channelFactory");
+
     private final EventLoop loop;
 
     public NettyByteBodyFactory(Channel channel) {
@@ -56,6 +60,29 @@ public final class NettyByteBodyFactory extends ByteBodyFactory {
     NettyByteBodyFactory(ByteBufAllocator alloc, EventLoop loop) {
         super(new NettyByteBufferFactory(alloc), NettyReadBufferFactory.of(alloc));
         this.loop = loop;
+    }
+
+    /**
+     * Get the factory shared by all users of the given channel. A factory only carries the
+     * channel's allocator and event loop, both of which are fixed once the channel is registered,
+     * so one instance can serve every request and every body on that channel. The instance is
+     * created on first access and stored as a channel attribute.
+     *
+     * @param channel The channel
+     * @return The shared factory for the channel
+     * @since 5.2.0
+     */
+    public static NettyByteBodyFactory forChannel(Channel channel) {
+        Attribute<NettyByteBodyFactory> attribute = channel.attr(CHANNEL_FACTORY);
+        NettyByteBodyFactory factory = attribute.get();
+        if (factory == null) {
+            factory = new NettyByteBodyFactory(channel);
+            NettyByteBodyFactory existing = attribute.setIfAbsent(factory);
+            if (existing != null) {
+                factory = existing;
+            }
+        }
+        return factory;
     }
 
     @Override

--- a/http-netty/src/test/java/io/micronaut/http/netty/body/NettyByteBodyFactoryTest.java
+++ b/http-netty/src/test/java/io/micronaut/http/netty/body/NettyByteBodyFactoryTest.java
@@ -1,0 +1,37 @@
+package io.micronaut.http.netty.body;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class NettyByteBodyFactoryTest {
+    @Test
+    void forChannelReturnsOneInstancePerChannel() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        NettyByteBodyFactory first = NettyByteBodyFactory.forChannel(channel);
+        NettyByteBodyFactory second = NettyByteBodyFactory.forChannel(channel);
+        assertSame(first, second);
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void forChannelIsScopedToTheChannel() {
+        EmbeddedChannel a = new EmbeddedChannel();
+        EmbeddedChannel b = new EmbeddedChannel();
+        assertNotSame(NettyByteBodyFactory.forChannel(a), NettyByteBodyFactory.forChannel(b));
+        a.finishAndReleaseAll();
+        b.finishAndReleaseAll();
+    }
+
+    @Test
+    void forChannelIsIndependentOfDirectlyConstructedInstances() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        NettyByteBodyFactory direct = new NettyByteBodyFactory(channel);
+        NettyByteBodyFactory shared = NettyByteBodyFactory.forChannel(channel);
+        assertNotSame(direct, shared);
+        assertSame(shared, NettyByteBodyFactory.forChannel(channel));
+        channel.finishAndReleaseAll();
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -39,7 +39,6 @@ import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.PushCapableHttpRequest;
 import io.micronaut.http.ServerHttpRequest;
 import io.micronaut.http.body.ByteBody;
-import io.micronaut.http.body.ByteBodyFactory;
 import io.micronaut.http.body.CloseableByteBody;
 import io.micronaut.http.body.InternalByteBody;
 import io.micronaut.http.body.stream.AvailableByteArrayBody;
@@ -184,6 +183,11 @@ public final class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> imple
     @Nullable
     private NettyCookies nettyCookies;
     private final CloseableByteBody body;
+    /**
+     * The per-channel body factory, looked up lazily on first use.
+     */
+    @Nullable
+    private NettyByteBodyFactory byteBodyFactory;
     @Nullable
     private Object legacyBody;
     @Nullable
@@ -221,8 +225,13 @@ public final class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> imple
     }
 
     @Override
-    public ByteBodyFactory byteBodyFactory() {
-        return new NettyByteBodyFactory(channelHandlerContext.channel());
+    public NettyByteBodyFactory byteBodyFactory() {
+        NettyByteBodyFactory factory = byteBodyFactory;
+        if (factory == null) {
+            factory = NettyByteBodyFactory.forChannel(channelHandlerContext.channel());
+            byteBodyFactory = factory;
+        }
+        return factory;
     }
 
     public void setLegacyBody(@Nullable Object legacyBody) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyResponseLifecycle.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyResponseLifecycle.java
@@ -57,7 +57,7 @@ final class NettyResponseLifecycle extends ResponseLifecycle {
         super(routingInBoundHandler.routeExecutor,
             routingInBoundHandler.messageBodyHandlerRegistry,
             routingInBoundHandler.conversionService,
-            new NettyByteBodyFactory(request.getChannelHandlerContext().channel()));
+            request.byteBodyFactory());
         this.routingInBoundHandler = routingInBoundHandler;
         this.request = request;
     }
@@ -83,7 +83,7 @@ final class NettyResponseLifecycle extends ResponseLifecycle {
     }
 
     private NettyByteBodyFactory byteBodyFactory() {
-        return new NettyByteBodyFactory(request.getChannelHandlerContext().channel());
+        return request.byteBodyFactory();
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
@@ -214,7 +214,7 @@ public final class Http2ServerHandler extends MultiplexedServerHandler implement
 
         @Override
         public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-            handler.ctx = ctx;
+            handler.attach(ctx);
             super.handlerAdded(ctx);
         }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
@@ -58,10 +58,15 @@ import java.util.OptionalLong;
 abstract class MultiplexedServerHandler {
     final Logger LOG = LoggerFactory.getLogger(getClass());
 
-    @Nullable
-    ChannelHandlerContext ctx;
     BodySizeLimits bodySizeLimits = BodySizeLimits.UNLIMITED;
     private final RequestHandler requestHandler;
+    @Nullable
+    private ChannelHandlerContext ctx;
+    /**
+     * Body factory for this connection, shared by all streams. Set in {@link #attach}.
+     */
+    @Nullable
+    private NettyByteBodyFactory byteBodyFactory;
     @Nullable
     private Compressor compressor;
 
@@ -78,8 +83,19 @@ abstract class MultiplexedServerHandler {
      */
     abstract void flush();
 
+    /**
+     * Bind this handler to its channel. Called once when the connection handler is added to the
+     * pipeline.
+     *
+     * @param ctx The context of the connection handler
+     */
+    final void attach(ChannelHandlerContext ctx) {
+        this.ctx = ctx;
+        this.byteBodyFactory = NettyByteBodyFactory.forChannel(ctx.channel());
+    }
+
     private NettyByteBodyFactory byteBodyFactory() {
-        return new NettyByteBodyFactory(requiredCtx().channel());
+        return Objects.requireNonNull(byteBodyFactory, "byteBodyFactory");
     }
 
     protected ChannelHandlerContext requiredCtx() {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/MultiplexedServerHandler.java
@@ -303,11 +303,10 @@ abstract class MultiplexedServerHandler {
                 response.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
             }
 
-            NettyByteBodyFactory byteBodyFactory = byteBodyFactory();
             if (body instanceof AvailableByteBody available) {
                 writeFull(response, NettyByteBodyFactory.toByteBuf(available));
             } else {
-                StreamingNettyByteBody snbb = byteBodyFactory.toStreaming(body);
+                StreamingNettyByteBody snbb = byteBodyFactory().toStreaming(body);
                 var consumer = new BufferConsumer() {
                     @Nullable
                     Upstream upstream;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -124,6 +124,11 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
     @Nullable
     private ChannelHandlerContext ctx;
     /**
+     * Body factory for this channel, shared by all requests. Set in {@link #handlerAdded}.
+     */
+    @Nullable
+    private NettyByteBodyFactory byteBodyFactory;
+    /**
      * {@code true} iff we are in a read operation, before {@link #channelReadComplete}.
      */
     private boolean reading = false;
@@ -223,6 +228,7 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
         this.ctx = ctx;
+        this.byteBodyFactory = NettyByteBodyFactory.forChannel(ctx.channel());
         // we take control of reading now.
         ctx.channel().config().setAutoRead(false);
         refreshNeedMore();
@@ -388,8 +394,7 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
     }
 
     private NettyByteBodyFactory byteBodyFactory() {
-        assert ctx != null;
-        return new NettyByteBodyFactory(requiredCtx().channel());
+        return Objects.requireNonNull(byteBodyFactory, "byteBodyFactory");
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/FormDemuxer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/FormDemuxer.java
@@ -99,7 +99,7 @@ public final class FormDemuxer implements BufferConsumer {
             complete();
         } else {
             this.eventLoop = channel.eventLoop();
-            this.byteBodyFactory = new NettyByteBodyFactory(channel);
+            this.byteBodyFactory = NettyByteBodyFactory.forChannel(channel);
             this.totalTracker = SizeLimitTracker.notThreadSafe(totalLimits).makeBothAtomic();
             try (var s = byteBodyFactory.toStreaming(byteBody)) {
                 this.upstream = s.primary(this);

--- a/http-server-netty/src/test/java/io/micronaut/http/server/netty/handler/PerChannelByteBodyFactoryTest.java
+++ b/http-server-netty/src/test/java/io/micronaut/http/server/netty/handler/PerChannelByteBodyFactoryTest.java
@@ -1,0 +1,55 @@
+package io.micronaut.http.server.netty.handler;
+
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.http.body.CloseableByteBody;
+import io.micronaut.http.netty.body.NettyByteBodyFactory;
+import io.micronaut.http.server.HttpServerConfiguration;
+import io.micronaut.http.server.netty.NettyHttpRequest;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PerChannelByteBodyFactoryTest {
+    @Test
+    void requestsOnOneChannelShareTheBodyFactory() {
+        List<NettyHttpRequest<?>> requests = new ArrayList<>();
+        EmbeddedChannel channel = new EmbeddedChannel(new PipeliningServerHandler(new RequestHandler() {
+            @Override
+            public void accept(ChannelHandlerContext ctx, HttpRequest request, CloseableByteBody body, OutboundAccess outboundAccess) {
+                requests.add(new NettyHttpRequest<>(request, body, ctx, ConversionService.SHARED, new HttpServerConfiguration()));
+                outboundAccess.write(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK), NettyByteBodyFactory.empty());
+            }
+
+            @Override
+            public void handleUnboundError(Throwable cause) {
+                throw new AssertionError(cause);
+            }
+        }));
+
+        channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/a"));
+        channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/b"));
+        channel.checkException();
+
+        assertEquals(2, requests.size());
+        NettyByteBodyFactory shared = NettyByteBodyFactory.forChannel(channel);
+        for (NettyHttpRequest<?> request : requests) {
+            // one lookup per request, one instance per channel
+            assertSame(request.byteBodyFactory(), request.byteBodyFactory());
+            assertSame(shared, request.byteBodyFactory());
+            request.release();
+        }
+        channel.finishAndReleaseAll();
+    }
+}


### PR DESCRIPTION

## Summary

- `NettyByteBodyFactory.forChannel(Channel)` returns one factory per channel, created on first access and kept as a channel attribute. Every other change in this PR is a call site switching from `new NettyByteBodyFactory(channel)` to that shared instance.
- `PipeliningServerHandler` resolves the factory once in `handlerAdded` and keeps it in a field. Before, `byteBodyFactory()` built a new factory for every full request, every buffered body, every streamed chunk (`InputStreamer.add`) and every streaming response (`toStreaming`).
- `MultiplexedServerHandler` (HTTP/2) does the same: `Http2ServerHandler.ConnectionHandler.handlerAdded` now calls a package-private `attach(ctx)` that sets both the context and the factory, and the `ctx` field is private. Before, a factory was built per HEADERS-with-body, per DATA frame and per streaming response.
- `NettyHttpRequest.byteBodyFactory()` looks the shared instance up once per request and caches it in a field. The override now returns `NettyByteBodyFactory` (covariant, binary compatible; `japiCmp` passes for both modules).
- `NettyResponseLifecycle` uses the request's factory instead of constructing one in its constructor and another on every `concatenate`/`concatenateJson`/streamed `encodeNoBody` call.
- `FormDemuxer`'s streaming branch reuses the channel's factory. The `AvailableByteBody` branch keeps its purpose-built non-netty `ByteBodyFactory`, which is a different type and not affected.

### Why one instance per channel is equivalent

A `NettyByteBodyFactory` holds exactly two things: the channel's `ByteBufAllocator` (wrapped in a `NettyByteBufferFactory` and a `NettyReadBufferFactory`) and the channel's `EventLoop`. It has no mutable state; every method either allocates a fresh body/buffer or wraps its argument. Both inputs are fixed for the lifetime of a registered channel: the event loop cannot change after registration, and nothing in the server reconfigures the allocator after the pipeline is built. The old code already relied on this by caching `EventLoopFlow(requiredCtx().channel().eventLoop())` in fields. Bodies created by the shared instance are therefore identical to bodies created by a per-call instance: same allocator identity, same loop for `StreamingNettyByteBody.SharedBuffer`, same `isCompatible(loop)` answer in `toStreaming`.

The attribute lookup is confined to the channel, so nothing is shared across channels or across event loops. `NettyHttpRequest.byteBodyFactory()` can be called from a worker thread; its lazy field is a benign race on an immutable, idempotently resolved value (the attribute always returns the same instance, and `NettyByteBodyFactory`'s fields are final).

Each old construction allocated four objects (`NettyByteBodyFactory`, `NettyByteBufferFactory`, its allocator `Supplier` lambda, `NettyReadBufferFactory`), so a simple GET on HTTP/1 paid for two of these (handler, lifecycle) plus one per `byteBodyFactory()` call on the request, and a chunked upload paid one more per chunk.

## Benchmarks

Base is `origin/5.2.x` at fc92af42a4 (the parent of this branch) built into a JMH jar in the same session as the branch jar; both were run from the same JDK 25 with `-f 1 -wi 5 -w 3s -i 5 -r 3s -t 1 -bm avgt -prof gc -jvmArgs "-Dmicronaut.python.enabled=false -Djmh.executor=CUSTOM -Djmh.executor.class=io.micronaut.http.server.stack.JmhFastThreadLocalExecutor"`, `-tu ns` for the first two classes and `-tu us` for `ServerScenariosBenchmark`. Every run was started only when the 1-minute load average was below 3 and no other java process was busy; start loads were 2.57/2.49 (Controllers base/branch), 1.98/1.85 (FullHttpStack), 2.38/2.59 (ServerScenarios). The load rises to 3.5-4.7 during a run because of the benchmark itself.

"Within noise" means the difference is smaller than the sum of the two error bars (99.9% CI).

| Benchmark | Param | Base time | After time | Δ time | Base alloc (B/op) | After alloc (B/op) | Δ alloc |
|---|---|---|---|---|---|---|---|
| ControllersBenchmark | TFB_LIKE | 2,497 ± 144 ns/op | 2,476 ± 18 ns/op | -22 ns/op (-0.9%) (within noise) | 6,320 ± 1 | 6,248 ± 1 | -72 (-1.1%) |
| ControllersBenchmark | TFB_STRING | 2,478 ± 190 ns/op | 2,388 ± 50 ns/op | -90 ns/op (-3.6%) (within noise) | 6,456 ± 1 | 6,384 ± 1 | -72 (-1.1%) |
| ControllersBenchmark | TFB_LIKE_BEANS1 | 1,883 ± 61 ns/op | 1,836 ± 32 ns/op | -47 ns/op (-2.5%) (within noise) | 3,856 ± 1 | 3,720 ± 1 | -136 (-3.5%) |
| ControllersBenchmark | TFB_LIKE_BEANS2 | 1,893 ± 97 ns/op | 1,807 ± 19 ns/op | -86 ns/op (-4.6%) (within noise) | 3,888 ± 1 | 3,776 ± 1 | -112 (-2.9%) |
| ControllersBenchmark | TFB_LIKE_ASYNC_BEANS1 | 1,844 ± 121 ns/op | 1,919 ± 125 ns/op | +75 ns/op (+4.1%) (within noise) | 3,808 ± 1 | 3,800 ± 1 | -8 (-0.2%) |
| ControllersBenchmark | TFB_LIKE_ASYNC_BEANS2 | 1,916 ± 49 ns/op | 1,892 ± 215 ns/op | -24 ns/op (-1.2%) (within noise) | 3,928 ± 1 | 3,792 ± 1 | -136 (-3.5%) |
| ControllersBenchmark | TFB_LIKE_MAP | 1,740 ± 55 ns/op | 1,679 ± 18 ns/op | -61 ns/op (-3.5%) (within noise) | 3,968 ± 1 | 3,936 ± 1 | -32 (-0.8%) |
| ControllersBenchmark | MISSING_QUERY_PARAMETER | 2,026 ± 29 ns/op | 2,115 ± 84 ns/op | +89 ns/op (+4.4%) (within noise) | 4,984 ± 1 | 4,832 ± 1 | -152 (-3.0%) |
| FullHttpStackBenchmark | MICRONAUT | 2,861 ± 381 ns/op | 2,846 ± 300 ns/op | -15 ns/op (-0.5%) (within noise) | 6,528 ± 2 | 6,464 ± 2 | -64 (-1.0%) |
| ServerScenariosBenchmark | MULTIPART_FILE_COMPLETED | 35 ± 2 us/op | 34 ± 1 us/op | -1 us/op (-1.7%) (within noise) | 145,563 ± 22 | 145,379 ± 21 | -184 (-0.1%) |
| ServerScenariosBenchmark | MULTIPART_FILE_BYTES | 39 ± 1 us/op | 39 ± 2 us/op | -1 us/op (-1.4%) (within noise) | 211,131 ± 24 | 211,267 ± 25 | +136 (+0.1%) |
| ServerScenariosBenchmark | MULTIPART_FILE_CHUNKED | 35 ± 1 us/op | 34 ± 2 us/op | -1 us/op (-3.8%) (within noise) | 82,155 ± 21 | 81,898 ± 20 | -256 (-0.3%) |
| ServerScenariosBenchmark | FORM_URLENCODED_POJO | 6 ± 0 us/op | 6 ± 0 us/op | +0 us/op (+6.3%) (within noise) | 13,976 ± 3 | 13,960 ± 4 | -16 (-0.1%) |
| ServerScenariosBenchmark | JSON_POST_LARGE_LIST | 165 ± 3 us/op | 168 ± 2 us/op | +2 us/op (+1.5%) (within noise) | 245,932 ± 97 | 245,948 ± 98 | +16 (+0.0%) (within noise) |
| ServerScenariosBenchmark | JSON_POST_LARGE_LIST_CHUNKED | 168 ± 5 us/op | 171 ± 4 us/op | +3 us/op (+1.9%) (within noise) | 246,556 ± 99 | 246,508 ± 99 | -48 (-0.0%) (within noise) |
| ServerScenariosBenchmark | JSON_POST_LARGE_LIST_REACTIVE_CHUNKED | 411 ± 12 us/op | 408 ± 6 us/op | -4 us/op (-0.9%) (within noise) | 744,566 ± 204 | 745,166 ± 203 | +600 (+0.1%) |
| ServerScenariosBenchmark | JSON_STREAM_RESPONSE | 317 ± 1 us/op | 322 ± 15 us/op | +5 us/op (+1.5%) (within noise) | 335,847 ± 172 | 342,664 ± 179 | +6,816 (+2.0%) |
| ServerScenariosBenchmark | JSON_STREAM_RESPONSE_NDJSON | 206 ± 4 us/op | 210 ± 15 us/op | +3 us/op (+1.6%) (within noise) | 244,063 ± 121 | 243,943 ± 123 | -120 (-0.0%) (within noise) |
| ServerScenariosBenchmark | LARGE_TEXT_RESPONSE | 14 ± 0 us/op | 14 ± 0 us/op | +0 us/op (+2.6%) (within noise) | 3,521 ± 8 | 3,449 ± 9 | -72 (-2.0%) |

**Reading the numbers.** The expected signal is allocation, not time, and that is what the table shows: every time delta is within noise. The allocation drop per request is one to two `NettyByteBodyFactory` graphs (one factory is exactly 72 bytes: the factory, a `NettyByteBufferFactory`, its allocator lambda and a `NettyReadBufferFactory`), i.e. about 1-3.5% of a simple GET. The other constructions the old code did per request were evidently already scalar-replaced by C2 (`byteBodyFactory().createChecked(...)` in the handler does not escape), which is why the saving is smaller than a count of the removed `new` sites would suggest.

Two caveats, both checked with supplementary 3-fork runs (same flags plus `-f 3`, start loads 2.41/2.63 for the Controllers pair and 2.33/2.70 for the JSON stream pair):

- Fork-to-fork variance in `gc.alloc.rate.norm` for the *same* jar is of the same order as this effect (a first branch run of `ControllersBenchmark`, discarded because its start load was 3.30, put `TFB_LIKE` at 6,336 B/op against 6,248 B/op above). With 3 forks per side `TFB_STRING` goes from 6,456.1 ± 0.3 to 6,384.2 ± 0.3 B/op (-72, exactly one factory) and `TFB_LIKE` from 6,378.8 ± 29.2 to 6,277.5 ± 29.2 B/op (-101); time 2,449 ± 68 vs 2,460 ± 35 ns/op and 2,580 ± 86 vs 2,711 ± 191 ns/op, both within noise.
- The single-fork `JSON_STREAM_RESPONSE` row shows +6,816 B/op on the branch. That scenario is bimodal between forks on the unmodified base (three base forks: 342.7k, 335.9k, 342.8k B/op) and the single-fork comparison caught one mode against the other. With 3 forks per side the branch forks land on the same two modes (342.6k, 335.7k, 335.7k), each 90-170 B/op below the matching base mode; the aggregates are 340,494 ± 3,587 (base) vs 338,065 ± 3,604 B/op (branch) and 318.7 ± 4.0 vs 314.4 ± 1.7 us/op, both within noise. The change does not add allocation to that path.

So: a small, real allocation reduction on every request, no measurable time change. The PR is worth taking on that plus the simplification (one place that knows how a channel's factory is obtained), not for throughput.

## Testing

- New `NettyByteBodyFactoryTest` (http-netty): `forChannel` returns the same instance for a channel, distinct instances for distinct channels, and is independent of directly constructed factories.
- New `PerChannelByteBodyFactoryTest` (http-server-netty): two requests through `PipeliningServerHandler` on one `EmbeddedChannel` build `NettyHttpRequest`s whose `byteBodyFactory()` is the same instance as `NettyByteBodyFactory.forChannel(channel)`, and repeated calls on one request return the same instance. Fail-before verified by restoring the 5.2.x `NettyHttpRequest`/`NettyResponseLifecycle` and running the test: `AssertionFailedError: expected: <NettyByteBodyFactory@56f521c6> but was: <NettyByteBodyFactory@680a66dd>` at `PerChannelByteBodyFactoryTest.java:49`.
- `./gradlew :micronaut-http-netty:test :micronaut-http-netty:checkstyleTest`: 151 tests, 0 failures.
- `./gradlew :micronaut-http-server-netty:test :micronaut-http-server-netty:checkstyleTest`: 1157 tests, 3 failures in the first run (`FileCertificateProviderTest` JKS/PEM with `TLSV1_ALERT_CERTIFICATE_REQUIRED`, and `ThreadSelectionSpec` "request event listeners IO" with a connection reset), all under a 1-minute load average of 9 from the four parallel test forks. All three pass when re-run alone (`FileCertificateProviderTest` 7 tests, `ThreadSelectionSpec` 30 tests, 0 failures); none touch body factories.
- `checkstyleMain` clean for both modules; `japiCmp` clean for both modules.

## Out of scope

- `Http2ServerHandler.ConnectionHandler.channelReadComplete` still walks every active stream per read batch to call `devolveToStreaming()`. Replacing that with a "streams still buffering" list needs bookkeeping on the reset/goaway/close paths so that a reset stream is never devolved late; that is a separate change with its own tests.
- `NettyWebSocketSession.getOpenSessions()` scanning the channel group and `LoomBranchSupport.currentScheduler()` invoking a method handle per off-loop execute are unrelated to factory allocation and left for a follow-up.
- `FormDemuxer`'s `AvailableByteBody` branch still builds an anonymous non-netty `ByteBodyFactory` per demuxer; it is a different type with different threading rules and was left alone.
- The `ServerScenariosBenchmark` numbers above were produced with the harness from #13112 applied locally for measurement only; it is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
