### PR TITLE
Share interceptor instances between a proxy target and its proxy

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableIntercepted.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InitializableIntercepted.java
@@ -43,6 +43,11 @@ public interface InitializableIntercepted<T> extends InitializingBeanDefinition<
         // every @PostConstruct callback of the bean, superclass callbacks first. An interceptor that does not proceed
         // keeps all of them from running. The callbacks themselves are listed by getPostConstructExecutableMethods().
         Collection<BeanRegistration<Interceptor<?, ?>>> shared = SharedInterceptorRegistrations.peek(resolutionContext, this);
+        if (shared == null) {
+            // A proxy target without constructor advice that its proxy is creating: resolve the set now, with the
+            // interceptor instances adopted from the proxy, so the proxy's method calls use the same instances.
+            shared = SharedInterceptorRegistrations.resolveForProxyTarget(resolutionContext, this);
+        }
         return Objects.requireNonNull(MethodInterceptorChain.initialize(
             resolutionContext,
             context,

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
@@ -21,14 +21,10 @@ import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
-import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.inject.InstantiatableBeanDefinition;
-import io.micronaut.inject.qualifiers.Qualifiers;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -59,6 +55,10 @@ public interface InterceptedBeanDefinition<T> extends InstantiatableBeanDefiniti
      * needs; each interception point filters it again by its own binding and kind. Resolving once is what lets a
      * non-singleton interceptor be shared by every phase of one bean.</p>
      *
+     * <p>When this bean is the target of a proxy with {@code proxyTarget = true}, the non-singleton interceptor
+     * instances the proxy was constructed with are selected instead of new ones, so that the proxy's method calls
+     * share them too.</p>
+     *
      * <p>Override to supply the set another way. Returning {@code null} leaves each interception point to resolve its
      * own, which is the behaviour of a bean that declares no interceptor binding at all.</p>
      *
@@ -72,14 +72,7 @@ public interface InterceptedBeanDefinition<T> extends InstantiatableBeanDefiniti
                                                                                    AnnotationMetadataProvider constructor) {
         // The constructor already exposes this bean's metadata combined with the constructor's, so use it rather
         // than building a second hierarchy around it on every bean creation.
-        AnnotationMetadata metadata = constructor.getAnnotationMetadata();
-        if (metadata.getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING).isEmpty()) {
-            return null;
-        }
-        return new ArrayList(resolutionContext.getBeanRegistrations(
-            Interceptor.ARGUMENT,
-            Qualifiers.byInterceptorBinding(metadata)
-        ));
+        return SharedInterceptorRegistrations.resolve(resolutionContext, this, constructor.getAnnotationMetadata());
     }
 
     @Override

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
@@ -21,14 +21,10 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
-import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.inject.ParametrizedInstantiatableBeanDefinition;
-import io.micronaut.inject.qualifiers.Qualifiers;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -81,14 +77,7 @@ public interface ParameterizedInterceptedBeanDefinition<T>
                                                                                             AnnotationMetadataProvider constructor) {
         // The constructor already exposes this bean's metadata combined with the constructor's, so use it rather
         // than building a second hierarchy around it on every bean creation.
-        AnnotationMetadata metadata = constructor.getAnnotationMetadata();
-        if (metadata.getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING).isEmpty()) {
-            return null;
-        }
-        return new ArrayList(resolutionContext.getBeanRegistrations(
-            Interceptor.ARGUMENT,
-            Qualifiers.byInterceptorBinding(metadata)
-        ));
+        return SharedInterceptorRegistrations.resolve(resolutionContext, this, constructor.getAnnotationMetadata());
     }
 
     @Override

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/SharedInterceptorRegistrations.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/SharedInterceptorRegistrations.java
@@ -16,13 +16,19 @@
 package io.micronaut.aop.beandefinition;
 
 import io.micronaut.aop.Interceptor;
+import io.micronaut.context.ProxyInterceptorRegistrations;
+import io.micronaut.context.Qualifier;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.IdentityHashMap;
@@ -150,6 +156,69 @@ public final class SharedInterceptorRegistrations {
             resolutionContext.setAttribute(BeanResolutionContext.INTERCEPTOR_REGISTRATIONS, completed);
         }
         completed.put(definition, registrations);
