### PR TITLE
Do not retain lazy proxy targets as dependents of the proxy's context

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/beandefinition/SharedInterceptorRegistrations.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/SharedInterceptorRegistrations.java
@@ -67,8 +67,6 @@ import java.util.List;
 @Internal
 public final class SharedInterceptorRegistrations {
 
-    private static final String ATTRIBUTE = "io.micronaut.aop.sharedInterceptorRegistrations";
-
     private SharedInterceptorRegistrations() {
     }
 
@@ -94,10 +92,10 @@ public final class SharedInterceptorRegistrations {
         if (registrations == null || registrations.isEmpty()) {
             return;
         }
-        Deque<Entry> stack = (Deque<Entry>) resolutionContext.getAttribute(ATTRIBUTE);
+        Deque<Entry> stack = (Deque<Entry>) resolutionContext.getAttribute(BeanResolutionContext.SHARED_INTERCEPTOR_REGISTRATIONS);
         if (stack == null) {
             stack = new ArrayDeque<>(3);
-            resolutionContext.setAttribute(ATTRIBUTE, stack);
+            resolutionContext.setAttribute(BeanResolutionContext.SHARED_INTERCEPTOR_REGISTRATIONS, stack);
         }
         stack.push(new Entry(definition, registrations));
     }
@@ -181,7 +179,7 @@ public final class SharedInterceptorRegistrations {
 
     @SuppressWarnings("unchecked")
     private static @Nullable Deque<Entry> stack(BeanResolutionContext resolutionContext) {
-        return (Deque<Entry>) resolutionContext.getAttribute(ATTRIBUTE);
+        return (Deque<Entry>) resolutionContext.getAttribute(BeanResolutionContext.SHARED_INTERCEPTOR_REGISTRATIONS);
     }
 
     private record Entry(BeanDefinition<?> definition, List<?> registrations) {

--- a/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/LazyProxyTargetDependentBeansSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/LazyProxyTargetDependentBeansSpec.groovy
@@ -7,6 +7,8 @@ import io.micronaut.context.scope.CustomScope
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.runtime.context.scope.ThreadLocal
 
+import java.util.concurrent.CyclicBarrier
+
 /**
  * A lazy proxy retains a copy of the resolution context it was created with and resolves its target through that
  * copy on every intercepted call. A target that is created on each call, a prototype or a bean whose scope is not
@@ -150,6 +152,141 @@ class Test {
         targetClass.DESTROYED.get() == 1
 
         cleanup:
+        context.close()
+    }
+
+    void 'test concurrent lazy proxy target creations do not share the lifecycle interceptors of one another'() {
+        given: 'a lazy proxy injected while a bean with constructor and post construct advice is being created'
+        def context = buildContext('''
+package lazyproxydependents;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.AroundConstruct;
+import io.micronaut.aop.ConstructorInvocationContext;
+import io.micronaut.aop.Interceptor;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.InterceptorBinding;
+import io.micronaut.aop.InterceptorKind;
+import io.micronaut.aop.InvocationContext;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.lang.annotation.Retention;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around(proxyTarget = true, lazy = true)
+@Retention(RUNTIME)
+@interface LazilyProxied {
+}
+
+@Singleton
+@InterceptorBean(LazilyProxied.class)
+class LazilyProxiedInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Retention(RUNTIME)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Managed {
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.POST_CONSTRUCT)
+class ManagedInterceptor implements Interceptor<Object, Object> {
+    public static volatile CyclicBarrier barrier;
+    public static final AtomicInteger postConstructs = new AtomicInteger();
+    public static final AtomicInteger mismatches = new AtomicInteger();
+    private static final ThreadLocal<Object> CONSTRUCTED_BY = new ThreadLocal<>();
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        CyclicBarrier currentBarrier = barrier;
+        if (context instanceof ConstructorInvocationContext<?> constructorContext) {
+            if (currentBarrier != null && constructorContext.getConstructor().getDeclaringBeanType() == Target.class) {
+                CONSTRUCTED_BY.set(this);
+                try {
+                    // both threads are constructing a target before either runs its post construct interception
+                    currentBarrier.await(10, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+            return context.proceed();
+        }
+        MethodInvocationContext<?, ?> methodContext = (MethodInvocationContext<?, ?>) context;
+        if (currentBarrier != null && methodContext.getTarget() instanceof Target) {
+            postConstructs.incrementAndGet();
+            if (CONSTRUCTED_BY.get() != this) {
+                mismatches.incrementAndGet();
+            }
+        }
+        return context.proceed();
+    }
+}
+
+@LazilyProxied
+@Managed
+@Prototype
+class Target {
+    @PostConstruct
+    void init() {
+    }
+
+    public Object instance() {
+        return this;
+    }
+}
+
+@Managed
+@Singleton
+class Holder {
+    @Inject
+    Target target;
+
+    @PostConstruct
+    void init() {
+    }
+}
+''')
+        def interceptorClass = context.classLoader.loadClass('lazyproxydependents.ManagedInterceptor')
+        def holder = context.getBean(context.classLoader.loadClass('lazyproxydependents.Holder'))
+        def proxy = holder.target
+        int rounds = 20
+        interceptorClass.barrier = new CyclicBarrier(2)
+
+        when: 'two threads create a target through the same proxy at the same time'
+        def failures = Collections.synchronizedList([])
+        rounds.times {
+            def threads = (1..2).collect {
+                Thread.start {
+                    try {
+                        proxy.instance()
+                    } catch (Throwable e) {
+                        failures << e
+                    }
+                }
+            }
+            threads*.join()
+        }
+
+        then: 'each target is post constructed by the interceptor that constructed it'
+        failures.isEmpty()
+        interceptorClass.postConstructs.get() == rounds * 2
+        interceptorClass.mismatches.get() == 0
+
+        cleanup:
+        interceptorClass?.barrier = null
         context.close()
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/LazyProxyTargetDependentBeansSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/LazyProxyTargetDependentBeansSpec.groovy
@@ -1,0 +1,208 @@
+package io.micronaut.aop.lazyproxytarget
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanResolutionContext
+import io.micronaut.context.scope.CustomScope
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.runtime.context.scope.ThreadLocal
+
+/**
+ * A lazy proxy retains a copy of the resolution context it was created with and resolves its target through that
+ * copy on every intercepted call. A target that is created on each call, a prototype or a bean whose scope is not
+ * registered, must not be recorded as a dependent of the retained context, which lives as long as the proxy and
+ * would otherwise grow with every call.
+ */
+class LazyProxyTargetDependentBeansSpec extends AbstractTypeElementSpec {
+
+    private static final int CALLS = 100
+
+    void 'test a prototype lazy proxy target is not retained by the proxy resolution context'() {
+        given:
+        def context = buildContext(source('@io.micronaut.context.annotation.Prototype'))
+        def proxy = lookupProxy(context)
+
+        when:
+        def instances = (1..CALLS).collect { proxy.instance() } as Set
+
+        then: 'every call resolves a new target'
+        instances.size() == CALLS
+
+        and: 'none of them is retained by the context the proxy keeps'
+        retainedResolutionContext(proxy).dependentBeans.isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a lazy proxy target of an unregistered scope is not retained by the proxy resolution context'() {
+        given: 'a context that does not include the thread local scope bean'
+        def context = buildContext(source('@io.micronaut.runtime.context.scope.ThreadLocal'))
+
+        expect: 'the scope is not found, so the target is created as if it had no scope'
+        !threadLocalScope(context).isPresent()
+
+        when:
+        def proxy = lookupProxy(context)
+        def instances = (1..CALLS).collect { proxy.instance() } as Set
+
+        then:
+        instances.size() == CALLS
+        retainedResolutionContext(proxy).dependentBeans.isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a lazy proxy target of a registered scope resolves the scoped instance'() {
+        given: 'a context that includes the thread local scope bean'
+        def context = buildContext('lazyproxydependents.Test', source('@io.micronaut.runtime.context.scope.ThreadLocal'), true)
+
+        expect:
+        threadLocalScope(context).isPresent()
+
+        when:
+        def proxy = lookupProxy(context)
+        def instances = (1..CALLS).collect { proxy.instance() } as Set
+
+        then:
+        instances.size() == 1
+        retainedResolutionContext(proxy).dependentBeans.isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a cached lazy proxy target is still destroyed with the proxy'() {
+        given:
+        def context = buildContext('''
+package lazyproxydependents;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.Retention;
+import java.util.concurrent.atomic.AtomicInteger;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around(proxyTarget = true, lazy = true, cacheableLazyTarget = true)
+@Retention(RUNTIME)
+@interface LazilyProxied {
+}
+
+@Singleton
+@InterceptorBean(LazilyProxied.class)
+class LazilyProxiedInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Prototype
+class Dependency {
+}
+
+@LazilyProxied
+@Prototype
+class Test {
+    static final AtomicInteger DESTROYED = new AtomicInteger();
+
+    final Dependency dependency;
+
+    Test(Dependency dependency) {
+        this.dependency = dependency;
+    }
+
+    public Object instance() {
+        return this;
+    }
+
+    public Dependency dependency() {
+        return dependency;
+    }
+
+    @PreDestroy
+    void destroy() {
+        DESTROYED.incrementAndGet();
+    }
+}
+''')
+        def targetClass = context.classLoader.loadClass('lazyproxydependents.Test')
+        def registration = context.getBeanRegistration(context.getBeanDefinition(targetClass))
+        def proxy = registration.bean
+
+        when:
+        def instances = (1..CALLS).collect { proxy.instance() } as Set
+
+        then: 'the target is created once, with its dependency injected'
+        instances.size() == 1
+        proxy.dependency() != null
+
+        when:
+        context.destroyBean(registration)
+
+        then: 'destroying the proxy destroys the cached target'
+        targetClass.DESTROYED.get() == 1
+
+        cleanup:
+        context.close()
+    }
+
+    private static Optional<CustomScope> threadLocalScope(ApplicationContext context) {
+        // how the custom scope registry looks a scope up: a bean, which a test context only has if it includes all beans
+        return context.findBean(CustomScope, Qualifiers.byTypeArguments(ThreadLocal))
+    }
+
+    private static Object lookupProxy(ApplicationContext context) {
+        def proxy = context.getBean(context.classLoader.loadClass('lazyproxydependents.Test'))
+        assert proxy.class.name != 'lazyproxydependents.Test'
+        return proxy
+    }
+
+    private static BeanResolutionContext retainedResolutionContext(Object proxy) {
+        def field = proxy.class.getDeclaredField('$beanResolutionContext')
+        field.accessible = true
+        return (BeanResolutionContext) field.get(proxy)
+    }
+
+    private static String source(String scope) {
+        return """
+package lazyproxydependents;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import jakarta.inject.Singleton;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around(proxyTarget = true, lazy = true)
+@Retention(RUNTIME)
+@interface LazilyProxied {
+}
+
+@Singleton
+@InterceptorBean(LazilyProxied.class)
+class LazilyProxiedInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@LazilyProxied
+$scope
+class Test {
+    public Object instance() {
+        return this;
+    }
+}
+"""
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -68,6 +68,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     private Qualifier<?> qualifier;
     @Nullable
     private List<BeanRegistration<?>> dependentBeans;
+    private boolean lazyProxyTarget;
     @Nullable
     private List<BeanRegistration<?>> dependentBeansToDestroyAfterResolution;
     @Nullable
@@ -405,7 +406,22 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         if (!context.getBeanResolutionCustomizer().shouldPreserveLazyProxyTargetResolutionPath(this, proxyBeanDefinition)) {
             copy.getPath().clear();
         }
+        if (copy instanceof AbstractBeanResolutionContext abstractCopy) {
+            abstractCopy.lazyProxyTarget = true;
+        }
         return copy;
+    }
+
+    /**
+     * Whether this context was copied by {@link #copyForLazyProxyTarget(BeanDefinition)}. Such a context is retained
+     * by the lazy proxy for its whole life and the proxy target is resolved through it on every intercepted call,
+     * possibly from several threads at once, so a bean must not be created directly in it.
+     *
+     * @return True if the context is retained by a lazy proxy
+     * @since 5.2.0
+     */
+    final boolean isLazyProxyTarget() {
+        return lazyProxyTarget;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -406,6 +406,10 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         if (!context.getBeanResolutionCustomizer().shouldPreserveLazyProxyTargetResolutionPath(this, proxyBeanDefinition)) {
             copy.getPath().clear();
         }
+        // the copy shares attribute values with this context, and these belong to the creation in progress: a target
+        // resolved later, possibly by several threads at once, must start its own
+        copy.removeAttribute(SHARED_INTERCEPTOR_REGISTRATIONS);
+        copy.removeAttribute(INTERCEPTOR_REGISTRATIONS);
         if (copy instanceof AbstractBeanResolutionContext abstractCopy) {
             abstractCopy.lazyProxyTarget = true;
         }
@@ -415,7 +419,8 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     /**
      * Whether this context was copied by {@link #copyForLazyProxyTarget(BeanDefinition)}. Such a context is retained
      * by the lazy proxy for its whole life and the proxy target is resolved through it on every intercepted call,
-     * possibly from several threads at once, so a bean must not be created directly in it.
+     * possibly from several threads at once, so a bean must not be created directly in it. Beans are created in a
+     * copy of it, which starts without the attributes a creation in progress keeps.
      *
      * @return True if the context is retained by a lazy proxy
      * @since 5.2.0

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -70,6 +70,17 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
     String INTERCEPTOR_REGISTRATIONS = "io.micronaut.aop.interceptorRegistrations";
 
     /**
+     * Attribute used while a bean with constructor advice is being constructed to share the interceptor registrations
+     * selected for it with its post-construct interception.
+     *
+     * <p>The value is a mutable stack that belongs to the creation in progress and must be treated as an
+     * implementation detail.</p>
+     *
+     * @since 5.2.1
+     */
+    String SHARED_INTERCEPTOR_REGISTRATIONS = "io.micronaut.aop.sharedInterceptorRegistrations";
+
+    /**
      * Attribute that exposes the interceptor registrations selected while creating the bean being disposed.
      *
      * <p>The value is a read-only {@code List<BeanRegistration<?>>}. It is set only while a bean is being disposed and

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -3369,6 +3369,12 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                                                      @Nullable Qualifier<T> qualifier,
                                                      BeanDefinition<T> definition,
                                                      boolean dependent) {
+        if (resolutionContext instanceof AbstractBeanResolutionContext abstractContext && abstractContext.isLazyProxyTarget()) {
+            // The context is retained by a lazy proxy, which resolves its target through it on every call. Create
+            // the bean in a copy, so that the created bean is not recorded as a dependent of the retained context
+            // and the resolution path is not shared by concurrent calls.
+            resolutionContext = resolutionContext.copy();
+        }
         try (BeanResolutionContext context = newResolutionContext(definition, resolutionContext)) {
             final BeanResolutionContext.Path path = context.getPath();
             final boolean isNewPath = path.isEmpty();


### PR DESCRIPTION
## Problem

A lazy AOP proxy (`@Around(proxyTarget = true, lazy = true)`) stores the context returned by `copyForLazyProxyTarget` in `$beanResolutionContext`. It keeps that context for its whole life and resolves its target through it on every intercepted call (see `AopProxyWriter#getLazyInterceptedTargetMethod`).

Sometimes the target is created on every call. That happens for a `@Prototype` target, or for a bean whose scope isn't registered. In that case `resolveBeanRegistration` falls through to `createRegistration(..., dependent = true)`, which calls `addDependentBean` on the retained context. The list grows by one registration per call and is never cleared. A benchmark hit `OutOfMemoryError` after a few million calls:

```
at io.micronaut.context.AbstractBeanResolutionContext.addDependentBean(AbstractBeanResolutionContext.java:427)
at io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:3432)
at io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:3252)
at io.micronaut.context.DefaultBeanContext.getProxyTargetBean(DefaultBeanContext.java:1659)
```

Nothing reads those dependents. The proxy's own registration takes its dependents from the original context when the proxy is created, and `destroyProxyTargetBean` uses the registration's dependents. For a cached lazy target it also uses the cached instance. It never looks at the retained context.

That benchmark used `@io.micronaut.runtime.context.scope.ThreadLocal`. The scope wasn't found because `AbstractTypeElementSpec.buildContext(...)` only registers the compiled beans plus a few built-ins. `ThreadLocalCustomScope` is a bean, and `DefaultCustomScopeRegistry` looks scopes up as `CustomScope` beans. So the `@ThreadLocal` target behaved like a prototype. The same thing happens in an application whose scope bean is missing.

## Fix

- `AbstractBeanResolutionContext#copyForLazyProxyTarget` marks the copy it returns (`isLazyProxyTarget()`, package-private).
- `DefaultBeanContext#createRegistration` creates the bean in a `copy()` of a marked context. The new registration and any "destroy after resolution" dependents go to that throwaway copy, not the retained context. A side benefit: concurrent calls on the proxy no longer write to the same resolution path and dependent lists.
- `copyForLazyProxyTarget` also removes two mutable attribute values from the copy the proxy keeps: the `SharedInterceptorRegistrations` stack (its key is now `BeanResolutionContext.SHARED_INTERCEPTOR_REGISTRATIONS`) and the `INTERCEPTOR_REGISTRATIONS` map. `copy()` shares attribute values, so without this, concurrent target creations pushed onto the stack of the outer bean's creation and could post-construct a target with the other thread's prototype interceptor.

What stays the same:
- Scoped targets: `getOrCreateScopedRegistration` already creates through `resolutionContext.copy()`, so the scope hot path gets no extra allocation.
- Destruction semantics: a per-call lazy target was never destroyed through the retained context, and still isn't. Cached lazy targets are still destroyed with the proxy.
- `shouldPreserveLazyProxyTargetResolutionPath`: `copy()` keeps the path, so a preserved path still applies.
- Already compiled proxies: the fix is at runtime, so they get it without being regenerated.

## Tests

`LazyProxyTargetDependentBeansSpec` (inject-java):
- a `@Prototype` lazy target called 100 times leaves the retained context's dependents empty (**fails on 5.2.x** with 100 registrations)
- a `@ThreadLocal` lazy target in a context without the scope bean: the test checks that the scope isn't found, then that nothing is retained (**fails on 5.2.x**)
- the same target in a context that includes all beans resolves one scoped instance
- a cached lazy prototype target is created once and destroyed with the proxy
- two threads create a target through a proxy injected into a bean with `@AroundConstruct` / `@PostConstruct` advice, and each target is post-constructed by the interceptor that constructed it (13 of 40 mismatches before the attribute fix)

Local runs with the fix, all green:
- `:micronaut-inject-java:test` for `io.micronaut.aop.*`, `io.micronaut.inject.lifecycle.*`, `io.micronaut.inject.injectionpoint.*`, `io.micronaut.inject.scope.*`, `io.micronaut.inject.factory.*` and `io.micronaut.runtime.*`: 3,802 tests, 0 failures, 1 skipped
- `:micronaut-inject:test`: 407 tests, 0 failures
- `:micronaut-context:test`: 48 tests, 0 failures, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)


