### PR TITLE
Carry scheduled invocations as an interceptor chain attribute

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/MethodInvocationContext.java
+++ b/aop/src/main/java/io/micronaut/aop/MethodInvocationContext.java
@@ -39,6 +39,23 @@ public interface MethodInvocationContext<T, R> extends InvocationContext<T, R>, 
         return getExecutableMethod().isSuspend();
     }
 
+    /**
+     * Whether this invocation was fired by the scheduler as a scheduled task, as opposed to a direct call of the
+     * same method from application code.
+     *
+     * <p>The scheduler marks each firing of a {@code @Scheduled} method through
+     * {@link ScheduledInvocation#invoke(ExecutableMethod, Object, Object...)}. The marker applies to that method
+     * only: a direct call to the method, and any method the scheduled invocation calls in turn, return
+     * {@code false}. Interceptors that apply timer-specific advice, such as Jakarta Interceptors' around-timeout
+     * methods, can use this flag to intercept only the scheduled firings.</p>
+     *
+     * @return {@code true} if the invocation was fired as a scheduled task
+     * @since 5.2.0
+     */
+    default boolean isScheduled() {
+        return false;
+    }
+
     @Override
     default boolean isAbstract() {
         return getExecutableMethod().isAbstract();

--- a/aop/src/main/java/io/micronaut/aop/ScheduledInvocation.java
+++ b/aop/src/main/java/io/micronaut/aop/ScheduledInvocation.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.ExecutableMethod;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * Invokes a method as a scheduled task, so that interceptors can tell the invocation apart from a direct call.
+ *
+ * <p>The scheduler fires a {@code @Scheduled} method through {@link #invoke(ExecutableMethod, Object, Object...)}.
+ * The invocation carries a thread-bound marker which the interceptor chain built for that method claims, and
+ * {@link MethodInvocationContext#isScheduled()} then returns {@code true} for every interceptor in that chain.
+ * A direct call to the same method from application code carries no marker, and neither do methods the scheduled
+ * method calls in turn: the marker is bound to one method and is claimed by the first chain built for it, so
+ * only the scheduled invocation itself observes it.</p>
+ *
+ * <p>Other schedulers or timer services can use the same entry point to fire methods, and interceptors that apply
+ * timer-specific advice, such as Jakarta Interceptors' around-timeout methods, can rely on the same flag.</p>
+ *
+ * @author Denis Stepanov
+ * @since 5.2.0
+ */
+public final class ScheduledInvocation {
+
+    private static final ScopedValue<ScheduledInvocation> CURRENT = ScopedValue.newInstance();
+
+    private final ExecutableMethod<?, ?> method;
+    private boolean claimed;
+
+    private ScheduledInvocation(ExecutableMethod<?, ?> method) {
+        this.method = method;
+    }
+
+    /**
+     * Invokes the method on the target as a scheduled task.
+     *
+     * <p>Interceptors of the method see {@link MethodInvocationContext#isScheduled()} return {@code true}.
+     * The marker applies only to the invocation of this method and only on the calling thread. Methods the
+     * invocation calls in turn, including a recursive call of the same method, are not marked.</p>
+     *
+     * @param method    The method to invoke
+     * @param target    The target bean, which may be an AOP proxy
+     * @param arguments The arguments
+     * @param <T>       The target type
+     * @param <R>       The return type
+     * @return The return value
+     */
+    @Nullable
+    public static <T, R> R invoke(ExecutableMethod<T, R> method, T target, @Nullable Object... arguments) {
+        return ScopedValue.where(CURRENT, new ScheduledInvocation(method))
+            .call(() -> method.invoke(target, arguments));
+    }
+
+    /**
+     * Claims the current scheduled invocation marker for a method being intercepted.
+     *
+     * <p>Returns {@code true} at most once per scheduled invocation, for the first chain whose method is the one
+     * that was scheduled: the same method name and argument types declared by a type the target is an instance of.
+     * Every other chain built while the marker is bound, and every chain built after the marker has been claimed,
+     * gets {@code false}.</p>
+     *
+     * @param target The target of the interception
+     * @param method The intercepted method
+     * @return Whether the interception is the scheduled invocation
+     */
+    @Internal
+    public static boolean claim(Object target, ExecutableMethod<?, ?> method) {
+        if (!CURRENT.isBound()) {
+            return false;
+        }
+        ScheduledInvocation current = CURRENT.get();
+        if (current.claimed) {
+            return false;
+        }
+        ExecutableMethod<?, ?> scheduled = current.method;
+        if (scheduled == method || (scheduled.getMethodName().equals(method.getMethodName())
+            && Arrays.equals(scheduled.getArgumentTypes(), method.getArgumentTypes())
+            && scheduled.getDeclaringType().isInstance(target))) {
+            current.claimed = true;
+            return true;
+        }
+        return false;
+    }
+}

--- a/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/MethodInterceptorChain.java
@@ -22,6 +22,7 @@ import io.micronaut.aop.InterceptorRegistry;
 import io.micronaut.aop.Introduced;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.aop.ScheduledInvocation;
 import io.micronaut.aop.exceptions.UnimplementedAdviceException;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
@@ -60,6 +61,7 @@ import static io.micronaut.core.util.ArrayUtils.EMPTY_OBJECT_ARRAY;
 public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> implements MethodInvocationContext<T, R> {
 
     private final @Nullable InterceptorKind kind;
+    private final boolean scheduled;
 
     /**
      * Constructor for empty parameters.
@@ -88,6 +90,7 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
         @Nullable InterceptorKind kind) {
         super(interceptors, target, executionHandle, EMPTY_OBJECT_ARRAY);
         this.kind = kind;
+        this.scheduled = ScheduledInvocation.claim(target, executionHandle);
     }
 
     /**
@@ -102,6 +105,17 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
     public MethodInterceptorChain(Interceptor<T, R>[] interceptors, T target, ExecutableMethod<T, R> executionHandle, @Nullable Object... originalParameters) {
         super(interceptors, target, executionHandle, originalParameters);
         this.kind = null;
+        this.scheduled = ScheduledInvocation.claim(target, executionHandle);
+    }
+
+    private MethodInterceptorChain(Interceptor<T, R>[] interceptors,
+                                   T target,
+                                   ExecutableMethod<T, R> executionHandle,
+                                   @Nullable Object[] originalParameters,
+                                   boolean scheduled) {
+        super(interceptors, target, executionHandle, originalParameters);
+        this.kind = null;
+        this.scheduled = scheduled;
     }
 
     @Override
@@ -112,12 +126,17 @@ public final class MethodInterceptorChain<T, R> extends InterceptorChain<T, R> i
     @Override
     @Nullable
     public R invoke(T instance, @Nullable Object... arguments) {
-        return new MethodInterceptorChain<>(interceptors, instance, executionHandle, originalParameters).proceed();
+        return new MethodInterceptorChain<>(interceptors, instance, executionHandle, originalParameters, scheduled).proceed();
     }
 
     @Override
     public boolean isSuspend() {
         return executionHandle.isSuspend();
+    }
+
+    @Override
+    public boolean isScheduled() {
+        return scheduled;
     }
 
     @Override

--- a/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
+++ b/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.scheduling.processor;
 
+import io.micronaut.aop.ScheduledInvocation;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.bind.DefaultExecutableBeanContextBinder;
 import io.micronaut.context.bind.ExecutableBeanContextBinder;
@@ -143,7 +144,7 @@ public class ScheduledMethodProcessor implements ExecutableMethodProcessor<Sched
                     boolean shouldRun = finalAnnotationValue.booleanValue(MEMBER_CONDITION).orElse(true);
                     if (shouldRun) {
                         try {
-                            boundExecutable.invoke(bean);
+                            ScheduledInvocation.invoke(method, bean, boundExecutable.getBoundArguments());
                         } catch (Throwable e) {
                             handleException(beanDefinition.getBeanType(), bean, e);
                         }

--- a/context/src/test/groovy/io/micronaut/scheduling/marker/RecordScheduled.java
+++ b/context/src/test/groovy/io/micronaut/scheduling/marker/RecordScheduled.java
@@ -1,0 +1,18 @@
+package io.micronaut.scheduling.marker;
+
+import io.micronaut.aop.Around;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Around
+@Type(ScheduledRecordingInterceptor.class)
+public @interface RecordScheduled {
+}

--- a/context/src/test/groovy/io/micronaut/scheduling/marker/RecordScheduledProxyTarget.java
+++ b/context/src/test/groovy/io/micronaut/scheduling/marker/RecordScheduledProxyTarget.java
@@ -1,0 +1,18 @@
+package io.micronaut.scheduling.marker;
+
+import io.micronaut.aop.Around;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Around(proxyTarget = true)
+@Type(ScheduledRecordingInterceptor.class)
+public @interface RecordScheduledProxyTarget {
+}

--- a/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledInvocationMarkerSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledInvocationMarkerSpec.groovy
@@ -1,0 +1,54 @@
+package io.micronaut.scheduling.marker
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class ScheduledInvocationMarkerSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext ctx = ApplicationContext.run(['spec.name': 'ScheduledInvocationMarkerSpec'])
+
+    void "the scheduler's firing of a scheduled method is marked as scheduled"() {
+        given:
+        ScheduledRecordingInterceptor interceptor = ctx.getBean(ScheduledRecordingInterceptor)
+        String testThread = Thread.currentThread().name
+
+        expect:
+        new PollingConditions(timeout: 10).eventually {
+            assert interceptor.records('run').any { it.scheduled() }
+            assert interceptor.records('tick').any { it.scheduled() }
+        }
+
+        and: 'every firing the scheduler made is marked, for a subclass proxy and a proxyTarget proxy alike'
+        interceptor.records('run').findAll { it.thread() != testThread }.every { it.scheduled() }
+        interceptor.records('tick').findAll { it.thread() != testThread }.every { it.scheduled() }
+
+        and: 'the methods the scheduled method calls in turn are not'
+        !interceptor.records('nested').empty
+        !interceptor.records('work').empty
+        interceptor.records('nested').every { !it.scheduled() }
+        interceptor.records('work').every { !it.scheduled() }
+    }
+
+    void "a direct call to the scheduled method on the same bean is not marked"() {
+        given:
+        ScheduledRecordingInterceptor interceptor = ctx.getBean(ScheduledRecordingInterceptor)
+        ScheduledMarkerTask task = ctx.getBean(ScheduledMarkerTask)
+        ScheduledMarkerProxyTargetTask proxyTargetTask = ctx.getBean(ScheduledMarkerProxyTargetTask)
+        String testThread = Thread.currentThread().name
+
+        when:
+        task.run()
+        task.nested()
+        proxyTargetTask.tick()
+
+        then:
+        def direct = interceptor.records.findAll { it.thread() == testThread }
+        direct*.method() == ['run', 'nested', 'work', 'nested', 'tick']
+        direct.every { !it.scheduled() }
+    }
+}

--- a/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledMarkerHelper.java
+++ b/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledMarkerHelper.java
@@ -1,0 +1,13 @@
+package io.micronaut.scheduling.marker;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "ScheduledInvocationMarkerSpec")
+public class ScheduledMarkerHelper {
+
+    @RecordScheduled
+    public void work() {
+    }
+}

--- a/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledMarkerProxyTargetTask.java
+++ b/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledMarkerProxyTargetTask.java
@@ -1,0 +1,15 @@
+package io.micronaut.scheduling.marker;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "ScheduledInvocationMarkerSpec")
+public class ScheduledMarkerProxyTargetTask {
+
+    @Scheduled(fixedDelay = "50ms")
+    @RecordScheduledProxyTarget
+    public void tick() {
+    }
+}

--- a/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledMarkerTask.java
+++ b/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledMarkerTask.java
@@ -1,0 +1,28 @@
+package io.micronaut.scheduling.marker;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "ScheduledInvocationMarkerSpec")
+public class ScheduledMarkerTask {
+
+    private final ScheduledMarkerHelper helper;
+
+    public ScheduledMarkerTask(ScheduledMarkerHelper helper) {
+        this.helper = helper;
+    }
+
+    @Scheduled(fixedDelay = "50ms")
+    @RecordScheduled
+    public void run() {
+        // calls through the proxy: neither nested interception is a scheduled invocation
+        nested();
+        helper.work();
+    }
+
+    @RecordScheduled
+    public void nested() {
+    }
+}

--- a/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledRecordingInterceptor.java
+++ b/context/src/test/groovy/io/micronaut/scheduling/marker/ScheduledRecordingInterceptor.java
@@ -1,0 +1,34 @@
+package io.micronaut.scheduling.marker;
+
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Singleton
+@Requires(property = "spec.name", value = "ScheduledInvocationMarkerSpec")
+public class ScheduledRecordingInterceptor implements MethodInterceptor<Object, Object> {
+
+    public final List<Record> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        records.add(new Record(
+            context.getTarget().getClass().getSimpleName(),
+            context.getMethodName(),
+            context.isScheduled(),
+            Thread.currentThread().getName()
+        ));
+        return context.proceed();
+    }
+
+    public List<Record> records(String method) {
+        return records.stream().filter(r -> r.method().equals(method)).toList();
+    }
+
+    public record Record(String target, String method, boolean scheduled, String thread) {
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/scheduled/Marked.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/scheduled/Marked.java
@@ -1,0 +1,16 @@
+package io.micronaut.aop.scheduled;
+
+import io.micronaut.aop.Around;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Around
+@Type(MarkerInterceptor.class)
+public @interface Marked {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/scheduled/MarkedBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/scheduled/MarkedBean.java
@@ -1,0 +1,23 @@
+package io.micronaut.aop.scheduled;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "ScheduledInvocationSpec")
+public class MarkedBean {
+
+    private final OtherMarkedBean other;
+
+    public MarkedBean(OtherMarkedBean other) {
+        this.other = other;
+    }
+
+    @Marked
+    public int run(int depth) {
+        if (depth > 0) {
+            return run(depth - 1);
+        }
+        return other.run(depth);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/scheduled/MarkedProxyTarget.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/scheduled/MarkedProxyTarget.java
@@ -1,0 +1,16 @@
+package io.micronaut.aop.scheduled;
+
+import io.micronaut.aop.Around;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Around(proxyTarget = true)
+@Type(MarkerInterceptor.class)
+public @interface MarkedProxyTarget {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/scheduled/MarkedProxyTargetBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/scheduled/MarkedProxyTargetBean.java
@@ -1,0 +1,14 @@
+package io.micronaut.aop.scheduled;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "ScheduledInvocationSpec")
+public class MarkedProxyTargetBean {
+
+    @MarkedProxyTarget
+    public String tick(String name) {
+        return name;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/scheduled/MarkerInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/scheduled/MarkerInterceptor.java
@@ -1,0 +1,22 @@
+package io.micronaut.aop.scheduled;
+
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+@Requires(property = "spec.name", value = "ScheduledInvocationSpec")
+public class MarkerInterceptor implements MethodInterceptor<Object, Object> {
+
+    public final List<String> records = new ArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        records.add(context.getDeclaringType().getSimpleName() + "." + context.getMethodName() + ":" + context.isScheduled());
+        return context.proceed();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/scheduled/OtherMarkedBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/scheduled/OtherMarkedBean.java
@@ -1,0 +1,14 @@
+package io.micronaut.aop.scheduled;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "ScheduledInvocationSpec")
+public class OtherMarkedBean {
+
+    @Marked
+    public int run(int depth) {
+        return depth;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/scheduled/ScheduledInvocationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/scheduled/ScheduledInvocationSpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.aop.scheduled
+
+import io.micronaut.aop.ScheduledInvocation
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.ExecutableMethod
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ScheduledInvocationSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext ctx = ApplicationContext.run(['spec.name': 'ScheduledInvocationSpec'])
+
+    MarkerInterceptor interceptor = ctx.getBean(MarkerInterceptor)
+
+    def setup() {
+        interceptor.records.clear()
+    }
+
+    void "only the scheduled invocation is marked, not the calls it makes in turn"() {
+        given:
+        MarkedBean bean = ctx.getBean(MarkedBean)
+        ExecutableMethod<MarkedBean, Integer> method = ctx.getBeanDefinition(MarkedBean).getRequiredMethod("run", int)
+
+        when:
+        int result = ScheduledInvocation.invoke(method, bean, 2)
+
+        then: 'the first chain claims the marker; the recursive calls and the same-named method of another bean do not see it'
+        result == 0
+        interceptor.records == ['MarkedBean.run:true', 'MarkedBean.run:false', 'MarkedBean.run:false', 'OtherMarkedBean.run:false']
+    }
+
+    void "a direct call is not marked"() {
+        given:
+        MarkedBean bean = ctx.getBean(MarkedBean)
+
+        when:
+        bean.run(1)
+
+        then:
+        interceptor.records == ['MarkedBean.run:false', 'MarkedBean.run:false', 'OtherMarkedBean.run:false']
+    }
+
+    void "the marker reaches a proxyTarget proxy whose chain targets the real bean"() {
+        given:
+        MarkedProxyTargetBean bean = ctx.getBean(MarkedProxyTargetBean)
+        ExecutableMethod<MarkedProxyTargetBean, String> method = ctx.getBeanDefinition(MarkedProxyTargetBean).getRequiredMethod("tick", String)
+
+        when:
+        String scheduled = ScheduledInvocation.invoke(method, bean, "a")
+        String direct = bean.tick("b")
+
+        then:
+        scheduled == "a"
+        direct == "b"
+        interceptor.records == ['MarkedProxyTargetBean.tick:true', 'MarkedProxyTargetBean.tick:false']
+    }
+
+    void "the marker is bound to the calling thread only"() {
+        given:
+        MarkedBean bean = ctx.getBean(MarkedBean)
+        ExecutableMethod<MarkedBean, Integer> method = ctx.getBeanDefinition(MarkedBean).getRequiredMethod("run", int)
+
+        when:
+        Thread.ofPlatform().start { ScheduledInvocation.invoke(method, bean, 0) }.join()
+        bean.run(0)
+
+        then:
+        interceptor.records == ['MarkedBean.run:true', 'OtherMarkedBean.run:false', 'MarkedBean.run:false', 'OtherMarkedBean.run:false']
+    }
+}

--- a/src/main/docs/guide/aop/aroundAdvice.adoc
+++ b/src/main/docs/guide/aop/aroundAdvice.adoc
@@ -33,6 +33,10 @@ snippet::io.micronaut.docs.aop.around.AroundSpec[tags="test", indent=0, title="A
 
 NOTE: Since Micronaut injection happens at compile time, generally the advice should be packaged in a dependent JAR file that is on the classpath when the above test is compiled. It should not be in the same codebase since you don't want the test to be compiled before the advice itself is compiled.
 
+=== Around Advice and Scheduled Tasks
+
+An intercepted method may also be a <<scheduling, scheduled task>>. When the scheduler fires the task, `isScheduled()` on the api:aop.MethodInvocationContext[] returns `true`; for a direct call to the same method from application code it returns `false`. Advice that must only apply to the scheduled firings, such as a Jakarta Interceptors style around-timeout method, checks this flag before acting. See <<scheduling, Scheduled Tasks>> for the details.
+
 == Customizing Proxy Generation
 
 The default behaviour of the link:{api}/io/micronaut/aop/Around.html[Around] annotation is to generate a proxy at compile time that is a subclass of the proxied class. In other words, in the previous example a compile-time subclass of the `NotNullExample` class will be produced where proxied methods are decorated with interceptor handling, and the original behaviour is invoked via a call to `super`.

--- a/src/main/docs/guide/aop/scheduling.adoc
+++ b/src/main/docs/guide/aop/scheduling.adoc
@@ -75,6 +75,41 @@ micronaut:
 
 include::{includedir}configurationProperties/io.micronaut.scheduling.executor.UserExecutorConfiguration.adoc[]
 
+== Intercepting Scheduled Invocations
+
+A `@Scheduled` method is an ordinary method: application code can call it directly, and any api:aop.Around[] advice applied to it runs for both kinds of call. When the scheduler fires the task, the api:aop.MethodInvocationContext[] passed to the interceptors reports it through `isScheduled()`, so that advice which should only apply to scheduled firings, such as a Jakarta Interceptors style around-timeout method, can tell the two apart:
+
+[source,java]
+----
+@Singleton
+public class TimeoutInterceptor implements MethodInterceptor<Object, Object> {
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        if (!context.isScheduled()) {
+            return context.proceed(); // <1>
+        }
+        // <2>
+        return context.proceed();
+    }
+}
+----
+
+<1> A direct call from application code, or a call made by a scheduled method in turn
+<2> The scheduler firing the task
+
+The flag is set for the invocation of the scheduled method only. A direct call to the same method on the same bean, a recursive call, and the methods the scheduled method calls in turn all report `false`, even when they carry the same advice.
+
+Code that fires methods on its own schedule, such as a timer service integration, can mark its invocations the same way through api:aop.ScheduledInvocation[]:
+
+[source,java]
+----
+ExecutableMethod<MyTask, Object> method = beanDefinition.getRequiredMethod("run");
+ScheduledInvocation.invoke(method, bean); // <1>
+----
+
+<1> Invokes `run()` on the bean, which may be an AOP proxy, with the marker bound for that invocation
+
 == Handling Exceptions
 
 By default, the Micronaut framework includes a api:io.micronaut.scheduling.DefaultTaskExceptionHandler[] bean that implements the api:io.micronaut.scheduling.TaskExceptionHandler[] interface and simply logs the exception if an error occurs invoking a scheduled task.


### PR DESCRIPTION
Lets an interceptor tell a `@Scheduled` method fired by the scheduler apart from a direct call of the same method by application code. The interceptor chain of a scheduled firing carries a `ScheduledInvocation` attribute; nothing else does.

### Why

Jakarta Interceptors separates business methods (`@AroundInvoke`) from timeout methods (`@AroundTimeout`), and `InvocationContext.getTimer()` is only non-null for a timeout invocation. micronaut-jakarta-interceptors uses `@Scheduled` as its timer service, but it can only flag the *method* as a timeout method at compile time, so a direct application call to a `@Scheduled` method is also run through `@AroundTimeout` advice and shown a timer. Core had nothing at the invocation level to distinguish the two.

### What

- `io.micronaut.aop.ScheduledInvocation` is the attribute value, stored under `ScheduledInvocation.ATTRIBUTE` in `InvocationContext.getAttributes()`. It exposes the fired `ExecutableMethod` and `getSchedule()`, the `@Scheduled` annotation that fired (evaluated, so expressions are resolved). A method with several `@Scheduled` annotations is fired once per schedule, and each firing carries its own annotation, which gives Jakarta's `Timer` something to describe.
- Interceptors read it with `ScheduledInvocation.find(context)`, which is empty for every other invocation. This is the direct counterpart of a null `getTimer()`, and it adds nothing to `MethodInvocationContext` itself.
- `ScheduledInvocation.invoke(method, schedule, target, args...)` fires a method as a scheduled task. `ScheduledMethodProcessor` now goes through it, and other timer integrations can use it too.
- `MethodInterceptorChain` puts the value into its attributes when it is built. Chains without it never allocate the attribute map.
- Documented in the Scheduled Tasks page (new section "Intercepting Scheduled Invocations") and cross-referenced from Around Advice, with a note that Jakarta-style around-timeout advice can rely on it.

### How the attribute gets into the chain

The scheduler invokes the bean's `ExecutableMethod` on the bean instance, which is the AOP proxy, so the chain is built inside the generated proxy method and the scheduler cannot hand it an attribute directly. `ScheduledInvocation.invoke` therefore binds a `ScopedValue` around the call (core targets JDK 25, where `ScopedValue` is final), and the chain constructor claims it:

- The claim matches the first chain built for the scheduled method: same method name and argument types, declared by a type the target is an instance of. The instance check rather than declaring-type identity makes this work for both subclass proxies (target is the proxy) and `proxyTarget = true` proxies (target is the real bean), and it excludes a same-named method of an unrelated bean.
- The value is claimed once, so a recursive call of the scheduled method and every other intercepted method the scheduled method calls in turn carry no attribute.
- A `ScopedValue` is not inherited by other threads, so a direct call to the same method on the same bean, on any thread, never carries it. When nothing is bound, the claim is a single `isBound()` check per chain construction.

No generated code changes, so this works for beans compiled by earlier versions. The change is additive and binary compatible: one new class and a private constructor on `MethodInterceptorChain`.

### Tests

- `context`: `ScheduledInvocationMarkerSpec` runs `@Scheduled(fixedDelay)` beans with `@Around` advice (subclass proxy and `proxyTarget = true`). It asserts the scheduler's firings carry the attribute with the right method and schedule, a method with two schedules sees both, the calls the task makes in turn carry nothing, and direct calls from the test thread carry nothing.
- `inject-java`: `ScheduledInvocationSpec` drives `ScheduledInvocation.invoke` deterministically and checks the carried method and schedule, the claim-once behaviour (recursion, a same-named method on another bean), the `proxyTarget` case, and that the value stays on the calling thread.

Full `context` and `inject-java` test suites and checkstyle pass locally.
