### PR TITLE
Document where request event listeners run and report slow ones

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -58,6 +58,7 @@ import java.nio.channels.ClosedChannelException;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -78,6 +79,10 @@ public final class RoutingInBoundHandler implements RequestHandler {
      */
     private static final Pattern IGNORABLE_ERROR_MESSAGE = Pattern.compile(
         "^.*(?:connection (?:reset|closed|abort|broken)|broken pipe).*$", Pattern.CASE_INSENSITIVE);
+    /**
+     * Request event listeners that take longer than this on the event loop are reported at debug level.
+     */
+    private static final long SLOW_LISTENER_THRESHOLD_NANOS = TimeUnit.MILLISECONDS.toNanos(100);
 
     final StaticResourceResolver staticResourceResolver;
     final NettyHttpServerConfiguration serverConfiguration;
@@ -140,7 +145,7 @@ public final class RoutingInBoundHandler implements RequestHandler {
                     terminatedFlow = ExecutionFlow.async(getRequestEventExecutor(), () -> {
                         PropagatedContext.getOrEmpty()
                             .plus(new ServerHttpRequestContext(request))
-                            .propagate(() -> terminateEventPublisher.publishEvent(new HttpRequestTerminatedEvent(request)));
+                            .propagate(() -> publishRequestEvent(request, terminateEventPublisher, new HttpRequestTerminatedEvent(request)));
                         return ExecutionFlow.empty();
                     });
                 }
@@ -256,9 +261,30 @@ public final class RoutingInBoundHandler implements RequestHandler {
         return ExecutionFlow.async(getRequestEventExecutor(), () -> {
             PropagatedContext.getOrEmpty()
                 .plus(new ServerHttpRequestContext(request))
-                .propagate(() -> receivedPublisher.publishEvent(new HttpRequestReceivedEvent(request)));
+                .propagate(() -> publishRequestEvent(request, receivedPublisher, new HttpRequestReceivedEvent(request)));
             return ExecutionFlow.empty();
         });
+    }
+
+    /**
+     * Publish a request event. With the default thread selection the listeners run inline on the
+     * event loop, where a slow listener holds up every connection of that loop, so at debug level
+     * the time they take is checked against {@link #SLOW_LISTENER_THRESHOLD_NANOS}.
+     */
+    private <E> void publishRequestEvent(NettyHttpRequest<?> request, ApplicationEventPublisher<E> publisher, E event) {
+        if (!LOG.isDebugEnabled()) {
+            publisher.publishEvent(event);
+            return;
+        }
+        long start = System.nanoTime();
+        try {
+            publisher.publishEvent(event);
+        } finally {
+            long taken = System.nanoTime() - start;
+            if (taken > SLOW_LISTENER_THRESHOLD_NANOS && request.getChannelHandlerContext().executor().inEventLoop()) {
+                LOG.debug("Listeners for {} took {} ms on the event loop for {}. Request event listeners must not block; use @Async on the listener or micronaut.server.thread-selection=BLOCKING", event.getClass().getSimpleName(), TimeUnit.NANOSECONDS.toMillis(taken), request);
+            }
+        }
     }
 
     public void writeResponse(OutboundAccess outboundAccess,

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/SlowRequestEventListenerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/SlowRequestEventListenerSpec.groovy
@@ -1,0 +1,119 @@
+package io.micronaut.http.server.netty
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.context.event.HttpRequestReceivedEvent
+import io.micronaut.http.context.event.HttpRequestTerminatedEvent
+import io.micronaut.runtime.event.annotation.EventListener
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Request event listeners run on the event loop with the default thread selection. A listener
+ * that takes too long there is reported at debug level.
+ */
+class SlowRequestEventListenerSpec extends Specification {
+    private static final String LOGGER = RoutingInBoundHandler.class.name
+
+    def "slow request event listeners on the event loop are reported at debug level"(String threadSelection, long delayMillis, boolean expectReport) {
+        given:
+        def logger = (Logger) LoggerFactory.getLogger(LOGGER)
+        def previousLevel = logger.level
+        def appender = new ListAppender()
+        appender.start()
+        logger.addAppender(appender)
+        logger.level = Level.DEBUG
+        def ctx = ApplicationContext.run([
+                'spec.name'                           : 'SlowRequestEventListenerSpec',
+                'slow-listener.delay-millis'          : delayMillis,
+                'micronaut.server.thread-selection'   : threadSelection,
+        ])
+        def server = ctx.getBean(EmbeddedServer).start()
+        def client = ctx.createBean(HttpClient, server.URI)
+        def listener = ctx.getBean(SlowListener)
+
+        when:
+        def response = client.toBlocking().retrieve('/slow-listener')
+
+        then:
+        response == 'ok'
+        new PollingConditions(timeout: 10).eventually {
+            listener.terminated.size() == 1
+        }
+        (listener.received + listener.terminated).every { it.contains('eventLoopGroup') == (threadSelection != 'BLOCKING') }
+
+        when: 'the report is logged right after the listener returns'
+        Thread.sleep(200)
+
+        then:
+        appender.messages.count { it.contains('HttpRequestReceivedEvent') && it.contains('took') } == (expectReport ? 1 : 0)
+        appender.messages.count { it.contains('HttpRequestTerminatedEvent') && it.contains('took') } == (expectReport ? 1 : 0)
+
+        cleanup:
+        client.close()
+        ctx.close()
+        logger.detachAppender(appender)
+        logger.level = previousLevel
+
+        where:
+        threadSelection | delayMillis | expectReport
+        'MANUAL'        | 250         | true
+        'AUTO'          | 250         | true
+        'MANUAL'        | 0           | false
+        'BLOCKING'      | 250         | false
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'SlowRequestEventListenerSpec')
+    static class SlowListener {
+        final long delayMillis
+        final List<String> received = new CopyOnWriteArrayList<>()
+        final List<String> terminated = new CopyOnWriteArrayList<>()
+
+        SlowListener(@io.micronaut.context.annotation.Property(name = 'slow-listener.delay-millis') long delayMillis) {
+            this.delayMillis = delayMillis
+        }
+
+        @EventListener
+        void onReceived(HttpRequestReceivedEvent event) {
+            Thread.sleep(delayMillis)
+            received.add(Thread.currentThread().name)
+        }
+
+        @EventListener
+        void onTerminated(HttpRequestTerminatedEvent event) {
+            Thread.sleep(delayMillis)
+            terminated.add(Thread.currentThread().name)
+        }
+    }
+
+    @Controller('/slow-listener')
+    @Requires(property = 'spec.name', value = 'SlowRequestEventListenerSpec')
+    static class TestController {
+        @Get
+        String get() {
+            return 'ok'
+        }
+    }
+
+    static class ListAppender extends AppenderBase<ILoggingEvent> {
+        final List<String> messages = new CopyOnWriteArrayList<>()
+
+        @Override
+        protected void append(ILoggingEvent event) {
+            messages.add(event.formattedMessage)
+        }
+    }
+}

--- a/http/src/main/java/io/micronaut/http/context/event/HttpRequestReceivedEvent.java
+++ b/http/src/main/java/io/micronaut/http/context/event/HttpRequestReceivedEvent.java
@@ -18,9 +18,18 @@ package io.micronaut.http.context.event;
 import io.micronaut.context.event.ApplicationEvent;
 import io.micronaut.http.HttpRequest;
 /**
- * An event fired when an {@link HttpRequest} is received by the server. Not that the event is fired in a
- * non-blocking manner and access to the request body is not provided. Consumers can use this event to
- * trace the URI, headers and so on but should not perform I/O.
+ * An event fired when an {@link HttpRequest} is received by the server, before the request is
+ * routed. Access to the request body is not provided. Consumers can use this event to trace the
+ * URI, headers and so on but should not perform I/O.
+ * <p>
+ * Listeners are invoked on the thread the server selects for request handling, which with the
+ * default {@code micronaut.server.thread-selection} ({@code MANUAL}, and also with {@code AUTO})
+ * is the Netty event loop that received the request. Every listener runs to completion before the
+ * request is routed, so a listener that blocks or does slow work delays this request and every
+ * other connection on that event loop. Listeners that need to block must hand off, for example
+ * with {@code @Async} on the {@code @EventListener} method, or the server can be configured with
+ * {@code micronaut.server.thread-selection=BLOCKING} which moves the listeners (and controllers)
+ * off the event loop.
  *
  * @author graemerocher
  * @since 1.2.0

--- a/http/src/main/java/io/micronaut/http/context/event/HttpRequestTerminatedEvent.java
+++ b/http/src/main/java/io/micronaut/http/context/event/HttpRequestTerminatedEvent.java
@@ -18,8 +18,18 @@ package io.micronaut.http.context.event;
 import io.micronaut.context.event.ApplicationEvent;
 import io.micronaut.http.HttpRequest;
 /**
- * An event fired when an {@link HttpRequest} is finalized by the server. Note that the event is fired asynchronously and
- * consumers of the event should generally not perform I/O, instead this designed for tracing of headers, URI etc.
+ * An event fired when an {@link HttpRequest} is finalized by the server, once the server is done
+ * with the request (the response has been handed to the transport, which does not mean it was
+ * delivered, or the request was discarded). Consumers of the event should generally not perform
+ * I/O, instead this is designed for tracing of headers, URI etc.
+ * <p>
+ * Listeners are invoked on the thread the server selects for request handling, which with the
+ * default {@code micronaut.server.thread-selection} ({@code MANUAL}, and also with {@code AUTO})
+ * is the Netty event loop of the connection. A listener that blocks or does slow work delays every
+ * other connection on that event loop. Listeners that need to block must hand off, for example with {@code @Async} on the
+ * {@code @EventListener} method, or the server can be configured with
+ * {@code micronaut.server.thread-selection=BLOCKING} which moves the listeners (and controllers)
+ * off the event loop.
  *
  * @author graemerocher
  * @since 1.2.0

--- a/src/main/docs/guide/httpServer/serverEvents.adoc
+++ b/src/main/docs/guide/httpServer/serverEvents.adoc
@@ -16,9 +16,17 @@ The HTTP server emits a number of <<events, Bean Events>>, defined in the pkg:io
 |api:discovery.event.ServiceStoppedEvent[]
 |Emitted after all api:runtime.server.event.ServerShutdownEvent[] listeners have been invoked and exposes the api:discovery.EmbeddedServerInstance[]
 
+|api:http.context.event.HttpRequestReceivedEvent[]
+|Emitted for every request the server receives, before the request is routed. Exposes the request without its body.
+
+|api:http.context.event.HttpRequestTerminatedEvent[]
+|Emitted for every request once the server is done with it. This does not imply that a response was delivered.
+
 |===
 
 WARNING: Doing significant work within a listener for a api:runtime.server.event.ServerStartupEvent[] will increase startup time.
+
+WARNING: Listeners for api:http.context.event.HttpRequestReceivedEvent[] and api:http.context.event.HttpRequestTerminatedEvent[] are invoked on the thread the server selects for request handling, which with the default `micronaut.server.thread-selection` (`MANUAL`, and also with `AUTO`) is the Netty event loop of the connection. They must not block: a slow listener delays every other connection on that event loop. Annotate the `@EventListener` method with ann:scheduling.annotation.Async[] to run it on an executor, or set `micronaut.server.thread-selection` to `BLOCKING` to move listeners (and controllers) off the event loop. With debug logging enabled for `io.micronaut.http.server.netty.RoutingInBoundHandler`, the server logs listeners that take longer than 100 ms on the event loop.
 
 The following example defines a api:context.event.ApplicationEventListener[] that listens for api:runtime.server.event.ServerStartupEvent[]:
 


### PR DESCRIPTION
## Summary
- `HttpRequestReceivedEvent` and `HttpRequestTerminatedEvent` listeners are invoked on the executor the server selects for request handling (`ExecutorSelector.selectExecutor(null, config)`), which with the default `micronaut.server.thread-selection` (`MANUAL`, and also `AUTO`) is `ImmediateExecutor`, i.e. inline on the event loop of the connection: before the request is routed, and once the server is done with the request. The javadoc of both events said they are fired "in a non-blocking manner" / "asynchronously", which does not tell a listener author that blocking there stalls every connection of that event loop.
- Of the two options considered, this PR documents rather than re-dispatches. Running the listeners on the blocking executor whenever a listener bean exists would contradict the existing design and its test (`ThreadSelectionSpec` pins request event listeners to the loop for `MANUAL`/`AUTO` and to the blocking executor for `BLOCKING`/`IO`), and would add two thread hops per request (out to the executor and back to the loop via `executeOnEventLoopIfNeeded`) for every application that has any listener, including the many that only read headers.
- Javadoc of both events now states where listeners run, that they must not block, and the two ways out: `@Async` on the `@EventListener` method, or `micronaut.server.thread-selection=BLOCKING`. The guide's "Server Events" table gains both events and a `WARNING` with the same guidance (rendered with `publishGuide`; the `ann:scheduling.annotation.Async[]` link resolves).
- When debug logging is enabled for `io.micronaut.http.server.netty.RoutingInBoundHandler`, listeners that take longer than 100 ms while on the event loop are reported at debug level with the event type, the time and the request. With debug logging off the only cost is the `isDebugEnabled()` check; the timing only happens with it on, and the report is suppressed when the listeners ran off the loop (`BLOCKING`/`IO`).

## Testing
- New `SlowRequestEventListenerSpec`: a listener for both events sleeps for a configured time; with `MANUAL` (default) and `AUTO` and 250 ms, both listeners run on `default-eventLoopGroup-*` and one debug report per event is logged; with `MANUAL` and no delay, no report; with `BLOCKING`, the listeners run off the loop and no report is logged even though they take 250 ms.
- Fail-before: with the threshold effectively disabled (`TimeUnit.DAYS.toNanos(1)`), the 250 ms cases fail on the report count; the javadoc and guide changes are documentation.
- `./gradlew :micronaut-http-server-netty:test`: 1162 tests, 22 skipped (pre-existing), 0 failures. `:micronaut-http:test`: 1857 tests, 0 failures. `checkstyleMain` clean for `http` and, apart from the pre-existing `FileLength` violation in `NettyHttpServerConfiguration`, for `http-server-netty`. `./gradlew publishGuide` succeeds and the new section renders.
- Codex review (`gpt-5.6-sol`, high): (1) the terminated-event javadoc said "after the response has been written", which over-promises for streamed and discarded responses; reworded to "once the server is done with the request", with the guide saying the event does not imply a response was delivered. (2) The documentation named `AUTO` as the default thread selection; the default is `MANUAL` (`HttpServerConfiguration.threadSelection`); corrected in the javadoc and guide, and the test gained the `MANUAL` case. Third pass: no findings.

## Out of scope
- Making the threshold configurable; 100 ms is well beyond anything that belongs on an event loop and the report is debug-only.
- Changing `ThreadSelection` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
