### PR TITLE
Select the interceptors of a scoped proxy per target

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/Intercepted.java
+++ b/aop/src/main/java/io/micronaut/aop/Intercepted.java
@@ -56,6 +56,11 @@ public interface Intercepted extends InterceptedBean {
      * particular has no other route to them: it runs with a fresh resolution context, and the proxy instance is the
      * only thing that survives from creation to destruction.</p>
      *
+     * <p>A proxy whose target is not a singleton, such as a scoped proxy, keeps its own registrations as well but
+     * does not intercept its targets with them: each target resolves its own set when it is created, and the proxy
+     * selects the interceptors of every call from the set of the target of that call, so that a non-singleton
+     * interceptor is one instance per target. See {@code io.micronaut.aop.beandefinition.TargetInterceptorRegistrations}.</p>
+     *
      * <p>Proxies generated before this existed keep the empty default; the runtime then resolves interceptors by
      * binding as it always did.</p>
      *

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/InterceptedBeanDefinition.java
@@ -59,6 +59,10 @@ public interface InterceptedBeanDefinition<T> extends InstantiatableBeanDefiniti
      * needs; each interception point filters it again by its own binding and kind. Resolving once is what lets a
      * non-singleton interceptor be shared by every phase of one bean.</p>
      *
+     * <p>A bean that is the target of a proxy and is not a singleton resolves this set even without constructor
+     * advice: the proxy selects the interceptors of each call from the set of the target of that call, see
+     * {@link TargetInterceptorRegistrations}, so the same instances serve the target's methods too.</p>
+     *
      * <p>Override to supply the set another way. Returning {@code null} leaves each interception point to resolve its
      * own, which is the behaviour of a bean that declares no interceptor binding at all.</p>
      *

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/ParameterizedInterceptedBeanDefinition.java
@@ -66,8 +66,8 @@ public interface ParameterizedInterceptedBeanDefinition<T>
     @Nullable Object[] resolveInstantiationValues(BeanResolutionContext resolutionContext, BeanContext context, Map<String, Object> requiredArgumentValues);
 
     /**
-     * Resolves the interceptors that construction, post-construct and pre-destroy interception of this bean all
-     * select from. See
+     * Resolves the interceptors that construction, post-construct and pre-destroy interception of this bean, and the
+     * methods of a proxy fronting it when it is not a singleton, all select from. See
      * {@link InterceptedBeanDefinition#resolveInterceptors(BeanResolutionContext, AnnotationMetadataProvider)}, which
      * this mirrors for parametrized definitions.
      *

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/SharedInterceptorRegistrations.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/SharedInterceptorRegistrations.java
@@ -58,6 +58,10 @@ import java.util.List;
  * <p>Destruction happens later with a fresh resolution context, so nothing is shared with it here; see
  * {@code MethodInterceptorChain} for how pre-destroy reaches the interceptors a bean owns.</p>
  *
+ * <p>The registrations a bean keeps after its creation are stored as a {@link TargetInterceptorRegistrations}, so
+ * that a proxy fronting the bean can select the interceptors of each of its methods from them and keep the
+ * selection for the life of the bean.</p>
+ *
  * <p>Everything here is package-private except {@link #store}, which the runtime proxy path in
  * {@code io.micronaut.aop.runtime} calls from another package.</p>
  *
@@ -147,7 +151,7 @@ public final class SharedInterceptorRegistrations {
             completed = new IdentityHashMap<>(3);
             resolutionContext.setAttribute(BeanResolutionContext.INTERCEPTOR_REGISTRATIONS, completed);
         }
-        completed.put(definition, registrations);
+        completed.put(definition, TargetInterceptorRegistrations.of(registrations));
     }
 
     /**

--- a/aop/src/main/java/io/micronaut/aop/beandefinition/TargetInterceptorRegistrations.java
+++ b/aop/src/main/java/io/micronaut/aop/beandefinition/TargetInterceptorRegistrations.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.beandefinition;
+
+import io.micronaut.aop.Interceptor;
+import io.micronaut.aop.InterceptorKind;
+import io.micronaut.aop.InterceptorRegistry;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
+import io.micronaut.inject.ExecutableMethod;
+import org.jspecify.annotations.Nullable;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.RandomAccess;
+
+/**
+ * The interceptor registrations resolved for one bean, holding the interceptors they select for each method of the
+ * proxy that fronts the bean.
+ *
+ * <p>The scenario this exists for is a proxy whose target is not a singleton, such as a {@code @RequestScope} or
+ * {@code @ThreadLocal} bean, which fronts a different target from one call to the next:</p>
+ *
+ * <pre>{@code
+ * @RequestScope @Counted
+ * class Ledger { void record() {} }
+ * }</pre>
+ *
+ * <p>The interceptors bound to such a target are resolved while the target is created and belong to it, so the
+ * proxy selects the interceptors of a method from the target's registrations rather than from a set it resolved
+ * once for itself. That is what makes a non-singleton interceptor one instance per target, shared by the target's
+ * post-construct, its methods and its pre-destroy, and destroyed with it. Selection filters and orders the
+ * registrations by the method's bindings, which is too much to repeat on every call, so the outcome is kept here,
+ * by method, for the life of the target.</p>
+ *
+ * <p>The list is the one the bean's {@link BeanRegistration} carries and its pre-destroy interception reads,
+ * unchanged, and it is read-only. Selections are indexed by the method's position in the proxy and checked against
+ * the method itself, so a proxy of another shape over the same target selects afresh instead of reading an entry
+ * that is not its own.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.2.2
+ */
+@Internal
+public final class TargetInterceptorRegistrations extends AbstractList<BeanRegistration<Interceptor<?, ?>>> implements RandomAccess {
+
+    private static final Selection[] NONE = new Selection[0];
+
+    private final List<BeanRegistration<Interceptor<?, ?>>> registrations;
+    /**
+     * Replaced rather than mutated, so that a read needs no lock.
+     */
+    private volatile Selection[] selections = NONE;
+
+    private TargetInterceptorRegistrations(List<BeanRegistration<Interceptor<?, ?>>> registrations) {
+        this.registrations = registrations;
+    }
+
+    /**
+     * Wraps the registrations resolved for a bean, unless they are wrapped already.
+     *
+     * @param registrations The registrations
+     * @return The registrations, able to hold the selections made from them
+     */
+    @SuppressWarnings("unchecked")
+    static List<?> of(List<?> registrations) {
+        if (registrations instanceof TargetInterceptorRegistrations) {
+            return registrations;
+        }
+        return new TargetInterceptorRegistrations((List<BeanRegistration<Interceptor<?, ?>>>) registrations);
+    }
+
+    /**
+     * Selects the interceptors a proxy applies to one method of the target it fronts.
+     *
+     * <p>For a singleton target the interceptors the proxy selected for itself are returned: proxy and target are
+     * one to one, and a singleton target has always been intercepted by the proxy's own set, its own registrations
+     * serving its lifecycle phases. For any other target the interceptors are selected from the registrations
+     * resolved for that target while it was created, so that a non-singleton interceptor is the instance which
+     * also ran the target's post-construct, will run its pre-destroy, and is destroyed with it. A target that
+     * carries no registrations, because it was created some other way than by its definition or its scope obtained
+     * it some other way than through the context, is intercepted by the proxy's own set as before.</p>
+     *
+     * @param registry          The interceptor registry
+     * @param target            The registration of the target of this call, or {@code null} when the proxy holds
+     *                          none for it
+     * @param method            The intercepted method, as the proxy holds it
+     * @param index             The index of the method in the proxy
+     * @param proxyInterceptors The interceptors the proxy selected for the method from its own registrations
+     * @param <T>               The target type
+     * @return The interceptors to apply to this call
+     * @since 5.2.2
+     */
+    @UsedByGeneratedCode
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T> Interceptor<T, ?>[] select(InterceptorRegistry registry,
+                                                 @Nullable BeanRegistration<T> target,
+                                                 ExecutableMethod<T, ?> method,
+                                                 int index,
+                                                 Interceptor<T, ?>[] proxyInterceptors) {
+        if (target == null || target.getBeanDefinition().isSingleton()) {
+            return proxyInterceptors;
+        }
+        List<?> registrations = target.getInterceptorRegistrations();
+        if (registrations instanceof TargetInterceptorRegistrations resolved) {
+            return resolved.aroundInterceptors(registry, method, index);
+        }
+        if (registrations == null || registrations.isEmpty()) {
+            return proxyInterceptors;
+        }
+        // Stored by another route than SharedInterceptorRegistrations#store, so there is nowhere to keep the selection
+        return registry.resolveInterceptors(method, (Collection) registrations, InterceptorKind.AROUND);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Interceptor<T, ?>[] aroundInterceptors(InterceptorRegistry registry, ExecutableMethod<T, ?> method, int index) {
+        Selection[] current = selections;
+        if (index < current.length) {
+            Selection selection = current[index];
+            if (selection != null && selection.method == method) {
+                return (Interceptor<T, ?>[]) selection.interceptors;
+            }
+        }
+        return select(registry, method, index);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private synchronized <T> Interceptor<T, ?>[] select(InterceptorRegistry registry, ExecutableMethod<T, ?> method, int index) {
+        Selection[] current = selections;
+        if (index < current.length) {
+            Selection selection = current[index];
+            if (selection != null && selection.method == method) {
+                return (Interceptor<T, ?>[]) selection.interceptors;
+            }
+        }
+        Interceptor<T, ?>[] interceptors = registry.resolveInterceptors(method, (Collection) registrations, InterceptorKind.AROUND);
+        Selection[] replaced = Arrays.copyOf(current, Math.max(current.length, index + 1));
+        replaced[index] = new Selection(method, interceptors);
+        selections = replaced;
+        return interceptors;
+    }
+
+    @Override
+    public BeanRegistration<Interceptor<?, ?>> get(int index) {
+        return registrations.get(index);
+    }
+
+    @Override
+    public int size() {
+        return registrations.size();
+    }
+
+    /**
+     * The interceptors selected for one method, with the method they were selected for.
+     *
+     * @param method       The method
+     * @param interceptors The interceptors selected for it
+     */
+    private record Selection(ExecutableMethod<?, ?> method, Interceptor<?, ?>[] interceptors) {
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -22,6 +22,7 @@ import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.InterceptorKind;
 import io.micronaut.aop.InterceptorRegistry;
 import io.micronaut.aop.Introduced;
+import io.micronaut.aop.beandefinition.TargetInterceptorRegistrations;
 import io.micronaut.aop.chain.InterceptorChain;
 import io.micronaut.aop.chain.MethodInterceptorChain;
 import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
@@ -108,6 +109,29 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
         Qualifier.class
     );
 
+    private static final Method METHOD_GET_PROXY_TARGET_BEAN_REGISTRATION = ReflectionUtils.getRequiredInternalMethod(
+        BeanResolutionContext.class,
+        "getProxyTargetBeanRegistration",
+        BeanDefinition.class,
+        Argument.class,
+        Qualifier.class
+    );
+
+    private static final Method METHOD_REGISTRATION_GET_BEAN = ReflectionUtils.getRequiredMethod(
+        BeanRegistration.class,
+        "getBean"
+    );
+
+    private static final Method METHOD_SELECT_TARGET_INTERCEPTORS = ReflectionUtils.getRequiredInternalMethod(
+        TargetInterceptorRegistrations.class,
+        "select",
+        InterceptorRegistry.class,
+        BeanRegistration.class,
+        ExecutableMethod.class,
+        int.class,
+        Interceptor[].class
+    );
+
     private static final Method METHOD_GET_PROXY_BEAN_DEFINITION = ReflectionUtils.getRequiredInternalMethod(
         BeanDefinitionRegistry.class,
         "getProxyTargetBeanDefinition",
@@ -175,6 +199,8 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
     );
 
     private static final String FIELD_TARGET = "$target";
+    private static final String FIELD_TARGET_REGISTRATION = "$targetRegistration";
+    private static final String FIELD_INTERCEPTOR_REGISTRY = "$interceptorRegistry";
     private static final String FIELD_BEAN_RESOLUTION_CONTEXT = "$beanResolutionContext";
     private static final String FIELD_READ_WRITE_LOCK = "$target_rwl";
     private static final String FIELD_READ_LOCK = "$target_rl";
@@ -439,13 +465,38 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                                            int index,
                                            @Nullable FieldDef targetField,
                                            FieldDef interceptorsField,
-                                           FieldDef proxyMethodsField) {
+                                           FieldDef proxyMethodsField,
+                                           @Nullable ProxyTargetFields proxyTargetFields) {
         return MethodDef.override(methodElement)
             .build((aThis, methodParameters) -> {
-
+                ExpressionDef proxyInterceptors = aThis.field(interceptorsField).arrayElement(index);
+                ExpressionDef method = aThis.field(proxyMethodsField).arrayElement(index);
+                if (isProxyTarget && lazy) {
+                    // The target is resolved on each call and need not be the one of the last call, so the
+                    // interceptors are selected for the target of this call rather than taken from the set the
+                    // proxy holds; see TargetInterceptorRegistrations#select for which they are.
+                    ExpressionDef registry = aThis.field(proxyTargetFields.interceptorRegistry());
+                    if (cacheLazyTarget) {
+                        // interceptedTarget() resolves the target and its registration once and keeps both
+                        return aThis.invoke(METHOD_INTERCEPTED_TARGET).newLocal("target", target -> proceed(
+                            methodElement,
+                            methodParameters,
+                            selectTargetInterceptors(registry, aThis.field(proxyTargetFields.targetRegistration()), method, index, proxyInterceptors),
+                            target,
+                            method
+                        ));
+                    }
+                    return resolveProxyTargetRegistration(aThis, proxyTargetFields).newLocal("targetRegistration", targetRegistration -> proceed(
+                        methodElement,
+                        methodParameters,
+                        selectTargetInterceptors(registry, targetRegistration, method, index, proxyInterceptors),
+                        targetRegistration.invoke(METHOD_REGISTRATION_GET_BEAN),
+                        method
+                    ));
+                }
                 ExpressionDef targetArgument;
                 if (isProxyTarget) {
-                    if (hotswap || lazy) {
+                    if (hotswap) {
                         targetArgument = aThis.invoke(METHOD_INTERCEPTED_TARGET);
                     } else {
                         targetArgument = aThis.field(targetField);
@@ -453,41 +504,84 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                 } else {
                     targetArgument = aThis;
                 }
-
-                ExpressionDef.InvokeInstanceMethod invocation;
-                if (methodParameters.isEmpty()) {
-                    // invoke MethodInterceptorChain constructor without parameters
-                    invocation = METHOD_INTERCEPTOR_CHAIN_TYPE.instantiate(
-                        CONSTRUCTOR_METHOD_INTERCEPTOR_CHAIN_NO_PARAMS,
-
-                        // 1st argument: interceptors
-                        aThis.field(interceptorsField).arrayElement(index),
-                        // 2nd argument: this or target
-                        targetArgument,
-                        // 3rd argument: the executable method
-                        aThis.field(proxyMethodsField).arrayElement(index)
-                        // fourth argument: array of the argument values
-                    ).invoke(METHOD_PROCEED);
-                } else {
-                    // invoke MethodInterceptorChain constructor with parameters
-                    invocation = METHOD_INTERCEPTOR_CHAIN_TYPE.instantiate(
-                        CONSTRUCTOR_METHOD_INTERCEPTOR_CHAIN,
-
-                        // 1st argument: interceptors
-                        aThis.field(interceptorsField).arrayElement(index),
-                        // 2nd argument: this or target
-                        targetArgument,
-                        // 3rd argument: the executable method
-                        aThis.field(proxyMethodsField).arrayElement(index),
-                        // 4th argument: array of the argument values
-                        TypeDef.OBJECT.array().instantiate(methodParameters)
-                    ).invoke(METHOD_PROCEED);
-                }
-                if (!methodElement.getReturnType().isVoid() || methodElement.isSuspend()) {
-                    return invocation.returning();
-                }
-                return invocation;
+                return proceed(methodElement, methodParameters, proxyInterceptors, targetArgument, method);
             });
+    }
+
+    /**
+     * Runs the interceptor chain of one method and returns what it returns, unless the method returns nothing.
+     *
+     * @param methodElement    The intercepted method
+     * @param methodParameters The parameters of the proxy method
+     * @param interceptors     The interceptors to apply
+     * @param target           The target of the call: the proxy itself, or the target it fronts
+     * @param method           The executable method
+     * @return The statement
+     */
+    private static StatementDef proceed(MethodElement methodElement,
+                                        List<VariableDef.MethodParameter> methodParameters,
+                                        ExpressionDef interceptors,
+                                        ExpressionDef target,
+                                        ExpressionDef method) {
+        ExpressionDef.InvokeInstanceMethod invocation;
+        if (methodParameters.isEmpty()) {
+            // invoke MethodInterceptorChain constructor without parameters
+            invocation = METHOD_INTERCEPTOR_CHAIN_TYPE.instantiate(
+                CONSTRUCTOR_METHOD_INTERCEPTOR_CHAIN_NO_PARAMS,
+
+                // 1st argument: interceptors
+                interceptors,
+                // 2nd argument: this or target
+                target,
+                // 3rd argument: the executable method
+                method
+                // fourth argument: array of the argument values
+            ).invoke(METHOD_PROCEED);
+        } else {
+            // invoke MethodInterceptorChain constructor with parameters
+            invocation = METHOD_INTERCEPTOR_CHAIN_TYPE.instantiate(
+                CONSTRUCTOR_METHOD_INTERCEPTOR_CHAIN,
+
+                // 1st argument: interceptors
+                interceptors,
+                // 2nd argument: this or target
+                target,
+                // 3rd argument: the executable method
+                method,
+                // 4th argument: array of the argument values
+                TypeDef.OBJECT.array().instantiate(methodParameters)
+            ).invoke(METHOD_PROCEED);
+        }
+        if (!methodElement.getReturnType().isVoid() || methodElement.isSuspend()) {
+            return invocation.returning();
+        }
+        return invocation;
+    }
+
+    /**
+     * Selects the interceptors of one method for the target of a call, see
+     * {@link TargetInterceptorRegistrations#select}.
+     *
+     * @param registry          The interceptor registry
+     * @param targetRegistration The registration of the target
+     * @param method            The executable method
+     * @param index             The index of the method in the proxy
+     * @param proxyInterceptors The interceptors the proxy selected for the method from its own registrations
+     * @return The expression
+     */
+    private static ExpressionDef selectTargetInterceptors(ExpressionDef registry,
+                                                          ExpressionDef targetRegistration,
+                                                          ExpressionDef method,
+                                                          int index,
+                                                          ExpressionDef proxyInterceptors) {
+        return ClassTypeDef.of(TargetInterceptorRegistrations.class).invokeStatic(
+            METHOD_SELECT_TARGET_INTERCEPTORS,
+            registry,
+            targetRegistration,
+            method,
+            ExpressionDef.constant(index),
+            proxyInterceptors
+        );
     }
 
     @Override
@@ -577,10 +671,12 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
         interfaces.sort(Comparator.comparing(ClassTypeDef::getName));
         interfaces.forEach(proxyBuilder::addSuperinterface);
 
+        ProxyTargetFields proxyTargetFields = isProxyTarget ? createProxyTargetFields() : null;
+
         int index = 0;
         for (MethodElement method : interceptedMethods) {
             proxyBuilder.addMethod(
-                buildMethodIntercept(method, index++, targetField, interceptorsField, proxyMethodsField)
+                buildMethodIntercept(method, index++, targetField, interceptorsField, proxyMethodsField, proxyTargetFields)
             );
         }
         if (!interceptedMethods.isEmpty()) {
@@ -604,7 +700,7 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
 
         proxyBuilder.addSuperinterface(TypeDef.of(isIntroduction ? Introduced.class : Intercepted.class));
 
-        addConstructor(proxyBuilder, classTargetType, targetField, interceptorsField, interceptorRegistrationsField, proxyMethodsField, interceptedMethods);
+        addConstructor(proxyBuilder, classTargetType, targetField, interceptorsField, interceptorRegistrationsField, proxyMethodsField, interceptedMethods, proxyTargetFields);
 
         List<OutputObjectDef> classes = new ArrayList<>();
         classes.add(new OutputObjectDef(proxyBuilder.build(), null, originatingElements));
@@ -630,7 +726,8 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                                 FieldDef interceptorsField,
                                 FieldDef interceptorRegistrationsField,
                                 FieldDef proxyMethodsField,
-                                List<MethodElement> interceptedMethods) {
+                                List<MethodElement> interceptedMethods,
+                                @Nullable ProxyTargetFields proxyTargetFields) {
 
         List<MethodDef.MethodBodyBuilder> bodyBuilders = new ArrayList<>();
         bodyBuilders.add((aThis, methodParameters) -> aThis.field(interceptorRegistrationsField).assign(
@@ -644,9 +741,7 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
             int qualifierIndex = constructor.findParameterIndex(QUALIFIER_PARAMETER);
 
 
-            FieldDef proxyBeanDefinitionField = FieldDef.builder(FIELD_PROXY_BEAN_DEFINITION, BeanDefinition.class)
-                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .build();
+            FieldDef proxyBeanDefinitionField = proxyTargetFields.proxyBeanDefinition();
             proxyBuilder.addField(proxyBeanDefinitionField);
             bodyBuilders.add((aThis, methodParameters) -> aThis.field(proxyBeanDefinitionField).assign(
                 methodParameters.get(beanContextArgumentIndex).invoke(
@@ -658,9 +753,7 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                 )
             ));
 
-            FieldDef beanQualifierField = FieldDef.builder(FIELD_BEAN_QUALIFIER, TypeDef.of(Qualifier.class))
-                .addModifiers(Modifier.PRIVATE)
-                .build();
+            FieldDef beanQualifierField = proxyTargetFields.beanQualifier();
             proxyBuilder.addField(beanQualifierField);
             proxyBuilder.addMethod(writeWithQualifierMethod(beanQualifierField));
             bodyBuilders.add((aThis, methodParameters) ->
@@ -670,11 +763,12 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
             if (lazy) {
                 proxyBuilder.addSuperinterface(TypeDef.of(InterceptedProxy.class));
 
-                FieldDef beanResolutionContextField = FieldDef.builder(FIELD_BEAN_RESOLUTION_CONTEXT, BeanResolutionContext.class)
-                    .addModifiers(Modifier.PRIVATE)
-                    .build();
-
+                FieldDef beanResolutionContextField = proxyTargetFields.beanResolutionContext();
                 proxyBuilder.addField(beanResolutionContextField);
+
+                // Selects the interceptors of each call for the target of that call, see buildMethodIntercept
+                FieldDef interceptorRegistryField = proxyTargetFields.interceptorRegistry();
+                proxyBuilder.addField(interceptorRegistryField);
 
                 FieldDef beanLocatorField = FieldDef.builder(FIELD_BEAN_LOCATOR, BeanLocator.class)
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
@@ -683,8 +777,11 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                 proxyBuilder.addField(beanLocatorField);
 
                 if (cacheLazyTarget) {
+                    FieldDef targetRegistrationField = proxyTargetFields.targetRegistration();
+                    proxyBuilder.addField(targetRegistrationField);
                     interceptedTargetMethod = getCacheLazyTargetInterceptedTargetMethod(
                         targetField,
+                        targetRegistrationField,
                         beanResolutionContextField,
                         proxyBeanDefinitionField,
                         beanQualifierField
@@ -692,7 +789,7 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                     proxyBuilder.addMethod(
                         getHasCachedInterceptedTargetMethod(targetField)
                     );
-                    proxyBuilder.addMethod(getClearCachedInterceptedTargetMethod(targetField));
+                    proxyBuilder.addMethod(getClearCachedInterceptedTargetMethod(targetField, targetRegistrationField));
                 } else {
                     interceptedTargetMethod = getLazyInterceptedTargetMethod(
                         beanResolutionContextField,
@@ -706,6 +803,9 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                     aThis.field(beanResolutionContextField).assign(
                         methodParameters.get(beanResolutionContextArgumentIndex)
                             .invoke(COPY_BEAN_CONTEXT_FOR_LAZY_PROXY_TARGET_METHOD, aThis.field(proxyBeanDefinitionField))
+                    ),
+                    aThis.field(interceptorRegistryField).assign(
+                        methodParameters.get(constructor.findParameterIndex(INTERCEPTOR_REGISTRY_PARAMETER))
                     )
                 ));
                 if (shouldGenerateLazyProxyTargetToStringMethod(interceptedMethods)) {
@@ -751,25 +851,25 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                 // always cached. Saying so is what lets the context destroy the target when the proxy is destroyed.
                 proxyBuilder.addMethod(getHasCachedInterceptedTargetMethod(targetField));
 
-                // Non-lazy target
-                bodyBuilders.add((aThis, methodParameters) -> aThis.field(targetField).assign(
-                        methodParameters.get(beanResolutionContextArgumentIndex)
-                            .invoke(
-                                METHOD_GET_PROXY_TARGET_BEAN_WITH_BEAN_DEFINITION_AND_CONTEXT,
-                                // 1st argument: this.$proxyBeanDefinition
-                                aThis.field(proxyBeanDefinitionField),
-                                // 2nd argument: the type
-                                pushTargetArgument(targetType),
-                                // 3th argument: the qualifier
-                                methodParameters.get(qualifierIndex)
-                            ).cast(targetType)
-                    )
-                );
+                // Non-lazy target: resolved once, here, along with the interceptors of its methods, which are the
+                // target's own when the target is not a singleton
+                bodyBuilders.add((aThis, methodParameters) -> resolveProxyTargetRegistration(
+                    methodParameters.get(beanResolutionContextArgumentIndex),
+                    aThis.field(proxyBeanDefinitionField),
+                    methodParameters.get(qualifierIndex)
+                ).newLocal("targetRegistration", targetRegistration -> StatementDef.multi(
+                    aThis.field(targetField).assign(targetRegistration.invoke(METHOD_REGISTRATION_GET_BEAN).cast(targetType)),
+                    initializeProxyTargetMethodsAndInterceptors(aThis, methodParameters, proxyBeanDefinitionField, interceptorsField, proxyMethodsField, interceptedMethods, targetRegistration)
+                )));
             }
 
             proxyBuilder.addMethod(interceptedTargetMethod);
 
-            bodyBuilders.add((aThis, methodParameters) -> initializeProxyTargetMethodsAndInterceptors(aThis, methodParameters, proxyBeanDefinitionField, interceptorsField, proxyMethodsField, interceptedMethods));
+            if (lazy) {
+                // The set the proxy selects for itself: what a singleton target is intercepted by, and what a
+                // target that carries no registrations of its own falls back to
+                bodyBuilders.add((aThis, methodParameters) -> initializeProxyTargetMethodsAndInterceptors(aThis, methodParameters, proxyBeanDefinitionField, interceptorsField, proxyMethodsField, interceptedMethods, null));
+            }
         } else {
             bodyBuilders.add((aThis, methodParameters) -> initializeProxyMethodsAndInterceptors(aThis, methodParameters, interceptorsField, proxyMethodsField, interceptedMethods));
         }
@@ -842,13 +942,30 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
         ));
     }
 
+    /**
+     * Assigns the executable methods of a proxy that fronts a separate target and the interceptors of each.
+     *
+     * @param aThis                  The proxy
+     * @param parameters             The constructor parameters
+     * @param proxyBeanDefinitionField The field holding the target definition
+     * @param interceptorsField      The interceptors field
+     * @param proxyMethodsField      The methods field
+     * @param methods                The intercepted methods
+     * @param targetRegistration     The registration of the target the proxy holds for its life, whose own
+     *                               interceptors are selected when it is not a singleton, or {@code null} for a
+     *                               proxy that resolves its target on each call and selects them then
+     * @return The statement
+     */
     private StatementDef initializeProxyTargetMethodsAndInterceptors(VariableDef.This aThis,
                                                                      List<VariableDef.MethodParameter> parameters,
                                                                      FieldDef proxyBeanDefinitionField,
                                                                      FieldDef interceptorsField,
                                                                      FieldDef proxyMethodsField,
-                                                                     List<MethodElement> methods) {
+                                                                     List<MethodElement> methods,
+                                                                     @Nullable ExpressionDef targetRegistration) {
         AtomicInteger index = new AtomicInteger();
+        ExpressionDef registry = parameters.get(constructor.findParameterIndex(INTERCEPTOR_REGISTRY_PARAMETER));
+        ExpressionDef registrations = parameters.get(constructor.findParameterIndex(INTERCEPTORS_PARAMETER));
         return StatementDef.multi(
             aThis.field(proxyMethodsField).assign(
                 ClassTypeDef.of(ExecutableMethod.class).array().instantiate(
@@ -866,20 +983,80 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
             ),
             aThis.field(interceptorsField).assign(
                 ClassTypeDef.of(Interceptor.class).array(2).instantiate(
-                    methods.stream().map(methodElement ->
-                        ClassTypeDef.of(InterceptorChain.class).invokeStatic(
+                    methods.stream().<ExpressionDef>map(methodElement -> {
+                        int methodIndex = index.getAndIncrement();
+                        ExpressionDef method = aThis.field(proxyMethodsField).arrayElement(methodIndex);
+                        ExpressionDef proxyInterceptors = ClassTypeDef.of(InterceptorChain.class).invokeStatic(
                             (isIntroduction ? RESOLVE_INTRODUCTION_INTERCEPTORS_METHOD : RESOLVE_AROUND_INTERCEPTORS_METHOD),
 
                             // First argument. The interceptor registry
-                            parameters.get(constructor.findParameterIndex(INTERCEPTOR_REGISTRY_PARAMETER)),
+                            registry,
                             // Second argument i.e. proxyMethods[0]
-                            aThis.field(proxyMethodsField).arrayElement(index.getAndIncrement()),
+                            method,
                             // Third argument i.e. interceptors
-                            parameters.get(constructor.findParameterIndex(INTERCEPTORS_PARAMETER))
-                        )
-                    ).toList()
+                            registrations
+                        );
+                        if (targetRegistration == null) {
+                            return proxyInterceptors;
+                        }
+                        return selectTargetInterceptors(registry, targetRegistration, method, methodIndex, proxyInterceptors);
+                    }).toList()
                 )
             )
+        );
+    }
+
+    private ProxyTargetFields createProxyTargetFields() {
+        FieldDef proxyBeanDefinition = FieldDef.builder(FIELD_PROXY_BEAN_DEFINITION, BeanDefinition.class)
+            .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+            .build();
+        FieldDef beanQualifier = FieldDef.builder(FIELD_BEAN_QUALIFIER, TypeDef.of(Qualifier.class))
+            .addModifiers(Modifier.PRIVATE)
+            .build();
+        if (!lazy) {
+            return new ProxyTargetFields(proxyBeanDefinition, beanQualifier, null, null, null);
+        }
+        FieldDef beanResolutionContext = FieldDef.builder(FIELD_BEAN_RESOLUTION_CONTEXT, BeanResolutionContext.class)
+            .addModifiers(Modifier.PRIVATE)
+            .build();
+        FieldDef interceptorRegistry = FieldDef.builder(FIELD_INTERCEPTOR_REGISTRY, InterceptorRegistry.class)
+            .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+            .build();
+        FieldDef targetRegistration = cacheLazyTarget
+            ? FieldDef.builder(FIELD_TARGET_REGISTRATION, BeanRegistration.class).addModifiers(Modifier.PRIVATE).build()
+            : null;
+        return new ProxyTargetFields(proxyBeanDefinition, beanQualifier, beanResolutionContext, interceptorRegistry, targetRegistration);
+    }
+
+    private ExpressionDef.InvokeInstanceMethod resolveProxyTargetRegistration(VariableDef.This aThis, ProxyTargetFields fields) {
+        return resolveProxyTargetRegistration(
+            aThis.field(fields.beanResolutionContext()),
+            aThis.field(fields.proxyBeanDefinition()),
+            aThis.field(fields.beanQualifier())
+        );
+    }
+
+    /**
+     * Resolves the registration of the target, which carries the interceptors resolved for it when it is not a
+     * singleton.
+     *
+     * @param resolutionContext   The resolution context to resolve through
+     * @param proxyBeanDefinition The definition of the target
+     * @param qualifier           The qualifier
+     * @return The expression
+     */
+    private ExpressionDef.InvokeInstanceMethod resolveProxyTargetRegistration(ExpressionDef resolutionContext,
+                                                                              ExpressionDef proxyBeanDefinition,
+                                                                              ExpressionDef qualifier) {
+        return resolutionContext.invoke(
+            METHOD_GET_PROXY_TARGET_BEAN_REGISTRATION,
+
+            // 1st argument: this.$proxyBeanDefinition
+            proxyBeanDefinition,
+            // 2nd argument: the type
+            pushTargetArgument(ClassTypeDef.of(targetType.getName())),
+            // 3rd argument: the qualifier
+            qualifier
         );
     }
 
@@ -982,6 +1159,7 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
     }
 
     private MethodDef getCacheLazyTargetInterceptedTargetMethod(FieldDef targetField,
+                                                                FieldDef targetRegistrationField,
                                                                 FieldDef beanResolutionContextField,
                                                                 FieldDef proxyBeanDefinitionField,
                                                                 FieldDef beanQualifierField) {
@@ -993,7 +1171,9 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
 //                                synchronized(this) {
 //                                    var1 = this.$target;
 //                                    if (var1 == null) {
-//                                        this.$target = (B)((DefaultBeanContext)this.$beanLocator).getProxyTargetBean(this.$beanResolutionContext, this.$proxyBeanDefinition, Argument.of(B.class, $B$Definition$Intercepted$Definition.$ANNOTATION_METADATA, new Class[0]), this.$beanQualifier);
+//                                        BeanRegistration var2 = this.$beanResolutionContext.getProxyTargetBeanRegistration(this.$proxyBeanDefinition, Argument.of(B.class, $B$Definition$Intercepted$Definition.$ANNOTATION_METADATA, new Class[0]), this.$beanQualifier);
+//                                        this.$targetRegistration = var2;
+//                                        this.$target = var2.getBean();
 //                                        this.$beanResolutionContext = null;
 //                                    }
 //                                }
@@ -1008,16 +1188,15 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
                                 StatementDef.multi(
                                     targetVar.assign(targetFieldAccess),
                                     targetVar.ifNull(
-                                        StatementDef.multi(
-                                            targetFieldAccess.assign(
-                                                pushResolveLazyProxyTargetBean(
-                                                    aThis,
-                                                    beanResolutionContextField,
-                                                    proxyBeanDefinitionField,
-                                                    beanQualifierField)
-                                            ),
+                                        resolveProxyTargetRegistration(
+                                            aThis.field(beanResolutionContextField),
+                                            aThis.field(proxyBeanDefinitionField),
+                                            aThis.field(beanQualifierField)
+                                        ).newLocal("targetRegistration", targetRegistration -> StatementDef.multi(
+                                            aThis.field(targetRegistrationField).assign(targetRegistration),
+                                            targetFieldAccess.assign(targetRegistration.invoke(METHOD_REGISTRATION_GET_BEAN)),
                                             aThis.field(beanResolutionContextField).assign(ExpressionDef.nullValue())
-                                        )
+                                        ))
                                     )
                                 )
                             )
@@ -1066,12 +1245,15 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
             .build((aThis, methodParameters) -> aThis.field(targetField).isNonNull().returning());
     }
 
-    private MethodDef getClearCachedInterceptedTargetMethod(FieldDef targetField) {
+    private MethodDef getClearCachedInterceptedTargetMethod(FieldDef targetField, FieldDef targetRegistrationField) {
         Objects.requireNonNull(targetField);
         return MethodDef.builder(METHOD_CLEAR_CACHED_INTERCEPTED_METHOD.getName())
             .addModifiers(Modifier.PUBLIC)
             .addParameters(METHOD_CLEAR_CACHED_INTERCEPTED_METHOD.getParameterTypes())
-            .build((aThis, methodParameters) -> aThis.field(targetField).assign(ExpressionDef.nullValue()));
+            .build((aThis, methodParameters) -> StatementDef.multi(
+                aThis.field(targetField).assign(ExpressionDef.nullValue()),
+                aThis.field(targetRegistrationField).assign(ExpressionDef.nullValue())
+            ));
     }
 
     /**
@@ -1107,5 +1289,23 @@ public class AopProxyWriter extends ProxyingBeanDefinitionWriter {
         public int hashCode() {
             return Objects.hash(name, rawTypes, returnType);
         }
+    }
+
+    /**
+     * The fields of a proxy that fronts a separate target. They are created ahead of the intercepted methods and
+     * the constructor, which both refer to them.
+     *
+     * @param proxyBeanDefinition   The definition of the target
+     * @param beanQualifier         The qualifier of the target
+     * @param beanResolutionContext The context a lazy proxy resolves its target through, or {@code null}
+     * @param interceptorRegistry   The registry a lazy proxy selects the interceptors of each call with, or
+     *                              {@code null}
+     * @param targetRegistration    The registration a lazy proxy that caches its target keeps, or {@code null}
+     */
+    private record ProxyTargetFields(FieldDef proxyBeanDefinition,
+                                     FieldDef beanQualifier,
+                                     @Nullable FieldDef beanResolutionContext,
+                                     @Nullable FieldDef interceptorRegistry,
+                                     @Nullable FieldDef targetRegistration) {
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -581,7 +581,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     private static final Method METHOD_QUALIFIER_BY_TYPE = ReflectionUtils.getRequiredMethod(Qualifiers.class, "byType", Class[].class);
 
-    private static final Method METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY = ReflectionUtils.getRequiredMethod(BeanResolutionContext.class, "markDependentAsFactory");
+    private static final Method METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY = ReflectionUtils.getRequiredMethod(BeanResolutionContext.class, "markDependentAsFactory", Object.class);
 
     private static final Method METHOD_PROXY_TARGET_TYPE = ReflectionUtils.getRequiredInternalMethod(ProxyBeanDefinition.class, "getTargetDefinitionType");
 
@@ -1584,7 +1584,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
     private void addInstantiateMethod() {
         boolean isParametrized = isParametrized();
 
-        if (isConstructorIntercepted(elementProducerDefinition.annotationMetadata())) {
+        if (isConstructorIntercepted(elementProducerDefinition.annotationMetadata()) || resolvesInterceptorsForProxiedTarget()) {
             Method resolveValuesMethod;
             Method defaultInstantiateMethod;
             ClassTypeDef interceptedInterface;
@@ -2224,7 +2224,9 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
                 getQualifier(factoryClass, argumentExpression)
             ).cast(factoryTypeDef).newLocal("factoryBean");
         additionalStatements.add(defineAndAssign);
-        additionalStatements.add(beanResolutionContxt.invoke(METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY));
+        // by instance: the interceptors of an advised bean are resolved before the factory is looked up, so the
+        // factory need not be the first dependent
+        additionalStatements.add(beanResolutionContxt.invoke(METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY, defineAndAssign.variable()));
         return defineAndAssign.variable();
     }
 
@@ -2961,6 +2963,39 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
      */
     public boolean hasInterceptedLifecycle() {
         return isPostConstructIntercepted() || isPreDestroyIntercepted();
+    }
+
+    /**
+     * Whether this definition resolves the interceptors bound to the bean while creating it although nothing
+     * intercepts the bean's constructor: the bean is the target of a proxy and is not a singleton.
+     *
+     * <p>Such a proxy fronts a different target from one call to the next, one per thread, request or refresh,
+     * and takes the interceptors of each call from the target of that call rather than from a set it resolved
+     * once, see {@code io.micronaut.aop.beandefinition.TargetInterceptorRegistrations}. Resolving them with the
+     * target, as a bean with constructor advice does, makes them one set per target that is created with it,
+     * shared by its lifecycle phases and its methods, and destroyed with it. The set is resolved by the same
+     * {@code InterceptedBeanDefinition} that handles constructor advice, through a constructor interceptor chain
+     * that selects nothing for a constructor without advice.</p>
+     *
+     * <p>A singleton target is left as it is: proxy and target are one to one, and the proxy's own set serves the
+     * target's methods as it always has. So is a {@code @Nullable} bean, which a factory may produce as
+     * {@code null}: a constructor interceptor chain does not allow that, and the customizer that stands in for the
+     * null target has no registration of its own to carry a set.</p>
+     *
+     * @return {@code true} if this definition resolves its interceptors for the proxy that fronts it
+     * @since 5.2.2
+     */
+    private boolean resolvesInterceptorsForProxiedTarget() {
+        boolean proxiedTarget = isProxyTarget
+            || (proxiedBean && (isSuperFactory || elementProducerDefinition instanceof MethodDefinition<?, ?>));
+        if (!proxiedTarget
+            || StringUtils.isNotEmpty(interceptedType)
+            || beanTypeElement.isAssignable("io.micronaut.aop.Interceptor")
+            || annotationMetadata.hasStereotype(AnnotationUtil.NULLABLE)) {
+            return false;
+        }
+        String scope = annotationMetadata.getAnnotationNameByStereotype(AnnotationUtil.SCOPE).orElse(null);
+        return !isSingleton(scope) && annotationMetadata.getAnnotation(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS) != null;
     }
 
     private static MethodDefinition<ClassElement, MethodElement> createMethodDefinition(ClassElement beanType,

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/ScopedProxyInterceptorLifecycleSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/ScopedProxyInterceptorLifecycleSpec.groovy
@@ -1,0 +1,414 @@
+package io.micronaut.aop.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent
+import io.micronaut.runtime.context.scope.refresh.RefreshScope
+
+import java.util.concurrent.CountDownLatch
+
+/**
+ * A proxy whose target is not a singleton fronts more than one target over its life: a {@code @ThreadLocal} bean
+ * has one target per thread, a {@code @Refreshable} bean a new one after each refresh, a {@code @RequestScope}
+ * bean one per request. A non-singleton interceptor bound to such a bean is one instance per target, resolved
+ * while the target is created, and it is that instance which intercepts the target's methods through the proxy,
+ * so that what it saw in {@code POST_CONSTRUCT} is what it sees in {@code AROUND} and releases in
+ * {@code PRE_DESTROY}. The proxy's own interceptors are not shared by the targets it fronts.
+ */
+class ScopedProxyInterceptorLifecycleSpec extends AbstractTypeElementSpec {
+
+    private static final String PROBED = '''
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@InterceptorBinding(kind = InterceptorKind.AROUND)
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Probed {
+}
+
+class Events {
+    static final List<String> LOG = Collections.synchronizedList(new ArrayList<>());
+    // target -> kind -> the interceptor instance that intercepted that kind of that target
+    static final Map<Object, Map<String, Object>> SEEN = Collections.synchronizedMap(new IdentityHashMap<>());
+    static final AtomicInteger INTERCEPTORS = new AtomicInteger();
+    static final AtomicInteger TARGETS = new AtomicInteger();
+
+    static void seen(Object target, String kind, Object interceptor) {
+        SEEN.computeIfAbsent(target, t -> Collections.synchronizedMap(new LinkedHashMap<>())).put(kind, interceptor);
+    }
+}
+
+@Prototype
+@InterceptorBinding(value = Probed.class, kind = InterceptorKind.AROUND)
+@InterceptorBinding(value = Probed.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Probed.class, kind = InterceptorKind.PRE_DESTROY)
+class ProbingInterceptor implements MethodInterceptor<Object, Object> {
+    public final int id = Events.INTERCEPTORS.incrementAndGet();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        MyBean target = (MyBean) context.getTarget();
+        Events.seen(target, context.getKind().name(), this);
+        Events.LOG.add(id + ":" + context.getKind() + ":" + target.name);
+        return context.proceed();
+    }
+
+    @PreDestroy
+    void destroy() {
+        Events.LOG.add(id + ":DESTROYED");
+    }
+}
+'''
+
+    /**
+     * The interceptor instance that intercepted each kind, by the name of the target it intercepted.
+     */
+    private static Map<String, Map<String, Object>> byTargetName(Map<Object, Map<String, Object>> seen) {
+        seen.collectEntries { target, byKind -> [(target.name): byKind] }
+    }
+
+    /**
+     * The position of an entry in the log, or -1. Takes a String so that a GString argument is converted, which
+     * List#indexOf would not do.
+     */
+    private static int at(List<String> log, String entry) {
+        log.indexOf(entry)
+    }
+
+    /**
+     * For each target, the positions in the log of: the pre destroy interception by the instance that intercepted
+     * its methods, the target's own pre destroy callback, and the destruction of that instance.
+     */
+    private static List<List<Integer>> destruction(List<String> log, Map<String, Map<String, Object>> seen, List<String> targets) {
+        targets.collect { String target ->
+            int id = seen[target]['AROUND'].id
+            [at(log, "$id:PRE_DESTROY:$target"), at(log, "$target:CLOSED"), at(log, "$id:DESTROYED")]
+        }
+    }
+
+    private static boolean inOrder(List<Integer> positions) {
+        positions[0] != -1 && positions[0] < positions[1] && positions[1] < positions[2]
+    }
+
+    private static String source(String scope) {
+        """
+package scoped;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.lang.annotation.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+$PROBED
+
+$scope
+@Probed
+class MyBean {
+    final String name = "target" + Events.TARGETS.incrementAndGet();
+
+    @PostConstruct void init() {}
+
+    String work() { return name; }
+
+    @PreDestroy void close() {
+        Events.LOG.add(name + ":CLOSED");
+    }
+}
+"""
+    }
+
+    void 'test a thread local scoped proxy applies the interceptor resolved for the target of the current thread'() {
+        given:
+        ApplicationContext context = buildContext(
+                'scoped.MyBean',
+                source('@io.micronaut.runtime.context.scope.ThreadLocal(lifecycle = true)'),
+                true
+        )
+        def events = context.classLoader.loadClass('scoped.Events')
+        def proxy = context.getBean(context.classLoader.loadClass('scoped.MyBean'))
+
+        when: 'the bean is called twice on this thread and once on another, which stays alive until the context stops'
+        def onThisThread = proxy.work()
+        proxy.work()
+        def onOtherThread = null
+        def release = new CountDownLatch(1)
+        def other = new Thread({
+            onOtherThread = proxy.work()
+            release.await()
+        })
+        other.start()
+        while (onOtherThread == null) {
+            Thread.sleep(10)
+        }
+        Map<String, Map<String, Object>> seen = byTargetName(events.SEEN)
+
+        then: 'each thread had its own target'
+        onThisThread != onOtherThread
+        seen.size() == 2
+
+        and: 'for each target, post construct and every method call used the instance resolved for that target'
+        seen.values().every { it['POST_CONSTRUCT'].is(it['AROUND']) }
+
+        and: 'the two targets did not share an instance'
+        !seen.values()[0]['AROUND'].is(seen.values()[1]['AROUND'])
+
+        when: 'the context stops, which destroys the target of each thread'
+        context.stop()
+        release.countDown()
+        other.join()
+        List<String> log = events.LOG
+
+        then: 'pre destroy used the instance of the target being destroyed'
+        seen.values().every { it['PRE_DESTROY'].is(it['AROUND']) }
+
+        and: 'each instance was destroyed as a dependent of its target, after the target\'s own pre destroy'
+        destruction(log, seen, [onThisThread, onOtherThread]).every { inOrder(it) }
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a refreshable proxy applies the interceptor of the current target and destroys it with the target'() {
+        given:
+        ApplicationContext context = buildContext(
+                'scoped.MyBean',
+                source('@io.micronaut.runtime.context.scope.Refreshable'),
+                true
+        )
+        def events = context.classLoader.loadClass('scoped.Events')
+        def proxy = context.getBean(context.classLoader.loadClass('scoped.MyBean'))
+
+        when:
+        def first = proxy.work()
+        proxy.work()
+        context.getBean(RefreshScope).onRefreshEvent(new RefreshEvent())
+        def second = proxy.work()
+        Map<String, Map<String, Object>> seen = byTargetName(events.SEEN)
+        List<String> log = events.LOG
+
+        then: 'the refresh replaced the target'
+        first != second
+        seen.size() == 2
+
+        and: 'the first target was intercepted by one instance in every phase, and that instance died with it'
+        def firstTarget = seen[first]
+        firstTarget['POST_CONSTRUCT'].is(firstTarget['AROUND'])
+        firstTarget['PRE_DESTROY'].is(firstTarget['AROUND'])
+        at(log, "${firstTarget['AROUND'].id}:PRE_DESTROY:$first") != -1
+        at(log, "${firstTarget['AROUND'].id}:PRE_DESTROY:$first") < at(log, "$first:CLOSED")
+        at(log, "$first:CLOSED") < at(log, "${firstTarget['AROUND'].id}:DESTROYED")
+
+        and: 'the second target has an instance of its own'
+        def secondTarget = seen[second]
+        secondTarget['POST_CONSTRUCT'].is(secondTarget['AROUND'])
+        !secondTarget['AROUND'].is(firstTarget['AROUND'])
+        at(log, "${secondTarget['AROUND'].id}:DESTROYED") == -1
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a prototype proxy target is intercepted by the instance resolved for it'() {
+        given:
+        ApplicationContext context = buildContext('scoped.MyBean', '''
+package scoped;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+''' + PROBED + '''
+
+@Prototype
+@Around(proxyTarget = true)
+@Probed
+class MyBean {
+    final String name = "target" + Events.TARGETS.incrementAndGet();
+
+    @PostConstruct void init() {}
+
+    String work() { return name; }
+
+    @PreDestroy void close() {
+        Events.LOG.add(name + ":CLOSED");
+    }
+}
+
+@Singleton
+class Holder {
+    @Inject MyBean first;
+    @Inject MyBean second;
+}
+''', true)
+        def events = context.classLoader.loadClass('scoped.Events')
+        def holder = context.getBean(context.classLoader.loadClass('scoped.Holder'))
+
+        when:
+        def first = holder.first.work()
+        def second = holder.second.work()
+        Map<String, Map<String, Object>> seen = byTargetName(events.SEEN)
+
+        then: 'each proxy fronts its own target, intercepted in every phase by the instance resolved for that target'
+        first != second
+        seen.size() == 2
+        seen.values().every { it['POST_CONSTRUCT'].is(it['AROUND']) }
+        !seen.values()[0]['AROUND'].is(seen.values()[1]['AROUND'])
+
+        when:
+        context.stop()
+        List<String> log = events.LOG
+
+        then: 'each instance handled pre destroy of its target and was then destroyed with it'
+        seen.values().every { it['PRE_DESTROY'].is(it['AROUND']) }
+        destruction(log, seen, [first, second]).every { inOrder(it) }
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test a factory produced prototype proxy target is intercepted by the instance resolved for it'() {
+        given:
+        ApplicationContext context = buildContext('scoped.MyBean', '''
+package scoped;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+''' + PROBED + '''
+
+class MyBean {
+    final String name = "target" + Events.TARGETS.incrementAndGet();
+
+    // a factory produced bean is advised on its public methods only
+    public String work() { return name; }
+
+    // and its pre destroy callback is the one the factory names
+    void close() {
+        Events.LOG.add(name + ":CLOSED");
+    }
+}
+
+@Factory
+class MyBeanFactory {
+    @Prototype
+    @Bean(preDestroy = "close")
+    @Around(proxyTarget = true)
+    @Probed
+    MyBean myBean() {
+        return new MyBean();
+    }
+}
+
+@Singleton
+class Holder {
+    @Inject MyBean first;
+    @Inject MyBean second;
+}
+''', true)
+        def events = context.classLoader.loadClass('scoped.Events')
+        def holder = context.getBean(context.classLoader.loadClass('scoped.Holder'))
+
+        when:
+        def first = holder.first.work()
+        def second = holder.second.work()
+        Map<String, Map<String, Object>> seen = byTargetName(events.SEEN)
+
+        then: 'each proxy fronts its own target, intercepted in every phase by the instance resolved for that target'
+        first != second
+        seen.size() == 2
+        seen.values().every { it['POST_CONSTRUCT'].is(it['AROUND']) }
+        !seen.values()[0]['AROUND'].is(seen.values()[1]['AROUND'])
+
+        when:
+        context.stop()
+        List<String> log = events.LOG
+
+        then: 'each instance handled pre destroy of its target and was then destroyed with it'
+        seen.values().every { it['PRE_DESTROY'].is(it['AROUND']) }
+        destruction(log, seen, [first, second]).every { inOrder(it) }
+
+        cleanup:
+        context.close()
+    }
+
+    // The target of a lazy proxy that caches it is resolved on the first call rather than by the constructor, and
+    // kept from then on. Its destruction goes through a registration the context builds for it when the proxy is
+    // destroyed, see LazyProxyTargetDependentBeansSpec, so only the phases up to the method calls are pinned here.
+    void 'test a cached lazy proxy target is intercepted by the instance resolved for it'() {
+        given:
+        ApplicationContext context = buildContext('scoped.MyBean', '''
+package scoped;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+''' + PROBED + '''
+
+@Prototype
+@Around(proxyTarget = true, lazy = true, cacheableLazyTarget = true)
+@Probed
+class MyBean {
+    final String name = "target" + Events.TARGETS.incrementAndGet();
+
+    @PostConstruct void init() {}
+
+    String work() { return name; }
+
+    @PreDestroy void close() {
+        Events.LOG.add(name + ":CLOSED");
+    }
+}
+
+@Singleton
+class Holder {
+    @Inject MyBean first;
+    @Inject MyBean second;
+}
+''', true)
+        def events = context.classLoader.loadClass('scoped.Events')
+        def holder = context.getBean(context.classLoader.loadClass('scoped.Holder'))
+
+        when:
+        def first = holder.first.work()
+        holder.first.work()
+        def second = holder.second.work()
+        Map<String, Map<String, Object>> seen = byTargetName(events.SEEN)
+        List<String> log = events.LOG
+
+        then: 'each proxy resolved one target on its first call and keeps it'
+        first != second
+        holder.first.work() == first
+        seen.size() == 2
+
+        and: 'every call on a target is intercepted by the instance that ran its post construct'
+        seen.values().every { it['POST_CONSTRUCT'].is(it['AROUND']) }
+        !seen.values()[0]['AROUND'].is(seen.values()[1]['AROUND'])
+        log.count { it.endsWith(":AROUND:$first") } == 3
+        log.findAll { it.endsWith(":AROUND:$first") }.toSet().size() == 1
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -497,6 +497,21 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     }
 
     @Override
+    public void markDependentAsFactory(Object factoryBean) {
+        if (dependentBeans == null) {
+            return;
+        }
+        // the factory was looked up last, so search from the end
+        for (int i = dependentBeans.size() - 1; i >= 0; i--) {
+            BeanRegistration<?> dependent = dependentBeans.get(i);
+            if (dependent.getBean() == factoryBean) {
+                dependentFactory = dependentBeans.remove(i);
+                return;
+            }
+        }
+    }
+
+    @Override
     @Nullable
     public BeanRegistration<?> getAndResetDependentFactoryBean() {
         BeanRegistration<?> result = this.dependentFactory;
@@ -638,6 +653,11 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     @Override
     public <T> T getProxyTargetBean(BeanDefinition<T> definition, Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         return context.getProxyTargetBean(this, definition, beanType, qualifier);
+    }
+
+    @Override
+    public <T> BeanRegistration<T> getProxyTargetBeanRegistration(BeanDefinition<T> definition, Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return context.getProxyTargetBeanRegistration(this, definition, beanType, qualifier);
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
@@ -83,11 +83,9 @@ final class BeanDisposingRegistration<BT> extends BeanRegistration<BT> implement
         return dependents == null ? List.of() : List.copyOf(dependents);
     }
 
-    /**
-     * @return The interceptor registrations selected while this bean was created, or {@code null}
-     */
+    @Override
     @Nullable
-    List<?> getInterceptorRegistrations() {
+    public List<?> getInterceptorRegistrations() {
         return interceptorRegistrations;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/BeanRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanRegistration.java
@@ -16,6 +16,7 @@
 package io.micronaut.context;
 
 import io.micronaut.context.scope.CreatedBean;
+import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
@@ -148,6 +149,24 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
      */
     public T getBean() {
         return bean;
+    }
+
+    /**
+     * The interceptor registrations resolved while this bean was created, when the context tracked them.
+     *
+     * <p>A bean with interceptor bindings resolves the interceptors bound to it once, while it is created, and the
+     * registration created alongside it keeps them so that later phases of the bean's life reach the same instances:
+     * its pre-destroy interception, and the methods of a proxy that fronts it when the bean is not a singleton. The
+     * elements are registrations of interceptors, typed loosely here because this module does not know the
+     * interceptor type.</p>
+     *
+     * @return The interceptor registrations, or {@code null} when none were tracked
+     * @since 5.2.2
+     */
+    @Internal
+    @Nullable
+    public List<?> getInterceptorRegistrations() {
+        return null;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -308,10 +308,30 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      * Marks first dependent as factory.
      * Dependent can be missing which means it's a singleton or scoped bean.
      *
+     * <p>Superseded by {@link #markDependentAsFactory(Object)}, which generated code calls now; kept for bean
+     * definitions compiled by earlier versions.</p>
+     *
      * @since 3.5.0
      */
     @UsedByGeneratedCode
     default void markDependentAsFactory() {
+    }
+
+    /**
+     * Marks the dependent registration of the given factory bean as the factory that produces the bean being
+     * created, so that a factory which is itself a dependent, a prototype for instance, is destroyed once it has
+     * produced the bean. A singleton or scoped factory has no dependent registration, and nothing is marked.
+     *
+     * <p>Unlike {@link #markDependentAsFactory()}, which marks whichever dependent was resolved first, this finds
+     * the registration by the factory instance, so that dependents resolved before the factory was looked up, such
+     * as the interceptors of a bean whose creation is advised, are left alone.</p>
+     *
+     * @param factoryBean The factory bean that was just looked up
+     * @since 5.2.2
+     */
+    @UsedByGeneratedCode
+    default void markDependentAsFactory(Object factoryBean) {
+        markDependentAsFactory();
     }
 
     /**
@@ -363,6 +383,34 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
     <T> T getProxyTargetBean(BeanDefinition<T> definition,
                              Argument<T> beanType,
                              @Nullable Qualifier<T> qualifier);
+
+    /**
+     * Resolves the registration of the proxy target for a given proxy bean definition.
+     *
+     * <p>Where {@link #getProxyTargetBean(BeanDefinition, Argument, Qualifier)} returns the target alone, this
+     * returns the registration the context holds for it, which for a target that is not a singleton carries the
+     * interceptors resolved while the target was created. A generated proxy fronting such a target resolves the
+     * target of each intercepted call this way, so that the target's own interceptors apply to the call rather
+     * than a set the proxy resolved once for every target it will ever front.</p>
+     *
+     * @param definition The proxy target bean definition
+     * @param beanType   The bean type
+     * @param qualifier  The qualifier
+     * @param <T>        The generic type
+     * @return The registration of the proxy target
+     * @since 5.2.2
+     */
+    @UsedByGeneratedCode
+    default <T> BeanRegistration<T> getProxyTargetBeanRegistration(BeanDefinition<T> definition,
+                                                                  Argument<T> beanType,
+                                                                  @Nullable Qualifier<T> qualifier) {
+        return BeanRegistration.of(
+            getContext(),
+            new DefaultBeanContext.BeanKey<>(beanType, qualifier),
+            definition,
+            getProxyTargetBean(definition, beanType, qualifier)
+        );
+    }
 
     /**
      * Represents a path taken to resolve a bean definitions dependencies.

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -246,6 +246,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
     private final CustomScopeRegistry customScopeRegistry;
     private final BeanResolutionCustomizer beanResolutionCustomizer;
+    private final ScopedBeanRegistrations scopedBeanRegistrations = new ScopedBeanRegistrations();
 
     private @Nullable BeanDefinitionValidator beanValidator;
     private @Nullable List<BeanConfiguration> beanConfigurationsList;
@@ -1272,6 +1273,7 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 return;
             }
         }
+        scopedBeanRegistrations.remove(registration);
         T beanToDestroy = registration.getBean();
         BeanDefinition<T> definition = registration.getBeanDefinition();
         if (beanToDestroy != null) {
@@ -1657,6 +1659,46 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             registration = resolveNullBeanRegistration(beanType, beanType, registration);
         }
         return registration.bean;
+    }
+
+    /**
+     * Resolves the registration of the proxy target for a given proxy bean definition.
+     *
+     * <p>Where {@link #getProxyTargetBean(BeanResolutionContext, BeanDefinition, Argument, Qualifier)} returns the
+     * target alone, this returns the registration the context holds for it, which for a target that is not a
+     * singleton carries the interceptors resolved while the target was created. A generated proxy fronting such a
+     * target resolves the target of each intercepted call this way and applies the target's own interceptors; see
+     * {@code io.micronaut.aop.beandefinition.TargetInterceptorRegistrations}.</p>
+     *
+     * <p>A custom scope hands back only the bean it holds, so the registration behind it is looked up by the bean's
+     * identity in the index kept since the bean was created. A bean the index does not know, because the scope
+     * obtained it some other way than through this context, comes back in a registration of its own that carries
+     * nothing, and the proxy then falls back to its own interceptors.</p>
+     *
+     * @param resolutionContext The bean resolution context
+     * @param definition        The proxy target bean definition
+     * @param beanType          The bean type
+     * @param qualifier         The bean qualifier
+     * @param <T>               The generic type
+     * @return The registration of the proxy target
+     * @since 5.2.2
+     */
+    @Internal
+    @UsedByGeneratedCode
+    public <T> BeanRegistration<T> getProxyTargetBeanRegistration(@Nullable BeanResolutionContext resolutionContext,
+                                                                 BeanDefinition<T> definition,
+                                                                 Argument<T> beanType,
+                                                                 @Nullable Qualifier<T> qualifier) {
+        BeanRegistration<T> registration = Objects.requireNonNull(resolveBeanRegistration(resolutionContext, definition, beanType, qualifier));
+        if (registration.bean == null) {
+            return resolveNullBeanRegistration(beanType, beanType, registration);
+        }
+        if (registration.beanDefinition.isSingleton()) {
+            // the singleton scope hands out the registration it holds
+            return registration;
+        }
+        BeanRegistration<T> held = scopedBeanRegistrations.find(registration.bean);
+        return held != null ? held : registration;
     }
 
     @Override
@@ -3356,7 +3398,10 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
 
                 @Override
                 public CreatedBean<T> create() throws BeanCreationException {
-                    return createRegistration(resolutionContext == null ? null : resolutionContext.copy(), beanKey.beanType, qualifier, definition, true);
+                    BeanRegistration<T> created = createRegistration(resolutionContext == null ? null : resolutionContext.copy(), beanKey.beanType, qualifier, definition, true);
+                    // the scope will hand back only the bean; keep the way from the bean back to its registration
+                    scopedBeanRegistrations.add(created);
+                    return created;
                 }
             }
         );

--- a/inject/src/main/java/io/micronaut/context/ScopedBeanRegistrations.java
+++ b/inject/src/main/java/io/micronaut/context/ScopedBeanRegistrations.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The registrations the context created for the beans a custom scope holds, indexed by bean instance.
+ *
+ * <p>A custom scope keeps the registration created for a bean but hands back only the bean, so once a scoped bean
+ * exists nothing outside the scope can reach its registration again short of scanning the scope. A proxy that
+ * fronts a bean of a custom scope resolves the target of every call through the scope and needs that registration,
+ * because it carries the interceptors resolved for the target while the target was created; see
+ * {@link DefaultBeanContext#getProxyTargetBeanRegistration}. This index answers by identity what the scope cannot:
+ * the registration behind a bean instance.</p>
+ *
+ * <p>An entry is added when the context creates a bean for a scope and removed when that registration is destroyed,
+ * and both sides of it are weak. A scope may drop a bean without destroying it, as the thread-local scope does with
+ * the beans of a thread that has ended, and the index must not keep such a bean alive. The registration references
+ * the bean, so holding it strongly would hold the bean too; it is held weakly and stays reachable through the scope
+ * for exactly as long as the scope holds it. Keys compare by identity, since a bean may define equality however it
+ * likes.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.2.2
+ */
+@Internal
+final class ScopedBeanRegistrations {
+
+    private final Map<Key, WeakReference<BeanRegistration<?>>> registrations = new ConcurrentHashMap<>();
+    private final ReferenceQueue<Object> stale = new ReferenceQueue<>();
+
+    /**
+     * Indexes the registration of a bean just created for a scope.
+     *
+     * @param registration The registration
+     */
+    void add(BeanRegistration<?> registration) {
+        Object bean = registration.bean;
+        if (bean == null) {
+            return;
+        }
+        expunge();
+        registrations.put(new WeakKey(bean, stale), new WeakReference<>(registration));
+    }
+
+    /**
+     * Finds the registration created for a bean.
+     *
+     * @param bean The bean
+     * @param <T>  The bean type
+     * @return The registration, or {@code null} when the context did not create the bean for a scope, or the scope
+     * no longer holds the registration
+     */
+    @SuppressWarnings("unchecked")
+    @Nullable
+    <T> BeanRegistration<T> find(T bean) {
+        if (registrations.isEmpty()) {
+            return null;
+        }
+        WeakReference<BeanRegistration<?>> reference = registrations.get(new LookupKey(bean));
+        return reference == null ? null : (BeanRegistration<T>) reference.get();
+    }
+
+    /**
+     * Removes the entry of a registration being destroyed.
+     *
+     * <p>Only the entry of that very registration is removed: the context also builds registrations of its own
+     * around a scoped bean, and destroying one of those must not drop the entry of the registration the scope
+     * still holds.</p>
+     *
+     * @param registration The registration being destroyed
+     */
+    void remove(BeanRegistration<?> registration) {
+        if (registrations.isEmpty()) {
+            return;
+        }
+        Object bean = registration.bean;
+        if (bean != null) {
+            LookupKey key = new LookupKey(bean);
+            WeakReference<BeanRegistration<?>> reference = registrations.get(key);
+            if (reference != null && reference.get() == registration) {
+                registrations.remove(key, reference);
+            }
+        }
+        expunge();
+    }
+
+    private void expunge() {
+        Reference<?> key;
+        while ((key = stale.poll()) != null) {
+            registrations.remove((Key) key);
+        }
+    }
+
+    /**
+     * A key that compares by the identity of the bean it refers to. The stored form is weak; the lookup form is
+     * strong and lives only for the duration of one lookup.
+     */
+    private interface Key {
+        @Nullable Object bean();
+    }
+
+    private static boolean sameBean(Key key, @Nullable Object other) {
+        if (key == other) {
+            return true;
+        }
+        if (!(other instanceof Key otherKey)) {
+            return false;
+        }
+        Object bean = key.bean();
+        return bean != null && bean == otherKey.bean();
+    }
+
+    private static final class WeakKey extends WeakReference<Object> implements Key {
+        private final int hash;
+
+        WeakKey(Object bean, ReferenceQueue<Object> queue) {
+            super(bean, queue);
+            this.hash = System.identityHashCode(bean);
+        }
+
+        @Override
+        public @Nullable Object bean() {
+            return get();
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return sameBean(this, other);
+        }
+    }
+
+    private static final class LookupKey implements Key {
+        private final Object bean;
+
+        LookupKey(Object bean) {
+            this.bean = bean;
+        }
+
+        @Override
+        public Object bean() {
+            return bean;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(bean);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return sameBean(this, other);
+        }
+    }
+}

--- a/src/main/docs/guide/aop/interceptorLifecycle.adoc
+++ b/src/main/docs/guide/aop/interceptorLifecycle.adoc
@@ -92,7 +92,7 @@ The same instance serves every step. A singleton interceptor follows the same se
 every other intercepted bean, and it is destroyed with the context rather than with any one target.
 
 Where the interceptors are held depends on the shape of the intercepted bean, which is an implementation detail but
-explains the one case that behaves differently:
+explains the two cases that behave differently:
 
 |===
 |Target |Held by |Phases sharing one instance
@@ -101,16 +101,20 @@ explains the one case that behaves differently:
 |The generated proxy
 |construct, methods, post-construct, pre-destroy
 
-|`@Around(proxyTarget = true)`
-|The generated proxy
+|`@Around(proxyTarget = true)` on a bean that is not a singleton, which includes every scoped proxy
+|The target, one set per target
 |construct, methods, post-construct, pre-destroy
+
+|`@Around(proxyTarget = true)` on a singleton
+|The generated proxy holds the interceptors of the methods; the target holds those of its life cycle
+|construct, post-construct and pre-destroy share one instance; the methods use another
 
 |ann:aop.Introduction[] advice
 |The generated proxy
 |methods, post-construct, pre-destroy
 
 |Bean produced by a ann:context.annotation.Factory[] method
-|The generated proxy
+|The target when it is not a singleton, otherwise the generated proxy
 |methods, post-construct, pre-destroy
 
 |ann:aop.AroundConstruct[] advice with no ann:aop.Around[]
@@ -126,6 +130,26 @@ NOTE: In the last row the context has no registration for the instance, so nothi
 it was created with, and `PRE_DESTROY` resolves a new interceptor. A proxied bean created and destroyed the same way
 is unaffected: the proxy retained its registrations and `destroyBean(Object)` destroys the non-singleton ones with the
 target. Prototypes injected into other beans, and prototypes destroyed through their `BeanRegistration`, are unaffected.
+
+=== Scoped Proxies
+
+A bean whose scope is a ann:runtime.context.scope.ScopedProxy[], such as ann:runtime.http.scope.RequestScope[],
+ann:runtime.context.scope.ThreadLocal[] or ann:runtime.context.scope.Refreshable[], is injected as a proxy that fronts
+a different target from one call to the next: one per request, one per thread, or a new one after each refresh. The
+interceptors bound to such a bean belong to the target, not to the proxy. Each target resolves its own set when it is
+created, and the proxy takes the interceptors of every call from the target of that call, so a non-singleton
+interceptor is one instance per target: the instance that intercepted the target's `@PostConstruct` intercepts its
+methods, intercepts its `@PreDestroy`, and is destroyed with the target. Two requests, or two threads, never share an
+instance. The same holds for any `@Around(proxyTarget = true)` bean that is not a singleton, such as a
+ann:context.annotation.Prototype[].
+
+The proxy resolves a set for itself as well, since it is an intercepted bean in its own right. That set intercepts the
+target only when the target carries none of its own, which is the case for a singleton target and for a `@Nullable`
+bean produced by a factory, and a non-singleton interceptor in it is destroyed with the proxy.
+
+For a singleton behind `@Around(proxyTarget = true)`, proxy and target are one to one and the proxy's own set
+intercepts the methods, while the target's set serves its life cycle. A non-singleton interceptor bound to both is
+therefore two instances for such a bean: one for the methods and one for `@PostConstruct` and `@PreDestroy`.
 
 == Ordering
 
@@ -157,6 +181,8 @@ bound to that kind. Binding to one kind does not imply the others, so an interce
 never runs for `AROUND`, and an interceptor bound only to `AROUND` never runs for a lifecycle phase. Interceptors bound
 by a different annotation are never applied to the bean.
 
-TIP: Reuse of one interceptor instance across the phases of a proxied bean is part of the generated proxy. After
-upgrading, recompile intercepted classes so that beans compiled by an earlier version pick it up; until then they
-behave as they did before, resolving an interceptor per interception point.
+TIP: Reuse of one interceptor instance across the phases of a proxied bean is part of the generated proxy, and so is
+the selection of a scoped proxy's interceptors per target. After upgrading, recompile intercepted classes so that beans
+compiled by an earlier version pick it up; until then they behave as they did before, resolving an interceptor per
+interception point, and a scoped proxy compiled before 5.2.2 intercepts every target with the set it resolved for
+itself.


### PR DESCRIPTION
## What

A non-singleton interceptor behind a scoped proxy (`@Around(proxyTarget = true)` with a target that is not a singleton: `@RequestScope`, `@ThreadLocal`, `@Refreshable`, or a `@Prototype`) is now one instance per target, as `interceptorLifecycle.adoc` documents. The instance that intercepts a target's `POST_CONSTRUCT` intercepts its methods through the proxy, intercepts its `PRE_DESTROY`, and is destroyed as a dependent of that target. Singleton targets and singleton interceptors behave as before.

## Why

Reproduced with plain Micronaut: a `@Prototype` `MethodInterceptor` bound to `@Probed` for `AROUND` and `POST_CONSTRUCT`, and a `@ThreadLocal @Probed` bean called twice on one thread and once on another. Two violations of the documented contract:

1. For one target, the `POST_CONSTRUCT` instance was not the `AROUND` instance. The target definition resolved a fresh set each time a target was created, while the proxy intercepted methods with the set it resolved once in its constructor.
2. Across targets, `AROUND` was the same instance: every target behind the one proxy shared the proxy's method interceptors, which were destroyed with the proxy rather than with each target.

The motivating case is micronaut-cdi's `test-suite-java` test `RequestScopedInterceptorStateTest`, which fails against micronaut-jakarta-interceptors `main` (expected counts `[1, 2, 1]`, got `[1, 2, 3]`): `JakartaInterceptorAdvice` is `@Prototype` and keeps the Jakarta interceptor instances of one intercepted object, relying on this contract, so a `@RequestScoped` bean's single client proxy shared one interceptor across requests. The separate bug in that module, which never destroys the instances it obtains with `beanContext.getBean`, is not part of this change.

## How

- `BeanDefinitionWriter` generates the target definition of a proxy-target bean that is not a singleton as an `InterceptedBeanDefinition` whenever the bean declares an interceptor binding, so the target resolves its set while it is created even without constructor advice (the constructor chain selects nothing for an unadvised constructor). A `@Nullable` bean is left out, since a constructor chain cannot return null.
- The registration created alongside the target carries that set, as it already did for pre-destroy interception, exposed through `BeanRegistration#getInterceptorRegistrations()`. `SharedInterceptorRegistrations#store` wraps it in the new `TargetInterceptorRegistrations`, which keeps the interceptors selected for each proxied method for the life of the target.
- A custom scope hands back only the bean, so `DefaultBeanContext` keeps a weak identity index from a scoped bean to its registration (filled on creation, cleared on destruction, weak on both sides so a scope that drops a bean without destroying it, as the thread-local scope does for an ended thread, pins nothing). `getProxyTargetBeanRegistration` resolves the target of a call together with its registration.
- `AopProxyWriter` generates a proxy-target proxy to resolve the registration where it resolved the target, and to take the interceptors of each call from `TargetInterceptorRegistrations#select`: on every call for a lazy proxy, once in the constructor for a proxy that holds its target. For a singleton target `select` returns the proxy's own set.
- `BeanResolutionContext#markDependentAsFactory(Object)` marks the factory by instance. The no-arg form marked whichever dependent was resolved first, which for a factory bean whose creation is advised is an interceptor rather than the factory, so that interceptor was destroyed as soon as the bean was produced. The no-arg form stays for definitions compiled earlier.

Binary compatibility follows #12922: the new context, resolution context and registration methods have defaults, and only the generated code changed. A scoped proxy compiled by an earlier 5.2 version intercepts every target with the set it resolved for itself, as before; the docs TIP says so.

The proxy still resolves a set for itself, since it is an intercepted bean in its own right; for a non-singleton target it only intercepts a target that carries no set of its own (a `@Nullable` factory bean), and a non-singleton interceptor in it is destroyed with the proxy. Runtime proxies (`RuntimeProxyCreator`) are unchanged.

## Tests

`ScopedProxyInterceptorLifecycleSpec` (inject-java) covers a `@ThreadLocal` bean across two threads, a `@Refreshable` bean across a refresh, a `@Prototype` proxy target, a factory-produced `@Prototype` target, and a cached lazy target: one instance per target across `POST_CONSTRUCT`, `AROUND` and `PRE_DESTROY`, a different instance per target, and each instance destroyed after its target's own pre-destroy. The spec failed on the first two shapes before the fix with exactly the two violations above.

Run locally: the full `inject-java` suite, the AOP packages of `inject-groovy` and `inject-kotlin`, the `inject` and `context` modules, the Netty request-scope tests, and checkstyle for `inject`, `aop` and `core-processor`.

## Docs

`interceptorLifecycle.adoc`: the table describes proxied targets by whether they are singletons, and a new *Scoped Proxies* section explains where a scoped proxy's interceptors live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
