### PR TITLE
Destroy a bean's dependents once, with the bean, and identify a factory by identity

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -581,7 +581,7 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
 
     private static final Method METHOD_QUALIFIER_BY_TYPE = ReflectionUtils.getRequiredMethod(Qualifiers.class, "byType", Class[].class);
 
-    private static final Method METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY = ReflectionUtils.getRequiredMethod(BeanResolutionContext.class, "markDependentAsFactory");
+    private static final Method METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY = ReflectionUtils.getRequiredMethod(BeanResolutionContext.class, "markDependentAsFactory", Object.class);
 
     private static final Method METHOD_PROXY_TARGET_TYPE = ReflectionUtils.getRequiredInternalMethod(ProxyBeanDefinition.class, "getTargetDefinitionType");
 
@@ -2224,7 +2224,10 @@ public final class BeanDefinitionWriter implements BeanElement, Toggleable, Elem
                 getQualifier(factoryClass, argumentExpression)
             ).cast(factoryTypeDef).newLocal("factoryBean");
         additionalStatements.add(defineAndAssign);
-        additionalStatements.add(beanResolutionContxt.invoke(METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY));
+        // Identify the factory by the instance that was just looked up. For a bean with constructor advice this
+        // statement runs in doInstantiate, after the factory method arguments and the bean's interceptors have
+        // already been recorded as dependents, so the position of a dependent says nothing about what it is.
+        additionalStatements.add(beanResolutionContxt.invoke(METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY, defineAndAssign.variable()));
         return defineAndAssign.variable();
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/FactoryProducedBeanDependentsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/FactoryProducedBeanDependentsSpec.groovy
@@ -1,0 +1,216 @@
+package io.micronaut.aop.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+/**
+ * The dependents of a factory-produced bean have to survive its creation.
+ *
+ * <p>A generated bean definition records the bean that produced it by looking the factory up and then telling the
+ * resolution context that the registration just added is the factory, so that a {@code @Prototype} factory is
+ * destroyed as soon as the bean it produced has been built. For a bean with constructor advice that lookup happens
+ * in {@code doInstantiate}, which runs after the factory method arguments and the bean's interceptors have both been
+ * recorded in the same dependent list, and for a {@code @Singleton} factory the lookup records nothing at all.
+ * Identifying the factory by its position in that list therefore picks whatever was recorded first - an interceptor,
+ * or a dependency of the factory method - and destroys it as soon as the bean is created.</p>
+ */
+class FactoryProducedBeanDependentsSpec extends AbstractTypeElementSpec {
+
+    /**
+     * A snapshot, because Spock renders a failed condition lazily and the list keeps being appended to by the
+     * cleanup that closes the context.
+     */
+    private static List<String> recorded(Class<?> callsType) {
+        new ArrayList<String>(callsType.RECORDED)
+    }
+
+    private static String source(String pkg, String producedScope) {
+        """
+package $pkg;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.*;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+class Calls {
+    static final List<String> RECORDED = new ArrayList<>();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@AroundConstruct
+@interface Managed {
+}
+
+@Prototype
+@InterceptorBinding(value = Managed.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+class ManagedInterceptor implements ConstructorInterceptor<Object> {
+    @Override
+    public Object intercept(ConstructorInvocationContext<Object> context) {
+        Calls.RECORDED.add("construct");
+        return context.proceed();
+    }
+
+    @PreDestroy
+    public void close() {
+        Calls.RECORDED.add("interceptor-destroyed");
+    }
+}
+
+@Prototype
+class MethodArgument {
+
+    @PreDestroy
+    public void close() {
+        Calls.RECORDED.add("argument-destroyed");
+    }
+}
+
+class Produced {
+    public String work() {
+        return "done";
+    }
+
+    public void close() {
+        Calls.RECORDED.add("bean-destroyed");
+    }
+}
+
+@Factory
+class ProducedFactory {
+
+    @$producedScope
+    @Managed
+    @Bean(preDestroy = "close")
+    public Produced produced(MethodArgument argument) {
+        return new Produced();
+    }
+}
+"""
+    }
+
+    void 'test the dependents of a singleton produced by a singleton factory are not destroyed at creation'() {
+        given:
+        ApplicationContext context = buildContext(source('factorydependents.singleton', 'Singleton'))
+        Class<?> callsType = context.classLoader.loadClass('factorydependents.singleton.Calls')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('factorydependents.singleton.Produced'))
+
+        then: 'creating the bean destroys nothing'
+        bean.work() == 'done'
+        recorded(callsType) == ['construct']
+
+        when:
+        callsType.RECORDED.clear()
+        context.stop()
+
+        then: 'the dependents are destroyed with the bean they were created for, after the bean itself'
+        recorded(callsType) == ['bean-destroyed', 'interceptor-destroyed', 'argument-destroyed']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test one prototype interceptor serves every phase of a factory produced bean and is destroyed with it'() {
+        given: 'advice covering construction, post construct and pre destroy, which is what SharedInterceptorRegistrations carries the resolved interceptors through'
+        ApplicationContext context = buildContext('''
+package factorydependents.shared;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.*;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@AroundConstruct
+@InterceptorBinding(kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(kind = InterceptorKind.PRE_DESTROY)
+@interface Tracked {
+}
+
+@Prototype
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.AROUND_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.POST_CONSTRUCT)
+@InterceptorBinding(value = Tracked.class, kind = InterceptorKind.PRE_DESTROY)
+class TrackingInterceptor implements Interceptor<Object, Object> {
+    static int instances;
+    static final List<String> events = new ArrayList<>();
+
+    private final int id = ++instances;
+
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        String kind = context instanceof ConstructorInvocationContext
+            ? "AROUND_CONSTRUCT"
+            : ((MethodInvocationContext<?, ?>) context).getKind().name();
+        events.add(id + ":" + kind);
+        return context.proceed();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        events.add(id + ":DESTROYED");
+    }
+}
+
+class Produced {
+    public void close() {
+    }
+}
+
+@Factory
+class ProducedFactory {
+
+    @Singleton
+    @Tracked
+    @Bean(preDestroy = "close")
+    public Produced produced() {
+        return new Produced();
+    }
+}
+''')
+        Class<?> interceptorType = context.classLoader.loadClass('factorydependents.shared.TrackingInterceptor')
+
+        when:
+        context.getBean(context.classLoader.loadClass('factorydependents.shared.Produced'))
+
+        then: 'the one interceptor resolved for the bean serves construction and post construct, and survives them'
+        interceptorType.instances == 1
+        new ArrayList<String>(interceptorType.events) == ['1:AROUND_CONSTRUCT', '1:POST_CONSTRUCT']
+
+        when:
+        context.stop()
+
+        then: 'the same instance serves pre destroy and is only then destroyed, as a dependent of the bean'
+        interceptorType.instances == 1
+        new ArrayList<String>(interceptorType.events) == [
+                '1:AROUND_CONSTRUCT', '1:POST_CONSTRUCT', '1:PRE_DESTROY', '1:DESTROYED'
+        ]
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the dependents of a prototype produced by a singleton factory are not destroyed at creation'() {
+        given:
+        ApplicationContext context = buildContext(source('factorydependents.prototype', 'Prototype'))
+        Class<?> callsType = context.classLoader.loadClass('factorydependents.prototype.Calls')
+
+        when:
+        def bean = context.getBean(context.classLoader.loadClass('factorydependents.prototype.Produced'))
+
+        then: 'creating the bean destroys nothing'
+        bean.work() == 'done'
+        recorded(callsType) == ['construct']
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/ProxyTargetDependentDestructionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lifecycle/ProxyTargetDependentDestructionSpec.groovy
@@ -1,0 +1,117 @@
+package io.micronaut.aop.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+/**
+ * Destroying a proxy has to destroy each of the proxy's dependents once, after the target's {@code @PreDestroy}.
+ *
+ * <p>Destroying an around proxy means destroying the bean behind it, so the proxy hands its dependents over to the
+ * target and the target's destruction disposes of them in the usual order: the bean first, then what was created
+ * for it. Destroying them in the proxy as well runs each of them twice, and runs the first of the two before the
+ * target's own pre-destroy callback.</p>
+ */
+class ProxyTargetDependentDestructionSpec extends AbstractTypeElementSpec {
+
+    /**
+     * A snapshot, because Spock renders a failed condition lazily and the list keeps being appended to by the
+     * cleanup that closes the context.
+     */
+    private static List<String> recorded(Class<?> callsType) {
+        new ArrayList<String>(callsType.RECORDED)
+    }
+
+    private static String source(String pkg, String aroundAttributes) {
+        """
+package $pkg;
+
+import io.micronaut.aop.*;
+import io.micronaut.context.annotation.*;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+import java.util.*;
+
+class Calls {
+    static final List<String> RECORDED = new ArrayList<>();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Around($aroundAttributes)
+@interface Traced {
+}
+
+@Prototype
+@InterceptorBinding(value = Traced.class, kind = InterceptorKind.AROUND)
+class TracedInterceptor implements Interceptor<Object, Object> {
+    @Override
+    public Object intercept(InvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+
+    @PreDestroy
+    public void close() {
+        Calls.RECORDED.add("interceptor-destroyed");
+    }
+}
+
+@Prototype
+@Traced
+class Advised {
+    public String work() {
+        return "done";
+    }
+
+    @PreDestroy
+    public void close() {
+        Calls.RECORDED.add("target-destroyed");
+    }
+}
+
+@Singleton
+class Holder {
+    final Advised target;
+
+    Holder(Advised target) {
+        this.target = target;
+    }
+}
+"""
+    }
+
+    void 'test the dependents of an eager proxy target proxy are destroyed once, after the target'() {
+        given:
+        ApplicationContext context = buildContext(source('proxytargetdependents.eager', 'proxyTarget = true'))
+        Class<?> callsType = context.classLoader.loadClass('proxytargetdependents.eager.Calls')
+
+        when:
+        def holder = context.getBean(context.classLoader.loadClass('proxytargetdependents.eager.Holder'))
+        holder.target.work()
+        context.stop()
+
+        then:
+        recorded(callsType) == ['target-destroyed', 'interceptor-destroyed']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test the dependents of a lazy cacheable proxy target proxy are destroyed once, after the target'() {
+        given:
+        ApplicationContext context = buildContext(
+                source('proxytargetdependents.lazy', 'proxyTarget = true, lazy = true, cacheableLazyTarget = true'))
+        Class<?> callsType = context.classLoader.loadClass('proxytargetdependents.lazy.Calls')
+
+        when:
+        def holder = context.getBean(context.classLoader.loadClass('proxytargetdependents.lazy.Holder'))
+        holder.target.work()
+        context.stop()
+
+        then:
+        recorded(callsType) == ['target-destroyed', 'interceptor-destroyed']
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/PrototypeInstanceDestructionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/PrototypeInstanceDestructionSpec.groovy
@@ -1,0 +1,98 @@
+package io.micronaut.inject.lifecycle
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+/**
+ * Which beans a prototype takes with it when it is destroyed, and by which call.
+ *
+ * <p>The registration created alongside a bean is the only record of the beans that were created for it. Nothing
+ * tracks the registration of a prototype - tracking it is what prototype scope exists not to do - so a caller that
+ * wants a prototype destroyed with its dependents has to keep the registration rather than the bean, and
+ * {@code destroyBean(Object)} on the instance alone can only run the bean's own pre-destroy. Both halves of that
+ * are pinned here, because the second one reads like a defect until the first one is in view.</p>
+ */
+class PrototypeInstanceDestructionSpec extends AbstractTypeElementSpec {
+
+    /**
+     * A snapshot, because Spock renders a failed condition lazily and the list keeps being appended to by the
+     * cleanup that closes the context.
+     */
+    private static List<String> recorded(Class<?> callsType) {
+        new ArrayList<String>(callsType.RECORDED)
+    }
+
+    private static final String SOURCE = '''
+package prototypedestruction;
+
+import io.micronaut.context.annotation.*;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+import java.util.*;
+
+class Calls {
+    static final List<String> RECORDED = new ArrayList<>();
+}
+
+@Prototype
+class Dependent {
+    private static int counter;
+
+    final int id = ++counter;
+
+    @PreDestroy
+    public void close() {
+        Calls.RECORDED.add("dependent-destroyed:" + id);
+    }
+}
+
+@Prototype
+class Root {
+    final Dependent dependent;
+
+    Root(Dependent dependent) {
+        this.dependent = dependent;
+    }
+
+    @PreDestroy
+    public void close() {
+        Calls.RECORDED.add("root-destroyed");
+    }
+}
+'''
+
+    void 'test destroying the registration of a prototype destroys the dependents created with it'() {
+        given:
+        ApplicationContext context = buildContext(SOURCE)
+        Class<?> callsType = context.classLoader.loadClass('prototypedestruction.Calls')
+
+        when:
+        def registration = context.getBeanRegistration(context.classLoader.loadClass('prototypedestruction.Root'), null)
+        int dependentId = registration.bean.dependent.id
+        context.destroyBean(registration)
+
+        then:
+        recorded(callsType) == ['root-destroyed', "dependent-destroyed:$dependentId".toString()]
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test destroying a prototype instance alone cannot destroy the dependents created with it'() {
+        given:
+        ApplicationContext context = buildContext(SOURCE)
+        Class<?> callsType = context.classLoader.loadClass('prototypedestruction.Calls')
+
+        when:
+        def root = context.getBean(context.classLoader.loadClass('prototypedestruction.Root'))
+        int dependentId = root.dependent.id
+        context.destroyBean(root)
+
+        then: 'only the bean itself is destroyed; the context holds no registration to reach its dependents through'
+        dependentId == 1
+        recorded(callsType) == ['root-destroyed']
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/D.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/D.java
@@ -19,11 +19,20 @@ import io.micronaut.context.annotation.Prototype;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Prototype
 public class D {
 
     static int created;
     static int destroyed;
+
+    /**
+     * Which instances were destroyed, so that a test can tell one instance destroyed twice from two instances
+     * destroyed once.
+     */
+    static final List<D> destroyedInstances = new ArrayList<>();
 
     @PostConstruct
     public void create() {
@@ -33,6 +42,7 @@ public class D {
     @PreDestroy
     public void destroy() {
         destroyed++;
+        destroyedInstances.add(this);
     }
 
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec.groovy
@@ -28,6 +28,7 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
         C.closed = 0
         D.destroyed = 0
         D.created = 0
+        D.destroyedInstances.clear()
     }
 
     def cleanup() {
@@ -37,6 +38,7 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
         C.closed = 0
         D.destroyed = 0
         D.created = 0
+        D.destroyedInstances.clear()
     }
 
     void "test that a lazy target bean with a pre-destroy hook works"() {
@@ -63,7 +65,13 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
             B.noArgsDestroyCalled == 1
             B.injectedDestroyCalled == 1
             D.created == 2 // Create proxy + target
-            D.destroyed == 2
+            // The proxy owns one D and the lazy cached target owns another, and only the proxy's is destroyed:
+            // the target instance is cached on the proxy without its registration, so the beans created for the
+            // target are out of reach when the proxy is destroyed. Until 5.2.1 this read as two destructions,
+            // because the proxy's dependents were destroyed once in the proxy and then handed to the target and
+            // destroyed again - the same D twice, never the target's.
+            D.destroyed == 1
+            D.destroyedInstances.unique(false).size() == 1
 
         cleanup:
             context.close()
@@ -125,7 +133,9 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
             B.noArgsDestroyCalled == 1
             B.injectedDestroyCalled == 1
             D.created == 2
-            D.destroyed == 2  // Destroy proxy + target
+            // One D destroyed, and only one: see the first feature for why it is not two.
+            D.destroyed == 1
+            D.destroyedInstances.unique(false).size() == 1
 
         cleanup:
             context.close()
@@ -187,7 +197,9 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
             B.noArgsDestroyCalled == 1
             B.injectedDestroyCalled == 1
             D.created == 2
-            D.destroyed == 2
+            // One D destroyed, and only one: see the first feature for why it is not two.
+            D.destroyed == 1
+            D.destroyedInstances.unique(false).size() == 1
     }
 
     void "test proxies are prototypes and dependent beans not destroyed when created by `getBean(<ProxyClass>)`"() {

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -487,6 +487,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     }
 
     @Override
+    @Deprecated(since = "5.2.1", forRemoval = false)
     public void markDependentAsFactory() {
         if (dependentBeans != null) {
             if (dependentBeans.isEmpty()) {
@@ -494,6 +495,22 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
             }
             dependentFactory = dependentBeans.removeFirst();
         }
+    }
+
+    @Override
+    public void markDependentAsFactory(@Nullable Object factoryBean) {
+        if (factoryBean == null || dependentBeans == null || dependentBeans.isEmpty()) {
+            return;
+        }
+        // Search from the end, because the factory was looked up last and a definition that looks one up more than
+        // once has to mark the most recent registration.
+        for (int i = dependentBeans.size() - 1; i >= 0; i--) {
+            if (dependentBeans.get(i).bean == factoryBean) {
+                dependentFactory = dependentBeans.remove(i);
+                return;
+            }
+        }
+        // The factory is not a dependent of this bean, which is what a singleton or scoped factory looks like.
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/BeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanContext.java
@@ -228,6 +228,14 @@ public interface BeanContext extends
     /**
      * Destroys the given bean.
      *
+     * <p>The beans that were created for this one are destroyed with it only when the context still holds the
+     * registration the bean was created with, which is the case for a singleton and for a bean held by a custom
+     * scope. Nothing holds the registration of a {@code @Prototype} obtained from {@link #getBean} or of a bean
+     * from {@link #createBean}: such an instance has its own {@code @PreDestroy} invoked, but the beans created for
+     * it are not destroyed. To destroy one of those with its dependents, ask for its registration with
+     * {@link #getBeanRegistration(Argument, Qualifier)} and destroy that with
+     * {@link #destroyBean(BeanRegistration)}.</p>
+     *
      * @param bean The bean
      * @param <T>  The concrete class
      * @return The destroy instance

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -309,9 +309,30 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      * Dependent can be missing which means it's a singleton or scoped bean.
      *
      * @since 3.5.0
+     * @deprecated Since 5.2.1 use {@link #markDependentAsFactory(Object)}, which identifies the factory by the
+     * instance that was looked up instead of by its position. A bean definition generated before 5.2.1 still calls
+     * this method, so it cannot be removed; a definition generated since then does not.
      */
     @UsedByGeneratedCode
+    @Deprecated(since = "5.2.1", forRemoval = false)
     default void markDependentAsFactory() {
+    }
+
+    /**
+     * Marks the dependent registration of the given factory bean as the factory of the bean being created, so that a
+     * factory that only exists to produce this bean is destroyed once the bean has been built.
+     *
+     * <p>The factory is identified by the instance rather than by its position in the dependent list: by the time a
+     * bean with constructor advice looks its factory up, the factory method arguments and the bean's interceptors
+     * have already been recorded as dependents, and a {@code @Singleton} factory is recorded as a dependent of
+     * nothing at all. Nothing is marked when the factory is not one of the dependents, which is the normal case for
+     * a singleton or scoped factory.</p>
+     *
+     * @param factoryBean The factory bean that was just looked up, or {@code null} for a static factory member
+     * @since 5.2.1
+     */
+    @UsedByGeneratedCode
+    default void markDependentAsFactory(@Nullable Object factoryBean) {
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1165,6 +1165,34 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             .orElse(null);
     }
 
+    /**
+     * Destroys a bean the caller holds an instance of.
+     *
+     * <p>How complete that destruction is depends on whether the context still holds the registration the bean was
+     * created with, because that registration is the only record of which beans were created <em>for</em> this one
+     * and therefore have to be destroyed with it:</p>
+     *
+     * <ul>
+     *   <li>A singleton, or a bean held by a custom scope, is looked up by instance and destroyed through its own
+     *   registration, so its dependents are destroyed with it.</li>
+     *   <li>A bean with no registration - a {@code @Prototype} obtained from {@link #getBean}, or anything from
+     *   {@link #createBean} - is destroyed through a registration built here, which carries no dependents. Its own
+     *   {@code @PreDestroy} runs, and so does pre-destroy interception, but the beans created for it are not
+     *   destroyed. A generated proxy is the exception: it retained its interceptor registrations, so the
+     *   non-singleton ones among them are destroyed with the target.</li>
+     * </ul>
+     *
+     * <p>This cannot be fixed by remembering more, because remembering a prototype is what prototype scope exists
+     * not to do: the context would then hold every prototype instance ever handed out until the caller's own
+     * reference to it went away. A caller that needs a prototype destroyed with its dependents asks for the
+     * registration instead of the bean - {@link #getBeanRegistration(Argument, Qualifier)} - and destroys that with
+     * {@link #destroyBean(BeanRegistration)}, which is the same registration {@link #getBean} would have thrown
+     * away.</p>
+     *
+     * @param bean The bean
+     * @param <T>  The bean type
+     * @return The bean
+     */
     @Override
     public <T> T destroyBean(T bean) {
         ArgumentUtils.requireNonNull("bean", bean);
@@ -1175,6 +1203,15 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
             Optional<BeanDefinition<T>> beanDefinition = findBeanDefinition((Class<T>) bean.getClass());
             if (beanDefinition.isPresent()) {
                 BeanDefinition<T> definition = beanDefinition.get();
+                if (LOG_LIFECYCLE.isDebugEnabled()) {
+                    LOG_LIFECYCLE.debug(
+                        "Destroying bean [{}] of definition [{}] without a registration: the context tracks none for "
+                            + "this instance, so any beans created for it are not destroyed with it. Use "
+                            + "getBeanRegistration(..) and destroyBean(BeanRegistration) to destroy it with its dependents.",
+                        bean,
+                        definition
+                    );
+                }
                 BeanKey<T> key = new BeanKey<>(definition, definition.getDeclaredQualifier());
                 destroyBean(BeanRegistration.of(this, key, definition, bean, retainedInterceptorDependents(bean)));
             }
@@ -1294,14 +1331,8 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         if (beanToDestroy instanceof LifeCycle<?> cycle && !dependent) {
             destroyLifeCycleBean(cycle, definition);
         }
-        if (registration instanceof BeanDisposingRegistration) {
-            List<BeanRegistration<?>> dependents = ((BeanDisposingRegistration<T>) registration).getDependents();
-            if (CollectionUtils.isNotEmpty(dependents)) {
-                final ListIterator<BeanRegistration<?>> i = dependents.listIterator(dependents.size());
-                while (i.hasPrevious()) {
-                    destroyBean(i.previous(), true);
-                }
-            }
+        if (registration instanceof BeanDisposingRegistration<T> disposingRegistration) {
+            destroyDependents(disposingRegistration.getDependents());
         } else {
             try {
                 registration.close();
@@ -1409,22 +1440,29 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
         return bean;
     }
 
+    /**
+     * Destroys the bean behind an around proxy, along with the dependents the proxy owns.
+     *
+     * <p>The dependents are destroyed exactly once, and by the target's own destruction wherever the target is
+     * destroyed here, so that they go after the target's {@code @PreDestroy} rather than before it - the order every
+     * other bean's dependents are destroyed in. They are destroyed directly only when there is no target
+     * destruction to hand them to: a singleton target is destroyed in its own right by the singleton scope, a
+     * scoped target by its scope, and a lazy proxy that was never called has no target at all.</p>
+     *
+     * @param registration The registration of the proxy
+     * @param dependent    Whether the proxy is being destroyed as a dependent of another bean
+     * @param <T>          The bean type
+     */
     private <T> void destroyProxyTargetBean(BeanRegistration<T> registration, boolean dependent) {
-        Set<Object> destroyed = Collections.emptySet();
-        if (registration instanceof BeanDisposingRegistration<?> disposingRegistration) {
-            if (disposingRegistration.getDependents() != null) {
-                destroyed = Collections.newSetFromMap(new IdentityHashMap<>());
-                for (BeanRegistration<?> beanRegistration : disposingRegistration.getDependents()) {
-                    destroyBean(beanRegistration, true);
-                    destroyed.add(beanRegistration.bean);
-                }
-            }
-        }
+        List<BeanRegistration<?>> dependents = registration instanceof BeanDisposingRegistration<T> disposingRegistration
+            ? disposingRegistration.getDependents()
+            : null;
         BeanDefinition<T> proxyTargetBeanDefinition = findProxyTargetBeanDefinition(registration.beanDefinition)
             .orElseThrow(() -> new IllegalStateException("Cannot find a proxy target bean definition for: " + registration.beanDefinition));
         Optional<CustomScope<?>> declaredScope = customScopeRegistry.findDeclaredScope(proxyTargetBeanDefinition);
         if (declaredScope.isEmpty()) {
             if (proxyTargetBeanDefinition.isSingleton()) {
+                destroyDependents(dependents);
                 return;
             }
             // Scope is not present, try to get the actual target bean and destroy it
@@ -1432,20 +1470,27 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 InterceptedBeanProxy<T> interceptedProxy = (InterceptedBeanProxy<T>) registration.bean;
                 if (interceptedProxy.hasCachedInterceptedTarget()) {
                     T interceptedTarget = interceptedProxy.interceptedTarget();
-                    if (destroyed.contains(interceptedTarget)) {
-                        return;
+                    if (containsBean(dependents, interceptedTarget)) {
+                        // The target is one of the proxy's own dependents, which is what an eagerly resolved proxy
+                        // target looks like. Destroying the dependents destroys it once, with the dependents it
+                        // owns itself, so there is nothing left to hand over.
+                        destroyDependents(dependents);
+                    } else {
+                        destroyBean(BeanRegistration.of(this,
+                            new BeanKey<>(proxyTargetBeanDefinition, proxyTargetBeanDefinition.getDeclaredQualifier()),
+                            proxyTargetBeanDefinition,
+                            interceptedTarget,
+                            dependents
+                        ));
                     }
-                    destroyBean(BeanRegistration.of(this,
-                        new BeanKey<>(proxyTargetBeanDefinition, proxyTargetBeanDefinition.getDeclaredQualifier()),
-                        proxyTargetBeanDefinition,
-                        interceptedTarget,
-                        registration instanceof BeanDisposingRegistration ? ((BeanDisposingRegistration<T>) registration).getDependents() : null
-                    ));
                     interceptedProxy.clearCachedInterceptedTarget();
+                    return;
                 }
             }
+            destroyDependents(dependents);
             return;
         }
+        destroyDependents(dependents);
         CustomScope<?> customScope = declaredScope.get();
         if (dependent) {
             return;
@@ -1458,6 +1503,28 @@ public sealed class DefaultBeanContext implements ConfigurableBeanContext permit
                 interceptedProxy.clearCachedInterceptedTarget();
             }
         }
+    }
+
+    private void destroyDependents(@Nullable List<BeanRegistration<?>> dependents) {
+        if (CollectionUtils.isEmpty(dependents)) {
+            return;
+        }
+        final ListIterator<BeanRegistration<?>> i = dependents.listIterator(dependents.size());
+        while (i.hasPrevious()) {
+            destroyBean(i.previous(), true);
+        }
+    }
+
+    private static boolean containsBean(@Nullable List<BeanRegistration<?>> dependents, Object bean) {
+        if (dependents == null) {
+            return false;
+        }
+        for (BeanRegistration<?> dependentRegistration : dependents) {
+            if (dependentRegistration.bean == bean) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private <T> void triggerBeanDestroyedListeners(BeanDefinition<T> beanDefinition, T bean) {


### PR DESCRIPTION
Three defects in how a bean's dependents are destroyed, found while making Jakarta interceptor instances share a target's lifecycle. Each one is reproduced by a test that fails on `5.2.x` before the change.

## 1. `markDependentAsFactory` removed the wrong dependent

A generated bean definition records its factory so that a `@Prototype` factory can be destroyed once the bean it produced has been built: it looks the factory up and then tells the resolution context that a dependent it just recorded is the factory. `AbstractBeanResolutionContext.markDependentAsFactory` took that to mean the **first** recorded dependent.

That holds only for a definition with no constructor advice, where the lookup is the first thing `instantiate` does. For a bean with constructor advice, `InterceptedBeanDefinition.instantiate` resolves the factory method arguments (`resolveInstantiationValues`) and then the bean's interceptors (`resolveInterceptors`) before `doInstantiate` looks the factory up — and a `@Singleton` factory is resolved from the singleton scope and recorded as a dependent of nothing at all. So the "factory" removed from the list was a method argument or one of the bean's own interceptors, and `createRegistration` destroyed it immediately after creating the bean.

**Reproduction** — `FactoryProducedBeanDependentsSpec`: a `@Singleton` factory with an `@AroundConstruct`-advised factory method taking a `@Prototype` argument. On `5.2.x` the argument's `@PreDestroy` runs during `getBean`:

```
expected: [construct]
actual:   [construct, argument-destroyed]
```

**Fix** — the generated definition now calls a new `BeanResolutionContext.markDependentAsFactory(Object)` with the instance it just looked up, and the registration is found by identity (searching from the end). Nothing is marked when the factory is not among the dependents, which is the normal singleton/scoped case. The no-arg `markDependentAsFactory()` is kept and deprecated, because definitions generated before this change still call it.

## 2. `destroyProxyTargetBean` destroyed the proxy's dependents twice

It destroyed `registration.getDependents()` up front and then passed the same list to the registration it built for the target, so `destroyBean` destroyed each of them a second time — and the first of the two ran before the target's `@PreDestroy`, the opposite of the order every other bean's dependents are destroyed in. The `destroyed` set only guarded the target instance itself, not the dependents.

**Reproduction** — `ProxyTargetDependentDestructionSpec`: an `@Around(proxyTarget = true)` prototype with a `@Prototype` interceptor, held by a singleton. On `5.2.x`:

```
eager proxy target:           [interceptor-destroyed, target-destroyed]
lazy cacheable proxy target:  [interceptor-destroyed, target-destroyed, interceptor-destroyed]
expected in both cases:       [target-destroyed, interceptor-destroyed]
```

**Fix** — the dependents are destroyed once, by the target's own destruction wherever the target is destroyed here, and directly only when there is nothing to hand them to (a singleton target destroyed by the singleton scope, a scoped target destroyed by its scope, a lazy proxy that was never called). When the target is itself one of the proxy's dependents — an eagerly resolved proxy target — destroying the dependents destroys it once with the dependents it owns, so there is nothing left to hand over. The cached target is now also cleared on that path, which it was not before.

### A pre-existing gap this makes visible

`ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec` asserted `D.destroyed == 2` with the comment `// Destroy proxy + target`. It was not two beans: the proxy's own `D` was destroyed twice and the lazy cached target's `D` never. Verified by recording the destroyed instances — on `5.2.x` that assertion is satisfied by `2` destructions of `1` unique instance.

The reason the target's `D` is unreachable is that the proxy caches the target instance in its `$target` field without the registration that records what was created for it. Fixing that means changing what a generated proxy stores, so it is **not** in this PR. The spec now asserts `D.destroyed == 1` plus `destroyedInstances.unique().size() == 1`, with a comment saying why, so the gap is pinned rather than masked. Happy to follow up with it if you want it fixed here.

## 3. `destroyBean(Object)` on an untracked instance

Nothing tracks the registration of a `@Prototype` returned by `getBean` — only the singleton scope and custom scopes hold registrations — so `destroyBean(Object)` falls through to building a fresh registration with no dependents. The bean's own `@PreDestroy` runs and the beans created with it do not get destroyed.

**Reproduction** — `PrototypeInstanceDestructionSpec`: `[root-destroyed]`, with the prototype dependent left alone.

**This one is documented rather than changed.** Making it work means the context holding every prototype instance it ever handed out until the caller drops its own reference, which is what prototype scope exists not to do. The registration that carries the dependents already exists and is already reachable: `getBeanRegistration(..)` returns it and `destroyBean(BeanRegistration)` destroys it correctly, which the spec pins alongside the limitation. So:

- `BeanContext.destroyBean(T)` now documents which instances it can destroy completely and names the supported route for the rest;
- `DefaultBeanContext.destroyBean(T)` carries the longer version, including the one exception that already works (a generated proxy retains its interceptor registrations, so the non-singleton ones are destroyed with the target);
- destroying an instance with no registration logs a debug line saying the dependents were not reached. Not a warning, because the same shape is the legitimate and complete outcome for a `createBean` result with no dependents, and there is no way to tell the two apart from the instance.

Say the word if you would rather have the instance tracking; it is a self-contained change on top of this one.

## Interaction with `SharedInterceptorRegistrations` and custom scopes

`SharedInterceptorRegistrations` keeps the interceptors resolved for a bean in a separate resolution-context attribute, so nothing here changes what it stores. What defect 1 did break is the agreement between the two: an interceptor could be destroyed as the "factory" while still listed in the registrations the bean retains for its later interception points. `FactoryProducedBeanDependentsSpec` now covers that end to end — one `@Prototype` interceptor serving `AROUND_CONSTRUCT`, `POST_CONSTRUCT` and `PRE_DESTROY` of a factory-produced bean, destroyed only after the last of them.

For custom scopes, the scoped branch of `destroyProxyTargetBean` is unchanged apart from destroying the dependents through the shared helper; the branch that changed is the one taken when the target has no declared scope.

## Testing

`:micronaut-inject:check`, `:micronaut-context:check`, `:micronaut-aop:check`, `:micronaut-core-processor:check`, `:micronaut-inject-java:check` (5291 tests), plus `:micronaut-inject-groovy:test`, `:micronaut-inject-kotlin:test`, `:micronaut-inject-groovy-test:test`, `:micronaut-inject-kotlin-test:test`, `:micronaut-runtime:test` and `:test-suite:test` — all green. The one checkstyle error in `core-processor` (unused import in `IntrospectedTypeElementVisitor`) is pre-existing and in a file this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
