### PR TITLE
Bind Python transitive supertype arguments

### DIFF
--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/IntrospectionTypeArgumentsSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/IntrospectionTypeArgumentsSpec.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.annotation.processing.test
+
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.GenericPlaceholder
+
+class IntrospectionTypeArgumentsSpec extends AbstractPythonTypeElementSpec {
+
+    private static final String HIERARCHY = '''
+from typing import Generic, TypeVar
+from java.util import ArrayList, HashMap
+from io.micronaut.python.annotation.processing.test import TypeArgumentFlipped
+from io.micronaut.core.annotation import Introspected
+from jakarta.inject import Singleton
+
+A = TypeVar("A")
+B = TypeVar("B")
+K = TypeVar("K")
+V = TypeVar("V")
+X = TypeVar("X")
+Y = TypeVar("Y")
+
+@Introspected
+@Singleton
+class Reversed(HashMap[B, A], Generic[A, B]):
+    pass
+
+@Introspected
+@Singleton
+class Swapped(HashMap[V, K], Generic[K, V]):
+    pass
+
+@Introspected
+@Singleton
+class Holder(TypeArgumentFlipped[X, Y], Generic[X, Y]):
+    pass
+
+@Introspected
+@Singleton
+class Strings(ArrayList[str]):
+    pass
+'''
+
+    void "a Java type two levels above is reported in the variables of the Python type"() {
+        given:
+        def introspection = buildBeanIntrospection("python.Reversed", HIERARCHY)
+        def definition = buildBeanDefinition("python", "Reversed", HIERARCHY)
+
+        expect:
+        variableNames(introspection.getTypeArguments(HashMap)) == ["B", "A"]
+        introspection.getTypeArguments(Map)*.name == ["K", "V"]
+        variableNames(introspection.getTypeArguments(Map)) == ["B", "A"]
+        variableNames(definition.getTypeArguments(Map)) == ["B", "A"]
+        introspection.getTypeArguments(Map) == definition.getTypeArguments(Map)
+    }
+
+    void "a Python variable named like a Java super type variable is still bound by position"() {
+        given:
+        def introspection = buildBeanIntrospection("python.Swapped", HIERARCHY)
+        def definition = buildBeanDefinition("python", "Swapped", HIERARCHY)
+
+        expect:
+        variableNames(introspection.getTypeArguments(HashMap)) == ["V", "K"]
+        variableNames(introspection.getTypeArguments(Map)) == ["V", "K"]
+        variableNames(definition.getTypeArguments(Map)) == ["V", "K"]
+    }
+
+    void "a Java interface reached through an intermediate interface is reported in the variables of the Python type"() {
+        given:
+        def introspection = buildBeanIntrospection("python.Holder", HIERARCHY)
+        def definition = buildBeanDefinition("python", "Holder", HIERARCHY)
+
+        expect:
+        variableNames(introspection.getTypeArguments(TypeArgumentFlipped)) == ["X", "Y"]
+        introspection.getTypeArguments(TypeArgumentContainer)*.name == ["E", "F"]
+        variableNames(introspection.getTypeArguments(TypeArgumentContainer)) == ["Y", "X"]
+        variableNames(definition.getTypeArguments(TypeArgumentContainer)) == ["Y", "X"]
+    }
+
+    void "a concrete Java type bound one level up is reported for every type above"() {
+        given:
+        def introspection = buildBeanIntrospection("python.Strings", HIERARCHY)
+        def definition = buildBeanDefinition("python", "Strings", HIERARCHY)
+
+        expect:
+        introspection.getTypeArguments(Iterable)*.type == [String]
+        !introspection.getTypeArguments(Iterable)[0].isTypeVariable()
+        introspection.getTypeArguments(Collection)*.type == [String]
+        definition.getTypeArguments(Iterable)*.type == [String]
+    }
+
+    private static List<String> variableNames(List<Argument<?>> arguments) {
+        arguments.collect { it instanceof GenericPlaceholder ? it.variableName : null }
+    }
+}

--- a/inject-python-test/src/test/java/io/micronaut/python/annotation/processing/test/TypeArgumentContainer.java
+++ b/inject-python-test/src/test/java/io/micronaut/python/annotation/processing/test/TypeArgumentContainer.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.annotation.processing.test;
+
+/** Test interface used to verify transitive Python type-argument resolution. */
+public interface TypeArgumentContainer<E, F> {
+}

--- a/inject-python-test/src/test/java/io/micronaut/python/annotation/processing/test/TypeArgumentFlipped.java
+++ b/inject-python-test/src/test/java/io/micronaut/python/annotation/processing/test/TypeArgumentFlipped.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.annotation.processing.test;
+
+/** Intermediate test interface that reverses its parent's type arguments. */
+public interface TypeArgumentFlipped<F, E> extends TypeArgumentContainer<E, F> {
+}

--- a/inject-python/src/main/java/io/micronaut/python/processing/element/PythonClassElement.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/element/PythonClassElement.java
@@ -50,6 +50,7 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.GenericPlaceholderElement;
 import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.WildcardElement;
 import io.micronaut.inject.ast.beans.BeanElementBuilder;
 import io.micronaut.inject.processing.BeanDefinitionCreatorFactory;
 import io.micronaut.python.processing.PythonProcessingEnvironment;
