### PR TITLE
Fix/12578 uri builder

### DIFF
--- a/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
+++ b/core/src/main/java/io/micronaut/core/beans/DefaultBeanIntrospector.java
@@ -112,7 +112,7 @@ class DefaultBeanIntrospector implements BeanIntrospector {
         ArgumentUtils.requireNonNull("beanType", beanType);
         ClassLoader effectiveClassLoader = resolveClassLoader();
         @SuppressWarnings("unchecked") final BeanIntrospectionReference<T> reference =
-                (BeanIntrospectionReference<T>) findIntrospectionReference(beanType);
+                (BeanIntrospectionReference<T>) findIntrospectionReference(beanType, effectiveClassLoader);
         try {
             if (reference != null) {
                 return Optional.of(reference).map((Function<BeanIntrospectionReference<T>, BeanIntrospection<T>>) ref -> {
@@ -121,21 +121,6 @@ class DefaultBeanIntrospector implements BeanIntrospector {
                     }
                     return ref.load();
                 });
-            }
-            if (useContextClassLoader && Boolean.getBoolean(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER)) {
-                ClassLoader beanClassLoader = beanType.getClassLoader();
-                if (beanClassLoader != null && beanClassLoader != effectiveClassLoader) {
-                    @SuppressWarnings("unchecked") final BeanIntrospectionReference<T> beanClassLoaderReference =
-                            (BeanIntrospectionReference<T>) getIntrospections(beanClassLoader).get(beanType.getName());
-                    if (beanClassLoaderReference != null) {
-                        return Optional.of(beanClassLoaderReference).map((Function<BeanIntrospectionReference<T>, BeanIntrospection<T>>) ref -> {
-                            if (LOG.isDebugEnabled()) {
-                                LOG.debug("Found BeanIntrospection for type: {},", ref.getBeanType());
-                            }
-                            return ref.load();
-                        });
-                    }
-                }
             }
         } catch (Throwable e) {
             throw new IntrospectionException("Error loading BeanIntrospection for type [" + beanType + "]: " + e.getMessage(), e);
@@ -165,16 +150,22 @@ class DefaultBeanIntrospector implements BeanIntrospector {
         return Optional.empty();
     }
 
+    /**
+     * The introspection reference of the class loader the introspections are resolved with, or else of the class loader
+     * of the bean type, which may be a child class loader that the introspector cannot see.
+     * The class loader of the bean type is only asked when it shares this class' {@link BeanIntrospectionReference}:
+     * one that loads Micronaut on its own, as the application class loader does under a test harness that runs Micronaut
+     * in a class loader of its own, has introspections that cannot be cast to it, and a type from there is a lookup miss.
+     */
     @Nullable
-    private BeanIntrospectionReference<Object> findIntrospectionReference(Class<?> beanType) {
+    private BeanIntrospectionReference<Object> findIntrospectionReference(Class<?> beanType, ClassLoader effectiveClassLoader) {
         String beanTypeName = beanType.getName();
-        BeanIntrospectionReference<Object> reference = getIntrospections().get(beanTypeName);
+        BeanIntrospectionReference<Object> reference = getIntrospections(effectiveClassLoader).get(beanTypeName);
         if (reference != null) {
             return reference;
         }
         ClassLoader beanClassLoader = beanType.getClassLoader();
-        ClassLoader effectiveClassLoader = resolveClassLoader();
-        if (beanClassLoader != null && beanClassLoader != effectiveClassLoader) {
+        if (beanClassLoader != null && beanClassLoader != effectiveClassLoader && sharesBeanIntrospectionReference(beanClassLoader)) {
             return resolveIntrospections(beanClassLoader).get(beanTypeName);
         }
         return null;
@@ -233,11 +224,27 @@ class DefaultBeanIntrospector implements BeanIntrospector {
     private ClassLoader resolveClassLoader() {
         if (useContextClassLoader && Boolean.getBoolean(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER)) {
             ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-            if (contextClassLoader != null) {
+            if (contextClassLoader != null && (contextClassLoader == classLoader || sharesBeanIntrospectionReference(contextClassLoader))) {
                 return contextClassLoader;
             }
         }
         return classLoader;
+    }
+
+    /**
+     * Whether the given class loader resolves {@link BeanIntrospectionReference} to this class' own, so that the
+     * introspections and fallbacks it lists as services can be used here. A class loader that fails to answer, as a
+     * restricted or custom class loader may with any runtime exception, is taken as not sharing them.
+     *
+     * @param otherClassLoader The class loader
+     * @return Whether it shares the introspection types of this class
+     */
+    private static boolean sharesBeanIntrospectionReference(ClassLoader otherClassLoader) {
+        try {
+            return Class.forName(BeanIntrospectionReference.class.getName(), false, otherClassLoader) == BeanIntrospectionReference.class;
+        } catch (ClassNotFoundException | RuntimeException | LinkageError e) {
+            return false;
+        }
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -289,7 +289,7 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
             return false;
         }
         return Objects.equals(type, o.getType()) &&
-            Objects.equals(typeParameters, o.getTypeVariables());
+            equalsTypeVariables(typeParameters, o.getTypeVariables());
     }
 
     @Override
@@ -301,14 +301,44 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
             return false;
         }
         DefaultArgument<?> that = (DefaultArgument<?>) o;
-        return Objects.equals(type, that.type) &&
+        // A wildcard only equals a wildcard with the same bounds, so a plain argument must not equal one either
+        return (this instanceof WildcardArgument<?>) == (that instanceof WildcardArgument<?>) &&
+            Objects.equals(type, that.type) &&
             Objects.equals(getName(), that.getName()) &&
             Objects.equals(typeParameters, that.typeParameters);
     }
 
     @Override
     public int typeHashCode() {
-        return ObjectUtils.hash(type, typeParameters);
+        // Summed the way Map.hashCode sums its entries, but over the type hash codes, to agree with equalsType
+        int typeParametersHash = 0;
+        for (Map.Entry<String, Argument<?>> entry : typeParameters.entrySet()) {
+            typeParametersHash += entry.getKey().hashCode() ^ entry.getValue().typeHashCode();
+        }
+        return 31 * (31 + Objects.hashCode(type)) + typeParametersHash;
+    }
+
+    /**
+     * Compares type variables by their types at every depth, so that a type argument compiled to a
+     * {@link WildcardArgument} has the same type as a plain argument of the type the wildcard is bounded by, as
+     * it had before the bounds were kept: {@code Map<String, ? extends Object>}, which is what a Kotlin
+     * {@code Map<String, Any>} compiles to, has the type of {@code Map<String, Object>}.
+     *
+     * @param typeParameters The type variables of this argument
+     * @param other          The type variables of the other argument
+     * @return Whether they have the same types
+     */
+    private static boolean equalsTypeVariables(Map<String, Argument<?>> typeParameters, Map<String, Argument<?>> other) {
+        if (typeParameters.size() != other.size()) {
+            return false;
+        }
+        for (Map.Entry<String, Argument<?>> entry : typeParameters.entrySet()) {
+            Argument<?> otherTypeParameter = other.get(entry.getKey());
+            if (otherTypeParameter == null || !entry.getValue().equalsType(otherTypeParameter)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/core/src/main/java/io/micronaut/core/type/WildcardArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/WildcardArgument.java
@@ -34,7 +34,8 @@ import java.util.List;
  * <p>For compatibility with what the processors have always emitted, a wildcard argument also reports
  * {@link #isTypeVariable()} as {@code true} and may implement {@link GenericPlaceholder}, named after the type
  * parameter it stands for; a consumer that needs to tell a wildcard from a type variable should test for this
- * interface first. {@link #equalsType(Argument)} and {@link #typeHashCode()} do not consider the bounds.</p>
+ * interface first. {@link #equalsType(Argument)} and {@link #typeHashCode()} do not consider the bounds, at any
+ * depth: {@code Map<String, ? extends Object>} has the type of {@code Map<String, Object>}.</p>
  *
  * @param <T> The type the wildcard is bounded by
  * @author Denis Stepanov

--- a/core/src/test/groovy/io/micronaut/core/type/ArgumentSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/type/ArgumentSpec.groovy
@@ -216,6 +216,40 @@ class ArgumentSpec extends Specification {
             field << ["justString", "stringList", "mapStringInteger", "objectMap", "noTypeMap"]
     }
 
+    void 'a nested wildcard is compared by the type it is bounded by in equalsType and typeHashCode'() {
+        given: 'the JVM signature of a Kotlin Map<String, Any>: Map<String, ? extends Object>'
+        def wildcard = Argument.ofWildcard(Object, 'V', null, null, null, null)
+        def kotlinMap = Argument.of(Map, 'headers', Argument.of(String, 'K'), wildcard)
+        def map = Argument.mapOf(String, Object)
+        def upperBounded = Argument.of(List, 'numbers', Argument.ofWildcard(Number, 'E', null, null, [Argument.of(Number)] as Argument[], null))
+        def lowerBounded = Argument.of(List, 'numbers', Argument.ofWildcard(Number, 'E', null, null, null, [Argument.of(Number)] as Argument[]))
+        def nested = Argument.of(List, 'nested', Argument.of(Map, 'E', Argument.of(String, 'K'), wildcard))
+
+        expect:
+        kotlinMap.equalsType(map)
+        map.equalsType(kotlinMap)
+        kotlinMap.typeHashCode() == map.typeHashCode()
+        !kotlinMap.equalsType(Argument.mapOf(String, String))
+
+        and: 'whichever way the wildcard is bounded, as the processors compiled it before the bounds were kept'
+        upperBounded.equalsType(Argument.listOf(Number))
+        upperBounded.typeHashCode() == Argument.listOf(Number).typeHashCode()
+        lowerBounded.equalsType(Argument.listOf(Number))
+        lowerBounded.typeHashCode() == Argument.listOf(Number).typeHashCode()
+
+        and: 'at any depth, a type argument being matched by the name of the type parameter it stands for'
+        nested.equalsType(Argument.listOf(map.withName('E')))
+        Argument.listOf(map.withName('E')).equalsType(nested)
+        nested.typeHashCode() == Argument.listOf(map.withName('E')).typeHashCode()
+        !nested.equalsType(Argument.listOf(Argument.mapOf(String, String).withName('E')))
+
+        and: 'equals keeps telling a wildcard from a plain argument, in both directions'
+        wildcard != Argument.of(Object, 'V')
+        Argument.of(Object, 'V') != wildcard
+        kotlinMap != Argument.of(Map, 'headers', Argument.of(String, 'K'), Argument.of(Object, 'V'))
+        Argument.of(Map, 'headers', Argument.of(String, 'K'), Argument.of(Object, 'V')) != kotlinMap
+    }
+
 /*
     void "test inner class"() {
         def arg = new Test<String>() {}.get();

--- a/core/src/test/java/io/micronaut/core/beans/DefaultBeanIntrospectorTest.java
+++ b/core/src/test/java/io/micronaut/core/beans/DefaultBeanIntrospectorTest.java
@@ -8,18 +8,22 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
+import java.io.File;
 import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,6 +59,91 @@ class DefaultBeanIntrospectorTest {
             } else {
                 System.setProperty(CONTEXT_CLASSLOADER_PROPERTY, previousProperty);
             }
+        }
+    }
+
+    @Test
+    void beanClassLoaderWithItsOwnCoreIsALookupMiss() throws Exception {
+        // the Fn testing harness runs Micronaut in its own class loader while the test types come from the application
+        // class loader, whose introspections implement a BeanIntrospectionReference that is not the one of the introspector
+        Path classesDir = tempDir.resolve("classes");
+        compileChildLoaderIntrospection(classesDir);
+        writeMicronautServiceEntry(classesDir);
+
+        String previousProperty = System.getProperty(CONTEXT_CLASSLOADER_PROPERTY);
+        try (URLClassLoader isolatedCoreClassLoader = isolatedCoreClassLoader();
+             URLClassLoader childClassLoader = new URLClassLoader(new URL[] { classesDir.toUri().toURL() }, getClass().getClassLoader())) {
+            System.clearProperty(CONTEXT_CLASSLOADER_PROPERTY);
+            Class<?> isolatedIntrospector = isolatedCoreClassLoader.loadClass(BeanIntrospector.class.getName());
+            assertNotEquals(BeanIntrospector.class, isolatedIntrospector);
+            Object shared = isolatedIntrospector.getField("SHARED").get(null);
+
+            Class<?> beanType = childClassLoader.loadClass("example.ChildBean");
+            Optional<?> introspection = (Optional<?>) isolatedIntrospector.getMethod("findIntrospection", Class.class).invoke(shared, beanType);
+
+            assertTrue(introspection.isEmpty());
+        } finally {
+            restoreProperty(previousProperty);
+        }
+    }
+
+    @Test
+    void contextClassLoaderWithItsOwnCoreIsIgnored() throws Exception {
+        Path classesDir = tempDir.resolve("classes");
+        compileChildLoaderIntrospection(classesDir);
+        writeMicronautServiceEntry(classesDir);
+
+        Thread thread = Thread.currentThread();
+        ClassLoader previousContextClassLoader = thread.getContextClassLoader();
+        String previousProperty = System.getProperty(CONTEXT_CLASSLOADER_PROPERTY);
+        try (URLClassLoader isolatedCoreClassLoader = isolatedCoreClassLoader();
+             URLClassLoader childClassLoader = new URLClassLoader(new URL[] { classesDir.toUri().toURL() }, getClass().getClassLoader())) {
+            System.setProperty(CONTEXT_CLASSLOADER_PROPERTY, "true");
+            thread.setContextClassLoader(childClassLoader);
+            Class<?> isolatedIntrospector = isolatedCoreClassLoader.loadClass(BeanIntrospector.class.getName());
+            Object shared = isolatedIntrospector.getField("SHARED").get(null);
+
+            Class<?> beanType = childClassLoader.loadClass("example.ChildBean");
+            Optional<?> introspection = (Optional<?>) isolatedIntrospector.getMethod("findIntrospection", Class.class).invoke(shared, beanType);
+            Collection<?> introspectedTypes = (Collection<?>) isolatedIntrospector.getMethod("findIntrospectedTypes", Predicate.class)
+                .invoke(shared, (Predicate<Object>) ref -> true);
+
+            assertTrue(introspection.isEmpty());
+            assertFalse(introspectedTypes.contains(beanType));
+        } finally {
+            thread.setContextClassLoader(previousContextClassLoader);
+            restoreProperty(previousProperty);
+        }
+    }
+
+    /**
+     * A class loader that loads Micronaut core again, from the test class path, apart from the class loader of this test.
+     * Its {@link BeanIntrospector} is initialized with the class loader as the context class loader, since the static
+     * optimizations it initializes are service loaded through the context class loader.
+     */
+    private static URLClassLoader isolatedCoreClassLoader() throws Exception {
+        String[] entries = System.getProperty("java.class.path").split(File.pathSeparator);
+        URL[] urls = new URL[entries.length];
+        for (int i = 0; i < entries.length; i++) {
+            urls[i] = Path.of(entries[i]).toUri().toURL();
+        }
+        URLClassLoader classLoader = new URLClassLoader(urls, ClassLoader.getPlatformClassLoader());
+        Thread thread = Thread.currentThread();
+        ClassLoader previousContextClassLoader = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(classLoader);
+            Class.forName(BeanIntrospector.class.getName(), true, classLoader);
+        } finally {
+            thread.setContextClassLoader(previousContextClassLoader);
+        }
+        return classLoader;
+    }
+
+    private static void restoreProperty(String previousProperty) {
+        if (previousProperty == null) {
+            System.clearProperty(CONTEXT_CLASSLOADER_PROPERTY);
+        } else {
+            System.setProperty(CONTEXT_CLASSLOADER_PROPERTY, previousProperty);
         }
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/PipeliningServerHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/PipeliningServerHandlerSpec.groovy
@@ -639,7 +639,11 @@ class PipeliningServerHandlerSpec extends Specification {
                 failure = cause
             }
         })
-        handler.setBodySizeLimits(new BodySizeLimits(64, 64))
+        // Netty 4.2.18 requests at least 512 writable bytes when growing the decompression
+        // buffer, including after inflating a chunk. Allow enough headroom so this test
+        // reaches the cumulative 64-byte body limit instead of the decoder allocation limit.
+        // See https://github.com/netty/netty/pull/17370
+        handler.setBodySizeLimits(new BodySizeLimits(64, 1024))
         def ch = new EmbeddedChannel(handler)
         def compChannel = new EmbeddedChannel(compressor)
         def requestMessage = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/")

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatServerWebSocket.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatServerWebSocket.java
@@ -24,10 +24,18 @@ import io.micronaut.websocket.annotation.OnOpen;
 import io.micronaut.websocket.annotation.ServerWebSocket;
 
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Requires(property = "spec.name", value = "BinaryWebSocketSpec")
 @ServerWebSocket("/binary/chat/{topic}/{username}")
 public class BinaryChatServerWebSocket {
+    /**
+     * Usernames whose {@link #onOpen} handler has completed. This handler is blocking and so runs on the
+     * executor, i.e. after the client's connect() has already returned. Tests that need a deterministic
+     * "Joined!" broadcast order should wait for a username to appear here before connecting the next client.
+     */
+    private final Set<String> openedUsernames = ConcurrentHashMap.newKeySet();
+
     @OnOpen
     public void onOpen(String topic, String username, WebSocketSession session) {
         assert ServerRequestContext.currentRequest().isPresent();
@@ -41,6 +49,11 @@ public class BinaryChatServerWebSocket {
                 openSession.sendAsync(msg.getBytes());
             }
         }
+        openedUsernames.add(username);
+    }
+
+    public Set<String> getOpenedUsernames() {
+        return openedUsernames;
     }
 
     @OnMessage(maxPayloadLength = 32)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
@@ -46,11 +46,18 @@ class BinaryWebSocketSpec extends Specification {
     void "test binary websocket exchange"() {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.builder('spec.name': 'BinaryWebSocketSpec', 'micronaut.server.netty.log-level':'TRACE').run(EmbeddedServer)
+        BinaryChatServerWebSocket serverWebSocket = embeddedServer.applicationContext.getBean(BinaryChatServerWebSocket)
         PollingConditions conditions = new PollingConditions(timeout: 15, delay: 0.5)
 
         when: "a websocket connection is established"
         WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient, embeddedServer.getURI())
         BinaryChatClientWebSocket fred = Flux.from(wsClient.connect(BinaryChatClientWebSocket, "/binary/chat/stuff/fred")).blockFirst()
+        // The server's @OnOpen is a blocking handler and runs on the executor, so connect() returning does not
+        // mean it has run yet. If bob connects before fred's @OnOpen executes, fred's handler sees bob in
+        // getOpenSessions() and bob receives a "[fred] Joined!" message, which breaks the exact reply counts below.
+        conditions.eventually {
+            serverWebSocket.openedUsernames.contains('fred')
+        }
         BinaryChatClientWebSocket bob = Flux.from(wsClient.connect(BinaryChatClientWebSocket, [topic:"stuff",username:"bob"])).blockFirst()
 
         then:"The connection is valid"

--- a/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
+++ b/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
@@ -341,6 +341,8 @@ class DefaultUriBuilder implements UriBuilder {
             String pathStr = path.toString();
             if (isTemplate(pathStr, values)) {
                 pathStr = UriTemplate.of(pathStr).expand(values);
+            } else {
+                pathStr = encodePath(pathStr);
             }
 
             builder.append(pathStr);
@@ -440,5 +442,26 @@ class DefaultUriBuilder implements UriBuilder {
 
     private String encode(String userInfo) {
         return URLEncoder.encode(userInfo, StandardCharsets.UTF_8);
+    }
+
+    private static String encodePath(String path) {
+        if (path.indexOf('{') < 0 && path.indexOf('}') < 0 && path.indexOf(' ') < 0) {
+            return path;
+        }
+        StringBuilder sb = new StringBuilder(path.length() + 8);
+        int len = path.length();
+        for (int i = 0; i < len; i++) {
+            char c = path.charAt(i);
+            if (c == '{') {
+                sb.append("%7B");
+            } else if (c == '}') {
+                sb.append("%7D");
+            } else if (c == ' ') {
+                sb.append("%20");
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
@@ -198,6 +198,21 @@ class UriBuilderSpec extends Specification {
         builder.build().toString() == "https://google.com/search?q1=v1&q2=v2"
     }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/12578")
+    @Unroll
+    void "test uri builder path encoding for #url"() {
+        expect:
+        UriBuilder.of(url).build().toString() == expected
+
+        where:
+        url                                            | expected
+        'https://abc.com/XXX/YYY;abcd=${ABCD};ab_cd=1' | 'https://abc.com/XXX/YYY;abcd=$%7BABCD%7D;ab_cd=1'
+        'https://abc.com/foo bar'                      | 'https://abc.com/foo%20bar'
+        'https://abc.com/foo%20bar'                    | 'https://abc.com/foo%20bar'
+        'https://abc.com/foo%2Fbar'                    | 'https://abc.com/foo%2Fbar'
+        'https://abc.com/foo;param=value'              | 'https://abc.com/foo;param=value'
+    }
+
     void "test uri builder preserves IPv6 host and port"() {
         given:
         List<String> sources = [

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/WildcardTypeArgumentSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/WildcardTypeArgumentSpec.groovy
@@ -278,6 +278,43 @@ class FooFactory {
         context.close()
     }
 
+    void "an argument with a nested wildcard has the same type as the argument with the type it is bounded by"() {
+        given:
+        BeanDefinition<?> client = buildBeanDefinition('test.HeadersClient', '''
+package test
+
+import io.micronaut.context.annotation.Executable
+import jakarta.inject.Singleton
+
+@Singleton
+class HeadersClient {
+    @Executable
+    void send(Map<String, ? extends Object> headers, List<Map<String, ? extends Number>> nested, Map<String, Object> plain) {}
+}
+''')
+        Argument<?>[] arguments = client.executableMethods.find { it.methodName == 'send' }.arguments
+        Argument<?> headers = arguments[0]
+        Argument<?> nested = arguments[1]
+        Argument<?> plain = arguments[2]
+
+        expect:
+        headers.typeParameters[1] instanceof WildcardArgument
+        headers.equalsType(Argument.mapOf(String, Object))
+        Argument.mapOf(String, Object).equalsType(headers)
+        headers.typeHashCode() == Argument.mapOf(String, Object).typeHashCode()
+        headers.equalsType(plain) && plain.equalsType(headers)
+        headers.typeHashCode() == plain.typeHashCode()
+        !headers.equalsType(Argument.mapOf(String, String))
+
+        and: 'at any depth, the map named after the type parameter of List it stands for'
+        nested.equalsType(Argument.listOf(Argument.mapOf(String, Number).withName('E')))
+        nested.typeHashCode() == Argument.listOf(Argument.mapOf(String, Number).withName('E')).typeHashCode()
+
+        and: 'equals still tells the wildcard apart'
+        headers.typeParameters[1] != plain.typeParameters[1]
+        plain.typeParameters[1] != headers.typeParameters[1]
+    }
+
     void "a wildcard is recorded for introspected properties"() {
         given:
         BeanIntrospection<?> bean = buildBeanIntrospection('test.Bean', '''

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/WildcardTypeArgumentSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/WildcardTypeArgumentSpec.groovy
@@ -237,6 +237,45 @@ class Bean<B extends Book> extends Base<Foo<?>, List<? super Book>> implements F
         lowerBounded != renamed
     }
 
+    void "an argument with a nested wildcard has the same type as the argument with the type it is bounded by"() {
+        given: 'the signature kapt writes for a Kotlin Map<String, Any> parameter'
+        BeanDefinition<?> client = buildBeanDefinition('test.HeadersClient', '''
+package test;
+
+import io.micronaut.context.annotation.Executable;
+import jakarta.inject.Singleton;
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+class HeadersClient {
+    @Executable
+    void send(Map<String, ? extends Object> headers, List<Map<String, ? extends Number>> nested, Map<String, Object> plain) {}
+}
+''')
+        Argument<?>[] arguments = client.executableMethods.find { it.methodName == 'send' }.arguments
+        Argument<?> headers = arguments[0]
+        Argument<?> nested = arguments[1]
+        Argument<?> plain = arguments[2]
+
+        expect:
+        headers.typeParameters[1] instanceof WildcardArgument
+        headers.equalsType(Argument.mapOf(String, Object))
+        Argument.mapOf(String, Object).equalsType(headers)
+        headers.typeHashCode() == Argument.mapOf(String, Object).typeHashCode()
+        headers.equalsType(plain) && plain.equalsType(headers)
+        headers.typeHashCode() == plain.typeHashCode()
+        !headers.equalsType(Argument.mapOf(String, String))
+
+        and: 'at any depth, the map named after the type parameter of List it stands for'
+        nested.equalsType(Argument.listOf(Argument.mapOf(String, Number).withName('E')))
+        nested.typeHashCode() == Argument.listOf(Argument.mapOf(String, Number).withName('E')).typeHashCode()
+
+        and: 'equals still tells the wildcard apart'
+        headers.typeParameters[1] != plain.typeParameters[1]
+        plain.typeParameters[1] != headers.typeParameters[1]
+    }
+
     void "a wildcard is recorded for an injected field"() {
         given:
         def field = definition.injectedFields.find { it.name == 'field' }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/WildcardTypeArgumentSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/generics/WildcardTypeArgumentSpec.groovy
@@ -290,6 +290,41 @@ class FooFactory {
         context.close()
     }
 
+    void "an argument with a nested projection has the same type as the argument with the type it is bounded by"() {
+        given: 'a Kotlin Map<String, Any>, whose value parameter is declared out'
+        BeanDefinition<?> client = buildBeanDefinition('test.HeadersClient', '''
+package test
+
+import io.micronaut.context.annotation.Executable
+import jakarta.inject.Singleton
+
+@Singleton
+open class HeadersClient {
+    @Executable
+    open fun send(headers: Map<String, Any>, nested: java.util.List<java.util.Map<String, out Number>>, projected: java.util.Map<String, out Any>) {}
+}
+''')
+        Argument<?>[] arguments = client.executableMethods.find { it.methodName == 'send' }.arguments
+        Argument<?> headers = arguments[0]
+        Argument<?> nested = arguments[1]
+        Argument<?> projected = arguments[2]
+
+        expect:
+        headers.equalsType(Argument.mapOf(String, Object))
+        Argument.mapOf(String, Object).equalsType(headers)
+        headers.typeHashCode() == Argument.mapOf(String, Object).typeHashCode()
+
+        and: 'an explicit projection'
+        projected.typeParameters[1] instanceof WildcardArgument
+        projected.equalsType(Argument.mapOf(String, Object))
+        projected.typeHashCode() == Argument.mapOf(String, Object).typeHashCode()
+        !projected.equalsType(Argument.mapOf(String, String))
+
+        and: 'at any depth, the map named after the type parameter of List it stands for'
+        nested.equalsType(Argument.listOf(Argument.mapOf(String, Number).withName('E')))
+        nested.typeHashCode() == Argument.listOf(Argument.mapOf(String, Number).withName('E')).typeHashCode()
+    }
+
     void "a projection is recorded for introspected properties of a class and a data class"() {
         given:
         BeanIntrospection<?> bean = buildBeanIntrospection('test.Bean', '''

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -144,6 +144,7 @@ import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -218,6 +219,17 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         new ConcurrentLinkedHashMap.Builder<BeanCandidateKey, Optional<BeanDefinition>>().maximumWeightedCapacity(30).build();
 
     private final Map<Argument, Collection<BeanDefinition>> beanCandidateCache = new ConcurrentLinkedHashMap.Builder<Argument, Collection<BeanDefinition>>().maximumWeightedCapacity(30).build();
+
+    /**
+     * Whether the compile-time index of a self-indexed annotation holds every bean carrying it, by annotation type,
+     * with the {@link #beanDefinitionsEpoch} it was computed at.
+     */
+    private final Map<Argument<?>, IndexExhaustiveness> indexExhaustiveCache = new ConcurrentHashMap<>(5);
+
+    /**
+     * Advanced after bean definitions are added, so that an index exhaustiveness computed before is not used.
+     */
+    private final AtomicLong beanDefinitionsEpoch = new AtomicLong();
 
     private final ClassLoader classLoader;
     private final Set<Class<?>> thisInterfaces = CollectionUtils.setOf(
@@ -487,6 +499,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             beanCandidateCache.clear();
             beanProxyTargetCache.clear();
             containsBeanCache.clear();
+            indexExhaustiveCache.clear();
             beanConfigurations.clear();
             disabledConfigurations.clear();
             singletonScope.clear();
@@ -1716,7 +1729,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (qualifier instanceof FilteringQualifier<Object> filteringQualifier) {
             @SuppressWarnings("unchecked")
             Argument<Object> indexedArgument = (Argument<Object>) filteringQualifier.getIndexedArgument();
-            if (indexedArgument != null) {
+            if (indexedArgument != null && isIndexExhaustive(indexedArgument, filteringQualifier)) {
                 // the compile-time index holds every bean this qualifier selects, so there is nothing to filter
                 return getBeanDefinitions(indexedArgument);
             }
@@ -1738,6 +1751,55 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
         filterReplacedBeans(candidates);
         return candidates;
+    }
+
+    /**
+     * Whether every bean the qualifier selects is indexed by the annotation type it reports. A bean compiled
+     * before that annotation was indexed by itself carries the annotation without the index, as every module
+     * released against an earlier version does, so only filtering every reference finds it. That is checked
+     * once per annotation type, and the index is taken only when no such bean is present.
+     *
+     * @param indexedArgument The type the qualifier reports the beans it selects are indexed by
+     * @param qualifier       The qualifier
+     * @return True if the index holds every bean the qualifier selects
+     */
+    private boolean isIndexExhaustive(Argument<?> indexedArgument, FilteringQualifier<Object> qualifier) {
+        long epoch = beanDefinitionsEpoch.get();
+        IndexExhaustiveness cached = indexExhaustiveCache.get(indexedArgument);
+        if (cached != null && cached.epoch() == epoch) {
+            return cached.exhaustive();
+        }
+        boolean exhaustive = true;
+        Class<?> indexedType = indexedArgument.getType();
+        for (BeanDefinitionReference<Object> reference : beanDefinitionProvider.getBeanReferences()) {
+            // the qualifier first: few references match it, and getIndexes() reads the annotation metadata of
+            // any reference that was compiled without indexes
+            if (qualifier.doesQualify(Object.class, reference) && !isIndexedBy(reference, indexedType)) {
+                exhaustive = false;
+                break;
+            }
+        }
+        // stored with the epoch read before computing, so a result that raced a registration is never used
+        indexExhaustiveCache.put(indexedArgument, new IndexExhaustiveness(epoch, exhaustive));
+        return exhaustive;
+    }
+
+    private static boolean isIndexedBy(BeanDefinitionReference<?> reference, Class<?> indexedType) {
+        for (Class<?> index : reference.getIndexes()) {
+            if (index == indexedType) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether the compile-time index of an annotation holds every bean carrying it.
+     *
+     * @param epoch      The {@link #beanDefinitionsEpoch} it was computed at
+     * @param exhaustive True if the index holds every bean carrying the annotation
+     */
+    private record IndexExhaustiveness(long epoch, boolean exhaustive) {
     }
 
     @Override
@@ -1770,6 +1832,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     public <B> BeanContext registerBeanDefinition(RuntimeBeanDefinition<B> definition) {
         beanDefinitionProvider.addBeanDefinition(definition);
         purgeCacheForBeanDefinition(definition);
+        beanDefinitionsEpoch.incrementAndGet();
         if (CustomScope.class.isAssignableFrom(definition.getBeanType())) {
             // a bean of this scope resolved earlier left the scope's absence recorded in the registry
             customScopeRegistry.invalidate();
@@ -1973,6 +2036,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         beanCandidateCache.clear();
         beanConcreteCandidateCache.clear();
         singletonBeanRegistrations.clear();
+        indexExhaustiveCache.clear();
     }
 
     /**
@@ -4080,6 +4144,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (configured.compareAndSet(false, true)) {
             readAllBeanConfigurations();
             beanDefinitionProvider.initialize(this);
+            // an index exhaustiveness computed before the bean definitions were read does not hold for them
+            beanDefinitionsEpoch.incrementAndGet();
         }
     }
 

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -342,7 +342,48 @@ public final class AnnotationMetadataSupport {
      * @return The annotation
      */
     static Optional<Class<? extends Annotation>> getAnnotationType(String name) {
-        return getAnnotationType(name, AnnotationMetadataSupport.class.getClassLoader());
+        // a caller naming no loader is answered for the thread context loader, the loader of the deployment it
+        // runs in, never for the loader of this class: that one sees the application's copy of a type where a
+        // child-first deployment loader defines another
+        final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
+        final Class<? extends Annotation> type = ANNOTATION_TYPES.get(name);
+        if (type != null) {
+            // the registered type is kept for a context that defines it or sits above the loader defining it,
+            // a thread of the container a deployment runs in; only a context loader apart from it - another
+            // deployment, which may define a copy of its own - resolves the name again
+            if (contextLoader == null || isSelfOrAncestor(contextLoader, type.getClassLoader())) {
+                return Optional.of(type);
+            }
+            return getAnnotationType(name, contextLoader);
+        }
+        final ClassLoader ownLoader = AnnotationMetadataSupport.class.getClassLoader();
+        if (contextLoader != null && contextLoader != ownLoader) {
+            final Optional<Class<? extends Annotation>> fromContext = getAnnotationType(name, contextLoader);
+            if (fromContext.isPresent()) {
+                return fromContext;
+            }
+        }
+        return getAnnotationType(name, ownLoader);
+    }
+
+    /**
+     * Whether a loader is the given one or one of the parents it delegates to.
+     *
+     * @param candidate The loader that may be the given one or one of its parents
+     * @param loader    The loader whose parents are walked, {@code null} for the bootstrap loader
+     * @return True if it is
+     */
+    private static boolean isSelfOrAncestor(ClassLoader candidate, @Nullable ClassLoader loader) {
+        if (loader == null) {
+            // the bootstrap loader defines a type no other loader can shadow
+            return true;
+        }
+        for (ClassLoader current = loader; current != null; current = current.getParent()) {
+            if (current == candidate) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationTypeClassLoaderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationTypeClassLoaderSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.inject.annotation
 
+import io.micronaut.core.annotation.AnnotationClassValue
 import spock.lang.Specification
 
 class AnnotationTypeClassLoaderSpec extends Specification {
@@ -38,6 +39,59 @@ class AnnotationTypeClassLoaderSpec extends Specification {
         AnnotationMetadataSupport.getAnnotationType(Portable.name, null).get().is(Portable)
     }
 
+    void "a caller naming no loader is served for the thread context loader"() {
+        given: "a child-first deployment loader under the application loader, defining its own copy of an annotation the application loader also sees"
+        def deployment = new OwnCopy(Deployed.classLoader)
+        def own = deployment.define(Deployed.name)
+
+        and: "the generated metadata of that deployment registering its copy"
+        AnnotationMetadataSupport.registerAnnotationType(new AnnotationClassValue<>(own))
+
+        and: "metadata of that deployment carrying the annotation"
+        def metadata = new MutableAnnotationMetadata()
+        metadata.addAnnotation(Deployed.name, [:])
+
+        and: "another deployment defining a copy of its own, which the registry does not hold"
+        def other = new OwnCopy(Deployed.classLoader)
+        def otherOwn = other.define(Deployed.name)
+
+        expect: "the deployment that registered its copy is served that copy, not the one the loader of the support class resolves again"
+        !own.is(Deployed)
+        withContext(deployment) { AnnotationMetadataSupport.getAnnotationType(Deployed.name).get() }.is(own)
+        withContext(deployment) { metadata.getAnnotationType(Deployed.name).get() }.is(own)
+
+        and: "so is a thread of the application the deployment runs in, whose context loader is a parent of the deployment"
+        withContext(Deployed.classLoader) { AnnotationMetadataSupport.getAnnotationType(Deployed.name).get() }.is(own)
+
+        and: "so is a thread with no context loader"
+        withContext(null) { AnnotationMetadataSupport.getAnnotationType(Deployed.name).get() }.is(own)
+
+        and: "another deployment is served its own copy"
+        withContext(other) { AnnotationMetadataSupport.getAnnotationType(Deployed.name).get() }.is(otherOwn)
+        withContext(other) { metadata.getAnnotationType(Deployed.name).get() }.is(otherOwn)
+    }
+
+    void "a name nothing registered is loaded through the thread context loader first"() {
+        given: "a deployment loader defining its own copy of an annotation nothing registered"
+        def deployment = new OwnCopy()
+        def own = deployment.define(Unregistered.name)
+
+        expect:
+        !own.is(Unregistered)
+        withContext(deployment) { AnnotationMetadataSupport.getAnnotationType(Unregistered.name).get() }.is(own)
+    }
+
+    private static <T> T withContext(ClassLoader loader, Closure<T> action) {
+        def thread = Thread.currentThread()
+        def previous = thread.contextClassLoader
+        thread.contextClassLoader = loader
+        try {
+            return action.call()
+        } finally {
+            thread.contextClassLoader = previous
+        }
+    }
+
     void "an annotation type of the JDK is served whatever the loader asks"() {
         expect: "a type the bootstrap loader defines cannot be shadowed"
         Deprecated.classLoader == null
@@ -51,8 +105,8 @@ class AnnotationTypeClassLoaderSpec extends Specification {
      */
     static class OwnCopy extends ClassLoader {
 
-        OwnCopy() {
-            super(ClassLoader.platformClassLoader)
+        OwnCopy(ClassLoader parent = ClassLoader.platformClassLoader) {
+            super(parent)
         }
 
         Class<?> define(String name) {

--- a/inject/src/test/java/io/micronaut/inject/annotation/Deployed.java
+++ b/inject/src/test/java/io/micronaut/inject/annotation/Deployed.java
@@ -1,0 +1,15 @@
+package io.micronaut.inject.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation with no member that nothing else registers, so that a copy another class loader defines can be
+ * the registered one.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+public @interface Deployed {
+}

--- a/inject/src/test/java/io/micronaut/inject/annotation/Unregistered.java
+++ b/inject/src/test/java/io/micronaut/inject/annotation/Unregistered.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation with no member that no generated metadata registers, so that its first resolution is a load.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+public @interface Unregistered {
+}

--- a/management/src/test/groovy/io/micronaut/management/endpoint/NotRecompiledEndpointSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/NotRecompiledEndpointSpec.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultBeanDefinitionsProvider
+import io.micronaut.context.env.Environment
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.management.endpoint.annotation.Endpoint
+import io.micronaut.management.endpoint.annotation.Read
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * {@code @Endpoint} became {@code @Indexed(Endpoint)} in 5.2, so an endpoint compiled against an earlier
+ * version has no {@code Endpoint} index in its bean definition reference. Every released module that
+ * ships an endpoint, such as the metrics endpoint of micronaut-micrometer, is compiled that way, and
+ * resolving endpoints from the index alone lost them: their routes answered 404.
+ */
+class NotRecompiledEndpointSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer server = startServer()
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = server.applicationContext.createBean(HttpClient, server.URL)
+
+    void "test the reference is shaped like one compiled before @Endpoint was indexed"() {
+        expect:
+        BeanDefinitionReference reference = server.applicationContext.beanDefinitionReferences.find { it instanceof NotIndexedReference }
+        reference.beanType == NotRecompiled
+        !(Endpoint in reference.indexes)
+    }
+
+    void "test an endpoint without the index is still enumerated by its stereotype"() {
+        expect:
+        NotRecompiled in server.applicationContext.getBeanDefinitions(Qualifiers.byStereotype(Endpoint))*.beanType
+    }
+
+    void "test an endpoint without the index still has its route"() {
+        when:
+        def response = client.toBlocking().exchange("/not-recompiled", String)
+
+        then:
+        response.code() == HttpStatus.OK.code
+        response.body() == 'not recompiled'
+    }
+
+    private static EmbeddedServer startServer() {
+        ApplicationContext context = ApplicationContext.builder(Environment.TEST)
+                .beanDefinitionsProvider { ClassLoader classLoader ->
+                    NotIndexedReference.wrap(new DefaultBeanDefinitionsProvider().provide(classLoader), NotRecompiled, Endpoint)
+                }
+                .start()
+        return context.getBean(EmbeddedServer).start()
+    }
+}
+
+@Endpoint(id = 'notRecompiled', defaultSensitive = false)
+class NotRecompiled {
+
+    @Read
+    String value() {
+        'not recompiled'
+    }
+}

--- a/management/src/test/groovy/io/micronaut/management/endpoint/RuntimeRegisteredEndpointLookupSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/RuntimeRegisteredEndpointLookupSpec.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.RuntimeBeanDefinition
+import io.micronaut.context.env.Environment
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.annotation.MutableAnnotationMetadata
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.management.endpoint.annotation.Endpoint
+import spock.lang.Specification
+
+import java.util.function.Supplier
+
+/**
+ * Whether the compile-time index holds every endpoint is remembered once it is known, so a bean definition
+ * registered afterwards that carries {@code @Endpoint} without the index has to invalidate it.
+ */
+class RuntimeRegisteredEndpointLookupSpec extends Specification {
+
+    void "test an endpoint registered without the index after the index answered is still found"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(Environment.TEST)
+
+        when: 'every endpoint is indexed, so the index answers and that is remembered'
+        Collection<BeanDefinition<?>> before = context.getBeanDefinitions(Qualifiers.byStereotype(Endpoint))
+
+        then:
+        !before.isEmpty()
+        !(RuntimeEndpoint in before*.beanType)
+
+        when: 'a definition that carries @Endpoint but not its index is registered'
+        MutableAnnotationMetadata metadata = new MutableAnnotationMetadata()
+        metadata.addDeclaredAnnotation(Endpoint.name, [id: 'runtime'])
+        RuntimeBeanDefinition<RuntimeEndpoint> definition = RuntimeBeanDefinition.builder(RuntimeEndpoint, { new RuntimeEndpoint() } as Supplier<RuntimeEndpoint>)
+                .annotationMetadata(metadata)
+                .build()
+        context.registerBeanDefinition(definition)
+        Collection<BeanDefinition<?>> after = context.getBeanDefinitions(Qualifiers.byStereotype(Endpoint))
+
+        then: 'it carries no index, so it is only found by filtering every definition'
+        definition.annotationMetadata.hasStereotype(Endpoint)
+        !(Endpoint in definition.indexes)
+        RuntimeEndpoint in after*.beanType
+
+        and: 'every endpoint found before is still found'
+        after*.beanType.containsAll(before*.beanType)
+
+        cleanup:
+        context.close()
+    }
+}
+
+class RuntimeEndpoint {
+}

--- a/management/src/test/java/io/micronaut/management/endpoint/NotIndexedReference.java
+++ b/management/src/test/java/io/micronaut/management/endpoint/NotIndexedReference.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanDefinitionReference;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A bean definition reference as the processor emitted it before an annotation the bean carries was
+ * indexed by itself: the same reference, without that index.
+ *
+ * @param <T> The bean type
+ */
+public final class NotIndexedReference<T> implements BeanDefinitionReference<T> {
+
+    private final BeanDefinitionReference<T> delegate;
+    private final Class<?> withoutIndex;
+
+    public NotIndexedReference(BeanDefinitionReference<T> delegate, Class<?> withoutIndex) {
+        this.delegate = delegate;
+        this.withoutIndex = withoutIndex;
+    }
+
+    /**
+     * Replaces the reference of the given bean with one that is not indexed by the given type. Matched by
+     * definition name, so the other references are not introspected.
+     *
+     * @param references The references
+     * @param beanType The bean whose reference to replace
+     * @param withoutIndex The index to drop
+     * @return The references
+     */
+    public static List<BeanDefinitionReference<?>> wrap(List<BeanDefinitionReference<?>> references, Class<?> beanType, Class<?> withoutIndex) {
+        String definitionName = beanType.getPackageName() + ".$" + beanType.getSimpleName() + "$Definition";
+        List<BeanDefinitionReference<?>> result = new ArrayList<>(references.size());
+        for (BeanDefinitionReference<?> reference : references) {
+            result.add(reference.getBeanDefinitionName().equals(definitionName) ? new NotIndexedReference<>(reference, withoutIndex) : reference);
+        }
+        return result;
+    }
+
+    @Override
+    public Class<?>[] getIndexes() {
+        return Arrays.stream(delegate.getIndexes()).filter(type -> type != withoutIndex).toArray(Class<?>[]::new);
+    }
+
+    @Override
+    public String getBeanDefinitionName() {
+        return delegate.getBeanDefinitionName();
+    }
+
+    @Override
+    public BeanDefinition<T> load() {
+        return delegate.load();
+    }
+
+    @Override
+    public BeanDefinition<T> load(BeanContext context) {
+        return delegate.load(context);
+    }
+
+    @Override
+    public boolean isPresent() {
+        return delegate.isPresent();
+    }
+
+    @Override
+    public boolean isContextScope() {
+        return delegate.isContextScope();
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return delegate.isSingleton();
+    }
+
+    @Override
+    public boolean isConfigurationProperties() {
+        return delegate.isConfigurationProperties();
+    }
+
+    @Override
+    public boolean isProxiedBean() {
+        return delegate.isProxiedBean();
+    }
+
+    @Override
+    public boolean isProxyTarget() {
+        return delegate.isProxyTarget();
+    }
+
+    @Override
+    public boolean isParallel() {
+        return delegate.isParallel();
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return delegate.isPrimary();
+    }
+
+    @Override
+    public boolean requiresMethodProcessing() {
+        return delegate.requiresMethodProcessing();
+    }
+
+    @Override
+    public Class<T> getBeanType() {
+        return delegate.getBeanType();
+    }
+
+    @Override
+    public Set<Class<?>> getExposedTypes() {
+        return delegate.getExposedTypes();
+    }
+
+    @Override
+    public boolean isEnabled(BeanContext context, BeanResolutionContext resolutionContext) {
+        return delegate.isEnabled(context, resolutionContext);
+    }
+
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        return delegate.getAnnotationMetadata();
+    }
+}


### PR DESCRIPTION
## Issue

Fixes #12578

`UriBuilder.of(url).build()` throws `UriSyntaxException` when the URI path contains literal `{`, `}`, or spaces.

## Changes

- Encode `{` as `%7B` and `}` as `%7D` when building non-expanded URI paths.
- Encode spaces as `%20`.
- Preserve valid URI path characters such as `;`, `=`, `$`, and `_`.
- Preserve existing percent-encoded sequences such as `%20` and `%2F`.
- Keep URI template expansion behavior unchanged.
- Added regression tests covering curly braces, spaces, existing percent-encoded paths, and matrix parameters.

## Testing

`./gradlew :micronaut-http:test --tests 'io.micronaut.http.uri.UriBuilderSpec'`

All tests passed.