### PR TITLE
Add a reflection-free enum-keyed map to CollectionUtils

### DIFF
--- a/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
@@ -37,6 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.SequencedCollection;
@@ -159,6 +160,55 @@ public class CollectionUtils {
      */
     public static <K, V> LinkedHashMap<K, V> newLinkedHashMap(int size) {
         return new LinkedHashMap<>(calculateHashSetSize(size));
+    }
+
+    /**
+     * Create a new enum-keyed map for the given constants of an enum.
+     *
+     * <p>The map behaves like {@link java.util.EnumMap}: it keeps its mappings in an array indexed by
+     * {@link Enum#ordinal()}, iterates in ordinal order, permits {@code null} values, rejects
+     * {@code null} keys, and throws {@link ClassCastException} when a key of another enum is put.
+     * Unlike {@code EnumMap}, which is given the {@link Class} of the enum and looks its constants up
+     * reflectively (a lookup of the {@code values()} method, {@code setAccessible} and a reflective
+     * invocation), it is given the constants, so it does no reflection:</p>
+     *
+     * <pre>{@code
+     * Map<TimeUnit, String> names = CollectionUtils.newEnumMap(TimeUnit.values());
+     * }</pre>
+     *
+     * <p>The array is held by the map, not copied, and must not be mutated afterwards. Passing the
+     * result of {@code values()} directly is always safe, because every call returns a new array;
+     * an array cached in a constant can be shared by many maps.</p>
+     *
+     * <p>The array must contain all the constants of a single enum in ordinal order, as its
+     * {@code values()} method returns them. This method verifies that every element is a constant of
+     * the same enum whose ordinal equals its index. It cannot detect an array that stops short of the
+     * last constants: keys past its end are then treated as keys of another enum.</p>
+     *
+     * @param constants The constants of the enum, as its {@code values()} method returns them
+     * @param <K> The enum type
+     * @param <V> The value type
+     * @return A new, empty, mutable map
+     * @throws IllegalArgumentException if an element is not the constant of the enum at its index
+     * @since 5.3.0
+     */
+    public static <K extends Enum<K>, V extends @Nullable Object> Map<K, V> newEnumMap(K[] constants) {
+        Objects.requireNonNull(constants, "constants");
+        Class<?> enumType = null;
+        for (int i = 0; i < constants.length; i++) {
+            K constant = constants[i];
+            if (constant == null) {
+                throw new IllegalArgumentException("The constant at index " + i + " is null");
+            }
+            if (enumType == null) {
+                enumType = constant.getDeclaringClass();
+            }
+            if (constant.ordinal() != i || constant.getDeclaringClass() != enumType) {
+                throw new IllegalArgumentException("The constants must be those of a single enum in ordinal order, as its values() method returns them, but found "
+                    + constant + " with ordinal " + constant.ordinal() + " at index " + i);
+            }
+        }
+        return new EnumConstantsMap<>(constants);
     }
 
     private static int calculateHashSetSize(int size) {
@@ -491,6 +541,9 @@ public class CollectionUtils {
     /**
      * Create an enum set from an array.
      * NOTE: At least one item is required
+     *
+     * <p>The set is created with {@link EnumSet#noneOf(Class)}, which looks the constants of the enum
+     * up reflectively.</p>
      *
      * @param enums The array of enums
      * @param <E> The enum type

--- a/core/src/main/java/io/micronaut/core/util/EnumConstantsMap.java
+++ b/core/src/main/java/io/micronaut/core/util/EnumConstantsMap.java
@@ -63,9 +63,9 @@ final class EnumConstantsMap<K extends Enum<K>, V extends @Nullable Object> exte
     private final @Nullable Object[] vals;
     private int size;
 
-    private @Nullable Set<Entry<K, V>> entrySet;
-    private @Nullable Set<K> keySet;
-    private @Nullable Collection<V> values;
+    private @Nullable Set<Entry<K, V>> entrySetView;
+    private @Nullable Set<K> keySetView;
+    private @Nullable Collection<V> valuesView;
 
     /**
      * @param universe The constants of the enum in ordinal order, already validated
@@ -182,30 +182,30 @@ final class EnumConstantsMap<K extends Enum<K>, V extends @Nullable Object> exte
 
     @Override
     public Set<Entry<K, V>> entrySet() {
-        Set<Entry<K, V>> es = entrySet;
+        Set<Entry<K, V>> es = entrySetView;
         if (es == null) {
             es = new EntrySet();
-            entrySet = es;
+            entrySetView = es;
         }
         return es;
     }
 
     @Override
     public Set<K> keySet() {
-        Set<K> ks = keySet;
+        Set<K> ks = keySetView;
         if (ks == null) {
             ks = new KeySet();
-            keySet = ks;
+            keySetView = ks;
         }
         return ks;
     }
 
     @Override
     public Collection<V> values() {
-        Collection<V> vs = values;
+        Collection<V> vs = valuesView;
         if (vs == null) {
             vs = new Values();
-            values = vs;
+            valuesView = vs;
         }
         return vs;
     }

--- a/core/src/main/java/io/micronaut/core/util/EnumConstantsMap.java
+++ b/core/src/main/java/io/micronaut/core/util/EnumConstantsMap.java
@@ -1,0 +1,496 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.util;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * An enum-keyed map that behaves like {@link java.util.EnumMap} but is given the constants of the
+ * enum instead of looking them up reflectively from its class.
+ *
+ * <p>The values are kept in an array indexed by {@link Enum#ordinal()}. An empty slot is
+ * {@code null}, so a {@code null} value is stored as the {@link #NULL} sentinel. Iteration is in
+ * ordinal order and, like {@code EnumMap}, its iterators are weakly consistent: they never throw
+ * {@link java.util.ConcurrentModificationException}.</p>
+ *
+ * <p>The constants array is held, not copied. It must be shaped as the {@code values()} method of
+ * the enum returns it, which {@link CollectionUtils#newEnumMap(Enum[])} validates, and it must not
+ * be mutated afterwards.</p>
+ *
+ * @param <K> The enum type
+ * @param <V> The value type
+ * @author Denis Stepanov
+ */
+@SuppressWarnings("EnumOrdinal") // indexing by ordinal is the purpose of this map
+final class EnumConstantsMap<K extends Enum<K>, V extends @Nullable Object> extends AbstractMap<K, V> {
+
+    /**
+     * Stored in place of a {@code null} value, because {@code null} marks an empty slot.
+     */
+    private static final Object NULL = new Object() {
+        @Override
+        public String toString() {
+            return "EnumConstantsMap.NULL";
+        }
+    };
+
+    private final K[] universe;
+    private final @Nullable Object[] vals;
+    private int size;
+
+    private @Nullable Set<Entry<K, V>> entrySet;
+    private @Nullable Set<K> keySet;
+    private @Nullable Collection<V> values;
+
+    /**
+     * @param universe The constants of the enum in ordinal order, already validated
+     */
+    EnumConstantsMap(K[] universe) {
+        this.universe = universe;
+        this.vals = new Object[universe.length];
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    @Override
+    public boolean containsKey(@Nullable Object key) {
+        int index = indexOfKey(key);
+        return index >= 0 && vals[index] != null;
+    }
+
+    @Override
+    public boolean containsValue(@Nullable Object value) {
+        Object masked = mask(value);
+        for (Object val : vals) {
+            if (val != null && masked.equals(val)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public @Nullable V get(@Nullable Object key) {
+        int index = indexOfKey(key);
+        return index >= 0 ? unmask(vals[index]) : null;
+    }
+
+    @Override
+    public @Nullable V getOrDefault(@Nullable Object key, @Nullable V defaultValue) {
+        int index = indexOfKey(key);
+        if (index >= 0) {
+            Object val = vals[index];
+            if (val != null) {
+                return unmask(val);
+            }
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public @Nullable V put(K key, V value) {
+        int index = indexOfNewKey(key);
+        Object old = vals[index];
+        vals[index] = mask(value);
+        if (old == null) {
+            size++;
+        }
+        return unmask(old);
+    }
+
+    @Override
+    public @Nullable V remove(@Nullable Object key) {
+        int index = indexOfKey(key);
+        if (index < 0) {
+            return null;
+        }
+        Object old = vals[index];
+        if (old != null) {
+            vals[index] = null;
+            size--;
+        }
+        return unmask(old);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        if (m instanceof EnumConstantsMap<?, ?> other && hasSameUniverse(other)) {
+            Object[] otherVals = other.vals;
+            for (int i = 0; i < otherVals.length; i++) {
+                Object val = otherVals[i];
+                if (val != null) {
+                    if (vals[i] == null) {
+                        size++;
+                    }
+                    vals[i] = val;
+                }
+            }
+        } else {
+            super.putAll(m);
+        }
+    }
+
+    @Override
+    public void clear() {
+        Arrays.fill(vals, null);
+        size = 0;
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super K, ? super V> action) {
+        Objects.requireNonNull(action);
+        for (int i = 0; i < vals.length; i++) {
+            Object val = vals[i];
+            if (val != null) {
+                action.accept(universe[i], unmask(val));
+            }
+        }
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        Set<Entry<K, V>> es = entrySet;
+        if (es == null) {
+            es = new EntrySet();
+            entrySet = es;
+        }
+        return es;
+    }
+
+    @Override
+    public Set<K> keySet() {
+        Set<K> ks = keySet;
+        if (ks == null) {
+            ks = new KeySet();
+            keySet = ks;
+        }
+        return ks;
+    }
+
+    @Override
+    public Collection<V> values() {
+        Collection<V> vs = values;
+        if (vs == null) {
+            vs = new Values();
+            values = vs;
+        }
+        return vs;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof EnumConstantsMap<?, ?> other && hasSameUniverse(other)) {
+            // Both hold masked values, so the sentinel compares by identity
+            return size == other.size && Arrays.equals(vals, other.vals);
+        }
+        // Covers any other Map, including an EnumMap or a HashMap with the same mappings
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 0;
+        for (int i = 0; i < vals.length; i++) {
+            Object val = vals[i];
+            if (val != null) {
+                h += universe[i].hashCode() ^ Objects.hashCode(unmask(val));
+            }
+        }
+        return h;
+    }
+
+    /**
+     * The slot of a key being read. The identity check rejects a constant of another enum with the
+     * same ordinal without calling {@link Enum#getDeclaringClass()}.
+     *
+     * @param key The key
+     * @return The index of its value, or -1 if the key is not a constant of this map's enum
+     */
+    private int indexOfKey(@Nullable Object key) {
+        if (key instanceof Enum<?> e) {
+            int ordinal = e.ordinal();
+            if (ordinal < universe.length && universe[ordinal] == e) {
+                return ordinal;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * The slot of a key being stored, rejecting keys that {@code EnumMap} rejects.
+     *
+     * @param key The key
+     * @return The index of its value
+     * @throws NullPointerException if the key is null
+     * @throws ClassCastException if the key is a constant of another enum
+     */
+    private int indexOfNewKey(K key) {
+        Objects.requireNonNull(key, "key");
+        int ordinal = key.ordinal();
+        if (ordinal >= universe.length || universe[ordinal] != key) {
+            throw new ClassCastException(key.getDeclaringClass() + " is not the key type of the map, whose constants are " + Arrays.toString(universe));
+        }
+        return ordinal;
+    }
+
+    /**
+     * Whether the other map was created from the constants of the same enum. Both arrays passed the
+     * factory's validation, so arrays of the same length starting with the same constant hold the
+     * same constants. This lets two maps built from separate {@code values()} calls share fast paths.
+     *
+     * @param other The other map
+     * @return true if both maps are keyed by the same enum
+     */
+    private boolean hasSameUniverse(EnumConstantsMap<?, ?> other) {
+        Enum<?>[] otherUniverse = other.universe;
+        return otherUniverse == universe
+            || (otherUniverse.length == universe.length && universe.length > 0 && otherUniverse[0] == universe[0]);
+    }
+
+    private static Object mask(@Nullable Object value) {
+        return value == null ? NULL : value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private @Nullable V unmask(@Nullable Object value) {
+        return (V) (value == NULL ? null : value);
+    }
+
+    /**
+     * Iterates the occupied slots in ordinal order.
+     *
+     * @param <T> The element type
+     */
+    private abstract class SlotIterator<T> implements Iterator<T> {
+        private int next;
+        private int lastReturned = -1;
+
+        @Override
+        public boolean hasNext() {
+            while (next < vals.length && vals[next] == null) {
+                next++;
+            }
+            return next < vals.length;
+        }
+
+        @Override
+        public @Nullable T next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            lastReturned = next++;
+            return element(lastReturned);
+        }
+
+        @Override
+        public void remove() {
+            if (lastReturned < 0) {
+                throw new IllegalStateException();
+            }
+            if (vals[lastReturned] != null) {
+                vals[lastReturned] = null;
+                size--;
+            }
+            lastReturned = -1;
+        }
+
+        /**
+         * @param index An occupied slot
+         * @return The element of the slot
+         */
+        abstract @Nullable T element(int index);
+    }
+
+    private final class EntrySet extends AbstractSet<Entry<K, V>> {
+
+        @Override
+        public Iterator<Entry<K, V>> iterator() {
+            return new SlotIterator<>() {
+                @Override
+                Entry<K, V> element(int index) {
+                    return new SlotEntry(index);
+                }
+            };
+        }
+
+        @Override
+        public boolean contains(@Nullable Object o) {
+            return o instanceof Entry<?, ?> entry
+                && containsKey(entry.getKey())
+                && Objects.equals(get(entry.getKey()), entry.getValue());
+        }
+
+        @Override
+        public boolean remove(@Nullable Object o) {
+            if (o instanceof Entry<?, ?> entry && contains(entry)) {
+                EnumConstantsMap.this.remove(entry.getKey());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public void clear() {
+            EnumConstantsMap.this.clear();
+        }
+    }
+
+    private final class KeySet extends AbstractSet<K> {
+
+        @Override
+        public Iterator<K> iterator() {
+            return new SlotIterator<>() {
+                @Override
+                K element(int index) {
+                    return universe[index];
+                }
+            };
+        }
+
+        @Override
+        public boolean contains(@Nullable Object o) {
+            return containsKey(o);
+        }
+
+        @Override
+        public boolean remove(@Nullable Object o) {
+            if (containsKey(o)) {
+                EnumConstantsMap.this.remove(o);
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public void clear() {
+            EnumConstantsMap.this.clear();
+        }
+    }
+
+    private final class Values extends AbstractCollection<V> {
+
+        @Override
+        public Iterator<V> iterator() {
+            return new SlotIterator<>() {
+                @Override
+                @Nullable V element(int index) {
+                    return unmask(vals[index]);
+                }
+            };
+        }
+
+        @Override
+        public boolean contains(@Nullable Object o) {
+            return containsValue(o);
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public void clear() {
+            EnumConstantsMap.this.clear();
+        }
+    }
+
+    /**
+     * An entry reading and writing its slot, so {@link #setValue} writes through to the map.
+     */
+    private final class SlotEntry implements Entry<K, V> {
+        private final int index;
+
+        SlotEntry(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public K getKey() {
+            return universe[index];
+        }
+
+        @Override
+        public @Nullable V getValue() {
+            return unmask(occupied());
+        }
+
+        @Override
+        public @Nullable V setValue(V value) {
+            Object old = occupied();
+            vals[index] = mask(value);
+            return unmask(old);
+        }
+
+        private Object occupied() {
+            Object val = vals[index];
+            if (val == null) {
+                throw new IllegalStateException("Entry was removed");
+            }
+            return val;
+        }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            return o instanceof Entry<?, ?> e
+                && getKey() == e.getKey()
+                && Objects.equals(getValue(), e.getValue());
+        }
+
+        @Override
+        public int hashCode() {
+            return getKey().hashCode() ^ Objects.hashCode(getValue());
+        }
+
+        @Override
+        public String toString() {
+            return getKey() + "=" + getValue();
+        }
+    }
+}

--- a/core/src/main/java/io/micronaut/core/util/EnumConstantsMap.java
+++ b/core/src/main/java/io/micronaut/core/util/EnumConstantsMap.java
@@ -283,6 +283,23 @@ final class EnumConstantsMap<K extends Enum<K>, V extends @Nullable Object> exte
             || (otherUniverse.length == universe.length && universe.length > 0 && otherUniverse[0] == universe[0]);
     }
 
+    /**
+     * Whether the key is mapped to the value. The candidate value is compared with
+     * {@code candidate.equals(stored)}, as {@link Set#contains} specifies and {@code EnumMap} does.
+     *
+     * @param key   The candidate key
+     * @param value The candidate value
+     * @return true if the map holds the mapping
+     */
+    private boolean containsMapping(@Nullable Object key, @Nullable Object value) {
+        int index = indexOfKey(key);
+        if (index < 0) {
+            return false;
+        }
+        Object val = vals[index];
+        return val != null && mask(value).equals(val);
+    }
+
     private static Object mask(@Nullable Object value) {
         return value == null ? NULL : value;
     }
@@ -351,16 +368,17 @@ final class EnumConstantsMap<K extends Enum<K>, V extends @Nullable Object> exte
 
         @Override
         public boolean contains(@Nullable Object o) {
-            return o instanceof Entry<?, ?> entry
-                && containsKey(entry.getKey())
-                && Objects.equals(get(entry.getKey()), entry.getValue());
+            return o instanceof Entry<?, ?> entry && containsMapping(entry.getKey(), entry.getValue());
         }
 
         @Override
         public boolean remove(@Nullable Object o) {
-            if (o instanceof Entry<?, ?> entry && contains(entry)) {
-                EnumConstantsMap.this.remove(entry.getKey());
-                return true;
+            if (o instanceof Entry<?, ?> entry) {
+                Object key = entry.getKey();
+                if (containsMapping(key, entry.getValue())) {
+                    EnumConstantsMap.this.remove(key);
+                    return true;
+                }
             }
             return false;
         }

--- a/core/src/test/groovy/io/micronaut/core/util/EnumConstantsMapSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/util/EnumConstantsMapSpec.groovy
@@ -276,6 +276,27 @@ class EnumConstantsMapSpec extends Specification {
         map.isEmpty()
     }
 
+    void "entrySet contains and remove compare the candidate value with the stored one, as EnumMap does"() {
+        given: "a stored value equal to anything, which no candidate value equals"
+        def stored = new EqualToAnything()
+        Map<Colour, Object> map = CollectionUtils.newEnumMap(Colour.values())
+        map.put(Colour.RED, stored)
+        def enumMap = new EnumMap<Colour, Object>(Colour)
+        enumMap.put(Colour.RED, stored)
+        def candidate = new AbstractMap.SimpleEntry(Colour.RED, "red")
+
+        expect:
+        !enumMap.entrySet().contains(candidate)
+        !map.entrySet().contains(candidate)
+        !map.entrySet().remove(candidate)
+        map.containsKey(Colour.RED)
+
+        and: "the stored value itself is found and removed"
+        map.entrySet().contains(new AbstractMap.SimpleEntry(Colour.RED, stored))
+        map.entrySet().remove(new AbstractMap.SimpleEntry(Colour.RED, stored))
+        map.isEmpty()
+    }
+
     void "equals and hashCode agree with EnumMap and HashMap holding the same mappings"() {
         given:
         Map<Colour, String> map = CollectionUtils.newEnumMap(Colour.values())
@@ -465,6 +486,18 @@ class EnumConstantsMapSpec extends Specification {
 
         where:
         seed << [1L, 42L, 20260911L]
+    }
+
+    static class EqualToAnything {
+        @Override
+        boolean equals(Object o) {
+            true
+        }
+
+        @Override
+        int hashCode() {
+            0
+        }
     }
 
     private static String render(Map<?, ?> map) {

--- a/core/src/test/groovy/io/micronaut/core/util/EnumConstantsMapSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/util/EnumConstantsMapSpec.groovy
@@ -1,0 +1,501 @@
+package io.micronaut.core.util
+
+import spock.lang.Specification
+
+class EnumConstantsMapSpec extends Specification {
+
+    enum Colour {
+        RED, GREEN, BLUE, YELLOW
+    }
+
+    enum Size {
+        S, M, L, XL, XXL
+    }
+
+    enum Operation {
+        PLUS {
+            @Override
+            int apply(int a, int b) {
+                a + b
+            }
+        },
+        MINUS {
+            @Override
+            int apply(int a, int b) {
+                a - b
+            }
+        }
+
+        abstract int apply(int a, int b)
+    }
+
+    void "put, get, remove, containsKey, containsValue, size and clear"() {
+        given:
+        Map<Colour, String> map = CollectionUtils.newEnumMap(Colour.values())
+
+        expect:
+        map.isEmpty()
+        map.size() == 0
+        map.get(Colour.RED) == null
+        !map.containsKey(Colour.RED)
+        !map.containsValue(null)
+
+        when:
+        def previous = map.put(Colour.BLUE, "blue")
+
+        then:
+        previous == null
+        map.size() == 1
+        !map.isEmpty()
+        map.get(Colour.BLUE) == "blue"
+        map.containsKey(Colour.BLUE)
+        !map.containsKey(Colour.RED)
+        map.containsValue("blue")
+        !map.containsValue("red")
+
+        when:
+        previous = map.put(Colour.BLUE, "navy")
+
+        then:
+        previous == "blue"
+        map.size() == 1
+        map.get(Colour.BLUE) == "navy"
+
+        when:
+        map.put(Colour.RED, "red")
+        previous = map.remove(Colour.BLUE)
+
+        then:
+        previous == "navy"
+        map.size() == 1
+        !map.containsKey(Colour.BLUE)
+        map.remove(Colour.BLUE) == null
+        map.size() == 1
+
+        when:
+        map.clear()
+
+        then:
+        map.isEmpty()
+        map.get(Colour.RED) == null
+    }
+
+    void "null values are stored and distinguished from absent keys"() {
+        given:
+        Map<Colour, String> map = CollectionUtils.newEnumMap(Colour.values())
+
+        when:
+        def previous = map.put(Colour.GREEN, null)
+
+        then:
+        previous == null
+        map.size() == 1
+        map.containsKey(Colour.GREEN)
+        map.get(Colour.GREEN) == null
+        map.containsValue(null)
+        !map.containsKey(Colour.RED)
+        render(map) == "GREEN=null"
+
+        when:
+        previous = map.put(Colour.GREEN, "green")
+
+        then:
+        previous == null
+        map.size() == 1
+        !map.containsValue(null)
+
+        when:
+        map.put(Colour.GREEN, null)
+        previous = map.remove(Colour.GREEN)
+
+        then:
+        previous == null
+        map.isEmpty()
+        !map.containsKey(Colour.GREEN)
+    }
+
+    void "a null key is rejected on put and absent on read"() {
+        given:
+        Map<Colour, String> map = CollectionUtils.newEnumMap(Colour.values())
+
+        when:
+        map.put(null, "x")
+
+        then:
+        thrown(NullPointerException)
+
+        and:
+        map.get(null) == null
+        !map.containsKey(null)
+        map.remove(null) == null
+        map.isEmpty()
+    }
+
+    void "a key of another enum is absent on read and rejected on put"() {
+        given:
+        Map<Colour, String> map = CollectionUtils.newEnumMap(Colour.values())
+        map.put(Colour.RED, "red")
+        map.put(Colour.YELLOW, "yellow")
+
+        expect: "the same ordinal, and an ordinal beyond the universe"
+        map.get(Size.S) == null
+        map.get(Size.XXL) == null
+        !map.containsKey(Size.S)
+        !map.containsKey(Size.XXL)
+        map.remove(Size.S) == null
+        map.get("RED") == null
+        map.size() == 2
+
+        when:
+        ((Map) map).put(Size.S, "small")
+
+        then:
+        thrown(ClassCastException)
+
+        when:
+        ((Map) map).put(Size.XXL, "huge")
+
+        then:
+        thrown(ClassCastException)
+        map.size() == 2
+        map.get(Colour.RED) == "red"
+    }
+
+    void "iteration is in ordinal order regardless of insertion order"() {
+        given:
+        Map<Size, Integer> map = CollectionUtils.newEnumMap(Size.values())
+        map.put(Size.XXL, 5)
+        map.put(Size.S, 1)
+        map.put(Size.L, 3)
+        map.put(Size.M, 2)
+
+        expect:
+        map.entrySet().collect { it.key } == [Size.S, Size.M, Size.L, Size.XXL]
+        new ArrayList<>(map.keySet()) == [Size.S, Size.M, Size.L, Size.XXL]
+        new ArrayList<>(map.values()) == [1, 2, 3, 5]
+        render(map) == "S=1, M=2, L=3, XXL=5"
+
+        when:
+        def visited = []
+        map.forEach { k, v -> visited << k << v }
+
+        then:
+        visited == [Size.S, 1, Size.M, 2, Size.L, 3, Size.XXL, 5]
+    }
+
+    void "Iterator.remove removes the last returned mapping"() {
+        given:
+        Map<Size, Integer> map = CollectionUtils.newEnumMap(Size.values())
+        Size.values().each { map.put(it, it.ordinal()) }
+
+        when:
+        def iterator = map.entrySet().iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next().value % 2 == 0) {
+                iterator.remove()
+            }
+        }
+
+        then:
+        render(map) == "M=1, XL=3"
+        map.size() == 2
+
+        when: "remove is called twice"
+        iterator = map.keySet().iterator()
+        iterator.next()
+        iterator.remove()
+        iterator.remove()
+
+        then:
+        thrown(IllegalStateException)
+        render(map) == "XL=3"
+
+        when:
+        iterator = map.values().iterator()
+        iterator.next()
+        iterator.remove()
+
+        then:
+        map.isEmpty()
+        !iterator.hasNext()
+
+        when:
+        iterator.next()
+
+        then:
+        thrown(NoSuchElementException)
+    }
+
+    void "Entry.setValue writes through to the map"() {
+        given:
+        Map<Colour, String> map = CollectionUtils.newEnumMap(Colour.values())
+        map.put(Colour.RED, "red")
+        map.put(Colour.BLUE, "blue")
+
+        when:
+        def entry = map.entrySet().iterator().next()
+        def previous = entry.setValue("crimson")
+
+        then:
+        previous == "red"
+        entry.key == Colour.RED
+        entry.value == "crimson"
+        map.get(Colour.RED) == "crimson"
+
+        when:
+        entry.setValue(null)
+
+        then:
+        map.containsKey(Colour.RED)
+        map.get(Colour.RED) == null
+        entry.equals(new AbstractMap.SimpleEntry(Colour.RED, null))
+        entry.hashCode() == new AbstractMap.SimpleEntry(Colour.RED, null).hashCode()
+    }
+
+    void "the collection views remove from the map"() {
+        given:
+        Map<Colour, String> map = CollectionUtils.newEnumMap(Colour.values())
+        Colour.values().each { map.put(it, it.name().toLowerCase()) }
+
+        expect:
+        map.keySet().remove(Colour.RED)
+        !map.keySet().remove(Colour.RED)
+        !map.keySet().remove(Size.M)
+        map.values().remove("green")
+        map.entrySet().remove(new AbstractMap.SimpleEntry(Colour.BLUE, "blue"))
+        !map.entrySet().remove(new AbstractMap.SimpleEntry(Colour.YELLOW, "other"))
+        map.entrySet().contains(new AbstractMap.SimpleEntry(Colour.YELLOW, "yellow"))
+        map.keySet().contains(Colour.YELLOW)
+        map.values().contains("yellow")
+        render(map) == "YELLOW=yellow"
+
+        when:
+        map.entrySet().clear()
+
+        then:
+        map.isEmpty()
+    }
+
+    void "equals and hashCode agree with EnumMap and HashMap holding the same mappings"() {
+        given:
+        Map<Colour, String> map = CollectionUtils.newEnumMap(Colour.values())
+        map.put(Colour.YELLOW, "yellow")
+        map.put(Colour.RED, null)
+        def enumMap = new EnumMap<Colour, String>(Colour)
+        enumMap.putAll(map)
+        def hashMap = new HashMap<Colour, String>(map)
+        Map<Colour, String> other = CollectionUtils.newEnumMap(Colour.values())
+        other.put(Colour.RED, null)
+        other.put(Colour.YELLOW, "yellow")
+
+        expect:
+        map.equals(enumMap)
+        enumMap.equals(map)
+        map.equals(hashMap)
+        hashMap.equals(map)
+        map.equals(other)
+        other.equals(map)
+        map.hashCode() == enumMap.hashCode()
+        map.hashCode() == hashMap.hashCode()
+        map.hashCode() == other.hashCode()
+
+        when: "an absent key and a null value differ"
+        other.remove(Colour.RED)
+        other.put(Colour.GREEN, null)
+
+        then:
+        !map.equals(other)
+        !other.equals(map)
+
+        when:
+        hashMap.put(Colour.RED, "red")
+
+        then:
+        !map.equals(hashMap)
+        !hashMap.equals(map)
+
+        and: "empty maps of different enums are equal, as for any maps"
+        CollectionUtils.newEnumMap(Colour.values()).equals(CollectionUtils.newEnumMap(Size.values()))
+    }
+
+    void "putAll copies from a map of the same enum and from other maps"() {
+        given:
+        Map<Colour, String> source = CollectionUtils.newEnumMap(Colour.values())
+        source.put(Colour.GREEN, "green")
+        source.put(Colour.YELLOW, null)
+        Map<Colour, String> map = CollectionUtils.newEnumMap(Colour.values())
+        map.put(Colour.RED, "red")
+        map.put(Colour.GREEN, "lime")
+
+        when:
+        map.putAll(source)
+
+        then:
+        map.size() == 3
+        render(map) == "RED=red, GREEN=green, YELLOW=null"
+
+        when:
+        map.putAll([(Colour.BLUE): "blue"])
+
+        then:
+        map.size() == 4
+        map.get(Colour.BLUE) == "blue"
+
+        when:
+        Map<Size, String> sizes = CollectionUtils.newEnumMap(Size.values())
+        sizes.put(Size.S, "small")
+        ((Map) map).putAll(sizes)
+
+        then:
+        thrown(ClassCastException)
+    }
+
+    void "a map of an enum with constant-specific bodies"() {
+        given:
+        Map<Operation, String> map = CollectionUtils.newEnumMap(Operation.values())
+
+        when:
+        map.put(Operation.MINUS, "-")
+        map.put(Operation.PLUS, "+")
+
+        then:
+        render(map) == "PLUS=+, MINUS=-"
+        map.equals(new EnumMap<>(map))
+    }
+
+    void "the factory rejects an array that is not shaped as values() returns it"() {
+        when:
+        CollectionUtils.newEnumMap(constants as Enum[])
+
+        then:
+        thrown(expected)
+
+        where:
+        constants                              | expected
+        [Colour.GREEN, Colour.RED]             | IllegalArgumentException
+        [Colour.RED, Colour.BLUE]              | IllegalArgumentException
+        [Colour.RED, null]                     | IllegalArgumentException
+        [Colour.RED, Size.M]                   | IllegalArgumentException
+        [Colour.RED, Colour.GREEN, Colour.RED] | IllegalArgumentException
+    }
+
+    void "the factory rejects a null array and accepts an empty one"() {
+        when:
+        CollectionUtils.newEnumMap(null)
+
+        then:
+        thrown(NullPointerException)
+
+        expect:
+        CollectionUtils.newEnumMap(new Colour[0]).isEmpty()
+    }
+
+    void "behaves as EnumMap over a randomised sequence of operations"() {
+        given:
+        def random = new Random(seed)
+        Map<Size, String> map = CollectionUtils.newEnumMap(Size.values())
+        def expected = new EnumMap<Size, String>(Size)
+        def sizes = Size.values()
+        def values = [null, "a", "b", "c"]
+        def keys = (sizes as List<Object>) + [Colour.RED, Colour.YELLOW, null, "S"]
+
+        when:
+        10_000.times { step ->
+            def key = sizes[random.nextInt(sizes.length)]
+            def anyKey = keys[random.nextInt(keys.size())]
+            def value = values[random.nextInt(values.size())]
+            switch (random.nextInt(12)) {
+                case 0:
+                case 1:
+                    assert map.put(key, value) == expected.put(key, value)
+                    break
+                case 2:
+                    assert map.remove(anyKey) == expected.remove(anyKey)
+                    break
+                case 3:
+                    assert map.get(anyKey) == expected.get(anyKey)
+                    assert map.containsKey(anyKey) == expected.containsKey(anyKey)
+                    assert map.getOrDefault(anyKey, "default") == expected.getOrDefault(anyKey, "default")
+                    break
+                case 4:
+                    assert map.containsValue(value) == expected.containsValue(value)
+                    break
+                case 5:
+                    def source = [:]
+                    source.put(key, value)
+                    source.put(sizes[random.nextInt(sizes.length)], values[random.nextInt(values.size())])
+                    map.putAll(source)
+                    expected.putAll(source)
+                    break
+                case 6:
+                    Map<Size, String> source = CollectionUtils.newEnumMap(Size.values())
+                    source.put(key, value)
+                    map.putAll(source)
+                    expected.putAll(source)
+                    break
+                case 7:
+                    def target = random.nextInt(sizes.length)
+                    removeWhere(map.entrySet().iterator()) { it.key.ordinal() == target }
+                    removeWhere(expected.entrySet().iterator()) { it.key.ordinal() == target }
+                    break
+                case 8:
+                    setWhere(map.entrySet().iterator(), key, value)
+                    setWhere(expected.entrySet().iterator(), key, value)
+                    break
+                case 9:
+                    assert map.keySet().remove(anyKey) == expected.keySet().remove(anyKey)
+                    assert map.values().remove(value) == expected.values().remove(value)
+                    break
+                case 10:
+                    assert map.entrySet().remove(new AbstractMap.SimpleEntry(key, value)) ==
+                            expected.entrySet().remove(new AbstractMap.SimpleEntry(key, value))
+                    break
+                case 11:
+                    if (random.nextInt(20) == 0) {
+                        map.clear()
+                        expected.clear()
+                    }
+                    break
+            }
+            assertSame(map, expected, step)
+        }
+
+        then:
+        noExceptionThrown()
+
+        where:
+        seed << [1L, 42L, 20260911L]
+    }
+
+    private static String render(Map<?, ?> map) {
+        map.entrySet().collect { entry -> "${entry.key}=${entry.value}" }.join(", ")
+    }
+
+    private static void removeWhere(Iterator<Map.Entry<Size, String>> iterator, Closure<Boolean> predicate) {
+        while (iterator.hasNext()) {
+            if (predicate.call(iterator.next())) {
+                iterator.remove()
+            }
+        }
+    }
+
+    private static void setWhere(Iterator<Map.Entry<Size, String>> iterator, Size key, String value) {
+        while (iterator.hasNext()) {
+            def entry = iterator.next()
+            if (entry.key == key) {
+                entry.setValue(value)
+            }
+        }
+    }
+
+    private static void assertSame(Map<Size, String> map, EnumMap<Size, String> expected, int step) {
+        assert map.size() == expected.size(), "step $step"
+        assert map.isEmpty() == expected.isEmpty()
+        assert render(map) == render(expected)
+        assert new ArrayList<>(map.keySet()) == new ArrayList<>(expected.keySet())
+        assert new ArrayList<>(map.values()) == new ArrayList<>(expected.values())
+        assert map.equals(expected)
+        assert expected.equals(map)
+        assert map.hashCode() == expected.hashCode()
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/Http2ServerHandler.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.netty.handler;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.body.ByteBody;
 import io.micronaut.http.body.stream.BodySizeLimits;
 import io.micronaut.http.server.netty.HttpCompressionStrategy;
@@ -49,7 +50,6 @@ import io.netty.handler.timeout.IdleStateEvent;
 import org.jspecify.annotations.Nullable;
 
 import java.nio.channels.ClosedChannelException;
-import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -61,7 +61,7 @@ import java.util.Objects;
  */
 @Internal
 public final class Http2ServerHandler extends MultiplexedServerHandler implements Http2FrameListener {
-    private static final Map<Http2Error, Exception> HTTP2_ERRORS = new EnumMap<>(Http2Error.class);
+    private static final Map<Http2Error, Exception> HTTP2_ERRORS;
 
     @Nullable
     private Http2ConnectionHandler connectionHandler;
@@ -70,7 +70,9 @@ public final class Http2ServerHandler extends MultiplexedServerHandler implement
     private boolean upgradedFromHttp1 = false;
 
     static {
-        for (Http2Error value : Http2Error.values()) {
+        Http2Error[] errors = Http2Error.values();
+        HTTP2_ERRORS = CollectionUtils.newEnumMap(errors);
+        for (Http2Error value : errors) {
             Exception e;
             if (value == Http2Error.CANCEL) {
                 e = StacklessStreamClosedChannelException.INSTANCE;

--- a/jackson-databind/src/main/java/io/micronaut/jackson/codec/JacksonFeatures.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/codec/JacksonFeatures.java
@@ -21,11 +21,11 @@ import tools.jackson.databind.SerializationFeature;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.ObjectUtils;
 import io.micronaut.json.JsonFeatures;
 
 import java.util.ArrayList;
-import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -48,8 +48,8 @@ public final class JacksonFeatures implements JsonFeatures {
      * Empty jackson features.
      */
     public JacksonFeatures() {
-        this.serializationFeatures = new EnumMap<>(SerializationFeature.class);
-        this.deserializationFeatures = new EnumMap<>(DeserializationFeature.class);
+        this.serializationFeatures = CollectionUtils.newEnumMap(SerializationFeature.values());
+        this.deserializationFeatures = CollectionUtils.newEnumMap(DeserializationFeature.values());
         this.additionalModules = new ArrayList<>();
     }
 

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -62,7 +61,7 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
 
     private static final UriRouteInfo<Object, Object>[] EMPTY = new UriRouteInfo[0];
 
-    private final EnumMap<HttpMethod, UriRouteInfo<Object, Object>[]> methodRoutesByMethod;
+    private final Map<HttpMethod, UriRouteInfo<Object, Object>[]> methodRoutesByMethod;
     private final Map<String, UriRouteInfo<Object, Object>[]> allRoutesByMethod;
     private final StatusRouteInfo<Object, Object>[] statusRoutes;
     private final ErrorRouteInfo<Object, Object>[] errorRoutes;
@@ -95,7 +94,8 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
     public DefaultRouter(Collection<RouteBuilder> builders) {
         Set<Integer> exposedPorts = new HashSet<>(5);
         Map<String, List<UriRouteInfo<Object, Object>>> customRoutesByMethod = new HashMap<>();
-        EnumMap<HttpMethod, List<UriRouteInfo<Object, Object>>> routesByMethod = new EnumMap<>(HttpMethod.class);
+        HttpMethod[] httpMethods = HttpMethod.values();
+        Map<HttpMethod, List<UriRouteInfo<Object, Object>>> routesByMethod = CollectionUtils.newEnumMap(httpMethods);
         Set<StatusRouteInfo<Object, Object>> statusRoutes = new LinkedHashSet<>();
         Set<ErrorRouteInfo<Object, Object>> errorRoutes = new LinkedHashSet<>();
         alwaysMatchesFilterRoutes = new ArrayList<>(20);
@@ -152,7 +152,7 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
         } else {
             this.exposedPorts = Collections.emptySet();
         }
-        EnumMap<HttpMethod, UriRouteInfo<Object, Object>[]> methodMap = new EnumMap<>(HttpMethod.class);
+        Map<HttpMethod, UriRouteInfo<Object, Object>[]> methodMap = CollectionUtils.newEnumMap(httpMethods);
         Map<String, UriRouteInfo<Object, Object>[]> customMethodMap = CollectionUtils.newHashMap(routesByMethod.size() + customRoutesByMethod.size());
         for (Map.Entry<HttpMethod, List<UriRouteInfo<Object, Object>>> e : routesByMethod.entrySet()) {
             UriRouteInfo<Object, Object>[] values = finalizeRoutes(e.getValue());


### PR DESCRIPTION
Adds `CollectionUtils.newEnumMap(K[] constants)`, which returns an enum-keyed map that behaves like `java.util.EnumMap` without looking the enum's constants up by reflection. It also switches the three `new EnumMap<>(X.class)` calls in the repository to the new map.

## The reflection in `EnumMap`

Every `java.util.EnumMap` gets its key universe by reflection. In JDK 25, `EnumMap(Class)` calls `getKeyUniverse(keyType)`, which calls `SharedSecrets.getJavaLangAccess().getEnumConstantsShared(keyType)`, which calls `Class.getEnumConstantsShared()`:

```java
final Method values = getMethod("values");
values.setAccessible(true);
T[] temporaryConstants = (T[]) values.invoke(null);
enumConstants = constants = temporaryConstants;
```

That is:
- a `getMethod` lookup, which fills in the enum class's public-method reflection data
- `setAccessible`
- a reflective `invoke`
- a cache kept on the `Class` for as long as the class lives

`EnumMap(Map)` does the same when its argument is not already an `EnumMap`, and so does deserialization. Only `EnumMap(EnumMap)` skips it, by copying `keyUniverse` from a map that was itself built by reflection. `EnumMap` has no constructor that takes the constants. The same applies to `EnumSet.noneOf/allOf/of/range/copyOf` and to `Class.getEnumConstants`.

The `NoReflection` check in micronaut-projects/errorprone-no-reflection reports all of these under its `ENUM_CONSTANTS` category. To pass it, micronaut-projects/micronaut-jakarta-interceptors had to replace its `EnumMap`s with `LinkedHashMap`s filled in `values()` order.

## Why the new map avoids it

`EnumMap` only needs reflection because it is given a `Class`. At the call site the enum is known, so `MyEnum.values()` can hand over the constants directly. `values()` is a static method generated by the compiler, and the check does not report it. The rest of `EnumMap` is just an array of values indexed by `ordinal()`.

`EnumConstantsMap` is package-private in `io.micronaut.core.util`:

- **Storage:** it extends `AbstractMap` and holds the `values()` array, an `Object[]` of values and a size. An empty slot is `null`, so a `null` value is stored as a private sentinel.
- **Lookup:** a key is valid when `key instanceof Enum<?> e && e.ordinal() < universe.length && universe[e.ordinal()] == e`. The identity check rejects a constant of another enum without calling `getDeclaringClass()`.
- **Same behaviour as `EnumMap`:**
  - it accepts `null` values and rejects `null` keys with `NullPointerException`
  - `put` with a key from another enum throws `ClassCastException`
  - iteration follows ordinal order, and iterators are weakly consistent (no `ConcurrentModificationException`)
  - `Iterator.remove` works on all three views
  - `Entry.setValue` writes through to the map
- **Overrides:**
  - `get`, `getOrDefault`, `containsKey`, `containsValue`, `put`, `remove`, `size`, `clear` and `forEach`
  - `entrySet`, `keySet` and `values`
  - `putAll`, which copies the value array directly when the source is a map of the same enum
  - `equals` and `hashCode`: they compare arrays against a map of the same enum, and otherwise follow the `Map` contract, so the map equals an `EnumMap` or a `HashMap` with the same mappings
- **No `ENUM_CONSTANTS` calls.** The class uses no `EnumMap`, `EnumSet`, `Class.getEnumConstants`, `Enum.valueOf` or `describeConstable`.

The factory returns `Map<K, V>`. It checks that the array is non-null and that each element is a constant of one enum whose `ordinal()` equals its index, which is the shape `values()` returns. A mis-ordered array would otherwise corrupt lookups without any error. The map keeps the array rather than copying it, and the javadoc says it must not be mutated. Passing `values()` directly is always safe because each call returns a new array.

The javadoc of the existing `CollectionUtils.enumSet(E...)` now notes that it uses `EnumSet.noneOf`, which is reflective. Its behaviour is unchanged.

`@since 5.3.0`: this is new API, and `gradle.properties` on `5.3.x` says `5.3.0-SNAPSHOT`.

## Converted uses

`core`, `inject`, `aop` and `context` contain no `new EnumMap`. These are the only three in the repository's main sources, and all are now converted:

- `router` `DefaultRouter`: the two per-method route maps built in the constructor. The per-request lookup `methodRoutesByMethod.getOrDefault(httpMethod, EMPTY)` now does one slot read; the `Map` default method did `get` plus `containsKey`.
- `http-server-netty` `Http2ServerHandler`: the static `Http2Error` → exception map, built from the `values()` array its static initializer already iterates.
- `jackson-databind` `JacksonFeatures`: the serialization and deserialization feature maps created by each instance.

## Tests

`EnumConstantsMapSpec` covers:
- put, get, remove, `containsKey`, `containsValue`, size and clear
- `null` values, and rejection of `null` keys
- keys from another enum, both with the same ordinal and with an ordinal past the end: `get` returns null and `put` throws
- ordinal iteration order regardless of insertion order
- `Iterator.remove` on each view, and `Entry.setValue` writing through
- `equals`/`hashCode` against `EnumMap`, `HashMap` and a second map
- both `putAll` paths
- an enum whose constants have their own bodies
- the factory rejecting mis-ordered, sparse, `null`-containing and mixed-enum arrays
- a comparison against `java.util.EnumMap` over 10,000 random operations, for three seeds

