### PR TITLE
Register the physical signature of Kotlin suspend functions in the Graal reflection config

### DIFF
--- a/graal/build.gradle.kts
+++ b/graal/build.gradle.kts
@@ -3,17 +3,18 @@ plugins {
 }
 dependencies {
     annotationProcessor(projects.micronautInjectJava)
+
     api(projects.micronautCoreProcessor)
+
+    testAnnotationProcessor(projects.micronautInjectJava)
 
     testImplementation(projects.micronautInject)
     testImplementation(projects.micronautHttp)
     testImplementation(projects.micronautInjectJavaTest)
-    testImplementation(libs.managed.groovy.json)
-    testImplementation(libs.javax.persistence)
-    testAnnotationProcessor(projects.micronautInjectJava)
-
     testImplementation(projects.micronautInjectKotlin)
     testImplementation(projects.micronautInjectKotlinTest)
+    testImplementation(libs.managed.groovy.json)
+    testImplementation(libs.javax.persistence)
     testImplementation(libs.managed.kotlin.compiler.embeddable)
     testImplementation(libs.managed.kotlin.stdlib)
 }

--- a/graal/build.gradle.kts
+++ b/graal/build.gradle.kts
@@ -11,4 +11,19 @@ dependencies {
     testImplementation(libs.managed.groovy.json)
     testImplementation(libs.javax.persistence)
     testAnnotationProcessor(projects.micronautInjectJava)
+
+    testImplementation(projects.micronautInjectKotlin)
+    testImplementation(projects.micronautInjectKotlinTest)
+    testImplementation(libs.managed.kotlin.compiler.embeddable)
+    testImplementation(libs.managed.kotlin.stdlib)
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jetbrains.kotlin") {
+            useVersion(libs.versions.managed.kotlin.asProvider().get())
+        } else if (requested.group == "com.google.devtools.ksp") {
+            useVersion(libs.versions.managed.ksp.get())
+        }
+    }
 }

--- a/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
+++ b/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
@@ -332,7 +332,9 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
         final String methodName = element.getName();
         final ClassElement declaringType = element.getDeclaringType();
         final ReflectionConfigData data = resolveClassData(declaringType.getName(), classes);
