### PR TITLE
Look up optional netty types by name in the access log connection metadata

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/ConnectionMetadata.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/ConnectionMetadata.java
@@ -76,7 +76,7 @@ public interface ConnectionMetadata {
             return Optional.of(addr.getPath().toString())
                 // remote address is empty string
                 .filter(s -> !s.isEmpty());
-        } else if (ConnectionMetadataImpl.DOMAIN_SOCKET_ADDRESS.isInstance(a)) {
+        } else if (ConnectionMetadataImpl.DOMAIN_SOCKET_ADDRESS != null && ConnectionMetadataImpl.DOMAIN_SOCKET_ADDRESS.isInstance(a)) {
             String path = ConnectionMetadataImpl.DomainSocketUtil.getPath(a);
             if (path.isEmpty() || path.equals("\0")) {
                 return Optional.empty();

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/ConnectionMetadataImpl.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/ConnectionMetadataImpl.java
@@ -16,10 +16,10 @@
 package io.micronaut.http.server.netty.handler.accesslog.element;
 
 import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.Nullable;
 import io.netty.channel.Channel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.unix.DomainSocketAddress;
-import io.netty.channel.unix.DomainSocketChannel;
 import io.netty.handler.codec.quic.QuicChannel;
 
 import java.net.SocketAddress;
@@ -33,30 +33,38 @@ import java.util.Optional;
  */
 @Internal
 final class ConnectionMetadataImpl {
+    @Nullable
     static final Class<?> QUIC_CHANNEL;
+    @Nullable
     static final Class<?> DOMAIN_SOCKET_ADDRESS;
+    @Nullable
     static final Class<?> DOMAIN_SOCKET_CHANNEL;
 
     static {
-        Class<QuicChannel> quicChannelClass;
-        try {
-            quicChannelClass = QuicChannel.class;
-        } catch (Exception e) {
-            quicChannelClass = null;
-        }
-        QUIC_CHANNEL = quicChannelClass;
+        // These types come from optional netty modules. They must be looked up by name: a class
+        // literal is resolved by the JVM and a missing class surfaces as NoClassDefFoundError, which
+        // is an Error, so a catch (Exception) around it never runs and this initializer fails.
+        QUIC_CHANNEL = optionalClass("io.netty.handler.codec.quic.QuicChannel");
+        DOMAIN_SOCKET_ADDRESS = optionalClass("io.netty.channel.unix.DomainSocketAddress");
+        DOMAIN_SOCKET_CHANNEL = optionalClass("io.netty.channel.unix.DomainSocketChannel");
+    }
 
-        Class<DomainSocketAddress> domainSocketAddressClass;
-        Class<DomainSocketChannel> domainSocketChannelClass;
+    private ConnectionMetadataImpl() {
+    }
+
+    /**
+     * Look up a class from an optional dependency.
+     *
+     * @param name The binary class name
+     * @return The class, or {@code null} if it, or anything it depends on, is not available
+     */
+    @Nullable
+    static Class<?> optionalClass(String name) {
         try {
-            domainSocketAddressClass = DomainSocketAddress.class;
-            domainSocketChannelClass = DomainSocketChannel.class;
-        } catch (Exception e) {
-            domainSocketAddressClass = null;
-            domainSocketChannelClass = null;
+            return Class.forName(name, false, ConnectionMetadataImpl.class.getClassLoader());
+        } catch (ClassNotFoundException | LinkageError e) {
+            return null;
         }
-        DOMAIN_SOCKET_ADDRESS = domainSocketAddressClass;
-        DOMAIN_SOCKET_CHANNEL = domainSocketChannelClass;
     }
 
     static class DomainSocketUtil {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/ConnectionMetadataImpl.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/ConnectionMetadataImpl.java
@@ -42,8 +42,8 @@ final class ConnectionMetadataImpl {
 
     static {
         // These types come from optional netty modules. They must be looked up by name: a class
-        // literal is resolved by the JVM and a missing class surfaces as NoClassDefFoundError, which
-        // is an Error, so a catch (Exception) around it never runs and this initializer fails.
+        // literal is resolved by the JVM and a missing class surfaces as NoClassDefFoundError, an
+        // Error that an Exception handler does not see, which would fail this initializer.
         QUIC_CHANNEL = optionalClass("io.netty.handler.codec.quic.QuicChannel");
         DOMAIN_SOCKET_ADDRESS = optionalClass("io.netty.channel.unix.DomainSocketAddress");
         DOMAIN_SOCKET_CHANNEL = optionalClass("io.netty.channel.unix.DomainSocketChannel");

--- a/http-server-netty/src/test/java/io/micronaut/http/server/netty/handler/accesslog/element/ConnectionMetadataOptionalClassesTest.java
+++ b/http-server-netty/src/test/java/io/micronaut/http/server/netty/handler/accesslog/element/ConnectionMetadataOptionalClassesTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.handler.accesslog.element;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The QUIC channel type comes from an optional netty module. Access logging must keep working
+ * without it for connections that are not plain sockets (unix domain sockets, for example), where
+ * {@link ConnectionMetadata#ofNettyChannel} has to consult the optional types.
+ */
+class ConnectionMetadataOptionalClassesTest {
+    private static final String ELEMENT_PACKAGE = ConnectionMetadata.class.getPackageName() + ".";
+    private static final String QUIC_PACKAGE = "io.netty.handler.codec.quic.";
+
+    @Test
+    void optionalTypesArePresentOnTheTestClasspath() {
+        assertNotNull(ConnectionMetadataImpl.QUIC_CHANNEL);
+        assertNotNull(ConnectionMetadataImpl.DOMAIN_SOCKET_ADDRESS);
+        assertNotNull(ConnectionMetadataImpl.DOMAIN_SOCKET_CHANNEL);
+    }
+
+    @Test
+    void missingOptionalTypeIsNull() {
+        assertNull(ConnectionMetadataImpl.optionalClass("io.netty.handler.codec.quic.DoesNotExist"));
+    }
+
+    @Test
+    void nonSocketChannelMetadataWorksWithoutTheQuicModule() throws Exception {
+        ClassLoader hiding = new HidingClassLoader(getClass().getClassLoader());
+        Class<?> metadata = Class.forName(ConnectionMetadata.class.getName(), true, hiding);
+        Class<?> impl = Class.forName(ConnectionMetadataImpl.class.getName(), true, hiding);
+        // the hiding loader defines a distinct runtime package, so package access does not apply
+        assertNull(staticField(impl, "QUIC_CHANNEL"), "QUIC channel type should be absent");
+        assertNotNull(staticField(impl, "DOMAIN_SOCKET_ADDRESS"), "unix-common is not hidden");
+
+        // EmbeddedChannel is not a SocketChannel, so this is the branch that consults the optional types
+        Method ofNettyChannel = metadata.getDeclaredMethod("ofNettyChannel", Channel.class);
+        ofNettyChannel.setAccessible(true);
+        EmbeddedChannel channel = new EmbeddedChannel();
+        try {
+            Object result = ofNettyChannel.invoke(null, channel);
+            assertNotNull(result);
+            assertEquals(hiding, result.getClass().getClassLoader());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+
+        Method getHostName = metadata.getDeclaredMethod("getHostName", SocketAddress.class);
+        getHostName.setAccessible(true);
+        assertEquals(Optional.of("localhost"), getHostName.invoke(null, new InetSocketAddress("localhost", 0)));
+        assertEquals(Optional.empty(), getHostName.invoke(null, new SocketAddress() { }));
+    }
+
+    private static Object staticField(Class<?> type, String name) throws ReflectiveOperationException {
+        Field field = type.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(null);
+    }
+
+    /**
+     * Child-first for the access log element package, so those classes are initialized inside
+     * this loader; refuses the QUIC package outright; delegates everything else to the parent.
+     */
+    private static final class HidingClassLoader extends ClassLoader {
+        HidingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith(QUIC_PACKAGE)) {
+                throw new ClassNotFoundException(name);
+            }
+            if (!name.startsWith(ELEMENT_PACKAGE)) {
+                return super.loadClass(name, resolve);
+            }
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null) {
+                    byte[] bytes = readClass(name);
+                    loaded = defineClass(name, bytes, 0, bytes.length);
+                }
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+        }
+
+        private byte[] readClass(String name) throws ClassNotFoundException {
+            try (InputStream in = getParent().getResourceAsStream(name.replace('.', '/') + ".class")) {
+                if (in == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                return in.readAllBytes();
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`ConnectionMetadataImpl` guards its references to `QuicChannel`, `DomainSocketAddress` and `DomainSocketChannel`, which come from optional netty modules, with a class literal inside a `catch (Exception)`. A class literal is resolved by the JVM, and a missing class surfaces as `NoClassDefFoundError`. That is an `Error`, so the catch never runs and the static initializer fails.

The QUIC codec is not on `http-server-netty`'s runtime classpath; it arrives with the HTTP/3 module. So with access logging enabled and no HTTP/3 module, any request whose channel is not a `SocketChannel` fails with

```
java.lang.NoClassDefFoundError: io/netty/handler/codec/quic/QuicChannel
    at ...accesslog.element.ConnectionMetadataImpl.<clinit>
```

Reproduced by loading the class with the QUIC codec removed from the runtime classpath.

**Who is affected:** access logging on a unix domain socket listener (or any other non-socket channel) without `micronaut-http-netty-http3`. TCP listeners over HTTP/1 and HTTP/2 are not affected, because `ConnectionMetadata.ofNettyChannel` returns early for a `SocketChannel` without touching the class. That is why this has not been reported. The test classpath always carries the HTTP/3 module, which is why no test caught it.

## Change

- Look the three types up with `Class.forName(name, false, loader)`, catching `ClassNotFoundException | LinkageError`, and keep `null` when absent.
- `ConnectionMetadata.getHostName` null-checks `DOMAIN_SOCKET_ADDRESS`; it was the one consumer that assumed the field non-null. (`netty-transport-native-unix-common`, which provides the domain socket types, is always on the runtime classpath, so in practice only the QUIC guard matters. All three now behave as the original code intended.)
- The fields are `@Nullable`, which NullAway requires for a `@NullMarked` package.

## Testing

`ConnectionMetadataOptionalClassesTest` loads the access log element package through a child-first class loader that refuses the QUIC package, then calls `ofNettyChannel` with an `EmbeddedChannel` (not a `SocketChannel`, so it reaches the optional-type checks) and `getHostName` with an unknown address type. On the unmodified code the test fails with the `NoClassDefFoundError` above; with the change it passes. It also asserts the optional types are present on the normal test classpath, so the happy path stays covered.

`:micronaut-http-server-netty:test`: 1159 tests, 0 failures. `checkstyleMain` clean.

Noticed while benchmarking with access logging enabled for #13118, where the JMH harness uses an `EmbeddedChannel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
