### PR TITLE
Sync CI workflows from the project template and skip drafts in python.yml

### DIFF
--- a/.github/workflows/graalvm-dev.yml
+++ b/.github/workflows/graalvm-dev.yml
@@ -6,11 +6,39 @@
 name: GraalVM Dev CI
 on:
   schedule:
-    - cron: "0 1 * * 1-5" # Mon-Fri at 1am Europe/Madrid
+    - cron: "0 1 * * 6" # Saturdays at 1am Europe/Madrid; the gate below runs every other Saturday
       timezone: "Europe/Madrid"
 jobs:
-  build_matrix:
+  should_run:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.biweekly.outputs.should_run }}
+    steps:
+      - name: Check biweekly schedule
+        id: biweekly
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          current_date="$(TZ=Europe/Madrid date +%F)"
+          current_day="$(date -u -d "${current_date}" +%s)"
+          anchor_day="$(date -u -d "2026-09-12" +%s)"
+          days_since_anchor=$(( (current_day - anchor_day) / 86400 ))
+          should_run=false
+
+          if (( days_since_anchor >= 0 && days_since_anchor % 14 == 0 )); then
+            should_run=true
+          fi
+
+          echo "Current date: ${current_date}"
+          echo "Days since anchor: ${days_since_anchor}"
+          echo "Run build: ${should_run}"
+          echo "should_run=${should_run}" >> "${GITHUB_OUTPUT}"
+
+  build_matrix:
+    needs: should_run
+    if: github.repository != 'micronaut-projects/micronaut-project-template' && needs.should_run.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -8,14 +8,22 @@ on:
   push:
     branches:
       - master
+      - main
       - '[0-9]+.[0-9]+.x'
   pull_request:
     branches:
       - master
+      - main
       - '[0-9]+.[0-9]+.x'
+    types: [opened, synchronize, reopened, ready_for_review]
+# A new push to a pull request cancels its older run, freeing the shared runner
+# pool. Pushes to branches get a group of their own and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   build_matrix:
-    if: github.repository != 'micronaut-projects/micronaut-project-template'
+    if: github.repository != 'micronaut-projects/micronaut-project-template' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,15 +8,24 @@ on:
   push:
     branches:
       - master
+      - main
       - '[0-9]+.[0-9]+.x'
   pull_request:
     branches:
       - master
+      - main
       - '[0-9]+.[0-9]+.x'
+    types: [opened, synchronize, reopened, ready_for_review]
+# A new push to a pull request cancels its older run, freeing the shared runner
+# pool. Pushes to branches get a group of their own and are never cancelled:
+# they publish snapshots and docs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   build:
     name: "build"
-    if: github.repository != 'micronaut-projects/micronaut-project-template'
+    if: github.repository != 'micronaut-projects/micronaut-project-template' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,7 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1
+        uses: graalvm/setup-graalvm@0426e2e191540e8514dff98dc52a5f5146a2a276 # v1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
@@ -84,7 +93,7 @@ jobs:
 
       - name: "📊 Publish Test Report"
         if: always()
-        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
+        uses: mikepenz/action-junit-report@a9170d5795813c01ab4901ffb045b52bab4ab09d # v6
         with:
           check_name: Java CI / Test Report (${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,14 +6,20 @@ on:
       - master
       - '[0-9]+.[0-9]+.x'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
 
+# A new push to a pull request cancels its older run, freeing the shared runner
+# pool. Pushes to branches get a group of their own and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   build:
     name: build
-    if: github.repository != 'micronaut-projects/micronaut-project-template'
+    if: github.repository != 'micronaut-projects/micronaut-project-template' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     env:
       TESTCONTAINERS_RYUK_DISABLED: true

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -250,7 +250,7 @@ jobs:
       # and the job's token is `contents: read`. Kept because dropping it makes
       # release resolution flaky against the GitHub API rate limit.
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1
+        uses: graalvm/setup-graalvm@0426e2e191540e8514dff98dc52a5f5146a2a276 # v1
         with:
           distribution: 'graalvm'
           java-version: '25'

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - '[0-9]+.[0-9]+.x'
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '**/*.gradle'
       - '**/*.gradle.kts'
@@ -25,9 +26,14 @@ on:
       - '.github/workflows/release.yml'
       - '.github/scripts/vulnerability-audit.sh'
       - '.github/scripts/vulnerability-audit-filter.py'
+# A new push to a pull request cancels its older run, freeing the shared runner
+# pool.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   audit:
-    if: github.repository != 'micronaut-projects/micronaut-project-template'
+    if: github.repository != 'micronaut-projects/micronaut-project-template' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -57,7 +63,7 @@ jobs:
           fetch-depth: 0
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1
+        uses: graalvm/setup-graalvm@0426e2e191540e8514dff98dc52a5f5146a2a276 # v1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
Manual sync of `.github/workflows` from [micronaut-project-template](https://github.com/micronaut-projects/micronaut-project-template), rolling out the CI load reductions already trialled on micronaut-projects/micronaut-serialization#1418.

### What changes

- **Draft PRs skip CI** — Java CI, GraalVM Latest CI and the Vulnerability Audit are skipped while a PR is a draft and run once it is marked ready for review. Template PR: micronaut-projects/micronaut-project-template#791
- **Superseded PR runs are cancelled** — a new push to a PR cancels the in-progress run of the same workflow. Push builds get a group per run and are never cancelled, since Java CI publishes snapshots and docs on push. Template PR: micronaut-projects/micronaut-project-template#788
- **GraalVM Dev CI runs every other Saturday** (01:00 Europe/Madrid) instead of Mon–Fri. Template PR: micronaut-projects/micronaut-project-template#790
- Any other template drift (Renovate action digest bumps, `main` branch triggers, the on-demand `sonar-pr.yml`) is picked up as well.
- Where this repository has project-specific workflows triggered by `pull_request`, they get the same draft skip, `ready_for_review` trigger and concurrency group (see the diff).

### Verification

This PR is opened as a draft on purpose: with the synced workflows in place, no CI runs while it is a draft, which itself verifies the draft skip without occupying the shared runner pool. Mark it ready for review to run CI before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
