### PR TITLE
Instantiate beans with a private injected constructor reflectively

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/BeanDefinitionCreatorFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/BeanDefinitionCreatorFactory.java
@@ -28,6 +28,7 @@ import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.inject.processing.definition.ElementBeanDefinitionBuilderFactory;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.utils.BeanInjectionUtils;
 import io.micronaut.inject.visitor.VisitorContext;
 
 import java.util.List;
@@ -100,7 +101,9 @@ public abstract class BeanDefinitionCreatorFactory {
         }
         return classElement.hasStereotype(Executable.class) ||
             classElement.hasStereotype(AnnotationUtil.QUALIFIER) ||
-            classElement.getPrimaryConstructor().map(constructor -> constructor.hasStereotype(AnnotationUtil.INJECT)).orElse(false);
+            BeanInjectionUtils.findBeanConstructor(classElement)
+                .map(constructor -> constructor.hasStereotype(AnnotationUtil.INJECT))
+                .orElse(false);
     }
 
     private static boolean containsInjectMethod(ClassElement classElement) {

--- a/core-processor/src/main/java/io/micronaut/inject/processing/BeanDefinitionCreatorFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/BeanDefinitionCreatorFactory.java
@@ -48,6 +48,7 @@ public abstract class BeanDefinitionCreatorFactory {
     }
 
     private static <R> List<R> produceInternal(ClassElement classElement, ElementBeanDefinitionBuilderFactory<R> beanDefinitionBuilder, VisitorContext visitorContext) {
+        BeanInjectionUtils.validateBeanConstructor(classElement);
         boolean isAbstract = classElement.isAbstract();
         // An interceptor declares @InterceptorBinding(kind = INTRODUCTION) to state which advice it implements,
         // not to request advice for itself. Without the same guard that isAopProxyType applies, the interceptor is

--- a/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/definition/DefaultElementBeanDefinitionBuilderFactory.java
@@ -74,7 +74,7 @@ public class DefaultElementBeanDefinitionBuilderFactory implements ElementBeanDe
 
     @Override
     public ElementBeanDefinitionBuilder<OutputObjectDef> ofType(ClassElement classElement) {
-        MethodElement constructorElement = classElement.getPrimaryConstructor().orElse(null);
+        MethodElement constructorElement = BeanInjectionUtils.findBeanConstructor(classElement).orElse(null);
         if (constructorElement != null) {
             return constructor(
                 BeanInjectionUtils.createConstructorDefinition(constructorElement, visitorContext)
@@ -162,6 +162,12 @@ public class DefaultElementBeanDefinitionBuilderFactory implements ElementBeanDe
         BeanDefinitionWriter targetBeanWriter = (BeanDefinitionWriter) targetBeanDefinitionBuilder;
         MemberDefinition<ClassElement> elementProducerDefinition = targetBeanWriter.getElementProducerDefinition();
         boolean isFactoryMethod = !(elementProducerDefinition instanceof ConstructorDefinition<ClassElement, ?>);
+        if (elementProducerDefinition instanceof ConstructorDefinition<ClassElement, ?> constructorDefinition
+            && constructorDefinition.constructorElement() instanceof MethodElement constructor
+            && constructor.isPrivate()) {
+            // The generated proxy extends the bean type, and its constructor has to invoke the bean constructor
+            throw new ProcessingException(constructor, "Cannot apply AOP advice to a bean created with a private constructor. The constructor must be made non-private to support proxying: " + targetType.getName());
+        }
 
         Map<CharSequence, Boolean> settings = new LinkedHashMap<>();
         OptionalValues<Boolean> aroundSettings = aopElementAnnotationProcessor.getValues(AnnotationUtil.ANN_AROUND, Boolean.class);

--- a/core-processor/src/main/java/io/micronaut/inject/utils/BeanInjectionUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/utils/BeanInjectionUtils.java
@@ -35,8 +35,11 @@ import io.micronaut.context.beans.definition.ConstructorDefinition;
 import io.micronaut.context.beans.definition.FieldDefinition;
 import io.micronaut.context.beans.definition.MethodDefinition;
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ConstructorElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.FieldElement;
@@ -49,6 +52,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -123,7 +127,44 @@ public class BeanInjectionUtils {
      * @return The constructor definition
      */
     public static ConstructorDefinition<ClassElement, MethodElement> createConstructorDefinition(MethodElement constructorElement, VisitorContext visitorContext) {
-        return createConstructorDefinition(constructorElement, visitorContext, !constructorElement.isAccessible());
+        return createConstructorDefinition(constructorElement, visitorContext, constructorElement.isReflectionRequired());
+    }
+
+    /**
+     * Finds the constructor a bean of the given type is instantiated with.
+     *
+     * <p>This is {@link ClassElement#getPrimaryConstructor()} extended to private constructors, which that lookup
+     * never selects. A private constructor annotated with {@link AnnotationUtil#INJECT} or {@link Creator} takes
+     * precedence over an unannotated accessible one, and a type whose only constructor is private is instantiated
+     * with it. A private constructor is invoked with reflection, as private injected fields and methods are.</p>
+     *
+     * @param classElement The bean type
+     * @return The constructor, or a static creator method, if one is found
+     * @since 5.3.0
+     */
+    public static Optional<MethodElement> findBeanConstructor(ClassElement classElement) {
+        Optional<MethodElement> primaryConstructor = classElement.getPrimaryConstructor();
+        if ((primaryConstructor.isPresent() && isAnnotatedCreator(primaryConstructor.get()))
+            || (classElement.isInner() && !classElement.isStatic())) {
+            return primaryConstructor;
+        }
+        List<ConstructorElement> privateConstructors = classElement.getEnclosedElements(ElementQuery.CONSTRUCTORS)
+            .stream()
+            .filter(Element::isPrivate)
+            .toList();
+        for (ConstructorElement privateConstructor : privateConstructors) {
+            if (isAnnotatedCreator(privateConstructor)) {
+                return Optional.of(privateConstructor);
+            }
+        }
+        if (primaryConstructor.isEmpty() && privateConstructors.size() == 1 && classElement.getAccessibleConstructors().isEmpty()) {
+            return Optional.of(privateConstructors.get(0));
+        }
+        return primaryConstructor;
+    }
+
+    private static boolean isAnnotatedCreator(MethodElement constructor) {
+        return constructor.hasStereotype(AnnotationUtil.INJECT) || constructor.hasStereotype(Creator.class);
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/utils/BeanInjectionUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/utils/BeanInjectionUtils.java
@@ -37,6 +37,7 @@ import io.micronaut.context.beans.definition.MethodDefinition;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Creator;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ConstructorElement;
@@ -135,12 +136,14 @@ public class BeanInjectionUtils {
      *
      * <p>This is {@link ClassElement#getPrimaryConstructor()} extended to private constructors, which that lookup
      * never selects. A private constructor annotated with {@link AnnotationUtil#INJECT} or {@link Creator} takes
-     * precedence over an unannotated accessible one, and a type whose only constructor is private is instantiated
-     * with it. A private constructor is invoked with reflection, as private injected fields and methods are.</p>
+     * precedence over an unannotated accessible one when it is annotated with {@link ReflectiveAccess}, and a type
+     * whose only constructor is private is instantiated with it only when it is annotated with
+     * {@link ReflectiveAccess}. A private constructor is invoked with reflection, as private injected fields and
+     * methods are.</p>
      *
      * @param classElement The bean type
      * @return The constructor, or a static creator method, if one is found
-     * @since 5.3.0
+     * @since 5.2.1
      */
     public static Optional<MethodElement> findBeanConstructor(ClassElement classElement) {
         Optional<MethodElement> primaryConstructor = classElement.getPrimaryConstructor();
@@ -150,7 +153,7 @@ public class BeanInjectionUtils {
         }
         List<ConstructorElement> privateConstructors = classElement.getEnclosedElements(ElementQuery.CONSTRUCTORS)
             .stream()
-            .filter(Element::isPrivate)
+            .filter(constructor -> constructor.isPrivate() && constructor.hasAnnotation(ReflectiveAccess.class))
             .toList();
         for (ConstructorElement privateConstructor : privateConstructors) {
             if (isAnnotatedCreator(privateConstructor)) {

--- a/core-processor/src/main/java/io/micronaut/inject/utils/BeanInjectionUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/utils/BeanInjectionUtils.java
@@ -166,6 +166,25 @@ public class BeanInjectionUtils {
         return primaryConstructor;
     }
 
+    /**
+     * Validates that a constructor selected for injection can be invoked.
+     *
+     * <p>A private constructor is invoked with reflection, which has to be opted into with
+     * {@link ReflectiveAccess}. Without it {@link #findBeanConstructor(ClassElement)} skips the constructor, so
+     * the injection the annotation asks for would silently not happen.</p>
+     *
+     * @param classElement The bean type
+     * @throws ProcessingException if a constructor asks for injection but cannot be invoked
+     * @since 5.2.1
+     */
+    public static void validateBeanConstructor(ClassElement classElement) {
+        for (ConstructorElement constructor : classElement.getEnclosedElements(ElementQuery.CONSTRUCTORS)) {
+            if (constructor.isPrivate() && isAnnotatedCreator(constructor) && !constructor.hasAnnotation(ReflectiveAccess.class)) {
+                throw new ProcessingException(constructor, "Constructor is declared private and is not accessible for the instantiation. To instantiate the bean using reflection annotate the constructor with @ReflectiveAccess");
+            }
+        }
+    }
+
     private static boolean isAnnotatedCreator(MethodElement constructor) {
         return constructor.hasStereotype(AnnotationUtil.INJECT) || constructor.hasStereotype(Creator.class);
     }

--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -182,7 +182,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
     }
 
     private InternalBeanConstructorElement initConstructor(ClassElement beanType) {
-        return beanType.getPrimaryConstructor().map(m -> new InternalBeanConstructorElement(
+        return BeanInjectionUtils.findBeanConstructor(beanType).map(m -> new InternalBeanConstructorElement(
             m,
             !m.isPublic(),
             initBeanParameters(m.getParameters())

--- a/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
+++ b/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
@@ -33,6 +33,7 @@ import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.utils.BeanInjectionUtils;
 import io.micronaut.inject.visitor.TypeElementQuery;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -179,10 +180,6 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
                     element,
                     false
                 );
-                MethodElement me = element.getPrimaryConstructor().orElse(null);
-                if (me != null && me.isPrivate() && !me.hasAnnotation(ReflectiveAccess.class)) {
-                    processMethodElement(me, reflectiveClasses);
-                }
             }
 
             if (element.isInner()) {
@@ -294,7 +291,9 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
     }
 
     private void processBeanConstructor(Map<String, ReflectionConfigData> reflectiveClasses, ClassElement beanElement, boolean isImport) {
-        final MethodElement constructor = beanElement.getPrimaryConstructor().orElse(null);
+        final MethodElement constructor = isImport
+            ? beanElement.getPrimaryConstructor().orElse(null)
+            : BeanInjectionUtils.findBeanConstructor(beanElement).orElse(null);
         if (constructor != null &&
             (constructor.hasAnnotation(ReflectiveAccess.class) ||
                 (isImport && !constructor.isPublic()) ||

--- a/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
+++ b/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
@@ -291,13 +291,10 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
     }
 
     private void processBeanConstructor(Map<String, ReflectionConfigData> reflectiveClasses, ClassElement beanElement, boolean isImport) {
-        final MethodElement constructor = isImport
-            ? beanElement.getPrimaryConstructor().orElse(null)
-            : BeanInjectionUtils.findBeanConstructor(beanElement).orElse(null);
+        final MethodElement constructor = BeanInjectionUtils.findBeanConstructor(beanElement).orElse(null);
         if (constructor != null &&
             (constructor.hasAnnotation(ReflectiveAccess.class) ||
-                (isImport && !constructor.isPublic()) ||
-                (!isImport && constructor.isPrivate()))) {
+                (isImport && !constructor.isPublic()))) {
             processMethodElement(constructor, reflectiveClasses);
         }
     }

--- a/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorSpec.groovy
+++ b/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorSpec.groovy
@@ -269,10 +269,13 @@ class Other {}
         GraalReflectionConfigurer configurer = buildReflectionConfigurer('test.Test', '''
 package test;
 
+import io.micronaut.core.annotation.ReflectiveAccess;
+
 @jakarta.inject.Singleton
 class Test {
 
     @jakarta.inject.Inject
+    @ReflectiveAccess
     private Test(Other other) {
     }
 

--- a/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorSpec.groovy
+++ b/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorSpec.groovy
@@ -263,6 +263,38 @@ class Other {}
         config.getAnnotations("fields").first().stringValue("name").get() == 'name'
     }
 
+    void "test write reflect config for a private @Inject constructor"() {
+
+        given:
+        GraalReflectionConfigurer configurer = buildReflectionConfigurer('test.Test', '''
+package test;
+
+@jakarta.inject.Singleton
+class Test {
+
+    @jakarta.inject.Inject
+    private Test(Other other) {
+    }
+
+    public Test() {
+    }
+}
+
+@jakarta.inject.Singleton
+class Other {}
+''')
+
+        when:
+        AnnotationValue<ReflectionConfig> config = configurer.getAnnotationMetadata().getAnnotationValuesByType(ReflectionConfig).first()
+
+        then:
+        config
+        config.stringValue("type").get() == 'test.Test'
+        config.getAnnotations("methods").size() == 1
+        config.getAnnotations("methods").first().stringValue("name").get() == '<init>'
+        config.getAnnotations("methods").first().annotationClassValues("parameterTypes")*.name == ['test.Other']
+    }
+
     void "test write reflect config for @Inject on inherited inaccessible fields and methods"() {
 
         given:

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
@@ -1,0 +1,182 @@
+package io.micronaut.inject.constructor.privateinjection
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+
+class PrivateInjectConstructorSpec extends AbstractBeanDefinitionSpec {
+
+    void "test a private @Inject constructor is invoked with reflection"() {
+        given:
+        def context = buildContext('''
+package privatector.plain
+
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+
+@Prototype
+class Service {
+    @Inject
+    private Service() {
+    }
+}
+''')
+
+        expect:
+        getBean(context, 'privatector.plain.Service') != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a private @Inject constructor with arguments and #annotations"() {
+        given:
+        def context = buildContext("""
+package privatector.args
+
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+@Prototype
+class Service {
+    final Dependency dependency
+    final String origin
+
+    $annotations
+    private Service(Dependency dependency) {
+        this.dependency = dependency
+        this.origin = "injected"
+    }
+
+    Service() {
+        this.dependency = null
+        this.origin = "public"
+    }
+}
+
+@Singleton
+class Dependency {
+}
+""")
+
+        when:
+        def service = getBean(context, 'privatector.args.Service')
+
+        then:
+        service.origin == 'injected'
+        service.dependency.is(getBean(context, 'privatector.args.Dependency'))
+
+        cleanup:
+        context.close()
+
+        where:
+        annotations << [
+            '@Inject',
+            '@Inject @io.micronaut.core.annotation.ReflectiveAccess',
+            '@io.micronaut.core.annotation.Creator'
+        ]
+    }
+
+    void "test the only constructor of a bean is private"() {
+        given:
+        def context = buildContext('''
+package privatector.sole
+
+import jakarta.inject.Singleton
+
+@Singleton
+class Service {
+    private Service() {
+    }
+}
+''')
+
+        expect:
+        getBean(context, 'privatector.sole.Service') != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a private @Inject constructor with around construct advice"() {
+        given:
+        def context = buildContext('''
+package privatector.aroundconstruct
+
+import io.micronaut.aop.*
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.lang.annotation.*
+
+@Prototype
+@Constructed
+class Service {
+    @Inject
+    private Service() {
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.CONSTRUCTOR])
+@InterceptorBinding(kind = InterceptorKind.AROUND_CONSTRUCT)
+@interface Constructed {
+}
+
+@Singleton
+@InterceptorBean(Constructed)
+class ConstructedInterceptor implements ConstructorInterceptor<Object> {
+    int invocations
+
+    @Override
+    Object intercept(ConstructorInvocationContext<Object> context) {
+        invocations++
+        return context.proceed()
+    }
+}
+''')
+
+        when:
+        def service = getBean(context, 'privatector.aroundconstruct.Service')
+
+        then:
+        service != null
+        getBean(context, 'privatector.aroundconstruct.ConstructedInterceptor').invocations == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void "test around advice on a bean with a private @Inject constructor fails compilation"() {
+        when:
+        buildBeanDefinition('privatector.around.Service', '''
+package privatector.around
+
+import io.micronaut.aop.*
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+import java.lang.annotation.*
+
+@Prototype
+class Service {
+    @Inject
+    private Service() {
+    }
+
+    @Intercepting
+    String hello() {
+        return "hello"
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Around
+@interface Intercepting {
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains('Cannot apply AOP advice to a bean created with a private constructor. The constructor must be made non-private to support proxying: privatector.around.Service')
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
@@ -96,11 +96,11 @@ class Dependency {
         context.close()
 
         where:
-        [annotations, expectedOrigin] << [
-            ['@Inject', 'public'],
-            ['@Inject @io.micronaut.core.annotation.ReflectiveAccess', 'injected'],
-            ['@io.micronaut.core.annotation.Creator @io.micronaut.core.annotation.ReflectiveAccess', 'injected']
+        annotations << [
+            '@Inject @io.micronaut.core.annotation.ReflectiveAccess',
+            '@io.micronaut.core.annotation.Creator @io.micronaut.core.annotation.ReflectiveAccess'
         ]
+        expectedOrigin = 'injected'
     }
 
     void "test the only constructor of a bean is private"() {
@@ -175,6 +175,27 @@ class ConstructedInterceptor implements ConstructorInterceptor<Object> {
 
         cleanup:
         context.close()
+    }
+
+    void "test a private @Inject constructor without @ReflectiveAccess fails compilation"() {
+        when:
+        buildBeanDefinition('privatector.noreflectiveaccess.Service', '''
+package privatector.noreflectiveaccess
+
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+
+@Prototype
+class Service {
+    @Inject
+    private Service() {
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains('Constructor is declared private and is not accessible for the instantiation. To instantiate the bean using reflection annotate the constructor with @ReflectiveAccess')
     }
 
     void "test around advice on a bean with a private @Inject constructor fails compilation"() {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
@@ -10,11 +10,13 @@ class PrivateInjectConstructorSpec extends AbstractBeanDefinitionSpec {
 package privatector.plain
 
 import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.annotation.ReflectiveAccess
 import jakarta.inject.Inject
 
 @Prototype
 class Service {
     @Inject
+    @ReflectiveAccess
     private Service() {
     }
 }
@@ -22,6 +24,29 @@ class Service {
 
         expect:
         getBean(context, 'privatector.plain.Service') != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test an unscoped bean with a private @Inject constructor is discovered"() {
+        given:
+        def context = buildContext('''
+package privatector.unscoped
+
+import io.micronaut.core.annotation.ReflectiveAccess
+import jakarta.inject.Inject
+
+class Service {
+    @Inject
+    @ReflectiveAccess
+    private Service() {
+    }
+}
+''')
+
+        expect:
+        getBean(context, 'privatector.unscoped.Service') != null
 
         cleanup:
         context.close()
@@ -62,17 +87,19 @@ class Dependency {
         def service = getBean(context, 'privatector.args.Service')
 
         then:
-        service.origin == 'injected'
-        service.dependency.is(getBean(context, 'privatector.args.Dependency'))
+        service.origin == expectedOrigin
+        if (expectedOrigin == 'injected') {
+            service.dependency.is(getBean(context, 'privatector.args.Dependency'))
+        }
 
         cleanup:
         context.close()
 
         where:
-        annotations << [
-            '@Inject',
-            '@Inject @io.micronaut.core.annotation.ReflectiveAccess',
-            '@io.micronaut.core.annotation.Creator'
+        [annotations, expectedOrigin] << [
+            ['@Inject', 'public'],
+            ['@Inject @io.micronaut.core.annotation.ReflectiveAccess', 'injected'],
+            ['@io.micronaut.core.annotation.Creator @io.micronaut.core.annotation.ReflectiveAccess', 'injected']
         ]
     }
 
@@ -81,10 +108,12 @@ class Dependency {
         def context = buildContext('''
 package privatector.sole
 
+import io.micronaut.core.annotation.ReflectiveAccess
 import jakarta.inject.Singleton
 
 @Singleton
 class Service {
+    @ReflectiveAccess
     private Service() {
     }
 }
@@ -104,6 +133,7 @@ package privatector.aroundconstruct
 
 import io.micronaut.aop.*
 import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.annotation.ReflectiveAccess
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import java.lang.annotation.*
@@ -112,6 +142,7 @@ import java.lang.annotation.*
 @Constructed
 class Service {
     @Inject
+    @ReflectiveAccess
     private Service() {
     }
 }
@@ -153,12 +184,14 @@ package privatector.around
 
 import io.micronaut.aop.*
 import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.annotation.ReflectiveAccess
 import jakarta.inject.Inject
 import java.lang.annotation.*
 
 @Prototype
 class Service {
     @Inject
+    @ReflectiveAccess
     private Service() {
     }
 

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/beanimport/BeanImportSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/beanimport/BeanImportSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.inject.beanimport
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.beanimport.fixtures.PrivateInjectConstructorBean
 import io.smallrye.faulttolerance.CircuitBreakerMaintenanceImpl
 import io.smallrye.faulttolerance.DefaultAsyncExecutorProvider
 import io.smallrye.faulttolerance.DefaultExistingCircuitBreakerNames
@@ -39,6 +40,25 @@ class BytesFactory {
 
         expect:
         bean.toString() == 'test'
+    }
+
+    void "test bean import with a private reflective constructor"() {
+        given:
+        ApplicationContext context = buildContext('''
+package beanimporttest3;
+
+import io.micronaut.context.annotation.Import;
+import io.micronaut.inject.beanimport.fixtures.PrivateInjectConstructorBean;
+
+@Import(classes = PrivateInjectConstructorBean.class)
+class Application {}
+''')
+
+        expect:
+        context.getBean(PrivateInjectConstructorBean) != null
+
+        cleanup:
+        context.close()
     }
 
 

--- a/inject-java-test/src/test/java/io/micronaut/inject/beanimport/fixtures/PrivateInjectConstructorBean.java
+++ b/inject-java-test/src/test/java/io/micronaut/inject/beanimport/fixtures/PrivateInjectConstructorBean.java
@@ -1,0 +1,12 @@
+package io.micronaut.inject.beanimport.fixtures;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import jakarta.inject.Inject;
+
+public class PrivateInjectConstructorBean {
+
+    @Inject
+    @ReflectiveAccess
+    private PrivateInjectConstructorBean() {
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
@@ -10,11 +10,13 @@ class PrivateInjectConstructorSpec extends AbstractTypeElementSpec {
 package privatector.plain;
 
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Inject;
 
 @Prototype
 class Service {
     @Inject
+    @ReflectiveAccess
     private Service() {
     }
 }
@@ -22,6 +24,29 @@ class Service {
 
         expect:
         getBean(context, 'privatector.plain.Service') != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test an unscoped bean with a private @Inject constructor is discovered"() {
+        given:
+        def context = buildContext('''
+package privatector.unscoped;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import jakarta.inject.Inject;
+
+class Service {
+    @Inject
+    @ReflectiveAccess
+    private Service() {
+    }
+}
+''')
+
+        expect:
+        getBean(context, 'privatector.unscoped.Service') != null
 
         cleanup:
         context.close()
@@ -62,17 +87,19 @@ class Dependency {
         def service = getBean(context, 'privatector.args.Service')
 
         then:
-        service.origin == 'injected'
-        service.dependency.is(getBean(context, 'privatector.args.Dependency'))
+        service.origin == expectedOrigin
+        if (expectedOrigin == 'injected') {
+            service.dependency.is(getBean(context, 'privatector.args.Dependency'))
+        }
 
         cleanup:
         context.close()
 
         where:
-        annotations << [
-            '@Inject',
-            '@Inject @io.micronaut.core.annotation.ReflectiveAccess',
-            '@io.micronaut.core.annotation.Creator'
+        [annotations, expectedOrigin] << [
+            ['@Inject', 'public'],
+            ['@Inject @io.micronaut.core.annotation.ReflectiveAccess', 'injected'],
+            ['@io.micronaut.core.annotation.Creator @io.micronaut.core.annotation.ReflectiveAccess', 'injected']
         ]
     }
 
@@ -81,10 +108,12 @@ class Dependency {
         def context = buildContext('''
 package privatector.sole;
 
+import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Singleton;
 
 @Singleton
 class Service {
+    @ReflectiveAccess
     private Service() {
     }
 }
@@ -104,6 +133,7 @@ package privatector.aroundconstruct;
 
 import io.micronaut.aop.*;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.*;
 import java.lang.annotation.*;
 
@@ -111,6 +141,7 @@ import java.lang.annotation.*;
 @Constructed
 class Service {
     @Inject
+    @ReflectiveAccess
     private Service() {
     }
 }
@@ -152,12 +183,14 @@ package privatector.around;
 
 import io.micronaut.aop.*;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.*;
 import java.lang.annotation.*;
 
 @Prototype
 class Service {
     @Inject
+    @ReflectiveAccess
     private Service() {
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
@@ -96,11 +96,11 @@ class Dependency {
         context.close()
 
         where:
-        [annotations, expectedOrigin] << [
-            ['@Inject', 'public'],
-            ['@Inject @io.micronaut.core.annotation.ReflectiveAccess', 'injected'],
-            ['@io.micronaut.core.annotation.Creator @io.micronaut.core.annotation.ReflectiveAccess', 'injected']
+        annotations << [
+            '@Inject @io.micronaut.core.annotation.ReflectiveAccess',
+            '@io.micronaut.core.annotation.Creator @io.micronaut.core.annotation.ReflectiveAccess'
         ]
+        expectedOrigin = 'injected'
     }
 
     void "test the only constructor of a bean is private"() {
@@ -174,6 +174,27 @@ class ConstructedInterceptor implements ConstructorInterceptor<Object> {
 
         cleanup:
         context.close()
+    }
+
+    void "test a private @Inject constructor without @ReflectiveAccess fails compilation"() {
+        when:
+        buildBeanDefinition('privatector.noreflectiveaccess.Service', '''
+package privatector.noreflectiveaccess;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Inject;
+
+@Prototype
+class Service {
+    @Inject
+    private Service() {
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains('Constructor is declared private and is not accessible for the instantiation. To instantiate the bean using reflection annotate the constructor with @ReflectiveAccess')
     }
 
     void "test around advice on a bean with a private @Inject constructor fails compilation"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/privateinjection/PrivateInjectConstructorSpec.groovy
@@ -1,0 +1,181 @@
+package io.micronaut.inject.constructor.privateinjection
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class PrivateInjectConstructorSpec extends AbstractTypeElementSpec {
+
+    void "test a private @Inject constructor is invoked with reflection"() {
+        given:
+        def context = buildContext('''
+package privatector.plain;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Inject;
+
+@Prototype
+class Service {
+    @Inject
+    private Service() {
+    }
+}
+''')
+
+        expect:
+        getBean(context, 'privatector.plain.Service') != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a private @Inject constructor with arguments and #annotations"() {
+        given:
+        def context = buildContext("""
+package privatector.args;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Prototype
+class Service {
+    final Dependency dependency;
+    final String origin;
+
+    $annotations
+    private Service(Dependency dependency) {
+        this.dependency = dependency;
+        this.origin = "injected";
+    }
+
+    public Service() {
+        this.dependency = null;
+        this.origin = "public";
+    }
+}
+
+@Singleton
+class Dependency {
+}
+""")
+
+        when:
+        def service = getBean(context, 'privatector.args.Service')
+
+        then:
+        service.origin == 'injected'
+        service.dependency.is(getBean(context, 'privatector.args.Dependency'))
+
+        cleanup:
+        context.close()
+
+        where:
+        annotations << [
+            '@Inject',
+            '@Inject @io.micronaut.core.annotation.ReflectiveAccess',
+            '@io.micronaut.core.annotation.Creator'
+        ]
+    }
+
+    void "test the only constructor of a bean is private"() {
+        given:
+        def context = buildContext('''
+package privatector.sole;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+class Service {
+    private Service() {
+    }
+}
+''')
+
+        expect:
+        getBean(context, 'privatector.sole.Service') != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a private @Inject constructor with around construct advice"() {
+        given:
+        def context = buildContext('''
+package privatector.aroundconstruct;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.*;
+import java.lang.annotation.*;
+
+@Prototype
+@Constructed
+class Service {
+    @Inject
+    private Service() {
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.CONSTRUCTOR})
+@InterceptorBinding(kind = InterceptorKind.AROUND_CONSTRUCT)
+@interface Constructed {
+}
+
+@Singleton
+@InterceptorBean(Constructed.class)
+class ConstructedInterceptor implements ConstructorInterceptor<Object> {
+    int invocations;
+
+    @Override
+    public Object intercept(ConstructorInvocationContext<Object> context) {
+        invocations++;
+        return context.proceed();
+    }
+}
+''')
+
+        when:
+        def service = getBean(context, 'privatector.aroundconstruct.Service')
+
+        then:
+        service != null
+        getBean(context, 'privatector.aroundconstruct.ConstructedInterceptor').invocations == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void "test around advice on a bean with a private @Inject constructor fails compilation"() {
+        when:
+        buildBeanDefinition('privatector.around.Service', '''
+package privatector.around;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.inject.*;
+import java.lang.annotation.*;
+
+@Prototype
+class Service {
+    @Inject
+    private Service() {
+    }
+
+    @Intercepting
+    public String hello() {
+        return "hello";
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Around
+@interface Intercepting {
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains('Cannot apply AOP advice to a bean created with a private constructor. The constructor must be made non-private to support proxying: privatector.around.Service')
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/privatector/PrivateInjectConstructorSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/privatector/PrivateInjectConstructorSpec.groovy
@@ -1,0 +1,160 @@
+package io.micronaut.kotlin.processing.inject.privatector
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+
+class PrivateInjectConstructorSpec extends AbstractKotlinCompilerSpec {
+
+    void "test a private @Inject constructor is invoked with reflection"() {
+        given:
+        def context = buildContext('''
+package privatector.plain
+
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+
+@Prototype
+class Service @Inject private constructor()
+''')
+
+        expect:
+        getBean(context, 'privatector.plain.Service') != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a private @Inject constructor with arguments and #annotations"() {
+        given:
+        def context = buildContext("""
+package privatector.args
+
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+@Prototype
+class Service {
+    val dependency: Dependency?
+    val origin: String
+
+    $annotations
+    private constructor(dependency: Dependency) {
+        this.dependency = dependency
+        this.origin = "injected"
+    }
+
+    constructor() {
+        this.dependency = null
+        this.origin = "public"
+    }
+}
+
+@Singleton
+class Dependency
+""")
+
+        when:
+        def service = getBean(context, 'privatector.args.Service')
+
+        then:
+        service.origin == 'injected'
+        service.dependency.is(getBean(context, 'privatector.args.Dependency'))
+
+        cleanup:
+        context.close()
+
+        where:
+        annotations << [
+            '@Inject',
+            '@Inject @io.micronaut.core.annotation.ReflectiveAccess',
+            '@io.micronaut.core.annotation.Creator'
+        ]
+    }
+
+    void "test the only constructor of a bean is private"() {
+        given:
+        def context = buildContext('''
+package privatector.sole
+
+import jakarta.inject.Singleton
+
+@Singleton
+class Service private constructor()
+''')
+
+        expect:
+        getBean(context, 'privatector.sole.Service') != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test a private @Inject constructor with around construct advice"() {
+        given:
+        def context = buildContext('''
+package privatector.aroundconstruct
+
+import io.micronaut.aop.*
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+@Prototype
+@Constructed
+class Service @Inject private constructor()
+
+@Retention
+@Target(AnnotationTarget.CLASS, AnnotationTarget.CONSTRUCTOR)
+@InterceptorBinding(kind = InterceptorKind.AROUND_CONSTRUCT)
+annotation class Constructed
+
+@Singleton
+@InterceptorBean(Constructed::class)
+class ConstructedInterceptor : ConstructorInterceptor<Any> {
+    var invocations = 0
+
+    override fun intercept(context: ConstructorInvocationContext<Any>): Any {
+        invocations++
+        return context.proceed()
+    }
+}
+''')
+
+        when:
+        def service = getBean(context, 'privatector.aroundconstruct.Service')
+
+        then:
+        service != null
+        getBean(context, 'privatector.aroundconstruct.ConstructedInterceptor').invocations == 1
+
+        cleanup:
+        context.close()
+    }
+
+    void "test around advice on a bean with a private @Inject constructor fails compilation"() {
+        when:
+        buildBeanDefinition('privatector.around.Service', '''
+package privatector.around
+
+import io.micronaut.aop.*
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+
+@Prototype
+open class Service @Inject private constructor() {
+
+    @Intercepting
+    open fun hello() = "hello"
+}
+
+@Retention
+@Target(AnnotationTarget.FUNCTION)
+@Around
+annotation class Intercepting
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains('Cannot apply AOP advice to a bean created with a private constructor. The constructor must be made non-private to support proxying: privatector.around.Service')
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/privatector/PrivateInjectConstructorSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/privatector/PrivateInjectConstructorSpec.groovy
@@ -10,14 +10,33 @@ class PrivateInjectConstructorSpec extends AbstractKotlinCompilerSpec {
 package privatector.plain
 
 import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.annotation.ReflectiveAccess
 import jakarta.inject.Inject
 
 @Prototype
-class Service @Inject private constructor()
+class Service @Inject @ReflectiveAccess private constructor()
 ''')
 
         expect:
         getBean(context, 'privatector.plain.Service') != null
+
+        cleanup:
+        context.close()
+    }
+
+    void "test an unscoped bean with a private @Inject constructor is discovered"() {
+        given:
+        def context = buildContext('''
+package privatector.unscoped
+
+import io.micronaut.core.annotation.ReflectiveAccess
+import jakarta.inject.Inject
+
+class Service @Inject @ReflectiveAccess private constructor()
+''')
+
+        expect:
+        getBean(context, 'privatector.unscoped.Service') != null
 
         cleanup:
         context.close()
@@ -57,17 +76,19 @@ class Dependency
         def service = getBean(context, 'privatector.args.Service')
 
         then:
-        service.origin == 'injected'
-        service.dependency.is(getBean(context, 'privatector.args.Dependency'))
+        service.origin == expectedOrigin
+        if (expectedOrigin == 'injected') {
+            service.dependency.is(getBean(context, 'privatector.args.Dependency'))
+        }
 
         cleanup:
         context.close()
 
         where:
-        annotations << [
-            '@Inject',
-            '@Inject @io.micronaut.core.annotation.ReflectiveAccess',
-            '@io.micronaut.core.annotation.Creator'
+        [annotations, expectedOrigin] << [
+            ['@Inject', 'public'],
+            ['@Inject @io.micronaut.core.annotation.ReflectiveAccess', 'injected'],
+            ['@io.micronaut.core.annotation.Creator @io.micronaut.core.annotation.ReflectiveAccess', 'injected']
         ]
     }
 
@@ -76,10 +97,11 @@ class Dependency
         def context = buildContext('''
 package privatector.sole
 
+import io.micronaut.core.annotation.ReflectiveAccess
 import jakarta.inject.Singleton
 
 @Singleton
-class Service private constructor()
+class Service @ReflectiveAccess private constructor()
 ''')
 
         expect:
@@ -96,12 +118,13 @@ package privatector.aroundconstruct
 
 import io.micronaut.aop.*
 import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.annotation.ReflectiveAccess
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 
 @Prototype
 @Constructed
-class Service @Inject private constructor()
+class Service @Inject @ReflectiveAccess private constructor()
 
 @Retention
 @Target(AnnotationTarget.CLASS, AnnotationTarget.CONSTRUCTOR)
@@ -138,10 +161,11 @@ package privatector.around
 
 import io.micronaut.aop.*
 import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.annotation.ReflectiveAccess
 import jakarta.inject.Inject
 
 @Prototype
-open class Service @Inject private constructor() {
+open class Service @Inject @ReflectiveAccess private constructor() {
 
     @Intercepting
     open fun hello() = "hello"

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/privatector/PrivateInjectConstructorSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/privatector/PrivateInjectConstructorSpec.groovy
@@ -85,11 +85,11 @@ class Dependency
         context.close()
 
         where:
-        [annotations, expectedOrigin] << [
-            ['@Inject', 'public'],
-            ['@Inject @io.micronaut.core.annotation.ReflectiveAccess', 'injected'],
-            ['@io.micronaut.core.annotation.Creator @io.micronaut.core.annotation.ReflectiveAccess', 'injected']
+        annotations << [
+            '@Inject @io.micronaut.core.annotation.ReflectiveAccess',
+            '@io.micronaut.core.annotation.Creator @io.micronaut.core.annotation.ReflectiveAccess'
         ]
+        expectedOrigin = 'injected'
     }
 
     void "test the only constructor of a bean is private"() {
@@ -152,6 +152,23 @@ class ConstructedInterceptor : ConstructorInterceptor<Any> {
 
         cleanup:
         context.close()
+    }
+
+    void "test a private @Inject constructor without @ReflectiveAccess fails compilation"() {
+        when:
+        buildBeanDefinition('privatector.noreflectiveaccess.Service', '''
+package privatector.noreflectiveaccess
+
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Inject
+
+@Prototype
+class Service @Inject private constructor()
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains('Constructor is declared private and is not accessible for the instantiation. To instantiate the bean using reflection annotate the constructor with @ReflectiveAccess')
     }
 
     void "test around advice on a bean with a private @Inject constructor fails compilation"() {

--- a/src/main/docs/guide/ioc/injection/constructorInjection.adoc
+++ b/src/main/docs/guide/ioc/injection/constructorInjection.adoc
@@ -21,4 +21,4 @@ NOTE: If no `@Inject` or `@Creator` is specified Micronaut will try to locate th
 
 If there are multiple possible candidates for a particular constructor argument a qualifier can be specified (such as `jakarta.inject.Named`) to disambiguate the injection. If it is not possible to disambiguate then the result will be a api:context.exceptions.NonUniqueBeanException[]. See the <<qualifiers, Qualifiers>> section for more information.
 
-WARNING: If you use `@Inject` on a `private` constructor then the type will be instantiated via the Java reflection API which is not recommended.
+WARNING: A `private` constructor can only be invoked via the Java reflection API, which is not recommended. If you use `@Inject` or ann:core.annotation.Creator[] on a `private` constructor you must also annotate it with ann:core.annotation.ReflectiveAccess[] to opt into reflective instantiation, otherwise a compilation error will occur. Note that a type instantiated reflectively cannot have AOP advice applied to it, because the generated proxy has to invoke the constructor directly.


### PR DESCRIPTION
## Problem

A bean with a private injected constructor fails at runtime:

```java
@Prototype class Service { @Inject private Service() {} }
```

```
BeanInstantiationException ... IllegalAccessError: class probe.plain.$Service$Definition
tried to access private method 'void probe.plain.Service.<init>()'
```

Adding `@ReflectiveAccess`, or an `@AroundConstruct` binding, gave the same error. Java, Kotlin and Groovy all behaved this way.

**Cause.** `ClassElement#getPrimaryConstructor` uses `getAccessibleConstructors()`, which drops private constructors. `DefaultElementBeanDefinitionBuilderFactory#ofType` then found no constructor and made up a public no-arg `<init>` with `requiresReflection = false`, so `BeanDefinitionWriter` called a private constructor directly. When the class also had a public constructor, the `@Inject` one was silently ignored and the public one used.

A second bug hid behind the first: `createConstructorDefinition(MethodElement, VisitorContext)` computed `requiresReflection` as `!isAccessible()`. `isAccessible()` returns true for a private member carrying `@ReflectiveAccess`, so the flag was inverted in exactly that case.

## Behaviour

A private constructor is used only when it is annotated with `@ReflectiveAccess`, and it is then invoked reflectively:

```java
@Prototype class Service { @Inject @ReflectiveAccess private Service() {} }
```

Requiring the annotation keeps reflection opt-in, in line with the `@NextMajorVersion` note on `MemberElement#isAccessible`, and leaves an unannotated private constructor (including the implicit one of a private nested type) resolving exactly as before.

`@Inject` or `@Creator` on a private constructor without `@ReflectiveAccess` is now a compilation error rather than a silent no-op:

```
Constructor is declared private and is not accessible for the instantiation.
To instantiate the bean using reflection annotate the constructor with @ReflectiveAccess
```

An *unannotated* private constructor is left alone, so the implicit constructor of a private nested type and a `@Factory` with only static methods still compile.

## Changes

- `BeanInjectionUtils#findBeanConstructor(ClassElement)` does the primary constructor lookup and additionally considers `@ReflectiveAccess` private constructors:
  - one also annotated `@Inject` or `@Creator` wins over an unannotated accessible constructor;
  - if a type's only constructor is private and annotated, it is used;
  - otherwise the result is `getPrimaryConstructor()`, as before.
- `createConstructorDefinition` uses `isReflectionRequired()`.
- `BeanDefinitionCreatorFactory#isDeclaredBean` uses the same lookup, so a class declared a bean only by a private `@Inject` constructor is discovered without a scope annotation.
- `AbstractBeanDefinitionBuilder#initConstructor` uses it too, so `@Import` and other associated beans no longer fail with *"Cannot create associated bean with no accessible primary constructor"*.
- `aroundProxy` fails compilation when a class bean's constructor is private, since the generated proxy subclass has to call it. Reported on the constructor: *"Cannot apply AOP advice to a bean created with a private constructor. The constructor must be made non-private to support proxying: &lt;type&gt;"*. Factory-produced types are unaffected.
- `GraalTypeElementVisitor` uses the lookup for direct and imported beans alike, so the reflection config matches what the definition does. Its private-constructor registration was previously unreachable.
- `BeanInjectionUtils#validateBeanConstructor` raises the error above from `BeanDefinitionCreatorFactory`, the single entry point for bean creation, so it is reported even for a class that would not otherwise be a bean.
- The constructor injection guide said such a type is instantiated reflectively; it now describes the `@ReflectiveAccess` opt-in and the AOP restriction.

`ClassElement#getPrimaryConstructor` is unchanged, so introspections, mixins and other callers behave as before.

## Tests

`PrivateInjectConstructorSpec` in inject-java, inject-kotlin and inject-groovy, covering: a private `@Inject` constructor with no arguments; an unscoped bean declared only by one; a private constructor with arguments alongside a public one; a type whose only constructor is private; `@AroundConstruct`; the missing-`@ReflectiveAccess` compile error; and the AOP compile error. `BeanImportSpec` covers `@Import` of a pre-compiled type with a private injected constructor, and `GraalTypeElementVisitorSpec` checks the constructor reaches the reflection config.

Local run of core-processor, graal, inject-java, inject-groovy and inject-kotlin: 7322 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