-        final List<AnnotationClassValue<?>> params = Arrays.stream(element.getParameters())
+        // a Kotlin suspend function has a trailing Continuation parameter on the JVM
+        final ParameterElement[] parameters = element.isSuspend() ? element.getSuspendParameters() : element.getParameters();
+        final List<AnnotationClassValue<?>> params = Arrays.stream(parameters)
             .map(ParameterElement::getType)
             .map(this::resolveName).collect(Collectors.toList());
         data.methods.add(

--- a/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorKotlinSpec.groovy
+++ b/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorKotlinSpec.groovy
@@ -1,0 +1,133 @@
+package io.micronaut.graal.reflect
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.annotation.ReflectionConfig
+import io.micronaut.core.graal.GraalReflectionConfigurer
+import io.micronaut.core.naming.NameUtils
+
+import java.lang.reflect.Constructor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+class GraalTypeElementVisitorKotlinSpec extends AbstractKotlinCompilerSpec {
+
+    void "test write reflect config for a @ReflectiveAccess suspend function"() {
+        given:
+        ClassLoader classLoader = buildClassLoader('test.Test', '''
+package test
+
+import io.micronaut.core.annotation.ReflectiveAccess
+
+class Test {
+
+    @ReflectiveAccess
+    suspend fun suspending(name: String): String = name
+
+    @ReflectiveAccess
+    suspend fun suspendingUnit(name: String) {
+    }
+
+    @ReflectiveAccess
+    fun blocking(name: String): String = name
+}
+''')
+        GraalReflectionConfigurer configurer = reflectionConfigurer(classLoader, 'test.Test')
+
+        when:
+        AnnotationValue<ReflectionConfig> config = configurer.getAnnotationMetadata().getAnnotationValuesByType(ReflectionConfig).first()
+        Map<String, List<String>> methods = config.getAnnotations("methods").collectEntries {
+            [(it.stringValue("name").get()): it.stringValues("parameterTypes").toList()]
+        }
+
+        then:
+        config.stringValue("type").get() == 'test.Test'
+        methods == [
+                suspending    : ['java.lang.String', 'kotlin.coroutines.Continuation'],
+                suspendingUnit: ['java.lang.String', 'kotlin.coroutines.Continuation'],
+                blocking      : ['java.lang.String']
+        ]
+
+        when:
+        Class<?> type = classLoader.loadClass('test.Test')
+        List<Method> registered = registeredMethods(configurer, classLoader)
+
+        then:
+        registered.toSet() == [
+                type.getDeclaredMethod('suspending', String, classLoader.loadClass('kotlin.coroutines.Continuation')),
+                type.getDeclaredMethod('suspendingUnit', String, classLoader.loadClass('kotlin.coroutines.Continuation')),
+                type.getDeclaredMethod('blocking', String)
+        ].toSet()
+    }
+
+    void "test write reflect config for a private @Executable suspend function of a bean"() {
+        given:
+        ClassLoader classLoader = buildClassLoader('test.Test', '''
+package test
+
+import io.micronaut.context.annotation.Executable
+import io.micronaut.core.annotation.ReflectiveAccess
+import jakarta.inject.Singleton
+
+@Singleton
+open class Test {
+
+    @Executable
+    @ReflectiveAccess
+    private suspend fun suspending(name: String): String = name
+}
+''')
+        GraalReflectionConfigurer configurer = reflectionConfigurer(classLoader, 'test.Test')
+        Class<?> type = classLoader.loadClass('test.Test')
+
+        expect:
+        registeredMethods(configurer, classLoader).toSet() == [
+                type.getDeclaredMethod('suspending', String, classLoader.loadClass('kotlin.coroutines.Continuation'))
+        ].toSet()
+    }
+
+    private static GraalReflectionConfigurer reflectionConfigurer(ClassLoader classLoader, String className) {
+        String configurerName = NameUtils.getPackageName(className) + '.$' + NameUtils.getSimpleName(className) + GraalReflectionConfigurer.CLASS_SUFFIX
+        return (GraalReflectionConfigurer) classLoader.loadClass(configurerName).getDeclaredConstructor().newInstance()
+    }
+
+    /**
+     * Runs the configurer the way the native image feature does, which silently skips a method
+     * whose parameter types don't match a declared method.
+     */
+    private static List<Method> registeredMethods(GraalReflectionConfigurer configurer, ClassLoader classLoader) {
+        List<Method> methods = []
+        configurer.configure(new GraalReflectionConfigurer.ReflectionConfigurationContext() {
+            @Override
+            Class<?> findClassByName(String name) {
+                try {
+                    return Class.forName(name, false, classLoader)
+                } catch (ClassNotFoundException ignored) {
+                    return null
+                }
+            }
+
+            @Override
+            void register(Class<?>... types) {
+            }
+
+            @Override
+            void register(Method... ms) {
+                methods.addAll(ms)
+            }
+
+            @Override
+            void register(Field... fields) {
+            }
+
+            @Override
+            void register(Constructor<?>... constructors) {
+            }
+
+            @Override
+            void registerDynamicProxy(Class<?>... interfaces) {
+            }
+        })
+        return methods
+    }
+}

--- a/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorKotlinSpec.groovy
+++ b/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorKotlinSpec.groovy
@@ -109,6 +109,7 @@ open class Test {
 
             @Override
             void register(Class<?>... types) {
+                // only the registered methods are of interest here
             }
 
             @Override
@@ -118,14 +119,17 @@ open class Test {
 
             @Override
             void register(Field... fields) {
+                // only the registered methods are of interest here
             }
 
             @Override
             void register(Constructor<?>... constructors) {
+                // only the registered methods are of interest here
             }
 
             @Override
             void registerDynamicProxy(Class<?>... interfaces) {
+                // only the registered methods are of interest here
             }
         })
         return methods

--- a/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/suspend/ExecutableOnlySuspendingService.kt
+++ b/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/suspend/ExecutableOnlySuspendingService.kt
@@ -1,0 +1,15 @@
+package example.micronaut.suspend
+
+import io.micronaut.context.annotation.Executable
+import jakarta.inject.Singleton
+import kotlinx.coroutines.delay
+
+@Singleton
+open class ExecutableOnlySuspendingService {
+
+    @Executable
+    open suspend fun suspending(name: String): String {
+        delay(1)
+        return "Hello $name"
+    }
+}

--- a/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/suspend/SuspendingService.kt
+++ b/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/suspend/SuspendingService.kt
@@ -1,0 +1,17 @@
+package example.micronaut.suspend
+
+import io.micronaut.context.annotation.Executable
+import io.micronaut.core.annotation.ReflectiveAccess
+import jakarta.inject.Singleton
+import kotlinx.coroutines.delay
+
+@Singleton
+open class SuspendingService {
+
+    @Executable
+    @ReflectiveAccess
+    open suspend fun suspending(name: String): String {
+        delay(1)
+        return "Hello $name"
+    }
+}

--- a/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/suspend/SuspendingTargetMethodTest.kt
+++ b/test-suite-kotlin-graalvm/src/test/kotlin/example/micronaut/suspend/SuspendingTargetMethodTest.kt
@@ -1,0 +1,68 @@
+package example.micronaut.suspend
+
+import io.micronaut.context.BeanContext
+import io.micronaut.inject.ExecutableMethod
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+
+@MicronautTest
+class SuspendingTargetMethodTest {
+
+    @Inject
+    lateinit var beanContext: BeanContext
+
+    @Inject
+    lateinit var service: SuspendingService
+
+    @Inject
+    lateinit var executableOnlyService: ExecutableOnlySuspendingService
+
+    @Test
+    fun testTargetMethodOfSuspendFunction() {
+        val targetMethod = executableMethod(SuspendingService::class.java).targetMethod
+
+        assertInvocable(targetMethod, service)
+    }
+
+    @Test
+    fun testTargetMethodOfExecutableOnlySuspendFunction() {
+        val targetMethod = executableMethod(ExecutableOnlySuspendingService::class.java).targetMethod
+
+        assertInvocable(targetMethod, executableOnlyService)
+    }
+
+    @Test
+    fun testReflectiveLookupOfSuspendFunction() {
+        // The name and parameter types only exist at runtime, so the native image can't fold
+        // the lookup and has to rely on the reflection metadata written for @ReflectiveAccess
+        val executableMethod = executableMethod(SuspendingService::class.java)
+        val parameterTypes = executableMethod.arguments.map { it.type }.toTypedArray()
+        val method = SuspendingService::class.java.getDeclaredMethod(executableMethod.methodName, *parameterTypes)
+
+        assertInvocable(method, service)
+    }
+
+    private fun executableMethod(type: Class<*>): ExecutableMethod<*, *> =
+        beanContext.getBeanDefinition(type)
+            .executableMethods
+            .single { it.methodName == "suspending" }
+
+    private fun assertInvocable(method: Method, target: Any) {
+        Assertions.assertEquals(
+            listOf(String::class.java, Continuation::class.java),
+            method.parameterTypes.toList()
+        )
+        val result = runBlocking {
+            suspendCoroutineUninterceptedOrReturn<Any?> { continuation ->
+                method.invoke(target, "World", continuation)
+            }
+        }
+        Assertions.assertEquals("Hello World", result)
+    }
+}


### PR DESCRIPTION
## Problem (observed on v5.2.0)

When a Kotlin `suspend` method is annotated `@ReflectiveAccess`, directly or because a processor adds it, `GraalTypeElementVisitor` registers the method with its logical parameter list. That list leaves out the `kotlin.coroutines.Continuation` parameter, so the registered method doesn't exist on the JVM.

This showed up in micronaut-jakarta-interceptors' Kotlin test suite, with `micronaut-graal` on the KSP processor path, in the generated `$SuspendingService$ReflectConfig`:

```
REFLECT-CONFIG io.micronaut.interceptor.test.SuspendingService accessType=[]
REFLECT-CONFIG ...SuspendingService.suspending[java.lang.String] -> NO SUCH METHOD
ACTUAL JVM: public java.lang.Object ...SuspendingService.suspending(java.lang.String,kotlin.coroutines.Continuation<? super java.lang.String>)
```

Cause: `GraalTypeElementVisitor.processMethodElement` uses `MethodElement.getParameters()`. For Kotlin, `getParameters()` hides the continuation and `getSuspendParameters()` returns the physical list. `ExecutableMethodsDefinitionWriter` already uses `getSuspendParameters()` for the executable method. `GraalReflectionConfigurer.configure` catches the `NoSuchMethodException` for the wrong signature and silently registers nothing.

## Fix

`processMethodElement` uses `getSuspendParameters()` when `MethodElement.isSuspend()`. It is the only place in the graal module that turns a `MethodElement`'s parameters into reflection metadata; constructors go through it too but are never suspend functions.

## Native image: what actually fails

Checked with GraalVM CE 25.0.2 in `test-suite-kotlin-graalvm` (`nativeTest`), before and after the fix:

| Native test | Before | After |
|---|---|---|
| `ExecutableMethod.getTargetMethod()` + `Method.invoke` on a `@ReflectiveAccess` suspend method | passes | passes |
| same on a suspend method with only `@Executable` (control) | passes | passes |
| `getDeclaredMethod(name, *types)` with the name and argument types taken from the `ExecutableMethod` at runtime | **`NoSuchMethodException`** | passes |

So `getTargetMethod()` does **not** fail in a native image. The generated `$Exec.getTargetMethodByIndex` calls `ReflectionUtils.getRequiredMethod` with constant arguments (`SuspendingService.class`, `"suspending"`, `String.class`, `Continuation.class`). native-image apparently folds that lookup and registers the method on its own: it works even without `@ReflectiveAccess`. The broken metadata matters for reflective lookups whose arguments are only known at runtime; those fail on 5.2.0 and pass with this change.

## Tests

- `GraalTypeElementVisitorKotlinSpec` (graal module) compiles Kotlin through KSP with the graal visitor. Core had no Kotlin test for this visitor, so the graal module now has test dependencies on `micronaut-inject-kotlin-test` / the Kotlin compiler. The spec asserts that the generated config names `java.lang.String, kotlin.coroutines.Continuation` for `String`-returning and `Unit`-returning suspend functions, and `java.lang.String` only for a regular function. It also runs `GraalReflectionConfigurer.configure` the way `ServiceLoaderFeature` does and checks that the real methods get registered, including a private `@Executable @ReflectiveAccess` suspend function of a bean. Both features fail without the fix.
- `SuspendingTargetMethodTest` in `test-suite-kotlin-graalvm` covers the three native cases above and also runs on the JVM.

`./gradlew :micronaut-graal:check :test-suite-kotlin-graalvm:check :test-suite-kotlin-graalvm:nativeTest` passes locally. The full `check` was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
