### PR TITLE
Fix duplicate Kotlin collection introspection properties

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -420,6 +420,11 @@ internal open class KotlinClassElement(
                 val excludedAnnotations = propertyElementQuery.excludedAnnotations
                 if (hasAnnotation(nativeEl, JvmField::class.java) || excludedAnnotations.any { hasAnnotation(nativeEl, it) }) {
                     false
+                } else if (nativeEl is KSPropertyDeclaration && nativeEl.getter == null && nativeEl.setter == null) {
+                    // KSP models a Java field as a property without accessors. It cannot be read or
+                    // written as a bean property, so leave it to the field handling below, which
+                    // applies the configured access kinds and visibility.
+                    false
                 } else {
                     !propertyElementQuery.excludes.contains(el.name)
                             && (propertyElementQuery.includes.isEmpty() || propertyElementQuery.includes.contains(el.name))
@@ -446,8 +451,12 @@ internal open class KotlinClassElement(
 
         val allProperties: MutableMap<String, PropertyElement> = linkedMapOf()
         enclosedElementsQuery.getEnclosedElements(this, eq).forEach { property ->
-            // KSP can return the same mapped JDK collection property through multiple hierarchy paths.
-            allProperties.putIfAbsent(property.name, property)
+            // KSP can return the same logical property through multiple hierarchy paths, for example
+            // the mapped JDK collection members declared by both Map and MutableMap. Only one bean
+            // property can be written per name, so collapse them onto the most specific declaration.
+            allProperties.merge(property.name, property) { existing, candidate ->
+                if (isMoreSpecific(candidate, existing)) candidate else existing
+            }
         }
         // unfortunate hack since these are not excluded?
         if (hasDeclaredStereotype(ConfigurationReader::class.java)) {
@@ -504,6 +513,18 @@ internal open class KotlinClassElement(
         resolvedProperties.addAll(methodProperties)
         resolvedProperties.addAll(allProperties.values)
         return resolvedProperties
+    }
+
+    /**
+     * Whether a duplicate property declaration should replace the one already collected. A concrete
+     * declaration wins over an abstract one, and otherwise the declaration of the most specific type
+     * wins, so that an overriding declaration and its annotations are the ones retained.
+     */
+    private fun isMoreSpecific(candidate: PropertyElement, existing: PropertyElement): Boolean {
+        if (candidate.isAbstract != existing.isAbstract) {
+            return !candidate.isAbstract
+        }
+        return candidate.declaringType.isAssignable(existing.declaringType)
     }
 
     private fun mapToPropertyElement(value: AstBeanPropertiesUtils.BeanPropertyData) =

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -444,8 +444,11 @@ internal open class KotlinClassElement(
                 }
             }
 
-        val allProperties: MutableList<PropertyElement> = mutableListOf()
-        allProperties.addAll(enclosedElementsQuery.getEnclosedElements(this, eq))
+        val allProperties: MutableMap<String, PropertyElement> = linkedMapOf()
+        enclosedElementsQuery.getEnclosedElements(this, eq).forEach { property ->
+            // KSP can return the same mapped JDK collection property through multiple hierarchy paths.
+            allProperties.putIfAbsent(property.name, property)
+        }
         // unfortunate hack since these are not excluded?
         if (hasDeclaredStereotype(ConfigurationReader::class.java)) {
             val configurationBuilderQuery = ElementQuery.of(PropertyElement::class.java)
@@ -454,19 +457,17 @@ internal open class KotlinClassElement(
                 .onlyAccessible(this)
             enclosedElementsQuery.getEnclosedElements(this, configurationBuilderQuery)
                 .forEach { e ->
-                    if (!allProperties.contains(e)) {
-                        allProperties.add(e)
-                    }
+                    allProperties.putIfAbsent(e.name, e)
                 }
         }
-        val propertyNames = allProperties.map { it.name }.toMutableSet()
+        val propertyNames = allProperties.keys
         val resolvedProperties: MutableList<PropertyElement> = mutableListOf()
         val methods = ArrayList(getEnclosedElements(ElementQuery.ALL_METHODS))
         if (isJavaRecord(nativeType.declaration)) {
             propertyElementQuery.readPrefixes("")
             propertyElementQuery.writePrefixes(emptyArray())
         }
-        allProperties.forEach { prop ->
+        allProperties.values.forEach { prop ->
             methods.removeIf { m ->
                 prop.name == NameUtils.getPropertyNameForGetter(
                     m.name,
@@ -478,7 +479,7 @@ internal open class KotlinClassElement(
             }
         }
         val fields = ArrayList(getEnclosedElements(ElementQuery.ALL_FIELDS))
-        fields.removeIf { f -> allProperties.stream().anyMatch { p -> p.name == f.name }}
+        fields.removeIf { f -> allProperties.containsKey(f.name) }
         val methodProperties = AstBeanPropertiesUtils.resolveBeanProperties(propertyElementQuery,
             this,
             {
@@ -501,7 +502,7 @@ internal open class KotlinClassElement(
                 }
             })
         resolvedProperties.addAll(methodProperties)
-        resolvedProperties.addAll(allProperties)
+        resolvedProperties.addAll(allProperties.values)
         return resolvedProperties
     }
 

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
@@ -161,6 +161,10 @@ internal class KotlinVisitorContext(
         val declaration = enclosingDeclaration(decl)
         val mappedName = mapQualifiedNameToJava(declaration)
         if (mappedName != null) {
+            if (declaration is KSClassDeclaration && declaration.parentDeclaration is KSClassDeclaration) {
+                // The mapped name is canonical (for example java.util.Map.Entry), but bytecode needs the binary name.
+                return computeClassBinaryName(declaration) ?: mappedName
+            }
             return mappedName
         }
         if (declaration.qualifiedName == null) {

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/CollectionIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/CollectionIntrospectionSpec.groovy
@@ -32,10 +32,15 @@ import jakarta.inject.Singleton
 class Reversed<A, B> : java.util.HashMap<B, A>()
 ''')
 
-        then:
-        introspection.beanProperties*.name == introspection.beanProperties*.name.unique()
-        introspection.getProperty('keys').isPresent()
+        then: "each mapped collection property is generated once"
+        introspection.beanProperties*.name == ['empty', 'size', 'keys', 'values', 'entries']
+
+        and: "the mapped nested type uses its JVM binary name"
         introspection.getRequiredProperty('entries', Set).asArgument().typeParameters[0].type == Map.Entry
+
+        and: "the properties can be read"
+        def instance = introspection.instantiate()
+        introspection.beanProperties.every { it.get(instance) != null }
     }
 
     void "test introspection of ArrayList subclass has unique properties"() {
@@ -51,8 +56,13 @@ import jakarta.inject.Singleton
 class Strings : java.util.ArrayList<String>()
 ''')
 
-        then:
-        introspection.beanProperties*.name == introspection.beanProperties*.name.unique()
-        introspection.getProperty('size').isPresent()
+        then: "each mapped collection property is generated once"
+        introspection.beanProperties*.name == ['empty', 'first', 'last', 'size']
+
+        and: "a Java field without accessors is not a property"
+        !introspection.getProperty('modCount').isPresent()
+
+        and: "the properties can be read"
+        introspection.getRequiredProperty('size', int).get(introspection.instantiate()) == 0
     }
 }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/CollectionIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/CollectionIntrospectionSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.kotlin.processing.beans
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+
+class CollectionIntrospectionSpec extends AbstractKotlinCompilerSpec {
+
+    void "test introspection of HashMap subclass has unique properties"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Reversed', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+import jakarta.inject.Singleton
+
+@Introspected
+@Singleton
+class Reversed<A, B> : java.util.HashMap<B, A>()
+''')
+
+        then:
+        introspection.beanProperties*.name == introspection.beanProperties*.name.unique()
+        introspection.getProperty('keys').isPresent()
+        introspection.getRequiredProperty('entries', Set).asArgument().typeParameters[0].type == Map.Entry
+    }
+
+    void "test introspection of ArrayList subclass has unique properties"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Strings', '''
+package test
+
+import io.micronaut.core.annotation.Introspected
+import jakarta.inject.Singleton
+
+@Introspected
+@Singleton
+class Strings : java.util.ArrayList<String>()
+''')
+
+        then:
+        introspection.beanProperties*.name == introspection.beanProperties*.name.unique()
+        introspection.getProperty('size').isPresent()
+    }
+}


### PR DESCRIPTION
## Background

KSP exposes mapped JDK collection properties through multiple hierarchy paths. KotlinClassElement consequently returned duplicate logical bean properties such as keys and size, and BeanIntrospectionWriter emitted duplicate metadata methods that failed class verification.

After removing the duplicate properties, the HashMap case also exposed that the mapped nested Map.Entry type used its canonical name instead of its JVM binary name.

## Changes

- Deduplicate KSP native bean properties by logical property name before combining them with accessor-derived properties.
- Resolve mapped nested Kotlin/JDK classes to their JVM binary names.
- Add Kotlin compilation regressions for introspected HashMap and ArrayList subclasses, including the Map.Entry property type.

## Verification

- ./gradlew -Dorg.gradle.jvmargs=-Xmx4097m :micronaut-inject-kotlin:test --tests io.micronaut.kotlin.processing.beans.CollectionIntrospectionSpec
- ./gradlew -Dorg.gradle.jvmargs=-Xmx4097m :micronaut-inject-kotlin:test (868 tests passed, 12 skipped)
- ./gradlew -Dorg.gradle.jvmargs=-Xmx4097m :micronaut-inject-kotlin:check