### PR TITLE
Read Groovy annotation processor options from compiler configuration

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
@@ -33,6 +33,7 @@ import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.expressions.context.DefaultExpressionCompilationContextFactory;
 import io.micronaut.expressions.context.ExpressionCompilationContextFactory;
 import io.micronaut.inject.ast.ClassElement;
@@ -48,6 +49,7 @@ import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.control.ClassNodeResolver;
 import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.Janitor;
 import org.codehaus.groovy.control.SourceUnit;
 
@@ -59,10 +61,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The visitor context when visiting Groovy code.
@@ -339,14 +344,23 @@ public class GroovyVisitorContext implements VisitorContext {
     }
 
     /**
-     * Groovy options source are {@link System#getProperties()} based.
-     * <p><b>All properties MUST start with {@link GroovyVisitorContext#MICRONAUT_BASE_OPTION_NAME}</b></p>
+     * Groovy visitor context options from the Groovy {@link CompilerConfiguration}
+     * (joint-compilation {@code -A} flags / named values) and {@link System#getProperties()}.
+     * <p><b>System properties have priority over compiler arguments.</b></p>
+     * <p><b>All option names MUST start with {@link GroovyVisitorContext#MICRONAUT_BASE_OPTION_NAME}</b></p>
      *
      * @return options {@link Map}
      */
     @Override
     public Map<String, String> getOptions() {
-        return VisitorContextUtils.getSystemOptions();
+        Map<String, String> compilerOptions = getCompilerOptions();
+        Map<String, String> systemPropsOptions = VisitorContextUtils.getSystemOptions();
+        return Stream.of(compilerOptions, systemPropsOptions)
+            .flatMap(map -> map.entrySet().stream())
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue,
+                (v1, v2) -> StringUtils.isNotEmpty(v2) ? v2 : v1));
     }
 
     @Override
