### PR TITLE
ReadTimeoutException to allow fresh, per-failure instances:

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/exceptions/ReadTimeoutException.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/exceptions/ReadTimeoutException.java
@@ -23,9 +23,26 @@ package io.micronaut.http.client.exceptions;
  */
 public final class ReadTimeoutException extends HttpClientException {
 
-    public static final ReadTimeoutException TIMEOUT_EXCEPTION = new ReadTimeoutException();
+    /**
+     * Shared instance.
+     *
+     * @deprecated This shared instance captures its stack trace at static initialization time
+     * and is reused across concurrent requests. Use {@link #ReadTimeoutException()} instead so
+     * that the stack trace points to the request that actually timed out and so the exception
+     * can carry per-request metadata such as the service id.
+     */
+    @Deprecated(since = "4.9.0")
+    public static final ReadTimeoutException TIMEOUT_EXCEPTION = new ReadTimeoutException(true);
 
-    private ReadTimeoutException() {
-        super("Read Timeout", null, true);
+    /**
+     * Create a new read timeout exception. The stack trace is captured at the point of creation,
+     * so it points to the client/request path that timed out.
+     */
+    public ReadTimeoutException() {
+        super("Read Timeout");
+    }
+
+    private ReadTimeoutException(boolean shared) {
+        super("Read Timeout", null, shared);
     }
 }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyHttpClient.java
@@ -766,7 +766,7 @@ final class NettyHttpClient implements
                 flow = flow.timeout(requestTimeout, Objects.requireNonNull(scheduler.get()), null)
                     .onErrorResume(throwable -> {
                         if (throwable instanceof TimeoutException) {
-                            return ExecutionFlow.error(ReadTimeoutException.TIMEOUT_EXCEPTION);
+                            return ExecutionFlow.error(decorate(new ReadTimeoutException()));
                         }
                         return ExecutionFlow.error(throwable);
                     });
@@ -1908,7 +1908,7 @@ final class NettyHttpClient implements
         } else if (cause instanceof BufferLengthExceededException blee) {
             result = decorate(new ContentLengthExceededException(blee.getAdvertisedLength(), blee.getReceivedLength()));
         } else if (cause instanceof io.netty.handler.timeout.ReadTimeoutException) {
-            result = ReadTimeoutException.TIMEOUT_EXCEPTION;
+            result = decorate(new ReadTimeoutException());
         } else if (cause instanceof HttpClientException hce) {
             result = decorate(hce);
         } else {


### PR DESCRIPTION
Root cause:
`TIMEOUT_EXCEPTION` is a static singleton, so its stack trace is captured once at class-initialization time (not at the timeout site), and it's shared across all concurrent requests. It also can't be decorated with a service ID because it's locked as shared.

Fixes: #12655 