### PR TITLE
Record per pipeline whether the access log handler is installed

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -683,6 +683,12 @@ final class HttpPipelineBuilder {
 
     final class StreamPipeline {
         HttpVersion httpVersion = HttpVersion.HTTP_1_1;
+        /**
+         * Whether this pipeline carries the {@value ChannelPipelineCustomizer#HANDLER_ACCESS_LOGGER}
+         * handler, see {@link #hasAccessLogHandler()}. {@code null} until first needed.
+         */
+        @Nullable
+        private Boolean hasAccessLogHandler;
         private final Channel channel;
         private final ChannelPipeline pipeline;
         @Nullable
@@ -695,6 +701,27 @@ final class HttpPipelineBuilder {
             this.pipeline = channel.pipeline();
             this.sslHandler = sslHandler;
             this.streamCustomizer = streamCustomizer;
+        }
+
+        /**
+         * Whether this pipeline carries the {@value ChannelPipelineCustomizer#HANDLER_ACCESS_LOGGER}
+         * handler, which is where the {@link RoutingInBoundHandler} stores the current request in
+         * a channel attribute for the access log. HTTP/1 pipelines and the per-stream pipelines of
+         * the legacy HTTP/2 handlers carry it; the connection pipeline of the default HTTP/2
+         * handler logs through the {@link Http2AccessLogManager} instead and does not (a single
+         * channel attribute could not tell concurrent streams apart). The pipeline is inspected
+         * once, on the first request, so that customizers that add or remove the handler while
+         * the pipeline is built are taken into account.
+         *
+         * @return Whether the access log handler is in this pipeline
+         */
+        boolean hasAccessLogHandler() {
+            Boolean has = hasAccessLogHandler;
+            if (has == null) {
+                has = pipeline.get(ChannelPipelineCustomizer.HANDLER_ACCESS_LOGGER) != null;
+                hasAccessLogHandler = has;
+            }
+            return has;
         }
 
         void initializeChildPipelineForPushPromise(Channel childChannel) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -226,12 +226,27 @@ public final class RoutingInBoundHandler implements RequestHandler {
     }
 
     private void prepareRequest(ChannelHandlerContext ctx, OutboundAccess outboundAccess, NettyHttpRequest<Object> mnRequest) {
-        if (supportLoggingHandler && ctx.pipeline().get(ChannelPipelineCustomizer.HANDLER_ACCESS_LOGGER) != null) {
+        if (supportLoggingHandler && hasAccessLogHandler(ctx)) {
             // Micronaut Session needs this to extract values from the Micronaut Http Request for logging
             AttributeKey<NettyHttpRequest> key = AttributeKey.valueOf(NettyHttpRequest.class.getSimpleName());
             ctx.channel().attr(key).set(mnRequest);
         }
         outboundAccess.attachment(mnRequest);
+    }
+
+    /**
+     * Whether the pipeline of this context carries the
+     * {@value ChannelPipelineCustomizer#HANDLER_ACCESS_LOGGER} handler. The
+     * {@link HttpPipelineBuilder.StreamPipeline} remembers this per pipeline, so it does not have
+     * to be looked up in the pipeline for every request.
+     */
+    private static boolean hasAccessLogHandler(ChannelHandlerContext ctx) {
+        HttpPipelineBuilder.StreamPipeline streamPipeline = ctx.channel().attr(HttpPipelineBuilder.STREAM_PIPELINE_ATTRIBUTE.get()).get();
+        if (streamPipeline == null) {
+            // not built by the HttpPipelineBuilder
+            return ctx.pipeline().get(ChannelPipelineCustomizer.HANDLER_ACCESS_LOGGER) != null;
+        }
+        return streamPipeline.hasAccessLogHandler();
     }
 
     private void handleException(ChannelHandlerContext ctx, OutboundAccess outboundAccess, NettyHttpRequest<Object> request, Throwable throwable) {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogPipelineFlagSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogPipelineFlagSpec.groovy
@@ -1,0 +1,105 @@
+package io.micronaut.http.server.netty.handler.accesslog
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.event.BeanCreatedEventListener
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.netty.channel.ChannelPipelineCustomizer
+import io.micronaut.http.server.netty.NettyHttpRequest
+import io.micronaut.http.server.netty.NettyServerCustomizer
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.channel.Channel
+import io.netty.util.AttributeKey
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+/**
+ * The access log handler needs the current request in a channel attribute (Micronaut Session
+ * reads it from there). Whether a pipeline carries that handler is recorded when the pipeline is
+ * built, so this checks that the attribute is set exactly on the pipelines that have the handler.
+ */
+class AccessLogPipelineFlagSpec extends Specification {
+    private static final AttributeKey<NettyHttpRequest> KEY = AttributeKey.valueOf(NettyHttpRequest.class.getSimpleName())
+
+    def "request attribute is set only on pipelines with the access log handler"(Map<String, Object> properties, String expectedVersion, boolean expectAttribute) {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name'                                       : 'AccessLogPipelineFlagSpec',
+                'micronaut.server.netty.access-logger.logger-name': 'http-access-log',
+        ] + properties)
+        def server = ctx.getBean(EmbeddedServer).start()
+        def client = ctx.createBean(HttpClient, server.URI)
+
+        when:
+        def response = client.toBlocking().retrieve('/access-log-flag')
+
+        then:
+        response == "$expectedVersion $expectAttribute"
+
+        cleanup:
+        client.close()
+        ctx.close()
+
+        where:
+        properties                                                                                                                                                                    | expectedVersion | expectAttribute
+        ['micronaut.server.netty.access-logger.enabled': true]                                                                                                                        | 'HTTP_1_1'      | true
+        ['micronaut.server.netty.access-logger.enabled': false]                                                                                                                       | 'HTTP_1_1'      | false
+        // the default HTTP/2 handler logs through the Http2AccessLogManager on the connection pipeline, which has no per-stream channel for the attribute
+        ['micronaut.server.netty.access-logger.enabled': true, 'micronaut.server.http-version': '2.0', 'micronaut.server.ssl.enabled': false, 'micronaut.http.client.plaintext-mode': 'h2c_prior_knowledge']                                                             | 'HTTP_2_0'      | false
+        // the legacy HTTP/2 handlers build a pipeline with the access log handler per stream
+        ['micronaut.server.netty.access-logger.enabled': true, 'micronaut.server.http-version': '2.0', 'micronaut.server.ssl.enabled': false, 'micronaut.http.client.plaintext-mode': 'h2c_prior_knowledge', 'micronaut.server.netty.legacy-multiplex-handlers': true] | 'HTTP_2_0'      | true
+        // a customizer that removes the handler from the pipeline must be respected
+        ['micronaut.server.netty.access-logger.enabled': true, 'access-log-flag.remove-handler': true]                                                                                | 'HTTP_1_1'      | false
+    }
+
+    @Singleton
+    @Requires(property = 'access-log-flag.remove-handler', value = 'true')
+    static class RemovingCustomizer implements BeanCreatedEventListener<NettyServerCustomizer.Registry>, NettyServerCustomizer {
+        @Override
+        NettyServerCustomizer.Registry onCreated(BeanCreatedEvent<NettyServerCustomizer.Registry> event) {
+            event.bean.register(this)
+            return event.bean
+        }
+
+        @Override
+        NettyServerCustomizer specializeForChannel(Channel channel, ChannelRole role) {
+            return new Removing(channel)
+        }
+
+        static class Removing implements NettyServerCustomizer {
+            final Channel channel
+
+            Removing(Channel channel) {
+                this.channel = channel
+            }
+
+            @Override
+            NettyServerCustomizer specializeForChannel(Channel channel, ChannelRole role) {
+                return new Removing(channel)
+            }
+
+            @Override
+            void onStreamPipelineBuilt() {
+                if (channel.pipeline().get(ChannelPipelineCustomizer.HANDLER_ACCESS_LOGGER) != null) {
+                    channel.pipeline().remove(ChannelPipelineCustomizer.HANDLER_ACCESS_LOGGER)
+                }
+            }
+        }
+    }
+
+    @Controller('/access-log-flag')
+    @Requires(property = 'spec.name', value = 'AccessLogPipelineFlagSpec')
+    static class TestController {
+        @Get
+        String get(HttpRequest<?> request) {
+            def nettyRequest = (NettyHttpRequest<?>) request
+            def attribute = nettyRequest.channelHandlerContext.channel().attr(KEY).get()
+            // the attribute must hold this very request while it is being routed
+            return "${request.httpVersion} ${attribute.is(request)}"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- With the access logger enabled, `RoutingInBoundHandler.prepareRequest` called `ctx.pipeline().get(HANDLER_ACCESS_LOGGER)` for every request to decide whether to store the request in the `NettyHttpRequest` channel attribute that the access log (and Micronaut Session's `SessionLogElement`) reads. The answer is a property of the pipeline, not the request: HTTP/1 pipelines and the per-stream pipelines of the legacy HTTP/2 handlers carry the handler; the connection pipeline of the default HTTP/2 handler logs through `Http2AccessLogManager` and does not (a single channel attribute could not tell concurrent streams apart, so that is left as is).
- `HttpPipelineBuilder.StreamPipeline`, which is already attached to every channel the routing handler sees, now remembers whether its pipeline carries the handler. The pipeline is inspected once, on the first request, rather than at install time, so that a `NettyServerCustomizer` or `ChannelPipelineListener` that adds or removes the handler while the pipeline is built is still respected (Codex review finding, see below). Per request this is one channel-attribute read and a boolean instead of a pipeline walk. The `supportLoggingHandler` shortcut for servers without an access logger is unchanged, and a context without a `StreamPipeline` (a pipeline not built by `HttpPipelineBuilder`) falls back to the live lookup.
- Follows up on the "out of scope" note in #13118; it touches the same `if` in `prepareRequest`, so whichever merges second needs a trivial conflict resolution.

## Testing
- New `AccessLogPipelineFlagSpec`: a controller returns whether the channel attribute holds the request being routed. HTTP/1 with the logger enabled: set; logger disabled: not set; default HTTP/2 handler (h2c prior knowledge): not set, as before; legacy HTTP/2 handlers: set; a customizer that removes the handler in `onStreamPipelineBuilt`: not set.
- Fail-before: the change is meant to preserve behaviour, so the first four cases guard equivalence with the base rather than failing on it. The customizer case fails with an install-time flag (`has = accessLogHandler != null`: `HTTP_1_1 true` instead of `HTTP_1_1 false`), which is the Codex finding the first-request inspection addresses.
- `./gradlew :micronaut-http-server-netty:test`: 1163 tests, 22 skipped (pre-existing), 0 failures (1-minute load average 10 from other work on the machine, still green).
- `checkstyleMain` clean apart from the pre-existing `FileLength` violation in `NettyHttpServerConfiguration`.
- Codex review (`gpt-5.6-sol`, high): first pass flagged that an install-time flag diverges from the pipeline when a customizer removes or adds the handler; addressed by inspecting the pipeline on the first request. Second pass: no findings.

## Out of scope
- Setting the attribute for the default HTTP/2 handler (it never was; the connection channel is shared by concurrent streams).
- The `AttributeKey.valueOf` per request and clearing the attribute after the response, both handled in #13118.
- No benchmark: the path is only taken with the access logger enabled, which the harness on 5.2.x cannot switch on (#13118 adds that switch); the change replaces a ~10-node pipeline walk with an attribute read and is kept on its structural merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
