### PR TITLE
Cache the Date header and access log timestamp per second; clear the access log request attribute

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     api(projects.micronautContextPython)
     api(projects.micronautHttpServer)
     api(projects.micronautHttpServerNetty)
+    // the access logger's ConnectionMetadata resolves the QUIC channel class when it is initialized
+    api(projects.micronautHttpNettyHttp3)
     api(projects.micronautHttpClient)
     api(projects.micronautJacksonDatabind)
     api(projects.micronautRouter)

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -55,6 +55,15 @@ val jmhPoolSizes = providers.gradleProperty("jmh.poolSizes")
     .map { it.split(",").map(String::trim).filter(String::isNotEmpty) }
 val jmhHumanOutput = providers.gradleProperty("jmh.humanOutput")
     .map(layout.projectDirectory::file)
+// Benchmark switches read by BenchOptions in the forked JMH JVM. A -D on the Gradle command line
+// only reaches Gradle itself, so they are exposed as -P properties and forwarded as JVM arguments:
+// -Pjmh.dateHeader=true, -Pjmh.accessLog=true
+val jmhBenchSwitches = listOf(
+    "jmh.dateHeader" to "micronaut.bench.date-header",
+    "jmh.accessLog" to "micronaut.bench.access-log"
+).mapNotNull { (property, systemProperty) ->
+    providers.gradleProperty(property).orNull?.let { "-D$systemProperty=$it" }
+}
 
 jmh {
     includes = jmhIncludes
@@ -68,6 +77,7 @@ jmh {
         benchmarkParameters.put("poolSize", objects.listProperty(String::class.java).value(sizes))
     }
     humanOutputFile.set(jmhHumanOutput)
+    jvmArgsAppend.addAll(jmhBenchSwitches)
     duplicateClassesStrategy = DuplicatesStrategy.WARN
 }
 

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/BenchOptions.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/BenchOptions.java
@@ -1,0 +1,45 @@
+package io.micronaut.http.server.stack;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * System-property switches shared by the HTTP stack benchmarks.
+ */
+final class BenchOptions {
+    /**
+     * {@code -Dmicronaut.bench.date-header=true} keeps the {@code Date} response header on. The
+     * response then changes once per second, so only its length is verified.
+     */
+    static final boolean DATE_HEADER = Boolean.getBoolean("micronaut.bench.date-header");
+    /**
+     * {@code -Dmicronaut.bench.access-log=true} enables the access logger. {@code logback.xml}
+     * routes the {@code bench-access-log} logger to a NOP appender, so the log line is built but
+     * never written.
+     */
+    static final boolean ACCESS_LOG = Boolean.getBoolean("micronaut.bench.access-log");
+
+    private BenchOptions() {
+    }
+
+    static Map<String, Object> serverProperties(String specName) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("spec.name", specName);
+        // with the date header off the response is identical each time
+        properties.put("micronaut.server.date-header", DATE_HEADER);
+        if (ACCESS_LOG) {
+            properties.put("micronaut.server.netty.access-logger.enabled", true);
+            properties.put("micronaut.server.netty.access-logger.logger-name", "bench-access-log");
+        }
+        return properties;
+    }
+
+    static void verifyResponse(ByteBuf expected, ByteBuf actual) {
+        boolean mismatch = DATE_HEADER ? expected.readableBytes() != actual.readableBytes() : !expected.equals(actual);
+        if (mismatch) {
+            throw new AssertionError("Response did not match");
+        }
+    }
+}

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/BenchOptions.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/BenchOptions.java
@@ -9,6 +9,9 @@ import java.util.Map;
  * System-property switches shared by the HTTP stack benchmarks.
  */
 final class BenchOptions {
+    // When running through Gradle rather than the jar, pass -Pjmh.dateHeader=true and
+    // -Pjmh.accessLog=true: a -D on the Gradle command line does not reach the forked JMH JVM,
+    // and the build forwards those properties as the system properties below.
     /**
      * {@code -Dmicronaut.bench.date-header=true} keeps the {@code Date} response header on. The
      * response then changes once per second, so only its length is verified.

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/ControllersBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/ControllersBenchmark.java
@@ -68,9 +68,7 @@ public class ControllersBenchmark {
     @Benchmark
     public void test(Holder holder) {
         ByteBuf response = holder.exchange();
-        if (!holder.responseBytes.equals(response)) {
-            throw new AssertionError("Response did not match");
-        }
+        BenchOptions.verifyResponse(holder.responseBytes, response);
         response.release();
     }
 
@@ -86,10 +84,7 @@ public class ControllersBenchmark {
 
         @Setup
         public void setUp(Blackhole blackhole) {
-            ctx = ApplicationContext.run(Map.of(
-                "spec.name", "ControllersBenchmark",
-                "micronaut.server.date-header", false // disabling this makes the response identical each time
-            ));
+            ctx = ApplicationContext.run(BenchOptions.serverProperties("ControllersBenchmark"));
             ctx.registerSingleton(Blackhole.class, blackhole);
             EmbeddedServer server = ctx.getBean(EmbeddedServer.class);
             channel = ((NettyHttpServer) server).buildEmbeddedChannel(false);

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
@@ -31,7 +31,6 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class FullHttpStackBenchmark {
@@ -45,9 +44,7 @@ public class FullHttpStackBenchmark {
     @Benchmark
     public void test(Holder holder) {
         ByteBuf response = holder.exchange();
-        if (!holder.responseBytes.equals(response)) {
-            throw new AssertionError("Response did not match");
-        }
+        BenchOptions.verifyResponse(holder.responseBytes, response);
         response.release();
     }
 
@@ -151,11 +148,7 @@ public class FullHttpStackBenchmark {
         MICRONAUT {
             @Override
             Stack openChannel() {
-                ApplicationContext ctx = ApplicationContext.run(Map.of(
-                    "spec.name", "FullHttpStackBenchmark",
-                    //"micronaut.server.netty.server-type", NettyHttpServerConfiguration.HttpServerType.FULL_CONTENT,
-                    "micronaut.server.date-header", false // disabling this makes the response identical each time
-                ));
+                ApplicationContext ctx = ApplicationContext.run(BenchOptions.serverProperties("FullHttpStackBenchmark"));
                 EmbeddedServer server = ctx.getBean(EmbeddedServer.class);
                 EmbeddedChannel channel = ((NettyHttpServer) server).buildEmbeddedChannel(false);
                 return new Stack(channel, ctx);

--- a/benchmarks/src/jmh/resources/logback.xml
+++ b/benchmarks/src/jmh/resources/logback.xml
@@ -8,6 +8,13 @@
         </encoder>
     </appender>
 
+    <!-- access log used by the HTTP stack benchmarks with -Dmicronaut.bench.access-log=true:
+         the log line is built by the server but never written -->
+    <appender name="NOP" class="ch.qos.logback.core.helpers.NOPAppender"/>
+    <logger name="bench-access-log" level="info" additivity="false">
+        <appender-ref ref="NOP" />
+    </logger>
+
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -72,6 +72,12 @@ import java.util.regex.Pattern;
 @SuppressWarnings("FileLength")
 public final class RoutingInBoundHandler implements RequestHandler {
 
+    /**
+     * Channel attribute that exposes the current request to access log elements (Micronaut
+     * Session's log element reads it by this name). Set when the pipeline has an access logger,
+     * and cleared again once the response has been written.
+     */
+    static final AttributeKey<NettyHttpRequest> ACCESS_LOG_REQUEST_ATTRIBUTE = AttributeKey.valueOf(NettyHttpRequest.class.getSimpleName());
     private static final Logger LOG = LoggerFactory.getLogger(RoutingInBoundHandler.class);
     /*
      * Also present in {@link RouteExecutor}.
@@ -160,7 +166,13 @@ public final class RoutingInBoundHandler implements RequestHandler {
     @Override
     public void responseWritten(@Nullable Object attachment) {
         if (attachment != null) {
-            cleanupRequest((NettyHttpRequest<?>) attachment);
+            NettyHttpRequest<?> request = (NettyHttpRequest<?>) attachment;
+            if (supportLoggingHandler) {
+                // only clear our own request: with pipelining the attribute may already hold
+                // the next request on this connection
+                request.getChannelHandlerContext().channel().attr(ACCESS_LOG_REQUEST_ATTRIBUTE).compareAndSet(request, null);
+            }
+            cleanupRequest(request);
         }
     }
 
@@ -228,8 +240,7 @@ public final class RoutingInBoundHandler implements RequestHandler {
     private void prepareRequest(ChannelHandlerContext ctx, OutboundAccess outboundAccess, NettyHttpRequest<Object> mnRequest) {
         if (supportLoggingHandler && ctx.pipeline().get(ChannelPipelineCustomizer.HANDLER_ACCESS_LOGGER) != null) {
             // Micronaut Session needs this to extract values from the Micronaut Http Request for logging
-            AttributeKey<NettyHttpRequest> key = AttributeKey.valueOf(NettyHttpRequest.class.getSimpleName());
-            ctx.channel().attr(key).set(mnRequest);
+            ctx.channel().attr(ACCESS_LOG_REQUEST_ATTRIBUTE).set(mnRequest);
         }
         outboundAccess.attachment(mnRequest);
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -77,7 +77,7 @@ public final class RoutingInBoundHandler implements RequestHandler {
      * Session's log element reads it by this name). Set when the pipeline has an access logger,
      * and cleared again once the response has been written.
      */
-    static final AttributeKey<NettyHttpRequest> ACCESS_LOG_REQUEST_ATTRIBUTE = AttributeKey.valueOf(NettyHttpRequest.class.getSimpleName());
+    static final AttributeKey<NettyHttpRequest<?>> ACCESS_LOG_REQUEST_ATTRIBUTE = AttributeKey.valueOf(NettyHttpRequest.class.getSimpleName());
     private static final Logger LOG = LoggerFactory.getLogger(RoutingInBoundHandler.class);
     /*
      * Also present in {@link RouteExecutor}.

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/Http2AccessLogManager.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/Http2AccessLogManager.java
@@ -46,6 +46,8 @@ public final class Http2AccessLogManager {
 
     @Nullable
     AccessLog logForReuse;
+    @Nullable
+    private ConnectionMetadata connectionMetadata;
 
     public Http2AccessLogManager(Factory factory, Http2Connection connection) {
         this.connection = connection;
@@ -71,7 +73,13 @@ public final class Http2AccessLogManager {
             accessLog = formatParser.newAccessLogger();
         }
         connection.stream(streamId).setProperty(accessLogKey, accessLog);
-        accessLog.onRequestHeaders(ConnectionMetadata.ofNettyChannel(ctx.channel()), request.method().name(), request.headers(), request.uri(), HttpAccessLogHandler.H2_PROTOCOL_NAME);
+        ConnectionMetadata metadata = connectionMetadata;
+        if (metadata == null) {
+            // this manager is connection-scoped, and the metadata only wraps the channel
+            metadata = ConnectionMetadata.ofNettyChannel(ctx.channel());
+            connectionMetadata = metadata;
+        }
+        accessLog.onRequestHeaders(metadata, request.method().name(), request.headers(), request.uri(), HttpAccessLogHandler.H2_PROTOCOL_NAME);
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -122,7 +122,7 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
                 } else {
                     protocol = request.protocolVersion().text();
                 }
-                accessLogHolder.createLogForRequest().onRequestHeaders(ConnectionMetadata.ofNettyChannel(ctx.channel()), request.method().name(), request.headers(), request.uri(), protocol);
+                accessLogHolder.createLogForRequest().onRequestHeaders(accessLogHolder.connectionMetadata(ctx), request.method().name(), request.headers(), request.uri(), protocol);
             } else {
                 accessLogHolder.excludeRequest();
             }
@@ -194,6 +194,25 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
         private final Queue<AccessLog> liveLogs = new LinkedList<>(); // ArrayDeque doesn't like null elements :(
         @Nullable
         private AccessLog logForReuse;
+        @Nullable
+        private ConnectionMetadata connectionMetadata;
+
+        /**
+         * The metadata of the channel this holder belongs to. The metadata only wraps the
+         * channel and reads its addresses on demand, so one instance serves every request on
+         * the connection.
+         *
+         * @param ctx The context of the channel this holder is an attribute of
+         * @return The metadata
+         */
+        ConnectionMetadata connectionMetadata(ChannelHandlerContext ctx) {
+            ConnectionMetadata metadata = connectionMetadata;
+            if (metadata == null) {
+                metadata = ConnectionMetadata.ofNettyChannel(ctx.channel());
+                connectionMetadata = metadata;
+            }
+            return metadata;
+        }
 
         AccessLog createLogForRequest() {
             AccessLog log = logForReuse;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/DateTimeElement.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/DateTimeElement.java
@@ -15,10 +15,12 @@
  */
 package io.micronaut.http.server.netty.handler.accesslog.element;
 
+import io.micronaut.http.server.util.PerSecondCache;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.jspecify.annotations.Nullable;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -29,6 +31,10 @@ import java.util.Set;
 
 /**
  * DateTimeElement LogElement.
+ * <p>
+ * Unless the pattern prints a sub-second field, the formatted text only changes once per second
+ * and is cached in a {@link PerSecondCache}. The element is shared by every access log instance
+ * ({@link #copy()} returns {@code this}), so the cache is shared by all event loops.
  *
  * @author croudet
  * @since 2.0
@@ -48,6 +54,12 @@ final class DateTimeElement implements LogElement {
     private final Set<Event> events;
     @Nullable
     private final String dateFormat;
+    /**
+     * {@code null} when the pattern has a sub-second field, in which case every value is
+     * formatted from the exact current time.
+     */
+    @Nullable
+    private final PerSecondCache cache;
 
     /**
      * Create a DateTimeElement.
@@ -81,7 +93,53 @@ final class DateTimeElement implements LogElement {
         } else {
             formatter = DateTimeFormatter.ofPattern(formatSplit[0], Locale.US).withZone(ZoneId.of(formatSplit[1].strip()));
         }
+        cache = hasSubSecondField(formatSplit[0]) ? null : new PerSecondCache(this::formatSecond);
         events = fromStart ? Event.REQUEST_HEADERS_EVENTS : LAST_RESPONSE_EVENTS;
+    }
+
+    /**
+     * Whether the pattern contains an unquoted fraction-of-second ({@code S}), nano-of-second
+     * ({@code n}), nano-of-day ({@code N}) or milli-of-day ({@code A}) field. Every other pattern
+     * letter is a function of the instant truncated to the second.
+     *
+     * @param pattern The {@link DateTimeFormatter} pattern
+     * @return {@code true} if the output can change within a second
+     */
+    static boolean hasSubSecondField(String pattern) {
+        boolean quoted = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (c == '\'') {
+                quoted = !quoted;
+            } else if (!quoted && (c == 'S' || c == 'n' || c == 'N' || c == 'A')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String formatSecond(long epochSecond) {
+        return ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSecond), ZoneId.systemDefault()).format(formatter);
+    }
+
+    private String now() {
+        if (cache != null) {
+            return cache.now();
+        }
+        return ZonedDateTime.now().format(formatter);
+    }
+
+    /**
+     * The value this element produces for the given instant.
+     *
+     * @param epochMillis The instant, in milliseconds since the epoch
+     * @return The formatted text
+     */
+    String value(long epochMillis) {
+        if (cache != null) {
+            return cache.get(epochMillis);
+        }
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault()).format(formatter);
     }
 
     @Override
@@ -92,7 +150,7 @@ final class DateTimeElement implements LogElement {
     @Override
     public String onRequestHeaders(@Nullable SocketChannel channel, String method, HttpHeaders headers, String uri, String protocol) {
         if (events.contains(Event.ON_REQUEST_HEADERS)) {
-            return ZonedDateTime.now().format(formatter);
+            return now();
         } else {
             return ConstantElement.UNKNOWN_VALUE;
         }
@@ -101,7 +159,7 @@ final class DateTimeElement implements LogElement {
     @Override
     public String onLastResponseWrite(int contentSize) {
         if (events.contains(Event.ON_LAST_RESPONSE_WRITE)) {
-            return ZonedDateTime.now().format(formatter);
+            return now();
         } else {
             return ConstantElement.UNKNOWN_VALUE;
         }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/AccessLogRequestAttributeSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/AccessLogRequestAttributeSpec.groovy
@@ -1,0 +1,104 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.http.DefaultFullHttpRequest
+import io.netty.handler.codec.http.FullHttpResponse
+import io.netty.handler.codec.http.HttpClientCodec
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpObjectAggregator
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpVersion
+import io.netty.util.AttributeKey
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+/**
+ * The channel attribute named {@code NettyHttpRequest} exposes the current request to access
+ * log elements while the access logger is enabled. It must be visible to the route while the
+ * request is in flight, and must not keep the request reachable after the response is written.
+ */
+class AccessLogRequestAttributeSpec extends Specification {
+    private static final AttributeKey<NettyHttpRequest> KEY = AttributeKey.valueOf(NettyHttpRequest.class.simpleName)
+
+    def 'attribute holds the request during routing and is cleared once the response is written'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name': 'AccessLogRequestAttributeSpec',
+                'micronaut.server.netty.access-logger.enabled': true,
+                'micronaut.server.netty.access-logger.logger-name': 'AccessLogRequestAttributeSpec',
+        ])
+        def server = ((NettyHttpServer) ctx.getBean(EmbeddedServer)).buildEmbeddedChannel(false)
+        def client = new EmbeddedChannel(new HttpClientCodec(), new HttpObjectAggregator(1024))
+        EmbeddedTestUtil.connect(server, client)
+
+        expect:
+        server.attr(KEY).get() == null
+
+        when:
+        String first = exchange(server, client)
+        then:
+        first == 'same'
+        server.attr(KEY).get() == null
+
+        when: 'a second request on the same connection'
+        String second = exchange(server, client)
+        then:
+        second == 'same'
+        server.attr(KEY).get() == null
+
+        cleanup:
+        server.finishAndReleaseAll()
+        client.finishAndReleaseAll()
+        ctx.close()
+    }
+
+    def 'attribute is not set when the access logger is disabled'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'AccessLogRequestAttributeSpec'])
+        def server = ((NettyHttpServer) ctx.getBean(EmbeddedServer)).buildEmbeddedChannel(false)
+        def client = new EmbeddedChannel(new HttpClientCodec(), new HttpObjectAggregator(1024))
+        EmbeddedTestUtil.connect(server, client)
+
+        when:
+        String body = exchange(server, client)
+        then:
+        body == 'absent'
+        server.attr(KEY).get() == null
+
+        cleanup:
+        server.finishAndReleaseAll()
+        client.finishAndReleaseAll()
+        ctx.close()
+    }
+
+    private static String exchange(EmbeddedChannel server, EmbeddedChannel client) {
+        client.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/access-log-attribute'))
+        EmbeddedTestUtil.advance(server, client)
+        FullHttpResponse response = client.readInbound()
+        assert response.status() == HttpResponseStatus.OK
+        String body = response.content().toString(StandardCharsets.UTF_8)
+        response.release()
+        return body
+    }
+
+    @Requires(property = 'spec.name', value = 'AccessLogRequestAttributeSpec')
+    @Controller('/access-log-attribute')
+    static class Ctrl {
+        @Get
+        String get(HttpRequest<?> request) {
+            NettyHttpRequest<?> nettyRequest = (NettyHttpRequest<?>) request
+            def value = nettyRequest.channelHandlerContext.channel().attr(KEY).get()
+            if (value == null) {
+                return 'absent'
+            }
+            return value.is(nettyRequest) ? 'same' : 'other'
+        }
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/DateHeaderSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/DateHeaderSpec.groovy
@@ -1,0 +1,89 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.http.DefaultFullHttpRequest
+import io.netty.handler.codec.http.FullHttpResponse
+import io.netty.handler.codec.http.HttpClientCodec
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpObjectAggregator
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpVersion
+import spock.lang.Specification
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+class DateHeaderSpec extends Specification {
+    def 'date header is RFC 1123 and advances across a second boundary'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'DateHeaderSpec'])
+        def server = ((NettyHttpServer) ctx.getBean(EmbeddedServer)).buildEmbeddedChannel(false)
+        def client = new EmbeddedChannel(new HttpClientCodec(), new HttpObjectAggregator(1024))
+        EmbeddedTestUtil.connect(server, client)
+
+        when:
+        long before1 = System.currentTimeMillis().intdiv(1000)
+        String date1 = exchange(server, client)
+        long after1 = System.currentTimeMillis().intdiv(1000)
+        // sleep into the next second
+        Thread.sleep(1000 - (System.currentTimeMillis() % 1000) + 20)
+        long before2 = System.currentTimeMillis().intdiv(1000)
+        String date2 = exchange(server, client)
+        long after2 = System.currentTimeMillis().intdiv(1000)
+
+        then:
+        long second1 = ZonedDateTime.parse(date1, DateTimeFormatter.RFC_1123_DATE_TIME).toEpochSecond()
+        long second2 = ZonedDateTime.parse(date2, DateTimeFormatter.RFC_1123_DATE_TIME).toEpochSecond()
+        date1.endsWith(' GMT')
+        date2.endsWith(' GMT')
+        second1 >= before1 && second1 <= after1
+        second2 >= before2 && second2 <= after2
+        second2 > second1
+
+        cleanup:
+        server.finishAndReleaseAll()
+        client.finishAndReleaseAll()
+        ctx.close()
+    }
+
+    def 'date header can be disabled'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'DateHeaderSpec', 'micronaut.server.date-header': false])
+        def server = ((NettyHttpServer) ctx.getBean(EmbeddedServer)).buildEmbeddedChannel(false)
+        def client = new EmbeddedChannel(new HttpClientCodec(), new HttpObjectAggregator(1024))
+        EmbeddedTestUtil.connect(server, client)
+
+        expect:
+        exchange(server, client) == null
+
+        cleanup:
+        server.finishAndReleaseAll()
+        client.finishAndReleaseAll()
+        ctx.close()
+    }
+
+    private static String exchange(EmbeddedChannel server, EmbeddedChannel client) {
+        client.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/date-header'))
+        EmbeddedTestUtil.advance(server, client)
+        FullHttpResponse response = client.readInbound()
+        assert response.status() == HttpResponseStatus.OK
+        String date = response.headers().get(HttpHeaderNames.DATE)
+        response.release()
+        return date
+    }
+
+    @Requires(property = 'spec.name', value = 'DateHeaderSpec')
+    @Controller('/date-header')
+    static class Ctrl {
+        @Get
+        String get() {
+            return 'foo'
+        }
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/DateTimeElementSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/DateTimeElementSpec.groovy
@@ -1,0 +1,102 @@
+package io.micronaut.http.server.netty.handler.accesslog.element
+
+import io.netty.handler.codec.http.DefaultHttpHeaders
+import spock.lang.Specification
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+class DateTimeElementSpec extends Specification {
+    private static final long T = 1_700_000_000_000L // Tue, 14 Nov 2023 22:13:20 UTC
+
+    private static String uncached(String pattern, long epochMillis) {
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern(pattern, Locale.US))
+    }
+
+    def 'default pattern is cached per second and matches the uncached format'() {
+        given:
+        def element = new DateTimeElement(null)
+
+        expect:
+        element.@cache != null
+        element.value(T) == uncached("'['dd/MMM/yyyy:HH:mm:ss Z']'", T)
+        element.value(T).is(element.value(T + 999))
+        element.value(T + 1000) != element.value(T + 999)
+        element.value(T + 1000) == uncached("'['dd/MMM/yyyy:HH:mm:ss Z']'", T + 1000)
+    }
+
+    def 'custom pattern with explicit zone is exact'() {
+        given:
+        def element = new DateTimeElement("dd/MMM/yyyy:HH:mm:ss Z, UTC")
+
+        expect:
+        element.@cache != null
+        element.value(T) == '14/Nov/2023:22:13:20 +0000'
+        element.value(T + 999) == '14/Nov/2023:22:13:20 +0000'
+        element.value(T + 1000) == '14/Nov/2023:22:13:21 +0000'
+        element.toString() == '%{dd/MMM/yyyy:HH:mm:ss Z, UTC}t'
+    }
+
+    def 'custom pattern with a different zone respects that zone'() {
+        given:
+        def element = new DateTimeElement("end:yyyy-MM-dd HH:mm:ss, Asia/Tokyo")
+
+        expect:
+        element.events() == [LogElement.Event.ON_LAST_RESPONSE_WRITE] as Set
+        element.value(T) == '2023-11-15 07:13:20'
+        element.value(T + 1000) == '2023-11-15 07:13:21'
+    }
+
+    def 'pattern with sub-second precision is not cached and stays exact'() {
+        given:
+        def element = new DateTimeElement("HH:mm:ss.SSS, UTC")
+
+        expect:
+        element.@cache == null
+        element.value(T) == '22:13:20.000'
+        element.value(T + 1) == '22:13:20.001'
+        element.value(T + 999) == '22:13:20.999'
+        element.value(T + 1000) == '22:13:21.000'
+    }
+
+    def 'live values are current'() {
+        given:
+        def cached = new DateTimeElement("yyyy-MM-dd'T'HH:mm:ss, UTC")
+        def exact = new DateTimeElement("yyyy-MM-dd'T'HH:mm:ss.SSSSSS, UTC")
+        def headers = new DefaultHttpHeaders()
+
+        when:
+        long before = System.currentTimeMillis() / 1000
+        String cachedValue = cached.onRequestHeaders(ConnectionMetadata.empty(), 'GET', headers, '/', 'HTTP/1.1')
+        String exactValue = exact.onRequestHeaders(ConnectionMetadata.empty(), 'GET', headers, '/', 'HTTP/1.1')
+        long after = System.currentTimeMillis() / 1000
+
+        then:
+        long cachedSecond = Instant.parse(cachedValue + 'Z').epochSecond
+        long exactSecond = Instant.parse(exactValue + 'Z').epochSecond
+        cachedSecond >= before && cachedSecond <= after
+        exactSecond >= before && exactSecond <= after
+    }
+
+    def 'sub-second detection: #pattern'() {
+        expect:
+        DateTimeElement.hasSubSecondField(pattern) == subSecond
+
+        where:
+        pattern                            | subSecond
+        "'['dd/MMM/yyyy:HH:mm:ss Z']'"     | false
+        "dd/MMM/yyyy:HH:mm:ss Z"           | false
+        "yyyy-MM-dd'T'HH:mm:ssXXX"         | false
+        "HH:mm:ss.SSS"                     | true
+        "HH:mm:ss.n"                       | true
+        "N"                                | true
+        "A"                                | true
+        "'S'HH:mm:ss"                      | false // quoted literal
+        "'Sent at 'HH:mm:ss"               | false // quoted literal
+        "'it''s 'HH:mm:ss"                 | false // escaped quote inside literal
+        "'it''s 'HH:mm:ss.SSS"             | true
+        "HH:mm:ss 'ms='SSS"                | true
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
@@ -88,6 +88,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
         then:
         response.code() == HttpStatus.NOT_MODIFIED.code
+        response.headers.getAll(DATE).size() == 1
         response.header(DATE)
     }
 

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -50,6 +50,7 @@ import io.micronaut.http.reactive.execution.ReactiveExecutionFlow;
 import io.micronaut.http.server.binding.RequestArgumentSatisfier;
 import io.micronaut.http.server.exceptions.response.ErrorContext;
 import io.micronaut.http.server.exceptions.response.ErrorResponseProcessor;
+import io.micronaut.http.server.util.HttpDateHeader;
 import io.micronaut.inject.BeanType;
 import io.micronaut.inject.MethodReference;
 import io.micronaut.context.propagation.instrument.execution.ContextPropagatingExecutorService;
@@ -77,7 +78,6 @@ import reactor.util.context.ContextView;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
-import java.time.LocalDateTime;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -793,7 +793,7 @@ public final class RouteExecutor {
 
     private void applyConfiguredHeaders(MutableHttpHeaders headers) {
         if (serverConfiguration.isDateHeader() && !headers.contains(HttpHeaders.DATE)) {
-            headers.date(LocalDateTime.now());
+            headers.add(HttpHeaders.DATE, HttpDateHeader.now());
         }
         if (headers.get(HttpHeaders.SERVER) == null) {
             serverConfiguration.getServerHeader()

--- a/http-server/src/main/java/io/micronaut/http/server/body/AbstractFileBodyWriter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/body/AbstractFileBodyWriter.java
@@ -117,7 +117,8 @@ abstract sealed class AbstractFileBodyWriter permits InputStreamBodyWriter, Stre
      */
     protected void setDateHeader(MutableHttpResponse response) {
         MutableHttpHeaders headers = response.getHeaders();
-        headers.add(HttpHeaders.DATE, HttpDateHeader.now());
+        // replace, not add: a 304 has the original response's headers copied in first, Date included
+        headers.set(HttpHeaders.DATE, HttpDateHeader.now());
     }
 
     protected ByteBodyHttpResponse<?> notModified(ByteBodyFactory bodyFactory, MutableHttpResponse<?> originalResponse) {

--- a/http-server/src/main/java/io/micronaut/http/server/body/AbstractFileBodyWriter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/body/AbstractFileBodyWriter.java
@@ -27,13 +27,13 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.body.ByteBodyFactory;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.types.files.FileCustomizableResponseType;
+import io.micronaut.http.server.util.HttpDateHeader;
 
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Abstract implementation for types that write files.
@@ -89,15 +89,14 @@ abstract sealed class AbstractFileBodyWriter permits InputStreamBodyWriter, Stre
     protected void setDateAndCacheHeaders(MutableHttpResponse response, long lastModified) {
         // Date header
         MutableHttpHeaders headers = response.getHeaders();
-        LocalDateTime now = LocalDateTime.now();
+        long now = System.currentTimeMillis();
         if (!headers.contains(HttpHeaders.DATE)) {
-            headers.date(now);
+            headers.add(HttpHeaders.DATE, HttpDateHeader.get(now));
         }
 
         // Add cache headers
-        LocalDateTime cacheSeconds = now.plus(configuration.getCacheSeconds(), ChronoUnit.SECONDS);
         if (response.header(HttpHeaders.EXPIRES) == null) {
-            headers.expires(cacheSeconds);
+            headers.expires(now + TimeUnit.SECONDS.toMillis(configuration.getCacheSeconds()));
         }
 
         if (response.header(HttpHeaders.CACHE_CONTROL) == null) {
@@ -118,8 +117,7 @@ abstract sealed class AbstractFileBodyWriter permits InputStreamBodyWriter, Stre
      */
     protected void setDateHeader(MutableHttpResponse response) {
         MutableHttpHeaders headers = response.getHeaders();
-        LocalDateTime now = LocalDateTime.now();
-        headers.date(now);
+        headers.add(HttpHeaders.DATE, HttpDateHeader.now());
     }
 
     protected ByteBodyHttpResponse<?> notModified(ByteBodyFactory bodyFactory, MutableHttpResponse<?> originalResponse) {

--- a/http-server/src/main/java/io/micronaut/http/server/util/HttpDateHeader.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/HttpDateHeader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.util;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.http.MutableHttpHeaders;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Produces the value of the {@code Date} response header (RFC 1123, GMT). The text only changes
+ * once per second, so it is cached in a {@link PerSecondCache} shared by every response writer
+ * instead of being formatted for each response.
+ *
+ * @since 5.2.0
+ */
+@Internal
+public final class HttpDateHeader {
+    private static final PerSecondCache CACHE = new PerSecondCache(HttpDateHeader::format);
+
+    private HttpDateHeader() {
+    }
+
+    /**
+     * The {@code Date} header value for the current wall-clock time.
+     *
+     * @return The RFC 1123 text
+     */
+    public static String now() {
+        return CACHE.now();
+    }
+
+    /**
+     * The {@code Date} header value for the given instant.
+     *
+     * @param epochMillis The instant, in milliseconds since the epoch
+     * @return The RFC 1123 text
+     */
+    public static String get(long epochMillis) {
+        return CACHE.get(epochMillis);
+    }
+
+    private static String format(long epochSecond) {
+        return DateTimeFormatter.RFC_1123_DATE_TIME.format(Instant.ofEpochSecond(epochSecond).atZone(MutableHttpHeaders.GMT));
+    }
+}

--- a/http-server/src/main/java/io/micronaut/http/server/util/PerSecondCache.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/PerSecondCache.java
@@ -18,13 +18,14 @@ package io.micronaut.http.server.util;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongFunction;
 
 /**
  * Caches a string that is a pure function of the wall clock truncated to whole seconds, so that
  * callers on many threads that need the same value within the same second only compute it once.
  * <p>
- * Thread safety: the cache is a single {@code volatile} reference to an immutable
+ * Thread safety: the cache is a single atomic reference to an immutable
  * (second, text) pair. A reader loads the reference once and either returns the text, if the
  * pair's second matches its own clock reading, or computes the text for its own second and
  * publishes a new pair. Concurrent readers that both miss compute the same text for the same
@@ -37,8 +38,7 @@ import java.util.function.LongFunction;
 @Internal
 public final class PerSecondCache {
     private final LongFunction<String> formatter;
-    @Nullable
-    private volatile Entry cached;
+    private final AtomicReference<@Nullable Entry> cached = new AtomicReference<>();
 
     /**
      * Create a new cache.
@@ -66,12 +66,12 @@ public final class PerSecondCache {
      */
     public String get(long epochMillis) {
         long second = Math.floorDiv(epochMillis, 1000);
-        Entry entry = cached;
+        Entry entry = cached.get();
         if (entry != null && entry.second == second) {
             return entry.text;
         }
         String text = formatter.apply(second);
-        cached = new Entry(second, text);
+        cached.set(new Entry(second, text));
         return text;
     }
 

--- a/http-server/src/main/java/io/micronaut/http/server/util/PerSecondCache.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/PerSecondCache.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.util;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.LongFunction;
+
+/**
+ * Caches a string that is a pure function of the wall clock truncated to whole seconds, so that
+ * callers on many threads that need the same value within the same second only compute it once.
+ * <p>
+ * Thread safety: the cache is a single {@code volatile} reference to an immutable
+ * (second, text) pair. A reader loads the reference once and either returns the text, if the
+ * pair's second matches its own clock reading, or computes the text for its own second and
+ * publishes a new pair. Concurrent readers that both miss compute the same text for the same
+ * second and publish equivalent pairs; a reader that publishes a stale pair after a newer one
+ * only causes the next reader to recompute. In every interleaving a reader returns the text for
+ * the second it observed on the clock, never a torn or mixed value.
+ *
+ * @since 5.2.0
+ */
+@Internal
+public final class PerSecondCache {
+    private final LongFunction<String> formatter;
+    @Nullable
+    private volatile Entry cached;
+
+    /**
+     * Create a new cache.
+     *
+     * @param formatter Computes the text for a given epoch second
+     */
+    public PerSecondCache(LongFunction<String> formatter) {
+        this.formatter = formatter;
+    }
+
+    /**
+     * The text for the current wall-clock time.
+     *
+     * @return The text for the current second
+     */
+    public String now() {
+        return get(System.currentTimeMillis());
+    }
+
+    /**
+     * The text for the given instant.
+     *
+     * @param epochMillis The instant, in milliseconds since the epoch
+     * @return The text for the second that contains the instant
+     */
+    public String get(long epochMillis) {
+        long second = Math.floorDiv(epochMillis, 1000);
+        Entry entry = cached;
+        if (entry != null && entry.second == second) {
+            return entry.text;
+        }
+        String text = formatter.apply(second);
+        cached = new Entry(second, text);
+        return text;
+    }
+
+    private record Entry(long second, String text) {
+    }
+}

--- a/http-server/src/test/java/io/micronaut/http/server/util/HttpDateHeaderTest.java
+++ b/http-server/src/test/java/io/micronaut/http/server/util/HttpDateHeaderTest.java
@@ -1,0 +1,67 @@
+package io.micronaut.http.server.util;
+
+import io.micronaut.http.MutableHttpHeaders;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HttpDateHeaderTest {
+    /**
+     * The value {@link MutableHttpHeaders#date(java.time.LocalDateTime)} produced before the
+     * cache was introduced, for the given instant.
+     */
+    private static String legacy(long epochMillis) {
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault())
+            .withZoneSameInstant(MutableHttpHeaders.GMT)
+            .format(DateTimeFormatter.RFC_1123_DATE_TIME);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0L, 1L, 999L, 1_000L, 951_782_400_123L, 1_700_000_000_999L, 4_102_444_799_000L})
+    void matchesTheUncachedFormat(long epochMillis) {
+        assertEquals(legacy(epochMillis), HttpDateHeader.get(epochMillis));
+    }
+
+    @Test
+    void fixedValues() {
+        assertEquals("Thu, 1 Jan 1970 00:00:00 GMT", HttpDateHeader.get(0));
+        assertEquals("Tue, 14 Nov 2023 22:13:20 GMT", HttpDateHeader.get(1_700_000_000_000L));
+        assertEquals("Tue, 14 Nov 2023 22:13:20 GMT", HttpDateHeader.get(1_700_000_000_999L));
+        assertEquals("Tue, 14 Nov 2023 22:13:21 GMT", HttpDateHeader.get(1_700_000_001_000L));
+    }
+
+    @Test
+    void sameSecondReturnsTheCachedInstance() {
+        String first = HttpDateHeader.get(1_700_000_000_000L);
+        assertSame(first, HttpDateHeader.get(1_700_000_000_500L));
+        assertSame(first, HttpDateHeader.get(1_700_000_000_999L));
+    }
+
+    @Test
+    void changesAtTheSecondBoundary() {
+        String before = HttpDateHeader.get(1_700_000_000_999L);
+        String after = HttpDateHeader.get(1_700_000_001_000L);
+        assertNotEquals(before, after);
+        assertEquals(legacy(1_700_000_000_999L), before);
+        assertEquals(legacy(1_700_000_001_000L), after);
+    }
+
+    @Test
+    void nowParsesToTheCurrentTime() {
+        long before = System.currentTimeMillis() / 1000;
+        String now = HttpDateHeader.now();
+        long after = System.currentTimeMillis() / 1000;
+        long parsed = ZonedDateTime.parse(now, DateTimeFormatter.RFC_1123_DATE_TIME).toEpochSecond();
+        assertTrue(parsed >= before && parsed <= after, now);
+    }
+}

--- a/http-server/src/test/java/io/micronaut/http/server/util/PerSecondCacheTest.java
+++ b/http-server/src/test/java/io/micronaut/http/server/util/PerSecondCacheTest.java
@@ -1,0 +1,67 @@
+package io.micronaut.http.server.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PerSecondCacheTest {
+    @Test
+    void sameSecondIsFormattedOnce() {
+        AtomicInteger calls = new AtomicInteger();
+        PerSecondCache cache = new PerSecondCache(second -> {
+            calls.incrementAndGet();
+            return "s" + second;
+        });
+
+        String first = cache.get(1_000);
+        assertEquals("s1", first);
+        assertSame(first, cache.get(1_000));
+        assertSame(first, cache.get(1_500));
+        assertSame(first, cache.get(1_999));
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    void valueChangesAtTheSecondBoundary() {
+        AtomicInteger calls = new AtomicInteger();
+        PerSecondCache cache = new PerSecondCache(second -> {
+            calls.incrementAndGet();
+            return "s" + second;
+        });
+
+        String before = cache.get(1_999);
+        String after = cache.get(2_000);
+        assertEquals("s1", before);
+        assertEquals("s2", after);
+        assertNotEquals(before, after);
+        assertEquals(2, calls.get());
+
+        // going back to an earlier second is not served from the cache either
+        assertEquals("s1", cache.get(1_001));
+        assertEquals(3, calls.get());
+    }
+
+    @Test
+    void negativeInstantsRoundTowardsMinusInfinity() {
+        PerSecondCache cache = new PerSecondCache(second -> "s" + second);
+        assertEquals("s-1", cache.get(-1));
+        assertEquals("s-1", cache.get(-1_000));
+        assertEquals("s-2", cache.get(-1_001));
+        assertEquals("s0", cache.get(0));
+    }
+
+    @Test
+    void nowIsWithinTheCurrentSecond() {
+        PerSecondCache cache = new PerSecondCache(second -> "s" + second);
+        long before = Math.floorDiv(System.currentTimeMillis(), 1000);
+        String now = cache.now();
+        long after = Math.floorDiv(System.currentTimeMillis(), 1000);
+        long second = Long.parseLong(now.substring(1));
+        assertTrue(second >= before && second <= after, now + " not in [" + before + ", " + after + "]");
+    }
+}


### PR DESCRIPTION

## Summary

- **`Date` header** (`http-server`): `RouteExecutor.applyConfiguredHeaders` and `AbstractFileBodyWriter` formatted the header from scratch for every response (`LocalDateTime.now()`, `ZonedDateTime.of(...)`, `withZoneSameInstant(GMT)`, `DateTimeFormatter.RFC_1123_DATE_TIME.format(...)`). The text only changes once per second. New `@Internal` `PerSecondCache` (one `volatile` reference to an immutable `(second, text)` record) and `HttpDateHeader` (the RFC 1123 GMT text through that cache) replace the per-response formatting; both call sites now `add(DATE, HttpDateHeader.now())`. The file writer also derives `Expires` from the same `currentTimeMillis()` reading instead of a second `LocalDateTime`. There was no existing per-second cache to reuse: Netty's `DateFormatter` formats on every call, and the file writers used the same `LocalDateTime.now()` path as `RouteExecutor`.
- **Access log timestamp** (`DateTimeElement`): formatted a `ZonedDateTime` per request. Unless the pattern has an unquoted sub-second field (`S`, `n`, `N`, `A`) its output is a function of the instant truncated to the second, so it now goes through a `PerSecondCache`; the default `[dd/MMM/yyyy:HH:mm:ss Z]` pattern and any custom pattern without sub-second fields are cached, a pattern with sub-second precision keeps formatting `ZonedDateTime.now()` exactly as before. Custom time zones (`pattern, Zone/Id`) are unaffected: the formatter's zone override is applied to the cached instant the same way it was applied to `now()`.
- **Access log connection metadata** (`HttpAccessLogHandler`, `Http2AccessLogManager`): `ConnectionMetadata.ofNettyChannel(ctx.channel())` was called per request. The metadata only wraps the channel and reads its addresses on demand, so one instance per connection is equivalent; it is now kept in the per-channel `AccessLogHolder` and in the connection-scoped HTTP/2 manager.
- **Access log request attribute** (`RoutingInBoundHandler`), the correctness part of this PR: with the access logger enabled, the current `NettyHttpRequest` was stored in a channel attribute named `NettyHttpRequest` (Micronaut Session's `SessionLogElement` reads it by that name) and never removed, so an idle keep-alive connection kept its last request reachable, after `release()`, until the channel closed. It also resolved the `AttributeKey` by name on every request. The key is now a static field, and `responseWritten` clears the attribute with `compareAndSet(request, null)`, so that with pipelining a newer request already stored for the same connection is left alone.
- **Benchmark harness** (`benchmarks`): `ControllersBenchmark` and `FullHttpStackBenchmark` disable the `Date` header (so the response bytes are identical each iteration) and never enable access logging, so neither of the paths above could be measured. `-Dmicronaut.bench.date-header=true` keeps the header on and relaxes the response check to a length comparison; `-Dmicronaut.bench.access-log=true` enables the access logger, routed by `logback.xml` to a NOP appender so the line is built but not written. Both default to off, so the existing measurements are unchanged. The harness also gains `micronaut-http-netty-http3` on its classpath; see "Out of scope" for why.

### Thread safety of the cache

`PerSecondCache` is shared by every event loop (the `Date` cache is static; `DateTimeElement.copy()` returns `this`, so one element serves every `AccessLog` on every loop). It holds a single `volatile` reference to an immutable `record Entry(long second, String text)`. A reader loads the reference once; if `entry.second` equals `floorDiv(now, 1000)` it returns `entry.text`, otherwise it formats the text for its own second and publishes a new record. Two loops that miss in the same second both format the same text and publish equivalent records. A loop that is descheduled after formatting second *N* and publishes after another loop has already published *N+1* leaves a stale record, which only makes the next reader miss and republish. In every interleaving a reader returns the text for the second it read from the clock, and because the record is immutable and published through a `volatile` write there is no torn or mixed value. Cost on the hot path: one `System.currentTimeMillis()`, one volatile read, one `long` compare.

The `ConnectionMetadata` fields are written and read on the channel's event loop only (`channelRead` / the HTTP/2 frame listener), like the rest of the holder's state.

## Benchmarks

Base is `origin/5.2.x` at 6d53fc7bb4 (the parent of this branch) plus the harness commit only (063c17a5d3), so both sides run the same harness; branch is 95e8f096d8. Both jars were built in the same session from the same JDK 25 and run with `-f 1 -wi 5 -w 3s -i 5 -r 3s -t 1 -bm avgt -tu ns -prof gc -jvmArgs "-Dmicronaut.python.enabled=false -Djmh.executor=CUSTOM -Djmh.executor.class=io.micronaut.http.server.stack.JmhFastThreadLocalExecutor"` (plus the harness switches per mode). Every run was started only when the 1-minute load average was below 3 and no other java process was above 40% CPU; start loads (base/branch) were 2.04/2.40, 2.60/2.14 and 2.05/2.83 for the three `ControllersBenchmark` modes and 2.94/2.66, 2.74/2.74 and 2.84/2.92 for `FullHttpStackBenchmark`. "Within noise" means the difference is smaller than the sum of the two error bars (99.9% CI).

### Date header off, no access log (harness defaults)

None of the changed code runs in this mode, so this is a no-regression check.

| Benchmark | Param | Base time | After time | Δ time | Base alloc (B/op) | After alloc (B/op) | Δ alloc |
|---|---|---|---|---|---|---|---|
| ControllersBenchmark | TFB_LIKE | 2,610 ± 74 ns/op | 2,587 ± 30 ns/op | -23 ns/op (-0.9%) (within noise) | 6,408 ± 1 | 6,408 ± 1 | -0 (-0.0%) (within noise) |
| ControllersBenchmark | TFB_STRING | 2,394 ± 49 ns/op | 2,425 ± 47 ns/op | +31 ns/op (+1.3%) (within noise) | 6,456 ± 1 | 6,456 ± 1 | +0 (+0.0%) (within noise) |
| ControllersBenchmark | TFB_LIKE_BEANS1 | 1,932 ± 31 ns/op | 1,850 ± 34 ns/op | -81 ns/op (-4.2%) | 3,856 ± 1 | 3,856 ± 1 | -0 (-0.0%) (within noise) |
| ControllersBenchmark | TFB_LIKE_BEANS2 | 1,860 ± 20 ns/op | 1,878 ± 70 ns/op | +18 ns/op (+1.0%) (within noise) | 3,888 ± 1 | 3,888 ± 1 | +0 (+0.0%) (within noise) |
| ControllersBenchmark | TFB_LIKE_ASYNC_BEANS1 | 1,909 ± 24 ns/op | 1,899 ± 27 ns/op | -10 ns/op (-0.5%) (within noise) | 3,896 ± 1 | 3,896 ± 1 | -0 (-0.0%) (within noise) |
| ControllersBenchmark | TFB_LIKE_ASYNC_BEANS2 | 1,865 ± 39 ns/op | 1,842 ± 23 ns/op | -23 ns/op (-1.3%) (within noise) | 3,928 ± 1 | 3,928 ± 1 | -0 (-0.0%) (within noise) |
| ControllersBenchmark | TFB_LIKE_MAP | 1,689 ± 55 ns/op | 1,766 ± 65 ns/op | +77 ns/op (+4.5%) (within noise) | 3,984 ± 1 | 3,984 ± 1 | +0 (+0.0%) (within noise) |
| ControllersBenchmark | MISSING_QUERY_PARAMETER | 1,987 ± 61 ns/op | 2,089 ± 266 ns/op | +102 ns/op (+5.1%) (within noise) | 4,920 ± 1 | 4,856 ± 1 | -64 (-1.3%) |
| FullHttpStackBenchmark | MICRONAUT | 2,763 ± 74 ns/op | 2,718 ± 218 ns/op | -45 ns/op (-1.6%) (within noise) | 6,496 ± 2 | 6,480 ± 2 | -16 (-0.2%) |

The -81 ns on `TFB_LIKE_BEANS1` and the -64/-16 B/op on the last two rows are single-fork variance (no changed code executes with both switches off; the previous perf PR measured same-jar fork-to-fork differences of the same size), not an effect of this PR.

### Date header on (`-Dmicronaut.bench.date-header=true`)

| Benchmark | Param | Base time | After time | Δ time | Base alloc (B/op) | After alloc (B/op) | Δ alloc |
|---|---|---|---|---|---|---|---|
| ControllersBenchmark | TFB_LIKE | 2,585 ± 39 ns/op | 2,493 ± 26 ns/op | -93 ns/op (-3.6%) | 6,816 ± 1 | 6,392 ± 1 | -424 (-6.2%) |
| ControllersBenchmark | TFB_STRING | 2,945 ± 50 ns/op | 2,546 ± 103 ns/op | -399 ns/op (-13.5%) | 6,832 ± 1 | 6,416 ± 1 | -416 (-6.1%) |
| ControllersBenchmark | TFB_LIKE_BEANS1 | 2,187 ± 68 ns/op | 1,732 ± 23 ns/op | -455 ns/op (-20.8%) | 4,264 ± 1 | 3,856 ± 1 | -408 (-9.6%) |
| ControllersBenchmark | TFB_LIKE_BEANS2 | 2,243 ± 87 ns/op | 1,795 ± 64 ns/op | -448 ns/op (-20.0%) | 4,344 ± 1 | 3,888 ± 1 | -456 (-10.5%) |
| ControllersBenchmark | TFB_LIKE_ASYNC_BEANS1 | 2,186 ± 121 ns/op | 1,790 ± 39 ns/op | -396 ns/op (-18.1%) | 4,240 ± 1 | 3,856 ± 1 | -384 (-9.1%) |
| ControllersBenchmark | TFB_LIKE_ASYNC_BEANS2 | 2,076 ± 68 ns/op | 1,702 ± 16 ns/op | -374 ns/op (-18.0%) | 4,272 ± 1 | 3,888 ± 1 | -384 (-9.0%) |
| ControllersBenchmark | TFB_LIKE_MAP | 1,939 ± 38 ns/op | 1,674 ± 52 ns/op | -265 ns/op (-13.7%) | 4,392 ± 1 | 3,968 ± 1 | -424 (-9.7%) |
| ControllersBenchmark | MISSING_QUERY_PARAMETER | 2,216 ± 82 ns/op | 2,091 ± 39 ns/op | -125 ns/op (-5.6%) | 5,264 ± 1 | 4,880 ± 1 | -384 (-7.3%) |
| FullHttpStackBenchmark | MICRONAUT | 3,508 ± 355 ns/op | 3,024 ± 400 ns/op | -484 ns/op (-13.8%) (within noise) | 6,960 ± 2 | 6,544 ± 2 | -416 (-6.0%) |

With the header on, the branch is back to the "header off" numbers (compare `After` here with `Base` above: `TFB_LIKE_BEANS1` 1,732 vs 1,932, alloc 3,856 vs 3,856). The per-response cost of the header on 5.2.x was roughly 400 B/op and 250-450 ns; on the branch it is one `add` of a shared `String`.

### Date header on, access log on (`-Dmicronaut.bench.access-log=true`, NOP appender)

| Benchmark | Param | Base time | After time | Δ time | Base alloc (B/op) | After alloc (B/op) | Δ alloc |
|---|---|---|---|---|---|---|---|
| ControllersBenchmark | TFB_LIKE | 4,010 ± 187 ns/op | 3,054 ± 185 ns/op | -956 ns/op (-23.8%) | 7,728 ± 2 | 6,928 ± 2 | -800 (-10.4%) |
| ControllersBenchmark | TFB_STRING | 3,838 ± 225 ns/op | 2,690 ± 130 ns/op | -1,148 ns/op (-29.9%) | 7,696 ± 2 | 6,976 ± 1 | -720 (-9.4%) |
| ControllersBenchmark | TFB_LIKE_BEANS1 | 2,955 ± 91 ns/op | 2,153 ± 70 ns/op | -803 ns/op (-27.2%) | 5,200 ± 1 | 4,440 ± 1 | -760 (-14.6%) |
| ControllersBenchmark | TFB_LIKE_BEANS2 | 3,100 ± 118 ns/op | 2,110 ± 120 ns/op | -989 ns/op (-31.9%) | 5,256 ± 2 | 4,432 ± 1 | -824 (-15.7%) |
| ControllersBenchmark | TFB_LIKE_ASYNC_BEANS1 | 2,917 ± 70 ns/op | 2,202 ± 136 ns/op | -715 ns/op (-24.5%) | 5,168 ± 1 | 4,432 ± 1 | -736 (-14.2%) |
| ControllersBenchmark | TFB_LIKE_ASYNC_BEANS2 | 3,094 ± 97 ns/op | 2,183 ± 119 ns/op | -911 ns/op (-29.4%) | 5,200 ± 2 | 4,464 ± 1 | -736 (-14.2%) |
| ControllersBenchmark | TFB_LIKE_MAP | 2,682 ± 128 ns/op | 2,225 ± 176 ns/op | -457 ns/op (-17.0%) | 5,328 ± 1 | 4,544 ± 1 | -784 (-14.7%) |
| ControllersBenchmark | MISSING_QUERY_PARAMETER | 3,328 ± 171 ns/op | 2,440 ± 84 ns/op | -889 ns/op (-26.7%) | 6,144 ± 2 | 5,512 ± 1 | -632 (-10.3%) |
| FullHttpStackBenchmark | MICRONAUT | 4,168 ± 398 ns/op | 3,551 ± 428 ns/op | -617 ns/op (-14.8%) (within noise) | 7,824 ± 3 | 7,080 ± 2 | -744 (-9.5%) |

Subtracting the "header on" rows, access logging itself cost about 900 B/op and 1.4 µs per request on 5.2.x (`TFB_LIKE`: 7,728 - 6,816 B/op, 4,010 - 2,585 ns) and costs about 540 B/op and 0.56 µs on the branch (6,928 - 6,392 B/op, 3,054 - 2,493 ns). What remains is the log line itself (`AccessLog` string building, the logback event) plus the remaining per-request elements, which this PR does not touch.

**Reading the numbers.** The time and allocation deltas in the two switched-on modes are outside the error bars on every `ControllersBenchmark` row; `FullHttpStackBenchmark` time is within its (wide) error bars in all modes while its allocation delta matches the `ControllersBenchmark` rows. With both switches off, nothing changes. The default Micronaut configuration has the `Date` header on, so the "Date header on" table is the one that applies to a stock application.

## Testing

- New `PerSecondCacheTest` (http-server, 4 tests): same second is formatted once and returns the same instance, value changes at the 999 to 1000 ms boundary, negative instants round toward minus infinity, `now()` is within the current second.
- New `HttpDateHeaderTest` (http-server, 11 tests): the cached value equals the pre-PR `ZonedDateTime.of(LocalDateTime, systemDefault).withZoneSameInstant(GMT).format(RFC_1123_DATE_TIME)` text for seven instants, fixed expected strings (`Tue, 14 Nov 2023 22:13:20 GMT` for 1,700,000,000,000 and ,999 ms; `:21` for 1,700,000,001,000), same instance within a second, change at the boundary, `now()` parses to the current second.
- New `DateHeaderSpec` (http-server-netty): two requests on one embedded connection, the second after sleeping into the next wall-clock second; both `Date` values are RFC 1123 GMT, each within the second it was produced, and the second is strictly later than the first. Also that `micronaut.server.date-header=false` still omits the header.
- New `DateTimeElementSpec` (http-server-netty, 17 tests): default pattern is cached (same instance within a second, new value across the boundary) and equal to the uncached format; `dd/MMM/yyyy:HH:mm:ss Z, UTC` gives `14/Nov/2023:22:13:20 +0000` / `:21 +0000`; `end:yyyy-MM-dd HH:mm:ss, Asia/Tokyo` gives `2023-11-15 07:13:20` and selects the last-response-write event; `HH:mm:ss.SSS, UTC` is not cached and gives `.000`, `.001`, `.999`, `.000` for consecutive milliseconds; live values from `onRequestHeaders` are current; 12 cases for the sub-second pattern scan including quoted `'S'` and escaped quotes.
- New `AccessLogRequestAttributeSpec` (http-server-netty): with the access logger enabled, a controller sees its own `NettyHttpRequest` in the channel attribute during routing (`same`), and the attribute is `null` after the response for two consecutive requests on the same connection; with the logger disabled the attribute is never set. Fail-before verified by restoring the 5.2.x `RoutingInBoundHandler` and running the spec: `Condition not satisfied: server.attr(KEY).get() == null` with the attribute still holding `GET /access-log-attribute` at `AccessLogRequestAttributeSpec.groovy:48`. The `Date`/timestamp caches preserve behaviour by design, so their tests guard equivalence rather than failing before.
- `./gradlew :micronaut-http-server:test :micronaut-http-server:checkstyleTest`: 143 tests, 0 failures.
- `./gradlew :micronaut-http-netty:test :micronaut-http-netty:checkstyleTest`: 148 tests, 3 skipped (pre-existing), 0 failures.
- `./gradlew :micronaut-http-server-netty:test`: 1177 tests, 22 skipped (pre-existing), 0 failures on the first run; `checkstyleTest` is not configured for this module (task SKIPPED).
- `checkstyleMain` clean for http-server and http-server-netty apart from the pre-existing `NettyHttpServerConfiguration` FileLength violation; `japiCmp` clean for both modules.

## Out of scope

- Enabling the access logger without `micronaut-http-netty-http3` on the classpath fails every request on 5.2.x with `NoClassDefFoundError: io/netty/handler/codec/quic/QuicChannel` from `ConnectionMetadataImpl.<clinit>`: the initializer guards `QuicChannel.class` with `catch (Exception)`, which does not catch a `NoClassDefFoundError`. That is what the first access-log benchmark run hit (the benchmarks module only had `http-server-netty`, which declares the HTTP/3 module `compileOnly`). This PR adds the module to the benchmark classpath so the switch works; the initializer itself is a separate fix.
- `RoutingInBoundHandler.prepareRequest` still calls `ctx.pipeline().get(HANDLER_ACCESS_LOGGER)` per request. The answer differs per pipeline (HTTP/1 pipelines carry the handler, HTTP/2 connection pipelines use `Http2AccessLogManager` instead, and a configuration reload can remove it), so replacing the scan needs a per-pipeline flag threaded through `HttpPipelineBuilder`; it is a ~10-node name comparison and left alone.
- With the default (non-legacy) HTTP/2 connection handler the `NettyHttpRequest` attribute is never set, because that connection pipeline carries `Http2AccessLogManager` rather than a `HANDLER_ACCESS_LOGGER` handler, so `SessionLogElement` reports `-` there. Pre-existing and unrelated to the caches.
- Access log elements other than the timestamp still allocate per request (`Optional`s from `ConnectionMetadata.remoteAddress()`, the log line string), as does the logback event; visible as the residual ~540 B/op in the third table.
- `ServerScenariosBenchmark` was not run: its scenarios exercise bodies and multipart, not the header/access-log paths, and the harness switches only cover the two benchmarks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