@@ -446,7 +447,7 @@ public sealed class PythonClassElement extends AbstractPythonClassElement permit
         List<TypeRef> typeArguments = base.typeArguments();
         if (!typeArguments.isEmpty() && declaredGenericPlaceholders != null && !declaredGenericPlaceholders.isEmpty() && typeArguments.size() == declaredGenericPlaceholders.size()) {
             Map<String, ClassElement> resolvedTypeArguments = new HashMap<>(declaredGenericPlaceholders.size());
-            Map<String, ClassElement> boundGenerics = new HashMap<>(getTypeArguments());
+            Map<String, ClassElement> boundGenerics = typeVariableBindings();
             for (int i = 0; i < declaredGenericPlaceholders.size(); i++) {
                 GenericPlaceholderElement placeHolder = declaredGenericPlaceholders.get(i);
                 TypeRef typeRef = typeArguments.get(i);
@@ -467,12 +468,20 @@ public sealed class PythonClassElement extends AbstractPythonClassElement permit
     }
 
     private Optional<ClassElement> toJavaType(TypeRef typeRef) {
-        ClassElement baseType = environment.visitorContext().getTypeResolver().resolve(typeRef, Map.of()
-        );
+        ClassElement baseType = environment.visitorContext().getTypeResolver().resolve(typeRef, typeVariableBindings());
         if (baseType != null && !baseType.getName().equals(Object.class.getName())) {
             return Optional.of(baseType);
         }
         return Optional.empty();
+    }
+
+    private Map<String, ClassElement> typeVariableBindings() {
+        if (resolvedTypeArguments == null) {
+            // Bases of an open generic type must retain its variables so recursive supertype
+            // arguments can subsequently be bound through each level of the hierarchy.
+            return GenericBindings.declared(this, true);
+        }
+        return new HashMap<>(resolvedTypeArguments);
     }
 
     @Override
@@ -493,17 +502,65 @@ public sealed class PythonClassElement extends AbstractPythonClassElement permit
 
     @Override
     public Map<String, Map<String, ClassElement>> getAllTypeArguments() {
+        // Python can have multiple concrete bases, so retain the native-base traversal while
+        // applying the same per-level binding used by ClassElement's default implementation.
         Map<String, Map<String, ClassElement>> result = new LinkedHashMap<>();
         for (TypeRef base : getNativeType().bases()) {
             ClassElement baseElement = findPythonClass(base);
-            if (baseElement != null) {
-                result.putAll(resolveTypeArguments(baseElement, base).getAllTypeArguments());
-            } else {
-                toJavaType(base).ifPresent(javaType -> result.putAll(javaType.getAllTypeArguments()));
+            ClassElement resolvedBase = baseElement == null
+                ? toJavaType(base).orElse(null)
+                : resolveTypeArguments(baseElement, base);
+            if (resolvedBase == null) {
+                continue;
             }
+            Map<String, ClassElement> baseTypeArguments = resolvedBase.getTypeArguments();
+            String baseName = resolvedBase.getName();
+            resolvedBase.getAllTypeArguments().forEach((typeName, typeArguments) -> result.put(
+                typeName,
+                typeName.equals(baseName) ? typeArguments : bindTypeVariables(typeArguments, baseTypeArguments)
+            ));
         }
         result.put(getName(), getTypeArguments());
         return result;
+    }
+
+    private static Map<String, ClassElement> bindTypeVariables(Map<String, ClassElement> typeArguments,
+                                                               Map<String, ClassElement> bindings) {
+        if (typeArguments.isEmpty() || bindings.isEmpty()) {
+            return typeArguments;
+        }
+        Map<String, ClassElement> bound = new LinkedHashMap<>(typeArguments.size());
+        boolean changed = false;
+        for (Map.Entry<String, ClassElement> entry : typeArguments.entrySet()) {
+            ClassElement typeArgument = entry.getValue();
+            ClassElement boundTypeArgument = bindTypeVariables(typeArgument, bindings);
+            changed |= boundTypeArgument != typeArgument;
+            bound.put(entry.getKey(), boundTypeArgument);
+        }
+        return changed ? bound : typeArguments;
+    }
+
+    private static ClassElement bindTypeVariables(ClassElement type, Map<String, ClassElement> bindings) {
+        if (type instanceof GenericPlaceholderElement placeholder) {
+            ClassElement binding = bindings.get(placeholder.getVariableName());
+            if (binding == null) {
+                return type;
+            }
+            ClassElement bound = binding;
+            while (bound.getArrayDimensions() < placeholder.getArrayDimensions()) {
+                bound = bound.toArray();
+            }
+            return bound;
+        }
+        if (type instanceof WildcardElement) {
+            ClassElement folded = type.foldBoundGenericTypes(bound ->
+                bound instanceof GenericPlaceholderElement ? bindTypeVariables(bound, bindings) : bound
+            );
+            return folded == null ? type : folded;
+        }
+        Map<String, ClassElement> typeArguments = type.getTypeArguments();
+        Map<String, ClassElement> boundTypeArguments = bindTypeVariables(typeArguments, bindings);
+        return boundTypeArguments == typeArguments ? type : type.withTypeArguments(boundTypeArguments);
     }
 
     @Override


### PR DESCRIPTION
Depends on #13138.

## Summary

- resolve Java bases with the Python class type-variable bindings
- bind recursive ancestor arguments through each direct Python base while preserving Python multiple-inheritance traversal
- cover swapped variables, colliding variable names, an intermediate interface, and concrete ancestor bindings through BeanIntrospection and BeanDefinition

## Before/after

The focused regression spec executed four tests. Before the implementation change, three failed and only the concrete binding case passed. After the change, all four pass.

## Verification

- ./gradlew :micronaut-inject-python:clean :micronaut-inject-python-test:clean :micronaut-inject-python:test :micronaut-inject-python-test:test -Ppython-ci -Dorg.gradle.jvmargs=-Xmx4097m
  - micronaut-inject-python: 125 tests passed
  - micronaut-inject-python-test: 612 tests passed
- ./gradlew :micronaut-inject-python:check :micronaut-inject-python-test:check -Ppython-ci -Dorg.gradle.jvmargs=-Xmx4097m
  - BUILD SUCCESSFUL
- git diff --check