@@ -407,5 +421,114 @@ public class GroovyVisitorContext implements VisitorContext {
     @Internal
     void addBeanDefinitionBuilder(GroovyBeanDefinitionBuilder groovyBeanDefinitionBuilder) {
         this.beanDefinitionBuilders.add(groovyBeanDefinitionBuilder);
+    }
+
+    private Map<String, String> getCompilerOptions() {
+        CompilerConfiguration configuration = sourceUnit != null ? sourceUnit.getConfiguration() : null;
+        if (configuration == null && compilationUnit != null) {
+            configuration = compilationUnit.getConfiguration();
+        }
+        if (configuration == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> jointCompilationOptions = configuration.getJointCompilationOptions();
+        if (jointCompilationOptions == null || jointCompilationOptions.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> options = new LinkedHashMap<>();
+        collectProcessorFlags(jointCompilationOptions.get("flags"), options);
+        collectNamedProcessorValues(jointCompilationOptions.get("namedValues"), options);
+        for (Map.Entry<String, Object> entry : jointCompilationOptions.entrySet()) {
+            if (entry.getValue() != null) {
+                putIfMicronautOption(entry.getKey(), String.valueOf(entry.getValue()), options);
+            }
+        }
+        return options;
+    }
+
+    private static void collectProcessorFlags(Object flags, Map<String, String> options) {
+        if (flags instanceof String[] array) {
+            for (String flag : array) {
+                collectProcessorToken(flag, options);
+            }
+        } else if (flags instanceof Iterable<?> iterable) {
+            for (Object flag : iterable) {
+                if (flag != null) {
+                    collectProcessorToken(flag.toString(), options);
+                }
+            }
+        }
+    }
+
+    private static void collectNamedProcessorValues(Object namedValues, Map<String, String> options) {
+        if (namedValues instanceof String[] array) {
+            for (int i = 0; i + 1 < array.length; i += 2) {
+                collectNamedProcessorValue(array[i], array[i + 1], options);
+            }
+        } else if (namedValues instanceof List<?> list) {
+            for (int i = 0; i + 1 < list.size(); i += 2) {
+                Object name = list.get(i);
+                Object value = list.get(i + 1);
+                if (name != null && value != null) {
+                    collectNamedProcessorValue(name.toString(), value.toString(), options);
+                }
+            }
+        }
+    }
+
+    private static void collectNamedProcessorValue(String name, String value, Map<String, String> options) {
+        if (name == null || value == null) {
+            return;
+        }
+        String optionName = stripAnnotationProcessorPrefix(name);
+        if (optionName != null) {
+            putIfMicronautOption(optionName, value, options);
+            return;
+        }
+        if ("A".equals(name) || "-A".equals(name)) {
+            collectProcessorToken("-A" + value, options);
+        }
+    }
+
+    private static void collectProcessorToken(String token, Map<String, String> options) {
+        if (token == null || token.isEmpty()) {
+            return;
+        }
+        String option = stripAnnotationProcessorPrefix(token);
+        if (option == null) {
+            return;
+        }
+        int eq = option.indexOf('=');
+        if (eq < 0) {
+            putIfMicronautOption(option, "", options);
+        } else {
+            putIfMicronautOption(option.substring(0, eq), option.substring(eq + 1), options);
+        }
+    }
+
+    /**
+     * Groovy joint-compilation stores javac switches without the leading dash
+     * ({@code Amicronaut.foo=bar} becomes {@code -Amicronaut.foo=bar}).
+     *
+     * @param token a flag or named option
+     * @return the processor option without the {@code -A}/{@code A} prefix, or {@code null}
+     */
+    private static String stripAnnotationProcessorPrefix(String token) {
+        if (token.startsWith("-A")) {
+            return token.substring(2);
+        }
+        if (token.startsWith("A") && token.length() > 1) {
+            String remainder = token.substring(1);
+            if (remainder.startsWith(MICRONAUT_BASE_OPTION_NAME)) {
+                return remainder;
+            }
+        }
+        return null;
+    }
+
+    private static void putIfMicronautOption(String key, String value, Map<String, String> options) {
+        if (key != null && key.startsWith(MICRONAUT_BASE_OPTION_NAME)) {
+            options.put(key, value);
+        }
     }
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContextSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContextSpec.groovy
@@ -1,0 +1,76 @@
+package io.micronaut.ast.groovy.visitor
+
+import groovy.lang.GroovyClassLoader
+import org.codehaus.groovy.control.CompilationUnit
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.ErrorCollector
+import org.codehaus.groovy.control.SourceUnit
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class GroovyVisitorContextSpec extends Specification {
+
+    static final String VALID_CUSTOM_PROP = "micronaut.custom.prop"
+    static final String ANOTHER_CUSTOM_PROP = "micronaut.another.custom.prop"
+    static final String INVALID_CUSTOM_PROP = "invalid.custom.prop"
+
+    def "getOptions does not expose compiler -A flags when none are configured"() {
+        given:
+        def context = newVisitorContext(new CompilerConfiguration())
+
+        expect:
+        !context.options.containsKey(VALID_CUSTOM_PROP)
+    }
+
+    def "getOptions reads micronaut processor flags from joint compilation configuration"() {
+        given:
+        def configuration = new CompilerConfiguration()
+        configuration.jointCompilationOptions = [
+            flags: ["A${VALID_CUSTOM_PROP}=from-flag", "proc:none"] as String[],
+            namedValues: ["A${ANOTHER_CUSTOM_PROP}", "from-named"] as String[]
+        ]
+
+        when:
+        def options = newVisitorContext(configuration).options
+
+        then:
+        options[VALID_CUSTOM_PROP] == "from-flag"
+        options[ANOTHER_CUSTOM_PROP] == "from-named"
+        !options.containsKey(INVALID_CUSTOM_PROP)
+        !options.containsKey("proc:none")
+    }
+
+    def "getOptions reads micronaut keys stored directly on joint compilation options"() {
+        given:
+        def configuration = new CompilerConfiguration()
+        configuration.jointCompilationOptions = [
+            (VALID_CUSTOM_PROP): "from-map",
+            (INVALID_CUSTOM_PROP): "ignored"
+        ]
+
+        when:
+        def options = newVisitorContext(configuration).options
+
+        then:
+        options[VALID_CUSTOM_PROP] == "from-map"
+        !options.containsKey(INVALID_CUSTOM_PROP)
+    }
+
+    @RestoreSystemProperties
+    def "system properties override compiler configuration options"() {
+        given:
+        System.setProperty(VALID_CUSTOM_PROP, "from-system")
+        def configuration = new CompilerConfiguration()
+        configuration.jointCompilationOptions = [
+            flags: ["A${VALID_CUSTOM_PROP}=from-flag"] as String[]
+        ]
+
+        expect:
+        newVisitorContext(configuration).options[VALID_CUSTOM_PROP] == "from-system"
+    }
+
+    private static GroovyVisitorContext newVisitorContext(CompilerConfiguration configuration) {
+        def sourceUnit = new SourceUnit("test", "", configuration, new GroovyClassLoader(), new ErrorCollector(configuration))
+        return new GroovyVisitorContext(sourceUnit, new CompilationUnit(configuration))
+    }
+}


### PR DESCRIPTION
## Summary
`GroovyVisitorContext.getOptions()` previously returned only system properties. Java visitors already merge `ProcessingEnvironment` `-A` options with those properties, so Groovy `TypeElementVisitor` implementations could not see compiler-supplied `micronaut.*` processor options.

This change reads micronaut-prefixed annotation processor flags and named values from `CompilerConfiguration` joint compilation options, then merges them with system properties. System properties still win on conflict, matching `JavaVisitorContext`.

Fixes #10725

## Test Plan
- [x] `./gradlew :micronaut-inject-groovy:test --tests io.micronaut.ast.groovy.visitor.GroovyVisitorContextSpec` — 4 tests, 0 failures
- [x] `./gradlew :micronaut-inject-groovy:test` — 1130 tests, 17 skipped, 0 failures
- [x] `./gradlew :micronaut-inject-groovy:spotlessCheck`