+    }
+
+    /**
+     * Resolves the interceptors that construction, post-construct and pre-destroy interception of a bean all select
+     * from, by every interceptor binding in the given metadata whatever its kind.
+     *
+     * <p>When the bean is the target of a proxy with {@code proxyTarget = true} that the proxy is creating, the
+     * non-singleton interceptor instances the target adopted from the proxy are used instead of creating a second
+     * instance of the same interceptor, so that the proxy's method calls and the target's lifecycle share one, see
+     * {@link BeanResolutionContext#PROXY_INTERCEPTOR_REGISTRATIONS}.</p>
+     *
+     * @param resolutionContext The resolution context
+     * @param definition        The definition being created
+     * @param metadata          The metadata whose interceptor bindings select the interceptors
+     * @return The registrations, or {@code null} when the metadata binds none
+     * @since 5.2.1
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static @Nullable List resolve(BeanResolutionContext resolutionContext,
+                                  BeanDefinition<?> definition,
+                                  AnnotationMetadata metadata) {
+        if (metadata.getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING).isEmpty()) {
+            return null;
+        }
+        Qualifier qualifier = Qualifiers.byInterceptorBinding(metadata);
+        List<? extends BeanRegistration<?>> adopted = adoptedRegistrations(resolutionContext, definition);
+        return new ArrayList(adopted == null
+            ? resolutionContext.getBeanRegistrations(Interceptor.ARGUMENT, qualifier)
+            : resolutionContext.getBeanRegistrations(Interceptor.ARGUMENT, qualifier, adopted));
+    }
+
+    /**
+     * Resolves the interceptors of a proxy target that has no constructor advice, and stores them as if its
+     * construction had resolved them.
+     *
+     * <p>Nothing resolved interceptors before post-construct of such a bean. Resolving the whole set here, rather
+     * than only what post-construct binds, lets its post-construct use the instances adopted from the proxy and
+     * lets pre-destroy reuse the same set later.</p>
+     *
+     * @param resolutionContext The resolution context
+     * @param definition        The definition being initialized
+     * @return The registrations, or {@code null} when the bean is not a proxy target being created by its proxy
+     * @since 5.2.1
+     */
+    static @Nullable Collection<BeanRegistration<Interceptor<?, ?>>> resolveForProxyTarget(BeanResolutionContext resolutionContext,
+                                                                                         BeanDefinition<?> definition) {
+        if (adoptedRegistrations(resolutionContext, definition) == null) {
+            return null;
+        }
+        @SuppressWarnings("unchecked")
+        List<BeanRegistration<Interceptor<?, ?>>> registrations = resolve(resolutionContext, definition, definition.getAnnotationMetadata());
+        store(resolutionContext, definition, registrations);
+        return registrations;
+    }
+
+    private static @Nullable List<? extends BeanRegistration<?>> adoptedRegistrations(BeanResolutionContext resolutionContext,
+                                                                                     BeanDefinition<?> definition) {
+        if (resolutionContext.getAttribute(BeanResolutionContext.PROXY_INTERCEPTOR_REGISTRATIONS) instanceof ProxyInterceptorRegistrations adopted
+            && !adopted.registrations().isEmpty()
+            && adopted.isFor(definition)) {
+            return adopted.registrations();
+        }
+        return null;
     }
 
     /**

--- a/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
@@ -378,9 +378,9 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
      *
      * <p>Destruction runs with a fresh resolution context, so a bean with lifecycle advice but no retaining proxy has
      * nothing handed to it. The interceptor instances it owns are still reachable through the registrations the
-     * container passes to the dispose call, and every interceptor bound to the bean's lifecycle was created while the
-     * bean was, so those registrations are the candidate set. When the bean owns none, candidates are resolved by
-     * binding as before.</p>
+     * container passes to the dispose call. The exact set selected while the bean was created is used when the
+     * registration recorded one. Otherwise candidates are resolved by binding, selecting the instances the bean owns,
+     * such as the ones a proxy target adopted from its proxy, instead of creating new ones.</p>
      *
      * @param resolutionContext The resolution context
      * @param binding           The binding of the interception point
@@ -396,13 +396,15 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
         if (attribute instanceof List<?> existing) {
             return (List<BeanRegistration<Interceptor<?, ?>>>) existing;
         }
+        // Resolve by binding, but select an instance the bean owns instead of creating another of the same
+        // interceptor. Using only what the bean owns would drop an interceptor bound to pre-destroy that was never
+        // created with the bean, such as one a proxy target did not adopt from its proxy.
         List<BeanRegistration<Interceptor<?, ?>>> existing = findExistingInterceptors(resolutionContext);
-        return existing.isEmpty()
-            ? resolutionContext.getBeanRegistrations(
-                Interceptor.ARGUMENT,
-                Qualifiers.byInterceptorBindingValues(binding)
-            )
-            : existing;
+        return resolutionContext.getBeanRegistrations(
+            Interceptor.ARGUMENT,
+            Qualifiers.byInterceptorBindingValues(binding),
+            existing
+        );
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -108,6 +108,15 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
         Qualifier.class
     );
 
+    private static final Method METHOD_GET_PROXY_TARGET_BEAN_WITH_INTERCEPTOR_REGISTRATIONS = ReflectionUtils.getRequiredInternalMethod(
+        BeanResolutionContext.class,
+        "getProxyTargetBean",
+        BeanDefinition.class,
+        Argument.class,
+        Qualifier.class,
+        List.class
+    );
+
     private static final Method METHOD_GET_PROXY_BEAN_DEFINITION = ReflectionUtils.getRequiredInternalMethod(
         BeanDefinitionRegistry.class,
         "getProxyTargetBeanDefinition",
@@ -751,17 +760,22 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                 // always cached. Saying so is what lets the context destroy the target when the proxy is destroyed.
                 proxyBuilder.addMethod(getHasCachedInterceptedTargetMethod(targetField));
 
-                // Non-lazy target
+                // Non-lazy target. The proxy and the target it creates here are one intercepted bean, so the target
+                // is handed the interceptors the proxy was constructed with: it adopts the non-singleton ones for its
+                // own construction, post-construct and pre-destroy, and destroys them with itself. A lazy proxy stands
+                // for a target resolved later, possibly many, so it does not hand them over.
                 bodyBuilders.add((aThis, methodParameters) -> aThis.field(targetField).assign(
                         methodParameters.get(beanResolutionContextArgumentIndex)
                             .invoke(
-                                METHOD_GET_PROXY_TARGET_BEAN_WITH_BEAN_DEFINITION_AND_CONTEXT,
+                                METHOD_GET_PROXY_TARGET_BEAN_WITH_INTERCEPTOR_REGISTRATIONS,
                                 // 1st argument: this.$proxyBeanDefinition
                                 aThis.field(proxyBeanDefinitionField),
                                 // 2nd argument: the type
                                 pushTargetArgument(targetType),
                                 // 3th argument: the qualifier
-                                methodParameters.get(qualifierIndex)
+                                methodParameters.get(qualifierIndex),
+                                // 4th argument: the interceptor registrations
+                                methodParameters.get(constructor.findParameterIndex(INTERCEPTORS_PARAMETER))
                             ).cast(targetType)
                     )
                 );

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -581,7 +581,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     private static final Method METHOD_QUALIFIER_BY_TYPE = ReflectionUtils.getRequiredMethod(Qualifiers.class, "byType", Class[].class);
 
-    private static final Method METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY = ReflectionUtils.getRequiredMethod(BeanResolutionContext.class, "markDependentAsFactory");
+    private static final Method METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY = ReflectionUtils.getRequiredMethod(BeanResolutionContext.class, "markDependentAsFactory", Object.class);
 
     private static final Method METHOD_PROXY_TARGET_TYPE = ReflectionUtils.getRequiredInternalMethod(ProxyBeanDefinition.class, "getTargetDefinitionType");
 
@@ -2224,7 +2224,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
                 getQualifier(factoryClass, argumentExpression)
             ).cast(factoryTypeDef).newLocal("factoryBean");
         additionalStatements.add(defineAndAssign);
-        additionalStatements.add(beanResolutionContxt.invoke(METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY));
+        additionalStatements.add(beanResolutionContxt.invoke(METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY, defineAndAssign.variable()));
         return defineAndAssign.variable();
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/ProxyTargetInterceptorSharingSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/ProxyTargetInterceptorSharingSpec.groovy
@@ -1,0 +1,493 @@
+package io.micronaut.aop.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+/**
+ * A bean proxied with {@code proxyTarget = true}, which includes every bean a {@code @Factory} method produces with
+ * around advice, has two definitions: the proxy intercepts the business methods and the target is constructed,
+ * initialized and destroyed. A non-singleton interceptor is still one instance per intercepted bean, so both must use
+ * the same instance for one target.
+ */
+class ProxyTargetInterceptorSharingSpec extends AbstractTypeElementSpec {
+
+    private static final String SOURCE = '''
+package proxytarget.sharing;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around(proxyTarget = true)
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Paired {
+}
+
+@Prototype
+@InterceptorBinding(value = Paired.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Paired.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Paired.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Paired.class, kind = InterceptorKind.PRE_DESTROY)
+class PairedInterceptor implements MethodInterceptor<Object, Object>, ConstructorInterceptor<Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+
+    private final int id = ++instances;
+    private String state = "initial";
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        if (context instanceof MethodInvocationContext<Object, Object> method) {
+            return intercept(method);
+        }
+        return intercept((ConstructorInvocationContext<Object>) context);
+    }
+
+    @Override
+    public Object intercept(ConstructorInvocationContext<Object> context) {
+        events.add(id + ":AROUND_CONSTRUCT");
+        state = "constructed";
+        return context.proceed();
+    }
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        if (context.getKind() == InterceptorKind.POST_CONSTRUCT) {
+            state = "initialized";
+        }
+        events.add(id + ":" + context.getKind() + ":" + state + ":" + System.identityHashCode(context.getTarget()));
+        return context.proceed();
+    }
+
+    @PreDestroy
+    void destroy() {
+        events.add(id + ":DESTROYED");
+    }
+}
+
+@Singleton
+@Paired
+class ProxiedSingleton {
+    @PostConstruct void init() {}
+    public String work() { return "done"; }
+    @PreDestroy void close() { PairedInterceptor.events.add("TARGET_DESTROYED"); }
+}
+
+@Prototype
+@Paired
+class ProxiedPrototype {
+    @PostConstruct void init() {}
+    public String work() { return "done"; }
+}
+
+class Produced {
+    @PostConstruct void init() {}
+    public String work() { return "done"; }
+    void close() { PairedInterceptor.events.add("TARGET_DESTROYED"); }
+}
+
+class ProducedPrototype {
+    @PostConstruct void init() {}
+    public String work() { return "done"; }
+}
+
+@Factory
+class ProducingFactory {
+    @Bean(preDestroy = "close")
+    @Singleton
+    @Paired
+    Produced produced() {
+        return new Produced();
+    }
+
+    @Bean
+    @Prototype
+    @Paired
+    ProducedPrototype producedPrototype() {
+        return new ProducedPrototype();
+    }
+}
+'''
+
+    void 'test one interceptor instance serves every phase of a #description'() {
+        given:
+        ApplicationContext context = buildContext(SOURCE)
+        Class<?> interceptorType = context.classLoader.loadClass('proxytarget.sharing.PairedInterceptor')
+        Class<?> beanType = context.classLoader.loadClass('proxytarget.sharing.' + beanName)
+
+        when:
+        def bean = context.getBean(beanType)
+        bean.work()
+        bean.work()
+        List<String> events = interceptorType.events.toList()
+        println "$description events: $events"
+
+        then: 'post construct and every method call run on the same instance, which sees the state post construct set'
+        def phases = events.findAll { it.contains(':POST_CONSTRUCT:') || it.contains(':AROUND:') }
+        phases.size() == 3
+        phases.collect { it.split(':')[0] }.unique().size() == 1
+        phases.collect { it.split(':')[1..2].join(':') } == ['POST_CONSTRUCT:initialized', 'AROUND:initialized', 'AROUND:initialized']
+        phases.collect { it.split(':')[3] }.unique().size() == 1
+
+        when:
+        String id = phases.first().split(':')[0]
+        interceptorType.events.clear()
+        context.stop()
+        events = interceptorType.events.toList()
+        println "$description destroy events: $events"
+
+        then: 'the same instance serves pre destroy and is destroyed once, after the target'
+        events.findAll { it.contains(':PRE_DESTROY:') }.collect { it.split(':')[0] } == [id]
+        events.count("$id:DESTROYED".toString()) == 1
+        events.indexOf('TARGET_DESTROYED') >= 0
+        events.indexOf('TARGET_DESTROYED') < events.indexOf("$id:DESTROYED".toString())
+
+        cleanup:
+        interceptorType.events.clear()
+        context.close()
+
+        where:
+        description                   | beanName
+        'proxyTarget singleton'       | 'ProxiedSingleton'
+        'factory produced singleton'  | 'Produced'
+    }
+
+    void 'test each target of a #description gets its own interceptor instance for post construct and its methods'() {
+        given:
+        ApplicationContext context = buildContext(SOURCE)
+        Class<?> interceptorType = context.classLoader.loadClass('proxytarget.sharing.PairedInterceptor')
+        Class<?> beanType = context.classLoader.loadClass('proxytarget.sharing.' + beanName)
+
+        when:
+        def first = context.getBean(beanType)
+        def second = context.getBean(beanType)
+        first.work()
+        second.work()
+        first.work()
+        List<String> events = interceptorType.events.toList()
+        println "$description events: $events"
+        // target identity -> interceptor ids that intercepted it
+        Map<String, Set<String>> perTarget = [:].withDefault { new LinkedHashSet<String>() }
+        events.findAll { it.contains(':POST_CONSTRUCT:') || it.contains(':AROUND:') }.each {
+            def parts = it.split(':')
+            perTarget[parts[3]] << parts[0]
+        }
+
+        then: 'every target is intercepted by exactly one instance, and different targets by different instances'
+        perTarget.size() == 2
+        perTarget.values().every { it.size() == 1 }
+        perTarget.values().collect { it.first() }.unique().size() == 2
+        events.findAll { it.contains(':AROUND:') }.every { it.contains(':initialized:') }
+
+        cleanup:
+        interceptorType.events.clear()
+        context.close()
+
+        where:
+        description                   | beanName
+        'proxyTarget prototype'       | 'ProxiedPrototype'
+        'factory produced prototype'  | 'ProducedPrototype'
+    }
+
+    void 'test a proxy target with post construct advice and no constructor advice shares the instance'() {
+        given:
+        ApplicationContext context = buildContext('''
+package proxytarget.postconstruct;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around(proxyTarget = true)
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Paired {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Released {
+}
+
+@Prototype
+@InterceptorBinding(value = Paired.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Paired.class, kind = InterceptorKind.POST_CONSTRUCT)
+class PairedInterceptor implements MethodInterceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        events.add(id + ":" + context.getKind());
+        return context.proceed();
+    }
+
+    @PreDestroy
+    void destroy() {
+        events.add(id + ":DESTROYED");
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Released.class, kind = InterceptorKind.PRE_DESTROY)
+class ReleasingInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        PairedInterceptor.events.add("released:" + context.getKind());
+        return context.proceed();
+    }
+}
+
+@Singleton
+@InterceptorBinding(value = Paired.class, kind = InterceptorKind.AROUND)
+class SharedInterceptor implements MethodInterceptor<Object, Object> {
+    static int instances;
+
+    SharedInterceptor() {
+        instances++;
+    }
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+
+@Singleton
+@Paired
+@Released
+class MyBean {
+    @PostConstruct void init() {}
+    public String work() { return "done"; }
+    @PreDestroy void close() { PairedInterceptor.events.add("TARGET_DESTROYED"); }
+}
+
+@Prototype
+@Paired
+class OtherBean {
+    @PostConstruct void init() {}
+    public String work() { return "done"; }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('proxytarget.postconstruct.PairedInterceptor')
+        Class<?> sharedType = context.classLoader.loadClass('proxytarget.postconstruct.SharedInterceptor')
+        Class<?> beanType = context.classLoader.loadClass('proxytarget.postconstruct.MyBean')
+
+        when:
+        context.getBean(beanType).work()
+        context.getBean(context.classLoader.loadClass('proxytarget.postconstruct.OtherBean')).work()
+
+        then: 'each target has one prototype instance for post construct and its methods, the singleton is shared'
+        interceptorType.instances == 2
+        interceptorType.events.toList() == ['1:POST_CONSTRUCT', '1:AROUND', '2:POST_CONSTRUCT', '2:AROUND']
+        sharedType.instances == 1
+
+        when:
+        interceptorType.events.clear()
+        context.stop()
+        def events = interceptorType.events.toList()
+
+        then: 'pre destroy bound by another annotation still applies, and the adopted instance is destroyed once'
+        events.count('released:PRE_DESTROY') == 1
+        events.count('TARGET_DESTROYED') == 1
+        events.count('1:DESTROYED') == 1
+        events.indexOf('TARGET_DESTROYED') < events.indexOf('1:DESTROYED')
+
+        cleanup:
+        interceptorType.events.clear()
+        context.close()
+    }
+
+    void 'test a lazy proxy target and a hotswap proxy still intercept every call'() {
+        given:
+        ApplicationContext context = buildContext('''
+package proxytarget.lazy;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around(proxyTarget = true, lazy = true)
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface LazyPaired {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around(proxyTarget = true, hotswap = true)
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@interface Swappable {
+}
+
+@Prototype
+@InterceptorBinding(value = LazyPaired.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = LazyPaired.class, kind = InterceptorKind.POST_CONSTRUCT)
+class PairedInterceptor implements MethodInterceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        events.add(context.getTarget().getClass().getSimpleName() + ":" + id + ":" + context.getKind());
+        return context.proceed();
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Swappable.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Swappable.class, kind = InterceptorKind.POST_CONSTRUCT)
+class SwappableInterceptor extends PairedInterceptor {
+}
+
+@Singleton
+@LazyPaired
+class LazyBean {
+    @PostConstruct void init() {}
+    public String work() { return "lazy"; }
+}
+
+@Prototype
+@Swappable
+class SwappableBean {
+    @PostConstruct void init() {}
+    public String work() { return "swappable"; }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('proxytarget.lazy.PairedInterceptor')
+        Class<?> swappableType = context.classLoader.loadClass('proxytarget.lazy.SwappableBean')
+
+        when:
+        def lazy = context.getBean(context.classLoader.loadClass('proxytarget.lazy.LazyBean'))
+        def swappable = context.getBean(swappableType)
+        String lazyResult = lazy.work()
+        String swappableResult = swappable.work()
+        List<String> events = interceptorType.events.toList()
+        println "lazy and hotswap events: $events"
+
+        then:
+        lazyResult == 'lazy'
+        swappableResult == 'swappable'
+        events.count { it.endsWith(':AROUND') } == 2
+        events.count { it.endsWith(':POST_CONSTRUCT') } == 2
+
+        and: 'the hotswap proxy created its target, so they share one instance'
+        events.findAll { it.startsWith('SwappableBean:') }.collect { it.split(':')[1] }.unique().size() == 1
+
+        when: 'another target is swapped in'
+        def replacement = context.getBean(swappableType).interceptedTarget()
+        swappable.swap(replacement)
+
+        String swappedResult = swappable.work()
+        events = interceptorType.events.toList()
+        println "swapped events: $events"
+
+        then: 'calls keep being intercepted by the instance the proxy was constructed with'
+        swappedResult == 'swappable'
+        events.findAll { it.startsWith('SwappableBean:') && it.endsWith(':AROUND') }.collect { it.split(':')[1] }.unique().size() == 1
+
+        cleanup:
+        interceptorType.events.clear()
+        context.close()
+    }
+
+    void 'test a prototype argument of an intercepted factory method is not destroyed as the factory'() {
+        given:
+        ApplicationContext context = buildContext('''
+package proxytarget.factoryargument;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@AroundConstruct
+@interface Constructed {
+}
+
+@Singleton
+@InterceptorBean(Constructed.class)
+class ConstructedInterceptor implements ConstructorInterceptor<Object> {
+    @Override
+    public Object intercept(ConstructorInvocationContext<Object> context) {
+        return context.proceed();
+    }
+}
+
+@Prototype
+class Part {
+    static final List<String> events = new ArrayList<>();
+
+    @PreDestroy
+    void destroy() {
+        events.add("PART_DESTROYED");
+    }
+}
+
+class Product {
+    final Part part;
+
+    Product(Part part) {
+        this.part = part;
+    }
+}
+
+@Factory
+class ProductFactory {
+    @Bean
+    @Singleton
+    @Constructed
+    Product product(Part part) {
+        return new Product(part);
+    }
+}
+''')
+        Class<?> partType = context.classLoader.loadClass('proxytarget.factoryargument.Part')
+
+        when:
+        context.getBean(context.classLoader.loadClass('proxytarget.factoryargument.Product'))
+
+        then: 'the argument lives as long as the product'
+        partType.events.isEmpty()
+
+        when:
+        context.stop()
+
+        then:
+        partType.events.toList() == ['PART_DESTROYED']
+
+        cleanup:
+        partType.events.clear()
+        context.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -386,6 +386,24 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         return registrations;
     }
 
+    @Override
+    public <T> Collection<BeanRegistration<T>> getBeanRegistrations(Argument<T> beanType,
+                                                                    @Nullable Qualifier<T> qualifier,
+                                                                    Collection<? extends BeanRegistration<?>> reusable) {
+        if (reusable.isEmpty()) {
+            return getBeanRegistrations(beanType, qualifier);
+        }
+        Collection<BeanRegistration<T>> registrations = context.getBeanRegistrations(this, beanType, qualifier, reusable);
+        if (tracer != null) {
+            traceBeanCollection(
+                beanType,
+                qualifier,
+                registrations.stream().map(BeanRegistration::getBean).collect(Collectors.toList())
+            );
+        }
+        return registrations;
+    }
+
     /**
      * Copy the state from a previous resolution context.
      *
@@ -472,6 +490,22 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
                 return;
             }
             dependentFactory = dependentBeans.removeFirst();
+        }
+    }
+
+    @Override
+    public void markDependentAsFactory(Object factoryBean) {
+        if (dependentBeans == null) {
+            return;
+        }
+        // The factory was looked up last, so search from the end. A singleton factory is not a dependent at all.
+        for (ListIterator<BeanRegistration<?>> i = dependentBeans.listIterator(dependentBeans.size()); i.hasPrevious(); ) {
+            BeanRegistration<?> dependent = i.previous();
+            if (dependent.bean == factoryBean) {
+                i.remove();
+                dependentFactory = dependent;
+                return;
+            }
         }
     }
 
@@ -617,6 +651,39 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     @Override
     public <T> T getProxyTargetBean(BeanDefinition<T> definition, Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         return context.getProxyTargetBean(this, definition, beanType, qualifier);
+    }
+
+    @Override
+    public <T> T getProxyTargetBean(BeanDefinition<T> definition,
+                                    Argument<T> beanType,
+                                    @Nullable Qualifier<T> qualifier,
+                                    List<? extends BeanRegistration<?>> interceptorRegistrations) {
+        if (interceptorRegistrations.isEmpty()) {
+            return getProxyTargetBean(definition, beanType, qualifier);
+        }
+        Object previous = setAttribute(
+            PROXY_INTERCEPTOR_REGISTRATIONS,
+            new ProxyInterceptorRegistrations(definition, interceptorRegistrations)
+        );
+        try {
+            return getProxyTargetBean(definition, beanType, qualifier);
+        } finally {
+            restoreAttribute(PROXY_INTERCEPTOR_REGISTRATIONS, previous);
+        }
+    }
+
+    /**
+     * Sets an attribute back to the value it had before it was replaced.
+     *
+     * @param key      The attribute key
+     * @param previous The previous value, or {@code null} to remove the attribute
+     */
+    private void restoreAttribute(CharSequence key, @Nullable Object previous) {
+        if (previous == null) {
+            removeAttribute(key);
+        } else {
+            setAttribute(key, previous);
+        }
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -79,6 +79,20 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      */
     String EXISTING_INTERCEPTOR_REGISTRATIONS = "io.micronaut.aop.existingInterceptorRegistrations";
 
+    /**
+     * Attribute that hands the interceptor registrations of a proxy with {@code proxyTarget = true} to the target it
+     * resolves.
+     *
+     * <p>The value is a {@link ProxyInterceptorRegistrations}. It is set by
+     * {@link #getProxyTargetBean(BeanDefinition, Argument, Qualifier, List)} for the duration of the call. When the
+     * context creates the named target, it narrows the value to the non-singleton registrations the target adopted
+     * from the proxy, so that lifecycle interception of the target reuses them. Must be treated as an implementation
+     * detail.</p>
+     *
+     * @since 5.2.1
+     */
+    String PROXY_INTERCEPTOR_REGISTRATIONS = "io.micronaut.aop.proxyInterceptorRegistrations";
+
     @Override
     default void close() {
         // no-op
@@ -304,6 +318,22 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
     }
 
     /**
+     * Marks the dependent holding the given factory bean as the factory.
+     *
+     * <p>Unlike {@link #markDependentAsFactory()}, which takes the first dependent, this finds the factory itself.
+     * The first dependent is not the factory when the produced bean resolved other dependents before looking up its
+     * factory, such as the non-singleton interceptors and arguments of an intercepted factory method, and the factory
+     * is no dependent at all when it is a singleton.</p>
+     *
+     * @param factoryBean The factory bean
+     * @since 5.2.1
+     */
+    @UsedByGeneratedCode
+    default void markDependentAsFactory(Object factoryBean) {
+        markDependentAsFactory();
+    }
+
+    /**
      * @return The dependent factory beans that was used to create the bean in context
      * @since 3.5.0
      */
@@ -352,6 +382,54 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
     <T> T getProxyTargetBean(BeanDefinition<T> definition,
                              Argument<T> beanType,
                              @Nullable Qualifier<T> qualifier);
+
+    /**
+     * Resolves the target of a proxy, handing the target the interceptor registrations the proxy was constructed with.
+     *
+     * <p>A proxy with {@code proxyTarget = true} and the target it holds are one intercepted bean, so a non-singleton
+     * interceptor must be one instance for both: the proxy intercepts the business methods, the target its
+     * construction, post-construct and pre-destroy. When this call creates the target, the target adopts the proxy's
+     * non-singleton interceptor registrations, reuses them for its own lifecycle interception and destroys them with
+     * itself, see {@link #PROXY_INTERCEPTOR_REGISTRATIONS}. A target that already exists is returned as it is.</p>
+     *
+     * @param definition               The proxy target bean definition
+     * @param beanType                 The bean type
+     * @param qualifier                The bean qualifier
+     * @param interceptorRegistrations The interceptor registrations the proxy was constructed with
+     * @param <T>                      The generic type
+     * @return The proxy target
+     * @since 5.2.1
+     */
+    @Internal
+    @UsedByGeneratedCode
+    default <T> T getProxyTargetBean(BeanDefinition<T> definition,
+                                     Argument<T> beanType,
+                                     @Nullable Qualifier<T> qualifier,
+                                     List<? extends BeanRegistration<?>> interceptorRegistrations) {
+        return getProxyTargetBean(definition, beanType, qualifier);
+    }
+
+    /**
+     * Obtains the bean registrations for the given type and qualifier, using an existing registration instead of
+     * creating a non-singleton bean whose definition it belongs to.
+     *
+     * <p>Used by lifecycle interception of a proxy target to select from the interceptor instances it adopted from its
+     * proxy, see {@link #PROXY_INTERCEPTOR_REGISTRATIONS}, instead of creating a second instance of the same
+     * interceptor. Candidates the reusable registrations do not cover are resolved as usual.</p>
+     *
+     * @param beanType  The bean type
+     * @param qualifier The qualifier
+     * @param reusable  The registrations to use instead of creating a new instance of their definition
+     * @param <T>       The generic type
+     * @return A collection of {@link BeanRegistration}
+     * @since 5.2.1
+     */
+    @Internal
+    default <T> Collection<BeanRegistration<T>> getBeanRegistrations(Argument<T> beanType,
+                                                                     @Nullable Qualifier<T> qualifier,
+                                                                     Collection<? extends BeanRegistration<?>> reusable) {
+        return getBeanRegistrations(beanType, qualifier);
+    }
 
     /**
      * Represents a path taken to resolve a bean definitions dependencies.

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -3386,8 +3386,12 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 }
                 path.pushBeanCreate(definition, resolvedBeanType);
             }
+            Object proxyInterceptorRegistrations = context.getAttribute(BeanResolutionContext.PROXY_INTERCEPTOR_REGISTRATIONS);
             try {
                 List<BeanRegistration<?>> parentDependentBeans = context.popDependentBeans();
+                if (proxyInterceptorRegistrations instanceof ProxyInterceptorRegistrations handedOff && handedOff.isFor(definition)) {
+                    adoptProxyInterceptorRegistrations(context, definition, handedOff, parentDependentBeans);
+                }
                 T bean;
                 if (definition instanceof InstantiatableBeanDefinition<T> instantiatableBeanDefinition) {
                     bean = resolveByBeanFactory(context, instantiatableBeanDefinition, qualifier, Collections.emptyMap());
@@ -3427,11 +3431,68 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 }
                 return beanRegistration;
             } finally {
+                if (proxyInterceptorRegistrations != null) {
+                    // undo the narrowing done while adopting, for whatever else the proxy resolves
+                    context.setAttribute(BeanResolutionContext.PROXY_INTERCEPTOR_REGISTRATIONS, proxyInterceptorRegistrations);
+                }
                 if (isNewPath) {
                     path.close();
                 }
             }
         }
+    }
+
+    /**
+     * Makes the target of a proxy the owner of the non-singleton interceptor instances the proxy was constructed with.
+     *
+     * <p>A proxy with {@code proxyTarget = true} and its target are one intercepted bean: the proxy intercepts the
+     * business methods, the target its construction, post-construct and pre-destroy. A non-singleton interceptor is
+     * one instance per intercepted bean, so both halves must use the same instance. The proxy's constructor
+     * arguments, and so its interceptors, are resolved before the proxy resolves its target, which leaves each
+     * instance a dependent of the proxy.</p>
+     *
+     * <p>The instances are moved from the dependents of the proxy to the dependents of the target, so that they are
+     * destroyed with the target, after its {@code @PreDestroy}, and exactly once. Only an instance found among the
+     * proxy's dependents is moved: finding it there is what proves the proxy owns it, and a proxy whose target is
+     * resolved with a copied context, as a scope does, has none to give. The hand-off is then narrowed to the moved
+     * instances, which lifecycle interception of the target reuses instead of creating its own; restoring it is left
+     * to the caller.</p>
+     *
+     * @param context              The resolution context the target is created with
+     * @param definition           The definition of the target
+     * @param handedOff            The registrations the proxy handed to the target
+     * @param parentDependentBeans The dependents of the proxy, being created with the same context
+     */
+    private static void adoptProxyInterceptorRegistrations(BeanResolutionContext context,
+                                                           BeanDefinition<?> definition,
+                                                           ProxyInterceptorRegistrations handedOff,
+                                                           @Nullable List<BeanRegistration<?>> parentDependentBeans) {
+        List<BeanRegistration<?>> adopted = null;
+        if (parentDependentBeans != null && !parentDependentBeans.isEmpty()) {
+            for (BeanRegistration<?> registration : handedOff.registrations()) {
+                if (!registration.beanDefinition.isSingleton() && removeIdentical(parentDependentBeans, registration)) {
+                    if (adopted == null) {
+                        adopted = new ArrayList<>(handedOff.registrations().size());
+                    }
+                    adopted.add(registration);
+                    context.addDependentBean(registration);
+                }
+            }
+        }
+        context.setAttribute(
+            BeanResolutionContext.PROXY_INTERCEPTOR_REGISTRATIONS,
+            new ProxyInterceptorRegistrations(definition, adopted == null ? Collections.emptyList() : adopted)
+        );
+    }
+
+    private static boolean removeIdentical(List<BeanRegistration<?>> registrations, BeanRegistration<?> registration) {
+        for (Iterator<BeanRegistration<?>> i = registrations.iterator(); i.hasNext(); ) {
+            if (i.next() == registration) {
+                i.remove();
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -3695,6 +3756,27 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
     public <T> Collection<BeanRegistration<T>> getBeanRegistrations(@Nullable BeanResolutionContext resolutionContext,
                                                                     Argument<T> beanType,
                                                                     @Nullable Qualifier<T> qualifier) {
+        return getBeanRegistrations(resolutionContext, beanType, qualifier, null);
+    }
+
+    /**
+     * Obtains the bean registrations for the given type and qualifier, using an existing registration instead of
+     * creating a non-singleton bean whose definition it belongs to.
+     *
+     * @param resolutionContext The resolution context
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param reusable          The registrations to use instead of creating a new instance of their definition
+     * @param <T>               The generic type
+     * @return A collection of {@link BeanRegistration}
+     * @since 5.2.1
+     * @see BeanResolutionContext#getBeanRegistrations(Argument, Qualifier, Collection)
+     */
+    @Internal
+    public <T> Collection<BeanRegistration<T>> getBeanRegistrations(@Nullable BeanResolutionContext resolutionContext,
+                                                                    Argument<T> beanType,
+                                                                    @Nullable Qualifier<T> qualifier,
+                                                                    @Nullable Collection<? extends BeanRegistration<?>> reusable) {
         assertContextState();
         boolean hasQualifier = qualifier != null;
         if (LOG.isDebugEnabled()) {
@@ -3744,7 +3826,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                     return holder.registrations;
                 }
             } else {
-                beanRegistrations = resolveBeanRegistrations(resolutionContext, beanDefinitions, beanType, qualifier);
+                beanRegistrations = resolveBeanRegistrations(resolutionContext, beanDefinitions, beanType, qualifier, reusable);
             }
         }
         if (LOG.isDebugEnabled() && !beanRegistrations.isEmpty()) {
@@ -3764,12 +3846,36 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                                                                          Collection<BeanDefinition<T>> beanDefinitions,
                                                                          Argument<T> beanType,
                                                                          @Nullable Qualifier<T> qualifier) {
+        return resolveBeanRegistrations(resolutionContext, beanDefinitions, beanType, qualifier, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Collection<BeanRegistration<T>> resolveBeanRegistrations(@Nullable BeanResolutionContext resolutionContext,
+                                                                         Collection<BeanDefinition<T>> beanDefinitions,
+                                                                         Argument<T> beanType,
+                                                                         @Nullable Qualifier<T> qualifier,
+                                                                         @Nullable Collection<? extends BeanRegistration<?>> reusable) {
         List<BeanRegistration<T>> beansOfTypeList = new ArrayList<>(beanDefinitions.size());
         for (BeanDefinition<T> definition : beanDefinitions) {
-            addCandidateToList(resolutionContext, definition, beanType, qualifier, beansOfTypeList);
+            BeanRegistration<?> existing = reusable == null || definition.isSingleton() ? null : findRegistration(reusable, definition);
+            if (existing != null) {
+                beansOfTypeList.add((BeanRegistration<T>) existing);
+            } else {
+                addCandidateToList(resolutionContext, definition, beanType, qualifier, beansOfTypeList);
+            }
         }
         beansOfTypeList.sort(OrderUtil.ORDERED_COMPARATOR);
         return beansOfTypeList;
+    }
+
+    @Nullable
+    private static BeanRegistration<?> findRegistration(Collection<? extends BeanRegistration<?>> registrations, BeanDefinition<?> definition) {
+        for (BeanRegistration<?> registration : registrations) {
+            if (registration.beanDefinition.equals(definition)) {
+                return registration;
+            }
+        }
+        return null;
     }
 
     private <T> void logResolvedExistingBeanRegistrations(Argument<T> beanType, @Nullable Qualifier<T> qualifier, Collection<BeanRegistration<T>> existing) {

--- a/inject/src/main/java/io/micronaut/context/ProxyInterceptorRegistrations.java
+++ b/inject/src/main/java/io/micronaut/context/ProxyInterceptorRegistrations.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.BeanDefinition;
+
+import java.util.List;
+
+/**
+ * The interceptor registrations a proxy with {@code proxyTarget = true} hands to its target, the value of
+ * {@link BeanResolutionContext#PROXY_INTERCEPTOR_REGISTRATIONS}.
+ *
+ * <p>While the proxy resolves its target the registrations are the ones the proxy was constructed with. While the
+ * context creates that target they are narrowed to the non-singleton registrations the target adopted.</p>
+ *
+ * @param target        The definition of the proxy target
+ * @param registrations The interceptor registrations
+ * @author Denis Stepanov
+ * @since 5.2.1
+ */
+@Internal
+public record ProxyInterceptorRegistrations(BeanDefinition<?> target,
+                                            List<? extends BeanRegistration<?>> registrations) {
+
+    /**
+     * Whether the registrations are handed to the given definition.
+     *
+     * @param definition The definition being created
+     * @return {@code true} if the definition is the proxy target the registrations are handed to
+     */
+    public boolean isFor(BeanDefinition<?> definition) {
+        return target == definition || target.equals(definition);
+    }
+}

--- a/src/main/docs/guide/aop/interceptorLifecycle.adoc
+++ b/src/main/docs/guide/aop/interceptorLifecycle.adoc
@@ -102,7 +102,7 @@ explains the one case that behaves differently:
 |construct, methods, post-construct, pre-destroy
 
 |`@Around(proxyTarget = true)`
-|The generated proxy
+|The target's registration in the context; the generated proxy uses the same instances
 |construct, methods, post-construct, pre-destroy
 
 |ann:aop.Introduction[] advice
@@ -110,8 +110,8 @@ explains the one case that behaves differently:
 |methods, post-construct, pre-destroy
 
 |Bean produced by a ann:context.annotation.Factory[] method
-|The generated proxy
-|methods, post-construct, pre-destroy
+|The target's registration in the context; the generated proxy uses the same instances
+|construct, methods, post-construct, pre-destroy
 
 |ann:aop.AroundConstruct[] advice with no ann:aop.Around[]
 |The bean's registration in the context
@@ -126,6 +126,21 @@ NOTE: In the last row the context has no registration for the instance, so nothi
 it was created with, and `PRE_DESTROY` resolves a new interceptor. A proxied bean created and destroyed the same way
 is unaffected: the proxy retained its registrations and `destroyBean(Object)` destroys the non-singleton ones with the
 target. Prototypes injected into other beans, and prototypes destroyed through their `BeanRegistration`, are unaffected.
+
+A bean proxied with `proxyTarget = true`, which includes every bean a ann:context.annotation.Factory[] method
+produces with ann:aop.Around[] advice, is made of two objects: a proxy that intercepts the business methods and the
+target it delegates to, which is constructed, initialized and destroyed. They are still one intercepted bean. The
+proxy is constructed with its interceptors and then creates its target, handing those interceptors over: the target
+takes ownership of the non-singleton instances and uses them for its own construction, post-construct and pre-destroy
+interception. The instance that saw `POST_CONSTRUCT` is therefore the one that intercepts the method calls, and it is
+destroyed once, with the target and after the target's `@PreDestroy` methods. An interceptor that only the target
+binds, for example one bound to `AROUND_CONSTRUCT` by an annotation the proxied methods do not carry, is created by
+the target as usual.
+
+This applies when the proxy creates its target, which is how such a bean is normally obtained. It does not apply to a
+lazy proxy, that is `@Around(proxyTarget = true, lazy = true)` or a scoped proxy such as
+ann:runtime.context.scope.Refreshable[], whose targets are resolved later and can be many: the proxy intercepts every
+target with the instances it was constructed with, and each target resolves its own for its lifecycle.
 
 == Ordering
 
@@ -159,4 +174,6 @@ by a different annotation are never applied to the bean.
 
 TIP: Reuse of one interceptor instance across the phases of a proxied bean is part of the generated proxy. After
 upgrading, recompile intercepted classes so that beans compiled by an earlier version pick it up; until then they
-behave as they did before, resolving an interceptor per interception point.
+behave as they did before, resolving an interceptor per interception point. A proxy with `proxyTarget = true`, or a
+proxied factory-produced bean, compiled before 5.2.1 keeps intercepting its methods with instances other than the ones
+its target used for its lifecycle.


### PR DESCRIPTION
## Problem (observed on v5.2.0)

Since 5.2, `InterceptedBeanDefinition.instantiate` shares interceptor registrations across construct, post-construct and pre-destroy of one bean definition (`SharedInterceptorRegistrations`). A bean that uses a target proxy has two definitions, though:

- the **proxy wrapper**, generated by `AopProxyWriter`, which resolves the method (AROUND) interceptor registrations as a constructor argument;
- the **target definition**, selected in `BeanDefinitionWriter#isInterceptedLifeCycleByType`, which resolves its construct/post-construct/pre-destroy registrations separately.

A target proxy is used for `@Around(proxyTarget = true)`, and for every bean a `@Factory` method produces with AOP advice (`FactoryBeanElementCreator` forces target-proxy mode). The same prototype interceptor bean is therefore instantiated twice for one target instance: once for lifecycle, once for business methods.

Reproduced from micronaut-jakarta-interceptors, a Jakarta Interceptors implementation built on these registrations. A prototype interceptor sets a field in its post-construct interceptor method; its around-invoke method reads the field and records `System.identityHashCode(this)`:

- `@Around(proxyTarget = true)` bean: `[postConstruct on 848958019, micronaut around, around on 670689666 sees initial]`
- `@Factory`-produced bean: `[postConstruct on 260638966, around on 504478805 sees initial]`
- the same bean without a target proxy: one instance, and around-invoke sees the value set in post-construct.

The Jakarta Interceptors spec requires one interceptor instance per target instance for all its interceptor methods.

The Core reproduction (`ProxyTargetInterceptorSharingSpec`, first commit) also shows a second defect on factory-produced beans. The target's own interceptor instance was **destroyed right after post-construct** and kept serving calls: `[2:AROUND_CONSTRUCT, 2:POST_CONSTRUCT, 2:DESTROYED, 1:AROUND, 1:AROUND]`. The cause is `BeanResolutionContext#markDependentAsFactory()`, which takes the *first* dependent as the factory. An intercepted factory method resolves its arguments and interceptors before it looks the factory up, and a singleton factory is not a dependent at all. The first non-singleton interceptor or argument was then destroyed as "the factory".

## Fix

**The proxy hands its interceptors to the target it creates.** A non-lazy proxy (including `hotswap`) resolves its target in its constructor, after its interceptor registrations were resolved as a constructor argument. It now calls a new `BeanResolutionContext#getProxyTargetBean(definition, type, qualifier, interceptorRegistrations)`, which puts the registrations on the resolution context (`PROXY_INTERCEPTOR_REGISTRATIONS`) for the duration of the call.

**The target adopts the non-singleton ones.** When `DefaultBeanContext#createRegistration` creates that target, it moves each non-singleton registration from the proxy's dependents to the target's dependents.
- Only a registration actually found among the proxy's dependents is moved. That is the proof the proxy owns it, so nothing is destroyed twice.
- The adopted instances are destroyed with the target, after its `@PreDestroy`, exactly once.
- The hand-off is narrowed to the adopted instances for the target's creation, then restored.

**Lifecycle interception reuses them.** `SharedInterceptorRegistrations#resolve` passes the adopted instances to a new internal `BeanResolutionContext#getBeanRegistrations(type, qualifier, reusable)`. It resolves the target's set by binding as before, but takes an existing registration instead of creating a non-singleton candidate of the same definition. This covers:
- construction and post-construct (`InterceptedBeanDefinition`, `ParameterizedInterceptedBeanDefinition`);
- a target with post-construct advice but no constructor advice (`InitializableIntercepted` now resolves and stores the set when it is a proxy target);
- pre-destroy: when no set was recorded, `MethodInterceptorChain` resolves by binding while reusing the interceptors the bean owns, instead of using only those. Using only the owned instances would drop an interceptor bound to pre-destroy by a different annotation.

**Factory dependents.** Generated factory definitions call a new `markDependentAsFactory(Object factoryBean)`, which removes the dependent holding that factory instance, or nothing when the factory is a singleton.

**Nothing global.** The hand-off lives on the resolution context of one creation. Ownership is carried by the ordinary dependents of the target's registration. There is no weak or strong map, and no idle second interceptor instance on the proxy.

**Unchanged.**
- Singleton interceptors: never adopted, still shared.
- Non-proxied beans and `@Introduction` beans: no hand-off.
- Lazy proxies (`lazy`, `cacheableLazyTarget`, scoped proxies): resolve their targets later, possibly many, so they keep intercepting with the proxy's own instances.
- After a `hotswap` swap: the proxy keeps the instance it shared with its original target.
- A singleton target that already existed when the proxy was created: keeps its own instances.
- A target created through a copied resolution context, as a custom scope does: the proxy's instances are not among its dependents, so nothing is adopted.

**Binary compatibility.** The new `BeanResolutionContext` methods are defaults that fall back to the previous behaviour, so beans compiled by earlier versions behave as before. The docs TIP says to recompile. This changes generated code (proxy constructors and factory definitions), so it could equally go to 5.3.x if it should not ship in a patch release.

## Relation to #13127

#13127, also on 5.2.x, addresses the same split, starting from scoped proxies. It goes the other way: the target creates its own instances, which are recorded in a weak identity table, and the proxy swaps them in per call. This PR keeps no table, and the proxy is not left with an idle instance. It also fixes the factory-dependent destruction above, which #13127 does not: its factory-produced singleton case still destroys the instance after post-construct. It does not cover scoped/lazy proxies, which #13127 does. The two overlap in `DefaultBeanContext`, `BeanResolutionContext`, `AopProxyWriter` and the guide, so they need reconciling before either is merged.

## Tests

- New `ProxyTargetInterceptorSharingSpec` (committed first; the original cases fail without the fix):
  - one prototype `MethodInterceptor` + `ConstructorInterceptor` instance serves AROUND_CONSTRUCT, POST_CONSTRUCT, business methods and PRE_DESTROY of a `proxyTarget = true` singleton and of a `@Factory`-produced singleton, and is destroyed once, after the target;
  - each target of a `proxyTarget` prototype and of a factory-produced prototype gets its own instance;
  - a target with post-construct advice and no constructor advice; a pre-destroy interceptor bound by another annotation still applies; a singleton interceptor is still one instance;
  - lazy and hotswap proxies still intercept every call;
  - a prototype argument of an intercepted factory method is no longer destroyed as the factory.
- On this branch (5.2.x): `ProxyTargetInterceptorSharingSpec` 7/7 and `LifecycleInterceptorReuseSpec` 14/14 pass.
- The full `inject`, `context`, `inject-java`, `inject-groovy` and `inject-kotlin` test suites are still running locally (against the same change on a 5.3.x base); results will follow in a comment. Checkstyle on `aop`, `inject` and `core-processor` reports nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
