### PR TITLE
Reduce cold startup work: no zip file system scans, lazy MediaType quality, no Loom probe

### DIFF
--- a/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
+++ b/context-python/src/main/java/io/micronaut/context/python/PythonContextRuntime.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.exception.InstantiationException;
-import io.micronaut.scheduling.LoomSupport;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
@@ -464,7 +463,7 @@ public final class PythonContextRuntime {
         return provider != null
             && provider.isResolvable()
             && PythonAsyncioRuntime.currentEventLoopForContext() == null
-            && LoomSupport.isVirtual(Thread.currentThread());
+            && Thread.currentThread().isVirtual();
     }
 
     private static <T> T offloadPooledExecution(Supplier<T> action) {

--- a/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
+++ b/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
@@ -21,174 +21,107 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NullUnmarked;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 
 /**
+ * Virtual thread support from before virtual threads were part of every Java version Micronaut runs on.
+ *
  * @since 4.0.0
+ * @deprecated Virtual threads are always available, use {@link Thread#ofVirtual()},
+ * {@link Executors#newThreadPerTaskExecutor(ThreadFactory)} and {@link Thread#isVirtual()} directly.
+ * To be removed, see <a href="https://github.com/micronaut-projects/micronaut-core/issues/13119">#13119</a>.
  */
 @Internal
 @NullUnmarked
+@Deprecated(since = "5.2.1", forRemoval = true)
 public final class LoomSupport {
-    private static final boolean SUPPORTED;
-    private static Throwable failure;
-
-    private static final MethodHandle MH_NEW_THREAD_PER_TASK_EXECUTOR;
-    private static final MethodHandle MH_OF_VIRTUAL;
-    private static final MethodHandle MH_NAME;
-    private static final MethodHandle MH_NAME_COUNT;
-    private static final MethodHandle MH_FACTORY;
-    private static final MethodHandle MH_UNSTARTED;
-    private static final MethodHandle MH_IS_VIRTUAL;
-
-    static {
-        boolean sup;
-        MethodHandle newThreadPerTaskExecutor;
-        MethodHandle ofVirtual;
-        MethodHandle name;
-        MethodHandle nameCount;
-        MethodHandle factory;
-        MethodHandle unstarted;
-        MethodHandle isVirtual;
-        try {
-            newThreadPerTaskExecutor = MethodHandles.lookup()
-                .findStatic(Executors.class, "newThreadPerTaskExecutor", MethodType.methodType(ExecutorService.class, ThreadFactory.class));
-            Class<?> builderCl = Class.forName("java.lang.Thread$Builder");
-            Class<?> ofVirtualCl = Class.forName("java.lang.Thread$Builder$OfVirtual");
-            ofVirtual = MethodHandles.lookup()
-                .findStatic(Thread.class, "ofVirtual", MethodType.methodType(ofVirtualCl));
-            name = MethodHandles.lookup()
-                .findVirtual(builderCl, "name", MethodType.methodType(builderCl, String.class));
-            nameCount = MethodHandles.lookup()
-                .findVirtual(builderCl, "name", MethodType.methodType(builderCl, String.class, long.class));
-            factory = MethodHandles.lookup()
-                .findVirtual(builderCl, "factory", MethodType.methodType(ThreadFactory.class));
-            unstarted = MethodHandles.lookup()
-                .findVirtual(builderCl, "unstarted", MethodType.methodType(Thread.class, Runnable.class));
-            isVirtual = MethodHandles.lookup()
-                .findVirtual(Thread.class, "isVirtual", MethodType.methodType(boolean.class));
-
-            // This will throw if this Java doesn't support Loom, or if it does but only with
-            // --enable-preview.
-            Thread probe = (Thread) unstarted.invoke(ofVirtual.invoke(), (Runnable) () -> { });
-
-            // This checks if the JVM actually creates real virtual threads, or if it uses
-            // 'bound threads' which are just platform threads. As of June 2025 the Espresso JVM
-            // falls into this category. Checking here voids casting issues later in code that
-            // makes assumptions about the internals.
-            sup = Class.forName("java.lang.VirtualThread").isInstance(probe);
-            if (!sup) {
-                failure = new Exception("This JVM doesn't fully implement virtual threads and produces regular platform threads instead.");
-            }
-        } catch (Throwable e) {
-            newThreadPerTaskExecutor = null;
-            ofVirtual = null;
-            name = null;
-            nameCount = null;
-            factory = null;
-            unstarted = null;
-            isVirtual = null;
-            sup = false;
-            failure = e;
-        }
-
-        SUPPORTED = sup;
-        MH_NEW_THREAD_PER_TASK_EXECUTOR = newThreadPerTaskExecutor;
-        MH_OF_VIRTUAL = ofVirtual;
-        MH_NAME = name;
-        MH_NAME_COUNT = nameCount;
-        MH_FACTORY = factory;
-        MH_UNSTARTED = unstarted;
-        MH_IS_VIRTUAL = isVirtual;
-    }
 
     private LoomSupport() {
     }
 
+    /**
+     * @return Always true
+     */
     public static boolean isSupported() {
-        return SUPPORTED;
+        return true;
     }
 
+    /**
+     * Does nothing, virtual threads are always supported.
+     */
     public static void checkSupported() {
-        if (!isSupported()) {
-            throw new UnsupportedOperationException("Virtual threads are not supported on this JVM, you may have to pass --enable-preview", failure);
-        }
+        // virtual threads are always supported
     }
 
+    /**
+     * @param namePrefix      The thread name prefix, followed by a counter starting at 1
+     * @param builderModifier Modifies the {@link Thread.Builder.OfVirtual}, may be null
+     * @return A factory of virtual threads
+     */
     @Experimental
     public static ThreadFactory newVirtualThreadFactory(String namePrefix, Consumer<Object> builderModifier) {
-        checkSupported();
-        try {
-            Object builder = MH_OF_VIRTUAL.invoke();
-            builder = MH_NAME_COUNT.invoke(builder, namePrefix, 1L);
-            if (builderModifier != null) {
-                builderModifier.accept(builder);
-            }
-            return (ThreadFactory) MH_FACTORY.invoke(builder);
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
+        Thread.Builder.OfVirtual builder = Thread.ofVirtual().name(namePrefix, 1L);
+        if (builderModifier != null) {
+            builderModifier.accept(builder);
         }
+        return builder.factory();
     }
 
+    /**
+     * @param name            The thread name
+     * @param builderModifier Modifies the {@link Thread.Builder.OfVirtual}, may be null
+     * @param task            The task
+     * @return An unstarted virtual thread
+     */
     @Experimental
     public static Thread unstarted(String name, Consumer<Object> builderModifier, Runnable task) {
-        checkSupported();
-        try {
-            Object builder = MH_OF_VIRTUAL.invoke();
-            builder = MH_NAME.invoke(builder, name);
-            if (builderModifier != null) {
-                builderModifier.accept(builder);
-            }
-            return (Thread) MH_UNSTARTED.invoke(builder, task);
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
+        Thread.Builder.OfVirtual builder = Thread.ofVirtual().name(name);
+        if (builderModifier != null) {
+            builderModifier.accept(builder);
         }
+        return builder.unstarted(task);
     }
 
+    /**
+     * @param threadFactory The thread factory
+     * @return An executor starting a thread per task
+     */
     public static ExecutorService newThreadPerTaskExecutor(ThreadFactory threadFactory) {
-        checkSupported();
-        try {
-            return (ExecutorService) MH_NEW_THREAD_PER_TASK_EXECUTOR.invokeExact(threadFactory);
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
-        }
+        return Executors.newThreadPerTaskExecutor(threadFactory);
     }
 
+    /**
+     * @param namePrefix The thread name prefix, followed by a counter starting at 1
+     * @return A factory of virtual threads
+     */
     public static ThreadFactory newVirtualThreadFactory(String namePrefix) {
         return newVirtualThreadFactory(namePrefix, null);
     }
 
+    /**
+     * @param thread The thread
+     * @return Whether the thread is virtual
+     */
     public static boolean isVirtual(Thread thread) {
-        if (!isSupported()) {
-            // reasonable default.
-            return false;
-        }
-        try {
-            return (boolean) MH_IS_VIRTUAL.invokeExact(thread);
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
-        }
+        return thread.isVirtual();
     }
 
     /**
-     * Condition that only matches if virtual threads are supported on this platform.
+     * Condition that always matches, virtual threads are always supported.
+     *
+     * @deprecated Virtual threads are always supported, to be removed, see
+     * <a href="https://github.com/micronaut-projects/micronaut-core/issues/13119">#13119</a>.
      */
     @Internal
+    @Deprecated(since = "5.2.1", forRemoval = true)
     public static class LoomCondition implements Condition {
         @SuppressWarnings("rawtypes")
         @Override
         public boolean matches(ConditionContext context) {
-            if (isSupported()) {
-                return true;
-            } else {
-                context.fail("Virtual threads support not available: " + failure.getMessage());
-                return false;
-            }
+            return true;
         }
     }
 }

--- a/context/src/main/java/io/micronaut/scheduling/executor/ExecutorFactory.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/ExecutorFactory.java
@@ -22,7 +22,6 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.runtime.graceful.GracefulShutdownCapable;
-import io.micronaut.scheduling.LoomSupport;
 import jakarta.inject.Inject;
 import org.jspecify.annotations.Nullable;
 
@@ -76,7 +75,7 @@ public class ExecutorFactory implements GracefulShutdownCapable {
                 name = "virtual";
             }
             String prefix = name + "-executor-";
-            return r -> LoomSupport.unstarted(prefix + ThreadLocalRandom.current().nextInt(), null, r);
+            return r -> Thread.ofVirtual().name(prefix + ThreadLocalRandom.current().nextInt()).unstarted(r);
         }
         if (name != null) {
             return new NamedThreadFactory(name + "-executor");
@@ -114,7 +113,7 @@ public class ExecutorFactory implements GracefulShutdownCapable {
                 if ("false".equals(System.getProperty("jdk.trackAllThreads"))) {
                     return new FastThreadPerTaskExecutor(getThreadFactory(executorConfiguration));
                 } else {
-                    return LoomSupport.newThreadPerTaskExecutor(getThreadFactory(executorConfiguration));
+                    return Executors.newThreadPerTaskExecutor(getThreadFactory(executorConfiguration));
                 }
             default:
                 throw new IllegalStateException("Could not create Executor service for enum value: " + executorType);

--- a/context/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
@@ -18,7 +18,6 @@ package io.micronaut.scheduling.executor;
 import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.scheduling.LoomSupport;
 import io.micronaut.scheduling.TaskExecutors;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -49,12 +48,8 @@ public final class IOExecutorServiceConfig {
      */
     @Singleton
     @Named(TaskExecutors.VIRTUAL)
-    @Requires(
-        missingProperty = ExecutorConfiguration.PREFIX + "." + TaskExecutors.VIRTUAL,
-        condition = LoomSupport.LoomCondition.class)
+    @Requires(missingProperty = ExecutorConfiguration.PREFIX + "." + TaskExecutors.VIRTUAL)
     ExecutorConfiguration virtual() {
-        // sanity check
-        LoomSupport.checkSupported();
         UserExecutorConfiguration cfg = UserExecutorConfiguration.of(TaskExecutors.VIRTUAL, ExecutorType.THREAD_PER_TASK);
         cfg.setVirtual(true);
         return cfg;

--- a/context/src/test/java/io/micronaut/scheduling/LoomSupportTest.java
+++ b/context/src/test/java/io/micronaut/scheduling/LoomSupportTest.java
@@ -1,0 +1,62 @@
+package io.micronaut.scheduling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings({"removal", "deprecation"})
+class LoomSupportTest {
+
+    @Test
+    void virtualThreadsAreAlwaysSupported() {
+        assertTrue(LoomSupport.isSupported());
+        assertTrue(new LoomSupport.LoomCondition().matches(null));
+        LoomSupport.checkSupported();
+    }
+
+    @Test
+    void createsAnUnstartedVirtualThread() throws InterruptedException {
+        AtomicReference<String> ran = new AtomicReference<>();
+        Thread thread = LoomSupport.unstarted("test-thread", null, () -> ran.set(Thread.currentThread().getName()));
+
+        assertEquals("test-thread", thread.getName());
+        assertTrue(thread.isVirtual());
+        assertTrue(LoomSupport.isVirtual(thread));
+        assertFalse(LoomSupport.isVirtual(Thread.currentThread()));
+
+        thread.start();
+        thread.join();
+        assertEquals("test-thread", ran.get());
+    }
+
+    @Test
+    void appliesTheBuilderModifier() {
+        AtomicReference<Object> seen = new AtomicReference<>();
+        Thread thread = LoomSupport.unstarted("modified", seen::set, () -> { });
+
+        assertTrue(seen.get() instanceof Thread.Builder.OfVirtual);
+        assertEquals("modified", thread.getName());
+    }
+
+    @Test
+    void namesTheThreadsOfAFactoryWithACounter() {
+        ThreadFactory factory = LoomSupport.newVirtualThreadFactory("counted-");
+
+        assertEquals("counted-1", factory.newThread(() -> { }).getName());
+        assertEquals("counted-2", factory.newThread(() -> { }).getName());
+    }
+
+    @Test
+    void runsATaskPerThreadOnTheExecutor() throws Exception {
+        ThreadFactory factory = LoomSupport.newVirtualThreadFactory("executor-", builder -> { });
+        try (ExecutorService executor = LoomSupport.newThreadPerTaskExecutor(factory)) {
+            assertTrue(executor.submit(() -> Thread.currentThread().isVirtual()).get());
+        }
+    }
+}

--- a/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
@@ -27,6 +27,7 @@ import org.slf4j.helpers.NOPLogger;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -44,6 +45,8 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -150,7 +153,9 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
         if (startsWithBase(url)) {
             try {
                 URI uri = url.toURI();
-                if (uri.getScheme().equals("jar")) {
+                if (uri.getScheme().equals("jar") && isEntryOfJarFile(uri)) {
+                    return readJarEntry(url);
+                } else if (uri.getScheme().equals("jar")) {
                     synchronized (DefaultClassPathResourceLoader.class) {
                         FileSystem fileSystem = null;
                         try {
@@ -214,6 +219,45 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Whether the URI names an entry of a jar file, {@code jar:file:/app.jar!/entry}, rather than an entry of a
+     * jar nested in another one or of a jar that is not on the file system.
+     *
+     * @param uri The jar URI
+     * @return True if the URI names an entry of a jar file
+     */
+    private static boolean isEntryOfJarFile(URI uri) {
+        String spec = uri.getRawSchemeSpecificPart();
+        int sep = spec.indexOf("!/");
+        return sep != -1 && spec.indexOf("!/", sep + 2) == -1 && spec.startsWith("file:");
+    }
+
+    /**
+     * Reads an entry of a jar file through the jar the class loader has already opened. Opening the jar as a zip file
+     * system instead reads and indexes its whole central directory again, on every call.
+     *
+     * @param url The URL of the entry
+     * @return The content of the entry, or empty if it is a directory
+     * @throws IOException If the entry cannot be read
+     */
+    private static Optional<InputStream> readJarEntry(URL url) throws IOException {
+        JarURLConnection connection = (JarURLConnection) url.openConnection();
+        // do not keep the jar open in the cache of the jar protocol handler, closing the stream closes the jar
+        connection.setUseCaches(false);
+        JarFile jarFile = connection.getJarFile();
+        try {
+            JarEntry entry = connection.getJarEntry();
+            if (entry == null || entry.isDirectory()) {
+                return Optional.empty();
+            }
+            try (InputStream input = jarFile.getInputStream(entry)) {
+                return Optional.of(new ByteArrayInputStream(input.readAllBytes()));
+            }
+        } finally {
+            jarFile.close();
+        }
     }
 
     private boolean startsWithBase(URL url) {

--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -22,6 +22,7 @@ import io.micronaut.core.util.ExceptionUtils;
 import io.micronaut.core.io.service.ServiceScanner.ExclusiveStaticServiceDefinitions;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -34,6 +35,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -43,6 +45,8 @@ import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveAction;
 import java.util.function.Predicate;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 /**
  * The loader of Micronaut services under META-INF/micronaut/.
@@ -168,6 +172,9 @@ public final class MicronautMetaServiceLoaderUtils {
         List<Closeable> toClose = new ArrayList<>();
         try {
             for (URI uri : resourceDefs) {
+                if (collectJarServices(uri, services)) {
+                    continue;
+                }
                 Path myPath = IOUtils.resolvePath(uri, MICRONAUT_SERVICES_PATH, toClose);
                 if (myPath != null) {
                     Files.walkFileTree(myPath, Collections.emptySet(), 2, visitor);
@@ -184,6 +191,72 @@ public final class MicronautMetaServiceLoaderUtils {
             }
         }
         return services;
+    }
+
+    /**
+     * Collects the services of a jar file by listing the entries of the jar. Opening the jar as a zip file system
+     * reads and indexes its whole central directory again, which for an application jar costs several times more than
+     * listing the entries of the zip file the class loader has already opened.
+     *
+     * <p>The entries are added in the order walking the zip file system visits them, the reverse of the order the
+     * jar stores them in, so the services are found in the same order as before.</p>
+     *
+     * @param uri      The URI of the {@code META-INF/micronaut/} resource
+     * @param services The services to add to
+     * @return True if the URI names a directory in a jar file and its services were collected
+     */
+    private static boolean collectJarServices(URI uri, Map<String, Set<String>> services) {
+        if (!"jar".equals(uri.getScheme())) {
+            return false;
+        }
+        String spec = uri.getRawSchemeSpecificPart();
+        int sep = spec.indexOf("!/");
+        // nested jars and the WebLogic form without a file: URL are left to the zip file system
+        if (sep == -1 || spec.indexOf("!/", sep + 2) != -1 || !spec.startsWith("file:")) {
+            return false;
+        }
+        List<String> names = new ArrayList<>();
+        try (ZipFile zipFile = new ZipFile(new File(URI.create(spec.substring(0, sep))))) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                String name = entries.nextElement().getName();
+                if (name.startsWith(MICRONAUT_SERVICES_PATH)) {
+                    names.add(name);
+                }
+            }
+        } catch (IOException | RuntimeException e) {
+            return false;
+        }
+        for (int i = names.size() - 1; i >= 0; i--) {
+            addJarEntry(names.get(i), services);
+        }
+        return true;
+    }
+
+    /**
+     * Adds a {@code META-INF/micronaut/<service>/<entry>} jar entry. As walking two levels of the file system does,
+     * a directory below the service counts as an entry, and a file directly in {@code META-INF/micronaut/} is not one.
+     *
+     * @param name     The name of the jar entry
+     * @param services The services to add to
+     */
+    private static void addJarEntry(String name, Map<String, Set<String>> services) {
+        int start = MICRONAUT_SERVICES_PATH.length();
+        int serviceEnd = name.indexOf('/', start);
+        if (serviceEnd <= start) {
+            return;
+        }
+        String serviceName = name.substring(start, serviceEnd);
+        Set<String> definitions = services.get(serviceName);
+        if (definitions == null) {
+            definitions = new LinkedHashSet<>();
+            services.put(serviceName, definitions);
+        }
+        int entryEnd = name.indexOf('/', serviceEnd + 1);
+        String entry = entryEnd == -1 ? name.substring(serviceEnd + 1) : name.substring(serviceEnd + 1, entryEnd);
+        if (!entry.isEmpty()) {
+            definitions.add(entry);
+        }
     }
 
     @Nullable

--- a/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtils.java
@@ -205,6 +205,8 @@ public final class MicronautMetaServiceLoaderUtils {
      * @param services The services to add to
      * @return True if the URI names a directory in a jar file and its services were collected
      */
+    // S5042: only the names of the entries are read, nothing is expanded, so an archive cannot exhaust memory or disk here
+    @SuppressWarnings("java:S5042")
     private static boolean collectJarServices(URI uri, Map<String, Set<String>> services) {
         if (!"jar".equals(uri.getScheme())) {
             return false;
@@ -240,6 +242,8 @@ public final class MicronautMetaServiceLoaderUtils {
      * @param name     The name of the jar entry
      * @param services The services to add to
      */
+    // S3824: computeIfAbsent would add a lambda to link on the startup path this method exists to shorten
+    @SuppressWarnings("java:S3824")
     private static void addJarEntry(String name, Map<String, Set<String>> services) {
         int start = MICRONAUT_SERVICES_PATH.length();
         int serviceEnd = name.indexOf('/', start);

--- a/core/src/test/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoaderJarTest.java
+++ b/core/src/test/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoaderJarTest.java
@@ -1,0 +1,91 @@
+package io.micronaut.core.io.scan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Reading resources out of a jar, which is served by the jar entry fast path rather than by a zip file system.
+ */
+class DefaultClassPathResourceLoaderJarTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void readsAnEntryOfAJar() throws IOException {
+        try (URLClassLoader classLoader = jarClassLoader()) {
+            DefaultClassPathResourceLoader loader = new DefaultClassPathResourceLoader(classLoader);
+
+            Optional<InputStream> stream = loader.getResourceAsStream("conf/app.properties");
+
+            assertTrue(stream.isPresent());
+            try (InputStream input = stream.get()) {
+                assertEquals("name=test", new String(input.readAllBytes(), StandardCharsets.UTF_8));
+            }
+            assertTrue(loader.getResource("conf/app.properties").isPresent());
+        }
+    }
+
+    @Test
+    void readsAnEntryOfAJarUnderABasePath() throws IOException {
+        try (URLClassLoader classLoader = jarClassLoader()) {
+            DefaultClassPathResourceLoader loader = new DefaultClassPathResourceLoader(classLoader, "conf");
+
+            Optional<InputStream> stream = loader.getResourceAsStream("app.properties");
+
+            assertTrue(stream.isPresent());
+            try (InputStream input = stream.get()) {
+                assertEquals("name=test", new String(input.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        }
+    }
+
+    @Test
+    void doesNotReadADirectoryOfAJarAsAStream() throws IOException {
+        try (URLClassLoader classLoader = jarClassLoader()) {
+            DefaultClassPathResourceLoader loader = new DefaultClassPathResourceLoader(classLoader);
+
+            assertFalse(loader.getResourceAsStream("conf").isPresent());
+        }
+    }
+
+    @Test
+    void answersEmptyForAMissingEntry() throws IOException {
+        try (URLClassLoader classLoader = jarClassLoader()) {
+            DefaultClassPathResourceLoader loader = new DefaultClassPathResourceLoader(classLoader);
+
+            assertFalse(loader.getResourceAsStream("conf/missing.properties").isPresent());
+        }
+    }
+
+    private URLClassLoader jarClassLoader() throws IOException {
+        Path jar = tempDir.resolve("resources.jar");
+        try (OutputStream out = Files.newOutputStream(jar); ZipOutputStream zip = new ZipOutputStream(out)) {
+            for (String directory : List.of("META-INF/", "conf/")) {
+                zip.putNextEntry(new ZipEntry(directory));
+                zip.closeEntry();
+            }
+            zip.putNextEntry(new ZipEntry("conf/app.properties"));
+            zip.write("name=test".getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+        return new URLClassLoader(new URL[]{jar.toUri().toURL()}, null);
+    }
+}

--- a/core/src/test/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtilsTest.java
+++ b/core/src/test/java/io/micronaut/core/io/service/MicronautMetaServiceLoaderUtilsTest.java
@@ -1,0 +1,121 @@
+package io.micronaut.core.io.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MicronautMetaServiceLoaderUtilsTest {
+
+    private static final String BEANS = "META-INF/micronaut/io.micronaut.inject.BeanDefinitionReference/";
+    private static final String INTROSPECTIONS = "META-INF/micronaut/io.micronaut.core.beans.BeanIntrospectionReference/";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void listsTheServicesOfAJarInTheOrderOfItsZipFileSystem() throws IOException {
+        assertSameAsZipFileSystem(jar("with directories.jar", List.of(
+            "META-INF/",
+            "META-INF/micronaut/",
+            BEANS,
+            BEANS + "a.$A$Definition",
+            BEANS + "b.$B$Definition",
+            BEANS + "c.$C$Definition",
+            INTROSPECTIONS,
+            INTROSPECTIONS + "a.$A$Introspection",
+            INTROSPECTIONS + "b.$B$Introspection",
+            "META-INF/micronaut/io.micronaut.inject.BeanConfiguration/",
+            "META-INF/micronaut/io.micronaut.inject.BeanConfiguration/a.$BeanConfiguration",
+            "a/A.class"
+        )));
+    }
+
+    @Test
+    void listsTheServicesOfAJarWithoutServiceDirectoryEntries() throws IOException {
+        assertSameAsZipFileSystem(jar("files only.jar", List.of(
+            "META-INF/micronaut/",
+            BEANS + "z.$Z$Definition",
+            BEANS + "y.$Y$Definition",
+            INTROSPECTIONS + "x.$X$Introspection",
+            BEANS + "x.$X$Definition",
+            "META-INF/micronaut/empty/",
+            BEANS + "nested/deeper/entry",
+            "META-INF/micronaut/stray-file"
+        )));
+    }
+
+    private void assertSameAsZipFileSystem(Path jar) throws IOException {
+        Map<String, Set<String>> expected = walkZipFileSystem(jar);
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[]{jar.toUri().toURL()}, null)) {
+            Map<String, Set<String>> actual = MicronautMetaServiceLoaderUtils.findAllMicronautMetaServices(classLoader);
+            assertEquals(asLists(expected), asLists(actual));
+        }
+    }
+
+    private static Map<String, List<String>> asLists(Map<String, Set<String>> services) {
+        Map<String, List<String>> lists = new LinkedHashMap<>();
+        services.forEach((service, entries) -> lists.put(service, new ArrayList<>(entries)));
+        return lists;
+    }
+
+    private static Map<String, Set<String>> walkZipFileSystem(Path jar) throws IOException {
+        Map<String, Set<String>> services = new LinkedHashMap<>();
+        try (FileSystem fs = FileSystems.newFileSystem(jar)) {
+            Path root = fs.getPath("META-INF/micronaut/");
+            Files.walkFileTree(root, Collections.emptySet(), 2, new SimpleFileVisitor<>() {
+                private Set<String> definitions;
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (!dir.endsWith("META-INF/micronaut/")) {
+                        definitions = services.computeIfAbsent(dir.getFileName().toString(), k -> new LinkedHashSet<>());
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (file.getParent() != null && !file.getParent().endsWith("META-INF/micronaut/")) {
+                        definitions.add(file.getFileName().toString());
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        return services;
+    }
+
+    private Path jar(String name, List<String> entries) throws IOException {
+        Path dir = Files.createDirectories(tempDir.resolve("a dir"));
+        Path jar = dir.resolve(name);
+        try (OutputStream out = Files.newOutputStream(jar); ZipOutputStream zip = new ZipOutputStream(out)) {
+            for (String entry : entries) {
+                zip.putNextEntry(new ZipEntry(entry));
+                zip.closeEntry();
+            }
+        }
+        return jar;
+    }
+}

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/EventLoopLoomFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/EventLoopLoomFactory.java
@@ -20,7 +20,6 @@ import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.scheduling.LoomSupport;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.executor.ExecutorConfiguration;
 import io.micronaut.scheduling.executor.ExecutorFactory;
@@ -40,7 +39,6 @@ import java.util.concurrent.ThreadFactory;
 @Internal
 @Experimental
 @Factory
-@Requires(condition = LoomSupport.LoomCondition.class)
 @Requires(condition = PrivateLoomSupport.PrivateLoomCondition.class)
 final class EventLoopLoomFactory {
     final FastThreadLocal<ThreadFactory> targetScheduler = new FastThreadLocal<>();
@@ -53,7 +51,7 @@ final class EventLoopLoomFactory {
             throw new IllegalStateException("Virtual executor should be virtual");
         }
 
-        ThreadFactory delegate = LoomSupport.newVirtualThreadFactory("virtual-executor-");
+        ThreadFactory delegate = Thread.ofVirtual().name("virtual-executor-", 1L).factory();
         return r -> {
             ThreadFactory targetScheduler = EventLoopLoomFactory.this.targetScheduler.get();
             if (targetScheduler == null) {

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/EventLoopVirtualThreadScheduler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/EventLoopVirtualThreadScheduler.java
@@ -17,7 +17,6 @@ package io.micronaut.http.netty.channel.loom;
 
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
-import io.micronaut.scheduling.LoomSupport;
 import io.netty.util.AttributeMap;
 import io.netty.util.concurrent.EventExecutor;
 
@@ -55,7 +54,7 @@ public sealed interface EventLoopVirtualThreadScheduler
     @Nullable
     static EventLoopVirtualThreadScheduler current() {
         if (LoomBranchSupport.isSupported()) {
-            if (!LoomSupport.isVirtual(Thread.currentThread())) {
+            if (!Thread.currentThread().isVirtual()) {
                 return null;
             }
             if (LoomBranchSupport.currentScheduler() instanceof EventLoopVirtualThreadScheduler elvts) {
@@ -65,7 +64,7 @@ public sealed interface EventLoopVirtualThreadScheduler
             }
         } else if (PrivateLoomSupport.isSupported()) {
             Thread thread = Thread.currentThread();
-            if (!LoomSupport.isVirtual(thread)) {
+            if (!thread.isVirtual()) {
                 return null;
             }
             if (PrivateLoomSupport.getScheduler(thread) instanceof EventLoopVirtualThreadScheduler elvts) {

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/LoomBranchSupport.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/LoomBranchSupport.java
@@ -18,7 +18,6 @@ package io.micronaut.http.netty.channel.loom;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.SupplierUtil;
-import io.micronaut.scheduling.LoomSupport;
 import org.jspecify.annotations.NullUnmarked;
 
 import java.lang.invoke.LambdaMetafactory;
@@ -101,7 +100,7 @@ public final class LoomBranchSupport {
 
         if (isSupported()) {
             FutureTask<Object> task = new FutureTask<>(LoomBranchSupport::currentPrivate);
-            DEFAULT_SCHEDULER_THREAD = LoomSupport.newVirtualThreadFactory("default-scheduler-exposer").newThread(task);
+            DEFAULT_SCHEDULER_THREAD = Thread.ofVirtual().name("default-scheduler-exposer", 1L).factory().newThread(task);
             DEFAULT_SCHEDULER_THREAD.start();
             DEFAULT_SCHEDULER = SupplierUtil.memoized(() -> {
                 try {

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/LoomCarrierGroup.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/LoomCarrierGroup.java
@@ -79,6 +79,12 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
         return runner.delegate;
     }
 
+    private static Thread unstartedVirtualThread(String name, Consumer<Thread.Builder.OfVirtual> builderModifier, Runnable task) {
+        Thread.Builder.OfVirtual builder = Thread.ofVirtual().name(name);
+        builderModifier.accept(builder);
+        return builder.unstarted(task);
+    }
+
     /**
      * Factory for creating {@link LoomCarrierGroup} instances.
      */
@@ -525,12 +531,6 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
                 tick.commit();
             }
         }
-    }
-
-    private static Thread unstartedVirtualThread(String name, Consumer<Thread.Builder.OfVirtual> builderModifier, Runnable task) {
-        Thread.Builder.OfVirtual builder = Thread.ofVirtual().name(name);
-        builderModifier.accept(builder);
-        return builder.unstarted(task);
     }
 
     record IoScheduler(Runner runner) implements Executor, EventLoopVirtualThreadScheduler, LoomBranchSupport.VirtualThreadSchedulerProxy {

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/LoomCarrierGroup.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/LoomCarrierGroup.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.NativeImageUtils;
-import io.micronaut.scheduling.LoomSupport;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.IoEventLoop;
 import io.netty.channel.IoHandler;
@@ -50,6 +49,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.Consumer;
 
 /**
  * Netty {@link EventLoopGroup} that can also carry virtual threads.
@@ -83,7 +83,6 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
      * Factory for creating {@link LoomCarrierGroup} instances.
      */
     @Singleton
-    @Requires(condition = LoomSupport.LoomCondition.class)
     @Requires(condition = PrivateLoomSupport.PrivateLoomCondition.class)
     public static final class Factory {
         final EventLoopLoomFactory holder;
@@ -216,7 +215,7 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
         }
 
         private boolean isOnRunner(Thread thread) {
-            if (!LoomSupport.isVirtual(thread)) {
+            if (!thread.isVirtual()) {
                 return false;
             }
             if (LoomBranchSupport.isSupported()) {
@@ -238,7 +237,7 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
 
         @Override
         public Thread newThread(Runnable r) {
-            return LoomSupport.unstarted("loom-on-netty-" + id + "-" + Long.toHexString(ThreadLocalRandom.current().nextLong()), b -> {
+            return unstartedVirtualThread("loom-on-netty-" + id + "-" + Long.toHexString(ThreadLocalRandom.current().nextLong()), b -> {
                 if (warmupTasks > 0) {
                     warmupTasks--;
                     if (!LoomBranchSupport.isSupported()) {
@@ -271,7 +270,7 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
         public void run() {
             carrier = Thread.currentThread();
 
-            ioThread = LoomSupport.unstarted(
+            ioThread = unstartedVirtualThread(
                 "loom-on-netty-" + id + "-io",
                 b -> {
                     if (LoomBranchSupport.isSupported()) {
@@ -528,6 +527,12 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
         }
     }
 
+    private static Thread unstartedVirtualThread(String name, Consumer<Thread.Builder.OfVirtual> builderModifier, Runnable task) {
+        Thread.Builder.OfVirtual builder = Thread.ofVirtual().name(name);
+        builderModifier.accept(builder);
+        return builder.unstarted(task);
+    }
+
     record IoScheduler(Runner runner) implements Executor, EventLoopVirtualThreadScheduler, LoomBranchSupport.VirtualThreadSchedulerProxy {
         @Override
         public AttributeMap attributeMap() {
@@ -557,7 +562,7 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
             Executor dst;
             if (currentThread instanceof ForkJoinWorkerThread fjwt && fjwt.getPool() == PrivateLoomSupport.getDefaultScheduler()) {
                 dst = PrivateLoomSupport.getDefaultScheduler();
-            } else if (LoomSupport.isVirtual(currentThread) && PrivateLoomSupport.getScheduler(currentThread) == PrivateLoomSupport.getDefaultScheduler()) {
+            } else if (currentThread.isVirtual() && PrivateLoomSupport.getScheduler(currentThread) == PrivateLoomSupport.getDefaultScheduler()) {
                 dst = PrivateLoomSupport.getDefaultScheduler();
             } else {
                 // move back to event loop whenever possible (e.g. after sleep)
@@ -569,7 +574,7 @@ public final class LoomCarrierGroup extends MultiThreadIoEventLoopGroup {
         @Override
         public void execute(Thread thread, Runnable task) {
             LoomBranchSupport.VirtualThreadSchedulerProxy dst;
-            if (LoomSupport.isVirtual(Thread.currentThread())) {
+            if (Thread.currentThread().isVirtual()) {
                 dst = LoomBranchSupport.currentScheduler();
                 if (dst instanceof EventLoopVirtualThreadScheduler) {
                     if (dst instanceof IoScheduler s) {

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/PrivateLoomSupport.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/loom/PrivateLoomSupport.java
@@ -148,6 +148,12 @@ public final class PrivateLoomSupport {
     static final class PrivateLoomCondition implements Condition {
         @Override
         public boolean matches(ConditionContext context) {
+            if (!Thread.class.getModule().isOpen("java.lang", PrivateLoomCondition.class.getModule())
+                && !LoomBranchSupport.isSupported()) {
+                // answered without initializing PrivateLoomSupport, which initializes the virtual thread scheduler
+                context.fail("Failed to access loom internals. Please make sure to add the `--add-opens=java.base/java.lang=ALL-UNNAMED` JVM argument.");
+                return false;
+            }
             if (!isSupported() && !LoomBranchSupport.isSupported()) {
                 context.fail("Failed to access loom internals. Please make sure to add the `--add-opens=java.base/java.lang=ALL-UNNAMED` JVM argument. (" + FAILURE + ")");
                 return false;

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/LoomCarrierSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/LoomCarrierSpec.groovy
@@ -12,7 +12,6 @@ import io.micronaut.http.netty.channel.loom.LoomBranchSupport
 import io.micronaut.http.netty.channel.loom.PrivateLoomSupport
 import io.micronaut.json.JsonMapper
 import io.micronaut.runtime.server.EmbeddedServer
-import io.micronaut.scheduling.LoomSupport
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
 import io.netty.util.concurrent.ThreadPerTaskExecutor
@@ -124,13 +123,13 @@ class LoomCarrierSpec extends Specification {
                     .executor(new ThreadPerTaskExecutor(new ThreadFactory() {
                         @Override
                         Thread newThread(@NonNull Runnable r) {
-                            return LoomSupport.unstarted("jdkclient", (b) -> {
-                                if (LoomBranchSupport.isSupported()) {
-                                    LoomBranchSupport.setScheduler(b, scheduler)
-                                } else {
-                                    PrivateLoomSupport.setScheduler(b, scheduler)
-                                }
-                            }, r)
+                            def b = Thread.ofVirtual().name("jdkclient")
+                            if (LoomBranchSupport.isSupported()) {
+                                LoomBranchSupport.setScheduler(b, scheduler)
+                            } else {
+                                PrivateLoomSupport.setScheduler(b, scheduler)
+                            }
+                            return b.unstarted(r)
                         }
                     }))
                     .build()) {

--- a/http-server-netty/src/test/groovy/io/micronaut/websocket/WebsocketExecuteOnSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/websocket/WebsocketExecuteOnSpec.groovy
@@ -3,7 +3,6 @@ package io.micronaut.websocket
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.runtime.server.EmbeddedServer
-import io.micronaut.scheduling.LoomSupport
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
@@ -47,7 +46,7 @@ class WebsocketExecuteOnSpec extends Specification {
     void "#type websocket server methods can run outside of the event loop with ExecuteOn"() {
         given:
         WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient.class, embeddedServer.getURL())
-        String threadName = (LoomSupport.isSupported() ? "virtual" : TaskExecutors.IO) + "-executor"
+        String threadName = "virtual-executor"
         String expectedJoined = "joined on thread " + threadName
         String expectedEcho = "Hello from thread " + threadName
 
@@ -85,7 +84,7 @@ class WebsocketExecuteOnSpec extends Specification {
     void "#type websocket server handler can handle errors with ExecuteOn"() {
         given:
         WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient.class, embeddedServer.getURL())
-        String threadName = (LoomSupport.isSupported() ? "virtual" : TaskExecutors.IO) + "-executor"
+        String threadName = "virtual-executor"
         String expectedJoined = "joined on thread " + threadName
         String expectedError = "error handled on thread " + threadName
         String expectedEcho = "Hello from thread " + threadName

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -804,7 +804,12 @@ public class MediaType implements CharSequence {
     private final String strRepr;
     private final String lowerName;
 
-    private BigDecimal qualityNumberField = BigDecimal.ONE;
+    /**
+     * The quality, or null for the default of one. Assigning {@link BigDecimal#ONE} to every media type would
+     * initialize {@link BigDecimal}, which computes its caches, while the media type constants are created.
+     */
+    @Nullable
+    private BigDecimal qualityNumberField;
 
     private boolean valid;
 
@@ -1109,14 +1114,15 @@ public class MediaType implements CharSequence {
      * @return The quality of the Mime type
      */
     public String getQuality() {
-        return qualityNumberField.toString();
+        return getQualityAsNumber().toString();
     }
 
     /**
      * @return The quality in BigDecimal form
      */
     public BigDecimal getQualityAsNumber() {
-        return this.qualityNumberField;
+        BigDecimal quality = this.qualityNumberField;
+        return quality == null ? BigDecimal.ONE : quality;
     }
 
     /**

--- a/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
@@ -2,7 +2,6 @@ package io.micronaut.runtime.executor
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.qualifiers.Qualifiers
-import io.micronaut.scheduling.LoomSupport
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.executor.ExecutorConfiguration
 import io.micronaut.scheduling.executor.UserExecutorConfiguration
@@ -19,7 +18,7 @@ import java.util.concurrent.ThreadPoolExecutor
  * @since 1.0
  */
 class ExecutorServiceConfigSpec extends Specification {
-    static final int expectedExecutorCount = LoomSupport.isSupported() ? 6 : 5
+    static final int expectedExecutorCount = 6
 
     void "test configure custom executor with invalidate cache: #invalidateCache"() {
         given:


### PR DESCRIPTION
Cold startup of a plain JVM (no AOT cache) got slower from 4.4 to 5.x. This fixes the startup costs in core that the profile showed as avoidable.

## Changes

- **`META-INF/micronaut` scan without a zip file system.** `MicronautMetaServiceLoaderUtils.findAllMicronautMetaServices` opened each class-path jar as a zip `FileSystem`, which reads and indexes the whole central directory again. For the 13 MB guide jar that is ~35 ms in a fresh JVM, compared with ~6.5 ms listing the entries of the `ZipFile` the class loader already opened. A zip file system walk visits entries in the reverse of jar order, so entries are added in that order and service order does not change. `MicronautMetaServiceLoaderUtilsTest` compares the result, including order, with a zip file system walk. Nested jars, and jar URLs that do not point at a file (the WebLogic form), still use the zip file system.
- **`DefaultClassPathResourceLoader.getResourceAsStream`** opened a zip file system to read one entry, such as `application.properties`. Plain `jar:file:…!/entry` URLs are now read through `JarURLConnection`, which does not cache the jar. With both changes the zip file system classes are no longer loaded at startup.
  - Edge case: with a base path, the old code first tried the unprefixed path at the jar root. The new code reads the entry the class loader resolved.
- **`MediaType`** no longer assigns `BigDecimal.ONE` to every instance. Doing so ran `BigDecimal`'s static initializer (~7 ms interpreted) while the media type constants were created. `getQuality()` and `getQualityAsNumber()` return the same values.
- **Virtual threads are always available on Java 25**, so there is no probe any more:
  - `LoomSupport` is `@Deprecated(forRemoval = true)`, with removal tracked in #13119. Its methods delegate to `Thread.ofVirtual()`, `isSupported()` returns true, and `LoomCondition` always matches.
  - Core no longer uses `LoomSupport` or `LoomCondition`.
  - `PrivateLoomCondition` checks that `java.lang` is opened before touching `VirtualThread` internals.
  - Startup no longer initializes `LoomSupport`, `PrivateLoomSupport` or `VirtualThread`.
  - micronaut-servlet's `JettyFactory` still calls `LoomSupport.isSupported()`, which keeps compiling and returns true.

## Measurements

The app is the "creating your first app" guide from the OpenJDK Leyden premain benchmark (Netty, serde-jackson, Logback, Platform 5.1.4), built against core published from 5.2.x HEAD and from this branch. JDK 25.0.2 on an M3 Max; each number comes from interleaved fresh JVMs with the first round dropped. The machine was shared, so absolute times vary between sessions.

| | 5.2.x | this PR | change |
|---|---|---|---|
| default JVM, median of 30 | 435 ms | 401 ms | −7.8% (process CPU −7.6%) |
| JDK 25 AOT cache, median of 20 | 155 ms | 135 ms | −12.9% |
| classes loaded | 4,901 | 4,808 | −93 |

Two earlier sessions under different load measured −6.9% and −7.9%. In async-profiler (CPU, 1 ms), per startup:
- the zip file system constructor: 19 ms → 0
- `findAllMicronautMetaServices`: 22 ms → 3 ms
- `getResourceAsStream`: 6 ms → 0
- `BigDecimal.<clinit>`: 7 ms → 0
- `LoomSupport` initialization and condition: 3 ms → 0

## Not changed

- **Parallel service loading.** Forcing the common pool to parallelism 1 made startup 25% slower.
- **Bean definition static initializers.** They cost ~119 ms CPU per startup, 93 ms of it loading referenced classes, and need a code generator change.
- **Upstream costs.** Logback initialization takes ~95 ms CPU and Netty server start ~53 ms.

## Tests

- `io.micronaut.core.io.*` (core)
- `ExecutorServiceConfigSpec` and `ExecutorSelectorSpec` (runtime)
- `LoomCarrierSpec`, `WebsocketExecuteOnSpec` and `ThreadSelectionSpec` (http-server-netty)
- `MediaTypeTest`, `MediaTypeSpec` and `MediaTypeMimeTypesTest` (http)
- `context-python` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
