### PR TITLE
Expose an annotation interface's targets, repeatable container and retention on AnnotationElement

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/AnnotationElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/AnnotationElement.java
@@ -15,6 +15,15 @@
  */
 package io.micronaut.inject.ast;
 
+import io.micronaut.core.annotation.NonNull;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+
 /**
  * Represents an annotation in the AST.
  *
@@ -23,6 +32,17 @@ package io.micronaut.inject.ast;
  * @since 3.1.0
  */
 public interface AnnotationElement extends ClassElement {
+
+    /**
+     * The element types an annotation interface that declares no {@link java.lang.annotation.Target} may be
+     * written on: every declaration context and no type context, as JLS 9.6.4.1 specifies. That is every
+     * {@link ElementType} except {@link ElementType#TYPE_USE} and {@link ElementType#TYPE_PARAMETER}.
+     *
+     * @since 5.3.0
+     */
+    Set<ElementType> DEFAULT_TARGETS = Collections.unmodifiableSet(
+        EnumSet.complementOf(EnumSet.of(ElementType.TYPE_USE, ElementType.TYPE_PARAMETER))
+    );
 
     /**
      * Is the annotation annotated with {@link java.lang.annotation.Inherited}?
@@ -39,5 +59,54 @@ public interface AnnotationElement extends ClassElement {
      */
     default boolean isInherited() {
         return false;
+    }
+
+    /**
+     * The element types this annotation interface may be written on, as its
+     * {@link java.lang.annotation.Target} (or {@code kotlin.annotation.Target}) declares them, mapped to
+     * {@link ElementType}. When the interface declares no target the result is {@link #DEFAULT_TARGETS}.
+     *
+     * <p>Like {@link #isInherited()}, the answer is resolved from the native element, because
+     * {@code java.lang.annotation} meta-annotations are excluded from the annotation metadata. The default
+     * implementation, for implementations that have no native element to inspect, returns
+     * {@link #DEFAULT_TARGETS}.</p>
+     *
+     * @return The element types the annotation may target; never {@code null}
+     * @since 5.3.0
+     */
+    @NonNull
+    default Set<ElementType> getTargets() {
+        return DEFAULT_TARGETS;
+    }
+
+    /**
+     * The annotation interface that holds the repetitions of this one, by binary name, when this annotation
+     * is repeatable: declared with {@link java.lang.annotation.Repeatable}, {@code kotlin.annotation.Repeatable}
+     * or {@code kotlin.jvm.JvmRepeatable} alike.
+     *
+     * <p>The default implementation, for implementations that have no native element to inspect, returns
+     * empty.</p>
+     *
+     * @return The binary name of the container annotation, or empty when the annotation is not repeatable
+     * @since 5.3.0
+     */
+    @NonNull
+    default Optional<String> getRepeatableContainer() {
+        return Optional.empty();
+    }
+
+    /**
+     * The retention of this annotation interface, as its {@link java.lang.annotation.Retention} (or
+     * {@code kotlin.annotation.Retention}) declares it; {@link RetentionPolicy#RUNTIME} when it declares none.
+     *
+     * <p>The default implementation, for implementations that have no native element to inspect, returns
+     * {@link RetentionPolicy#RUNTIME}.</p>
+     *
+     * @return The retention policy; never {@code null}
+     * @since 5.3.0
+     */
+    @NonNull
+    default RetentionPolicy getRetentionPolicy() {
+        return RetentionPolicy.RUNTIME;
     }
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
@@ -177,7 +177,7 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
     }
 
     @Override
-    protected @NonNull RetentionPolicy getRetentionPolicy(@NonNull AnnotatedNode annotation) {
+    public @NonNull RetentionPolicy getRetentionPolicy(@NonNull AnnotatedNode annotation) {
         List<AnnotationNode> annotations = annotation.getAnnotations();
         for (AnnotationNode ann : annotations) {
             if (ann.getClassNode().getName().equals(Retention.class.getName())) {
@@ -249,7 +249,7 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
     }
 
     @Override
-    protected String getRepeatableContainerNameForType(AnnotatedNode annotationType) {
+    public String getRepeatableContainerNameForType(AnnotatedNode annotationType) {
         List<AnnotationNode> annotationNodes = annotationType.getAnnotations(ClassHelper.makeCached(Repeatable.class));
         if (CollectionUtils.isNotEmpty(annotationNodes)) {
             Expression expression = annotationNodes.get(0).getMember("value");

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyAnnotationElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyAnnotationElement.java
@@ -21,6 +21,20 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.AnnotationElement;
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import org.codehaus.groovy.ast.AnnotationNode;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.ListExpression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Groovy implementation of {@link io.micronaut.inject.ast.AnnotationElement}.
@@ -51,5 +65,50 @@ final class GroovyAnnotationElement extends GroovyClassElement implements Annota
             }
         }
         return false;
+    }
+
+    @Override
+    public Set<ElementType> getTargets() {
+        List<AnnotationNode> targetNodes = classNode.getAnnotations(ClassHelper.makeCached(Target.class));
+        if (targetNodes.isEmpty()) {
+            return DEFAULT_TARGETS;
+        }
+        EnumSet<ElementType> targets = EnumSet.noneOf(ElementType.class);
+        for (Expression expression : targetNodes.get(0).getMembers().values()) {
+            addTargets(expression, targets);
+        }
+        return Collections.unmodifiableSet(targets);
+    }
+
+    private static void addTargets(Expression expression, EnumSet<ElementType> targets) {
+        String name = null;
+        if (expression instanceof ListExpression listExpression) {
+            for (Expression item : listExpression.getExpressions()) {
+                addTargets(item, targets);
+            }
+            return;
+        } else if (expression instanceof PropertyExpression propertyExpression) {
+            name = propertyExpression.getPropertyAsString();
+        } else if (expression instanceof VariableExpression variableExpression) {
+            name = variableExpression.getName();
+        }
+        if (name != null) {
+            for (ElementType elementType : ElementType.values()) {
+                if (elementType.name().equals(name)) {
+                    targets.add(elementType);
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public Optional<String> getRepeatableContainer() {
+        return Optional.ofNullable(visitorContext.getAnnotationMetadataBuilder().getRepeatableContainerNameForType(classNode));
+    }
+
+    @Override
+    public RetentionPolicy getRetentionPolicy() {
+        return visitorContext.getAnnotationMetadataBuilder().getRetentionPolicy(classNode);
     }
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyAnnotationElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyAnnotationElementSpec.groovy
@@ -1,6 +1,9 @@
 package io.micronaut.ast.groovy.visitor
 
 import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.PropertySource
+import io.micronaut.core.annotation.Generated
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.inject.ast.AnnotationElement
 import jakarta.inject.Singleton
@@ -8,6 +11,9 @@ import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.ErrorCollector
 import org.codehaus.groovy.control.SourceUnit
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.RetentionPolicy
 
 class GroovyAnnotationElementSpec extends AbstractBeanDefinitionSpec {
 
@@ -80,6 +86,99 @@ import java.lang.annotation.Inherited
         expect:
         ((AnnotationElement) introspected).isInherited()
         !((AnnotationElement) singleton).isInherited()
+    }
+
+    void "test getTargets, getRepeatableContainer and getRetentionPolicy as declared in the source"() {
+        given:
+        def element = (AnnotationElement) buildClassElement("test.MyAnn", """
+package test
+
+import java.lang.annotation.*
+
+@Target([ElementType.TYPE, ElementType.METHOD, ElementType.TYPE_USE])
+@Retention(RetentionPolicy.SOURCE)
+@Repeatable(MyAnns)
+@interface MyAnn {
+}
+
+@interface MyAnns {
+    MyAnn[] value()
+}
+""")
+        expect:
+        element.getTargets() == EnumSet.of(ElementType.TYPE, ElementType.METHOD, ElementType.TYPE_USE)
+        element.getRepeatableContainer().get() == 'test.MyAnns'
+        element.getRetentionPolicy() == RetentionPolicy.SOURCE
+
+        and: "a copy of the element keeps the answers"
+        def copy = (AnnotationElement) element.withAnnotationMetadata(element.getAnnotationMetadata())
+        copy.getTargets() == element.getTargets()
+        copy.getRepeatableContainer().get() == 'test.MyAnns'
+        copy.getRetentionPolicy() == RetentionPolicy.SOURCE
+    }
+
+    void "test a single @Target value"() {
+        given:
+        def element = (AnnotationElement) buildClassElement("""
+package test
+
+import java.lang.annotation.*
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.CLASS)
+@interface MyAnn {
+}
+""")
+        expect:
+        element.getTargets() == EnumSet.of(ElementType.FIELD)
+        !element.getRepeatableContainer().isPresent()
+        element.getRetentionPolicy() == RetentionPolicy.CLASS
+    }
+
+    void "test the JLS defaults when the annotation declares no @Target, @Repeatable or @Retention"() {
+        given:
+        def element = (AnnotationElement) buildClassElement("""
+package test
+
+@interface MyAnn {
+}
+""")
+        expect:
+        element.getTargets() == AnnotationElement.DEFAULT_TARGETS
+        !element.getRepeatableContainer().isPresent()
+        element.getRetentionPolicy() == RetentionPolicy.RUNTIME
+    }
+
+    void "test an empty @Target means the annotation targets nothing"() {
+        given:
+        def element = (AnnotationElement) buildClassElement("""
+package test
+
+import java.lang.annotation.*
+
+@Target([])
+@interface MyAnn {
+}
+""")
+        expect:
+        element.getTargets().isEmpty()
+    }
+
+    void "test getTargets, getRepeatableContainer and getRetentionPolicy for annotations on the classpath"() {
+        given:
+        def visitorContext = newVisitorContext()
+        def introspected = (AnnotationElement) visitorContext.getClassElement(Introspected.name).get()
+        def singleton = (AnnotationElement) visitorContext.getClassElement(Singleton.name).get()
+        def property = (AnnotationElement) visitorContext.getClassElement(Property.name).get()
+        def generated = (AnnotationElement) visitorContext.getClassElement(Generated.name).get()
+
+        expect:
+        introspected.getTargets() == EnumSet.of(ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.PACKAGE)
+        singleton.getTargets() == AnnotationElement.DEFAULT_TARGETS
+        property.getRepeatableContainer() == Optional.of(PropertySource.name)
+        singleton.getRepeatableContainer() == Optional.empty()
+        generated.getRetentionPolicy() == RetentionPolicy.CLASS
+        singleton.getRetentionPolicy() == RetentionPolicy.RUNTIME
     }
 
     private static GroovyVisitorContext newVisitorContext() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -140,7 +140,7 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
 
     @Nullable
     @Override
-    protected String getRepeatableContainerNameForType(Element annotationType) {
+    public String getRepeatableContainerNameForType(Element annotationType) {
         List<? extends AnnotationMirror> mirrors = annotationType.getAnnotationMirrors();
         for (AnnotationMirror mirror : mirrors) {
             String name = mirror.getAnnotationType().toString();
@@ -177,7 +177,7 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
     }
 
     @Override
-    protected RetentionPolicy getRetentionPolicy(Element annotation) {
+    public RetentionPolicy getRetentionPolicy(Element annotation) {
         final List<? extends AnnotationMirror> annotationMirrors = annotation.getAnnotationMirrors();
         for (AnnotationMirror annotationMirror : annotationMirrors) {
             final String annotationTypeName = getAnnotationTypeName(annotationMirror);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaAnnotationElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaAnnotationElement.java
@@ -21,7 +21,17 @@ import io.micronaut.inject.ast.AnnotationElement;
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Represents an annotation in the AST for Java.
@@ -59,5 +69,51 @@ final class JavaAnnotationElement extends JavaClassElement implements Annotation
             }
         }
         return false;
+    }
+
+    @Override
+    public Set<ElementType> getTargets() {
+        TypeElement typeElement = getNativeType().element();
+        for (AnnotationMirror annotationMirror : typeElement.getAnnotationMirrors()) {
+            if (annotationMirror.getAnnotationType().asElement() instanceof TypeElement annotationType
+                && Target.class.getName().contentEquals(annotationType.getQualifiedName())) {
+                EnumSet<ElementType> targets = EnumSet.noneOf(ElementType.class);
+                for (AnnotationValue annotationValue : annotationMirror.getElementValues().values()) {
+                    addTargets(annotationValue.getValue(), targets);
+                }
+                return Collections.unmodifiableSet(targets);
+            }
+        }
+        return DEFAULT_TARGETS;
+    }
+
+    private static void addTargets(Object value, EnumSet<ElementType> targets) {
+        if (value instanceof List<?> values) {
+            for (Object item : values) {
+                addTargets(item, targets);
+            }
+        } else if (value instanceof AnnotationValue annotationValue) {
+            addTargets(annotationValue.getValue(), targets);
+        } else if (value instanceof VariableElement constant) {
+            String name = constant.getSimpleName().toString();
+            for (ElementType elementType : ElementType.values()) {
+                if (elementType.name().equals(name)) {
+                    targets.add(elementType);
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public Optional<String> getRepeatableContainer() {
+        return Optional.ofNullable(
+            visitorContext.getAnnotationMetadataBuilder().getRepeatableContainerNameForType(getNativeType().element())
+        );
+    }
+
+    @Override
+    public RetentionPolicy getRetentionPolicy() {
+        return visitorContext.getAnnotationMetadataBuilder().getRetentionPolicy(getNativeType().element());
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/annotation/JavaAnnotationElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/JavaAnnotationElementSpec.groovy
@@ -1,12 +1,18 @@
 package io.micronaut.annotation
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.PropertySource
+import io.micronaut.core.annotation.Generated
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.inject.ast.AnnotationElement
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.visitor.VisitorContext
 import jakarta.inject.Singleton
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.RetentionPolicy
 
 class JavaAnnotationElementSpec extends AbstractTypeElementSpec {
 
@@ -60,6 +66,127 @@ import java.lang.annotation.Inherited;
     void "test the default isInherited implementation reports false"() {
         expect: "an implementation with no native element to inspect cannot answer the question"
         !new NoNativeTypeAnnotationElement().isInherited()
+    }
+
+    void "test getTargets, getRepeatableContainer and getRetentionPolicy as declared in the source"() {
+        given:
+        def element = (AnnotationElement) buildClassElement("""
+package test;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.SOURCE)
+@Repeatable(MyAnns.class)
+@interface MyAnn {
+}
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.TYPE_USE})
+@interface MyAnns {
+    MyAnn[] value();
+}
+""")
+        expect:
+        element.getTargets() == EnumSet.of(ElementType.TYPE, ElementType.METHOD, ElementType.TYPE_USE)
+        element.getRepeatableContainer().get() == 'test.MyAnns'
+        element.getRetentionPolicy() == RetentionPolicy.SOURCE
+
+        and: "a copy of the element keeps the answers"
+        def copy = (AnnotationElement) element.withAnnotationMetadata(element.getAnnotationMetadata())
+        copy.getTargets() == element.getTargets()
+        copy.getRepeatableContainer().get() == 'test.MyAnns'
+        copy.getRetentionPolicy() == RetentionPolicy.SOURCE
+    }
+
+    void "test a single @Target value and a nested container"() {
+        given:
+        def element = (AnnotationElement) buildClassElement("""
+package test;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.CLASS)
+@Repeatable(Outer.MyAnns.class)
+@interface MyAnn {
+}
+
+class Outer {
+    @Target(ElementType.FIELD)
+    @interface MyAnns {
+        MyAnn[] value();
+    }
+}
+""")
+        expect:
+        element.getTargets() == EnumSet.of(ElementType.FIELD)
+        element.getRepeatableContainer().get() == 'test.Outer$MyAnns'
+        element.getRetentionPolicy() == RetentionPolicy.CLASS
+    }
+
+    void "test the JLS defaults when the annotation declares no @Target, @Repeatable or @Retention"() {
+        given:
+        def element = (AnnotationElement) buildClassElement("""
+package test;
+
+@interface MyAnn {
+}
+""")
+        expect:
+        element.getTargets() == AnnotationElement.DEFAULT_TARGETS
+        !element.getTargets().contains(ElementType.TYPE_USE)
+        !element.getTargets().contains(ElementType.TYPE_PARAMETER)
+        element.getTargets().contains(ElementType.TYPE)
+        element.getTargets().contains(ElementType.RECORD_COMPONENT)
+        !element.getRepeatableContainer().isPresent()
+        element.getRetentionPolicy() == RetentionPolicy.RUNTIME
+    }
+
+    void "test an empty @Target means the annotation targets nothing"() {
+        given:
+        def element = (AnnotationElement) buildClassElement("""
+package test;
+
+import java.lang.annotation.*;
+
+@Target({})
+@interface MyAnn {
+}
+""")
+        expect:
+        element.getTargets().isEmpty()
+    }
+
+    void "test the default implementations for an element without a native type"() {
+        given:
+        def element = new NoNativeTypeAnnotationElement()
+
+        expect:
+        element.getTargets() == AnnotationElement.DEFAULT_TARGETS
+        !element.getRepeatableContainer().isPresent()
+        element.getRetentionPolicy() == RetentionPolicy.RUNTIME
+    }
+
+    void "test getTargets, getRepeatableContainer and getRetentionPolicy for annotations on the classpath"() {
+        given:
+        InheritedVisitor.RESULTS.clear()
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+@jakarta.inject.Singleton
+class MyBean {
+}
+''')
+
+        expect:
+        InheritedVisitor.TARGETS[Introspected.name] == EnumSet.of(ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.PACKAGE)
+        InheritedVisitor.TARGETS[Singleton.name] == AnnotationElement.DEFAULT_TARGETS
+        InheritedVisitor.TARGETS[Property.name] == AnnotationElement.DEFAULT_TARGETS
+        InheritedVisitor.TARGETS[Generated.name] == EnumSet.of(ElementType.PACKAGE, ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE)
+        InheritedVisitor.CONTAINERS[Property.name] == Optional.of(PropertySource.name)
+        InheritedVisitor.CONTAINERS[Singleton.name] == Optional.empty()
+        InheritedVisitor.RETENTIONS[Generated.name] == RetentionPolicy.CLASS
+        InheritedVisitor.RETENTIONS[Singleton.name] == RetentionPolicy.RUNTIME
     }
 
     void "test isInherited for annotations on the classpath"() {
@@ -128,12 +255,19 @@ class MyBean {
     static class InheritedVisitor implements TypeElementVisitor<Object, Object> {
 
         static final Map<String, Boolean> RESULTS = [:]
+        static final Map<String, Set<ElementType>> TARGETS = [:]
+        static final Map<String, Optional<String>> CONTAINERS = [:]
+        static final Map<String, RetentionPolicy> RETENTIONS = [:]
 
         @Override
         void start(VisitorContext visitorContext) {
-            for (String name : [Introspected.name, Singleton.name]) {
+            for (String name : [Introspected.name, Singleton.name, Property.name, Generated.name]) {
                 visitorContext.getClassElement(name).ifPresent { ClassElement ce ->
-                    RESULTS.put(name, ((AnnotationElement) ce).isInherited())
+                    def annotationElement = (AnnotationElement) ce
+                    RESULTS.put(name, annotationElement.isInherited())
+                    TARGETS.put(name, annotationElement.getTargets())
+                    CONTAINERS.put(name, annotationElement.getRepeatableContainer())
+                    RETENTIONS.put(name, annotationElement.getRetentionPolicy())
                 }
             }
         }

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
@@ -541,7 +541,7 @@ internal class KotlinAnnotationMetadataBuilder(
         return visitorContext
     }
 
-    override fun getRetentionPolicy(annotation: KSAnnotated): RetentionPolicy {
+    public override fun getRetentionPolicy(annotation: KSAnnotated): RetentionPolicy {
         var retention = annotation.annotations.find {
             getAnnotationTypeName(it) == java.lang.annotation.Retention::class.java.name
         }

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinAnnotationElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinAnnotationElement.kt
@@ -15,9 +15,17 @@
  */
 package io.micronaut.kotlin.processing.visitor
 
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSType
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.inject.ast.AnnotationElement
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory
+import java.lang.annotation.ElementType
+import java.lang.annotation.RetentionPolicy
+import java.util.Collections
+import java.util.EnumSet
+import java.util.Optional
 
 /**
  * Kotlin implementation of [io.micronaut.inject.ast.AnnotationElement].
@@ -45,5 +53,81 @@ internal class KotlinAnnotationElement(
 
     override fun isInherited() = declaration.annotations.any { annotation ->
         annotation.annotationType.resolve().declaration.qualifiedName?.asString() == AnnotationUtil.ANN_INHERITED
+    }
+
+    /*
+     * KSP presents a Java @Target on a compiled annotation as kotlin.annotation.Target with the Java element
+     * types mapped to AnnotationTarget, so PACKAGE, MODULE and RECORD_COMPONENT, which have no Kotlin
+     * target, cannot be reported for a Java annotation on the classpath.
+     */
+    override fun getTargets(): Set<ElementType> {
+        val target = declaration.annotations.find { annotation ->
+            val name = visitorContext.getAnnotationTypeName(annotation)
+            name == KOTLIN_TARGET || name == JAVA_TARGET
+        } ?: return AnnotationElement.DEFAULT_TARGETS
+        val targets = EnumSet.noneOf(ElementType::class.java)
+        for (argument in target.arguments) {
+            addTargets(argument.value, targets)
+        }
+        return Collections.unmodifiableSet(targets)
+    }
+
+    override fun getRepeatableContainer(): Optional<String> {
+        val container = visitorContext.getRepeatableContainerNameForType(declaration)
+        if (container != null) {
+            return Optional.of(container)
+        }
+        val kotlinRepeatable = declaration.annotations.any { annotation ->
+            visitorContext.getAnnotationTypeName(annotation) == KOTLIN_REPEATABLE
+        }
+        if (kotlinRepeatable) {
+            // Since Kotlin 1.6 the compiler generates the container of a kotlin.annotation.Repeatable
+            // annotation as a nested class named Container
+            return Optional.of(visitorContext.getBinaryName(declaration) + "\$Container")
+        }
+        return Optional.empty()
+    }
+
+    override fun getRetentionPolicy(): RetentionPolicy =
+        visitorContext.annotationMetadataBuilder.getRetentionPolicy(declaration)
+
+    private fun addTargets(value: Any?, targets: EnumSet<ElementType>) {
+        when (value) {
+            is List<*> -> value.forEach { addTargets(it, targets) }
+            is Array<*> -> value.forEach { addTargets(it, targets) }
+            is KSType -> addTargets(value.declaration, targets)
+            is KSDeclaration -> {
+                val elementType = when (value.simpleName.asString()) {
+                    // kotlin.annotation.AnnotationTarget
+                    "CLASS" -> ElementType.TYPE
+                    "ANNOTATION_CLASS" -> ElementType.ANNOTATION_TYPE
+                    "VALUE_PARAMETER" -> ElementType.PARAMETER
+                    "FUNCTION", "PROPERTY_GETTER", "PROPERTY_SETTER" -> ElementType.METHOD
+                    "TYPE" -> if (isKotlinTarget(value)) ElementType.TYPE_USE else ElementType.TYPE
+                    "TYPE_PARAMETER" -> ElementType.TYPE_PARAMETER
+                    "FIELD" -> ElementType.FIELD
+                    "CONSTRUCTOR" -> ElementType.CONSTRUCTOR
+                    "LOCAL_VARIABLE" -> ElementType.LOCAL_VARIABLE
+                    // PROPERTY, EXPRESSION, FILE and TYPEALIAS have no java.lang.annotation.ElementType
+                    "PROPERTY", "EXPRESSION", "FILE", "TYPEALIAS" -> null
+                    // java.lang.annotation.ElementType
+                    else -> ElementType.entries.find { it.name == value.simpleName.asString() }
+                }
+                if (elementType != null) {
+                    targets.add(elementType)
+                }
+            }
+            else -> {}
+        }
+    }
+
+    private fun isKotlinTarget(constant: KSDeclaration) =
+        constant.parentDeclaration?.qualifiedName?.asString() == KOTLIN_ANNOTATION_TARGET
+
+    companion object {
+        private const val KOTLIN_TARGET = "kotlin.annotation.Target"
+        private const val KOTLIN_REPEATABLE = "kotlin.annotation.Repeatable"
+        private const val JAVA_TARGET = "java.lang.annotation.Target"
+        private const val KOTLIN_ANNOTATION_TARGET = "kotlin.annotation.AnnotationTarget"
     }
 }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/ast/visitor/KotlinAnnotationElementSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/ast/visitor/KotlinAnnotationElementSpec.groovy
@@ -1,12 +1,18 @@
 package io.micronaut.kotlin.processing.ast.visitor
 
 import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.PropertySource
+import io.micronaut.core.annotation.Generated
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.inject.ast.AnnotationElement
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.visitor.VisitorContext
 import jakarta.inject.Singleton
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.RetentionPolicy
 
 class KotlinAnnotationElementSpec extends AbstractKotlinCompilerSpec {
 
@@ -35,6 +41,72 @@ class MyBean
         InheritedVisitor.RESULTS['test.MyPlainAnn:copy'] == false
     }
 
+    void "test getTargets, getRepeatableContainer and getRetentionPolicy"() {
+        given:
+        DeclarationVisitor.TARGETS.clear()
+        DeclarationVisitor.CONTAINERS.clear()
+        DeclarationVisitor.RETENTIONS.clear()
+        buildClassElement("test.MyBean", """
+package test
+
+import kotlin.annotation.AnnotationTarget.*
+
+@Target(CLASS, ANNOTATION_CLASS, FUNCTION, PROPERTY_GETTER, VALUE_PARAMETER, TYPE, TYPE_PARAMETER, PROPERTY, FIELD, CONSTRUCTOR, LOCAL_VARIABLE, EXPRESSION, FILE, TYPEALIAS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class MyTargetedAnn
+
+@Target(FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@Repeatable
+annotation class MyRepeatableAnn(val value: String)
+
+@JvmRepeatable(MyJvmRepeatableAnns::class)
+annotation class MyJvmRepeatableAnn(val value: String)
+
+annotation class MyJvmRepeatableAnns(val value: Array<MyJvmRepeatableAnn>)
+
+@Target()
+annotation class MyUntargetedAnn
+
+annotation class MyPlainAnn
+
+class MyBean
+""")
+
+        expect: "kotlin.annotation.AnnotationTarget is mapped to java.lang.annotation.ElementType"
+        DeclarationVisitor.TARGETS['test.MyTargetedAnn'] == EnumSet.of(
+            ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.PARAMETER,
+            ElementType.TYPE_USE, ElementType.TYPE_PARAMETER, ElementType.FIELD, ElementType.CONSTRUCTOR,
+            ElementType.LOCAL_VARIABLE
+        )
+        DeclarationVisitor.TARGETS['test.MyRepeatableAnn'] == EnumSet.of(ElementType.METHOD)
+        DeclarationVisitor.TARGETS['test.MyUntargetedAnn'].isEmpty()
+        DeclarationVisitor.TARGETS['test.MyPlainAnn'] == AnnotationElement.DEFAULT_TARGETS
+
+        and: "a Java @Target on the classpath is read as well, through the kotlin.annotation.AnnotationTarget view KSP gives of it: PACKAGE has no Kotlin target"
+        DeclarationVisitor.TARGETS[Introspected.name] == EnumSet.of(ElementType.TYPE, ElementType.ANNOTATION_TYPE)
+        DeclarationVisitor.TARGETS[Singleton.name] == AnnotationElement.DEFAULT_TARGETS
+
+        and: "kotlin.annotation.Repeatable, @JvmRepeatable and java.lang.annotation.Repeatable alike"
+        DeclarationVisitor.CONTAINERS['test.MyRepeatableAnn'] == Optional.of('test.MyRepeatableAnn$Container')
+        DeclarationVisitor.CONTAINERS['test.MyJvmRepeatableAnn'] == Optional.of('test.MyJvmRepeatableAnns')
+        DeclarationVisitor.CONTAINERS['test.MyPlainAnn'] == Optional.empty()
+        DeclarationVisitor.CONTAINERS[Property.name] == Optional.of(PropertySource.name)
+        DeclarationVisitor.CONTAINERS[Singleton.name] == Optional.empty()
+
+        and: "the retention"
+        DeclarationVisitor.RETENTIONS['test.MyTargetedAnn'] == RetentionPolicy.SOURCE
+        DeclarationVisitor.RETENTIONS['test.MyRepeatableAnn'] == RetentionPolicy.CLASS
+        DeclarationVisitor.RETENTIONS['test.MyPlainAnn'] == RetentionPolicy.RUNTIME
+        DeclarationVisitor.RETENTIONS[Generated.name] == RetentionPolicy.CLASS
+        DeclarationVisitor.RETENTIONS[Singleton.name] == RetentionPolicy.RUNTIME
+
+        and: "a copy of the element keeps the answers"
+        DeclarationVisitor.TARGETS['test.MyRepeatableAnn:copy'] == EnumSet.of(ElementType.METHOD)
+        DeclarationVisitor.CONTAINERS['test.MyRepeatableAnn:copy'] == Optional.of('test.MyRepeatableAnn$Container')
+        DeclarationVisitor.RETENTIONS['test.MyRepeatableAnn:copy'] == RetentionPolicy.CLASS
+    }
+
     static class InheritedVisitor implements TypeElementVisitor<Object, Object> {
 
         static final Map<String, Boolean> RESULTS = [:]
@@ -48,6 +120,31 @@ class MyBean
                     RESULTS.put(name + ':copy', ((AnnotationElement) copy).isInherited())
                 }
             }
+        }
+    }
+
+    static class DeclarationVisitor implements TypeElementVisitor<Object, Object> {
+
+        static final Map<String, Set<ElementType>> TARGETS = [:]
+        static final Map<String, Optional<String>> CONTAINERS = [:]
+        static final Map<String, RetentionPolicy> RETENTIONS = [:]
+
+        @Override
+        void start(VisitorContext visitorContext) {
+            def names = ['test.MyTargetedAnn', 'test.MyRepeatableAnn', 'test.MyJvmRepeatableAnn', 'test.MyUntargetedAnn', 'test.MyPlainAnn',
+                         Introspected.name, Singleton.name, Property.name, Generated.name]
+            for (String name : names) {
+                visitorContext.getClassElement(name).ifPresent { ClassElement ce ->
+                    record(name, (AnnotationElement) ce)
+                    record(name + ':copy', (AnnotationElement) ce.withAnnotationMetadata(ce.getAnnotationMetadata()))
+                }
+            }
+        }
+
+        private static void record(String name, AnnotationElement element) {
+            TARGETS.put(name, element.getTargets())
+            CONTAINERS.put(name, element.getRepeatableContainer())
+            RETENTIONS.put(name, element.getRetentionPolicy())
         }
     }
 }

--- a/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -16,3 +16,4 @@ io.micronaut.kotlin.processing.aop.introduction.MyIsEnumInTypeArgumentSpec$MyCon
 io.micronaut.kotlin.processing.ast.visitor.KotlinAnnotationElementSpec$InheritedVisitor
 io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsVisitor
 io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsRecordingVisitor
+io.micronaut.kotlin.processing.ast.visitor.KotlinAnnotationElementSpec$DeclarationVisitor

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PythonAnnotationElementSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PythonAnnotationElementSpec.groovy
@@ -16,6 +16,11 @@
 package io.micronaut.python.annotation.processing.test
 
 import io.micronaut.core.annotation.Introspected
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.PropertySource
+import io.micronaut.core.annotation.Generated
+import java.lang.annotation.ElementType
+import java.lang.annotation.RetentionPolicy
 import io.micronaut.inject.ast.AnnotationElement
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.visitor.TypeElementVisitor
@@ -63,6 +68,77 @@ class Test:
         and: "annotations resolved from the classpath answer too"
         InheritedVisitor.RESULTS[Introspected.name]
         InheritedVisitor.RESULTS[Singleton.name] == false
+    }
+
+    void "test getTargets, getRepeatableContainer and getRetentionPolicy"() {
+        expect:
+        buildClassElement('''
+from jakarta.inject import Singleton
+import java
+
+Target = java.type("java.lang.annotation.Target")
+ElementType = java.type("java.lang.annotation.ElementType")
+
+def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
+    def decorator(func):
+        return func
+    return decorator
+
+@Target([ElementType.TYPE, ElementType.METHOD])
+@micronaut_annotation("test.MyTargetedAnn")
+def my_targeted_ann():
+    def decorator(target):
+        return target
+    return decorator
+
+@micronaut_annotation("test.MyRepeatableAnns")
+def my_repeatable_anns(value):
+    def decorator(target):
+        return target
+    return decorator
+
+@micronaut_annotation("test.MyRepeatableAnn", repeated="test.MyRepeatableAnns")
+def my_repeatable_ann(value):
+    def decorator(target):
+        return target
+    return decorator
+
+@micronaut_annotation("test.MyPlainAnn")
+def my_plain_ann():
+    def decorator(target):
+        return target
+    return decorator
+
+@Singleton
+class Test:
+    pass
+''') { ClassElement element ->
+            // the Python visitor context resolves a Python declaration to its Python annotation element
+            def context = element.environment.visitorContext()
+            def targeted = (AnnotationElement) context.getClassElement('test.MyTargetedAnn').get()
+            def repeatable = (AnnotationElement) context.getClassElement('test.MyRepeatableAnn').get()
+            def plain = (AnnotationElement) context.getClassElement('test.MyPlainAnn').get()
+
+            // a Python declaration answers with what was written on it
+            assert targeted.getTargets() == EnumSet.of(ElementType.TYPE, ElementType.METHOD)
+            assert targeted.getRetentionPolicy() == RetentionPolicy.RUNTIME
+            assert repeatable.getRepeatableContainer() == Optional.of('test.MyRepeatableAnns')
+            assert plain.getTargets() == AnnotationElement.DEFAULT_TARGETS
+            assert plain.getRepeatableContainer() == Optional.empty()
+            assert plain.getRetentionPolicy() == RetentionPolicy.RUNTIME
+
+            // a Java annotation on the classpath answers with its own declaration
+            def introspected = (AnnotationElement) context.getClassElement(Introspected.name).get()
+            def singleton = (AnnotationElement) context.getClassElement(Singleton.name).get()
+            def property = (AnnotationElement) context.getClassElement(Property.name).get()
+            def generated = (AnnotationElement) context.getClassElement(Generated.name).get()
+            assert introspected.getTargets() == EnumSet.of(ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.PACKAGE)
+            assert singleton.getTargets() == AnnotationElement.DEFAULT_TARGETS
+            assert property.getRepeatableContainer() == Optional.of(PropertySource.name)
+            assert generated.getRetentionPolicy() == RetentionPolicy.CLASS
+            assert singleton.getRetentionPolicy() == RetentionPolicy.RUNTIME
+            return element
+        }
     }
 
     static class InheritedVisitor implements TypeElementVisitor<Object, Object> {

--- a/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonAnnotationMetadataBuilder.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonAnnotationMetadataBuilder.java
@@ -684,7 +684,7 @@ public final class PythonAnnotationMetadataBuilder extends AbstractAnnotationMet
     }
 
     @Override
-    protected String getRepeatableContainerNameForType(ElementDef annotationType) {
+    public String getRepeatableContainerNameForType(ElementDef annotationType) {
         if (visitorContext != null) {
             PythonProcessingEnvironment env = visitorContext.getProcessingEnvironment();
             DecoratorDef decoratorDef = findDecoratorDef(env.environment().decorators(), annotationType.name());
@@ -891,7 +891,7 @@ public final class PythonAnnotationMetadataBuilder extends AbstractAnnotationMet
     }
 
     @Override
-    protected RetentionPolicy getRetentionPolicy(ElementDef annotation) {
+    public RetentionPolicy getRetentionPolicy(ElementDef annotation) {
         JavaVisitorContext javaVisitorContext = visitorContext.getJavaVisitorContext();
         if (javaVisitorContext != null) {
             return javaVisitorContext.getAnnotationMetadataBuilder().getRetentionPolicy(annotation.name());

--- a/inject-python/src/main/java/io/micronaut/python/processing/element/PythonAnnotationElement.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/element/PythonAnnotationElement.java
@@ -18,9 +18,19 @@ package io.micronaut.python.processing.element;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.inject.ast.AnnotationElement;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.python.processing.PythonProcessingEnvironment;
 import io.micronaut.python.processing.model.ClassDef;
+import io.micronaut.python.processing.annotation.PythonAnnotationMetadataBuilder;
 import io.micronaut.python.processing.model.DecoratorDef;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Class element implementation for Python annotations, which are declared as decorators.
@@ -58,5 +68,93 @@ public final class PythonAnnotationElement extends PythonClassElement implements
             }
         }
         return false;
+    }
+
+    @Override
+    public Set<ElementType> getTargets() {
+        // A Python declaration may carry java.lang.annotation.Target like it carries @Inherited
+        for (DecoratorDef decorator : getNativeType().decorators()) {
+            if (Target.class.getName().equals(decorator.annotationName())) {
+                EnumSet<ElementType> targets = EnumSet.noneOf(ElementType.class);
+                for (Object value : decorator.members().values()) {
+                    addTargets(value, targets);
+                }
+                return Collections.unmodifiableSet(targets);
+            }
+        }
+        // A Java annotation used from Python answers with its own declaration
+        AnnotationElement javaAnnotation = javaAnnotation();
+        if (javaAnnotation != null) {
+            return javaAnnotation.getTargets();
+        }
+        return DEFAULT_TARGETS;
+    }
+
+    private static void addTargets(Object value, EnumSet<ElementType> targets) {
+        if (value instanceof Iterable<?> values) {
+            for (Object item : values) {
+                addTargets(item, targets);
+            }
+        } else if (value instanceof Object[] values) {
+            for (Object item : values) {
+                addTargets(item, targets);
+            }
+        } else if (value instanceof ElementType elementType) {
+            targets.add(elementType);
+        } else if (value != null) {
+            String name = value.toString();
+            name = name.substring(name.lastIndexOf('.') + 1);
+            for (ElementType elementType : ElementType.values()) {
+                if (elementType.name().equals(name)) {
+                    targets.add(elementType);
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public Optional<String> getRepeatableContainer() {
+        // The repeated name of the Python declaration, or the @Repeatable of the Java annotation
+        PythonAnnotationMetadataBuilder builder = environment.annotationMetadataBuilder();
+        DecoratorDef declaration = builder.decoratorDef(getName());
+        if (declaration != null && declaration.repeatedName() != null) {
+            return Optional.of(builder.binaryClassName(declaration.repeatedName()));
+        }
+        return Optional.ofNullable(builder.getRepeatableContainerNameForType(getNativeType()));
+    }
+
+    @Override
+    public RetentionPolicy getRetentionPolicy() {
+        for (DecoratorDef decorator : getNativeType().decorators()) {
+            if (Retention.class.getName().equals(decorator.annotationName())) {
+                for (Object value : decorator.members().values()) {
+                    if (value instanceof RetentionPolicy retentionPolicy) {
+                        return retentionPolicy;
+                    }
+                    if (value != null) {
+                        String name = value.toString();
+                        name = name.substring(name.lastIndexOf('.') + 1);
+                        for (RetentionPolicy retentionPolicy : RetentionPolicy.values()) {
+                            if (retentionPolicy.name().equals(name)) {
+                                return retentionPolicy;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return environment.annotationMetadataBuilder().getRetentionPolicy(getNativeType());
+    }
+
+    @Nullable
+    private AnnotationElement javaAnnotation() {
+        if (environment.javaVisitorContext() == null) {
+            return null;
+        }
+        return environment.javaVisitorContext().getClassElement(getName())
+            .filter(AnnotationElement.class::isInstance)
+            .map(AnnotationElement.class::cast)
+            .orElse(null);
     }
 }


### PR DESCRIPTION
### What this does

`io.micronaut.inject.ast.AnnotationElement` gains three default methods, all `@since 5.3.0` and modelled on the existing `isInherited()`:

- `Set<ElementType> getTargets()`: the element types the annotation interface may be written on, as its `@java.lang.annotation.Target` or `kotlin.annotation.Target` declares; when it declares none, the JLS 9.6.4.1 default set, exposed as `AnnotationElement.DEFAULT_TARGETS` (every `ElementType` except `TYPE_USE` and `TYPE_PARAMETER`). An empty `@Target({})` yields an empty set.
- `Optional<String> getRepeatableContainer()`: the binary name of the container annotation; empty when not repeatable. `java.lang.annotation.Repeatable`, `kotlin.annotation.Repeatable` (the compiler-generated nested `Container`) and `@JvmRepeatable` alike.
- `RetentionPolicy getRetentionPolicy()`: `RUNTIME` when none is declared.

### Why

The CDI Lite language model (`jakarta.enterprise.lang.model`) that micronaut-cdi builds on top of the AST needs these facts about an annotation *interface*. The metadata record strips `java.lang.annotation.*` meta-annotations (`AnnotationUtil.INTERNAL_ANNOTATION_NAMES`), so they cannot be read from `getAnnotationMetadata()`; today the processor reaches into the javac mirrors for them, which leaves KSP, Groovy and Python compilations without an answer.

### How

- javac: reads the `@Target` mirror on the `TypeElement`; container and retention reuse `JavaAnnotationMetadataBuilder.getRepeatableContainerNameForType` / `getRetentionPolicy`, widened to public.
- KSP: maps `kotlin.annotation.AnnotationTarget` (`CLASS`→`TYPE`, `ANNOTATION_CLASS`→`ANNOTATION_TYPE`, `VALUE_PARAMETER`→`PARAMETER`, `FUNCTION`/`PROPERTY_GETTER`/`PROPERTY_SETTER`→`METHOD`, `TYPE`→`TYPE_USE`; `PROPERTY`, `EXPRESSION`, `FILE`, `TYPEALIAS` have no `ElementType`) and honours a Java `@Target` as KSP presents it. Note that KSP shows a Java `@Target` on a compiled annotation through `AnnotationTarget`, so `PACKAGE`, `MODULE` and `RECORD_COMPONENT` cannot be reported for a Java annotation on the classpath under KSP. Container via `KotlinVisitorContext.getRepeatableContainerNameForType`, plus the `$Container` of a `kotlin.annotation.Repeatable` annotation.
- Groovy: `classNode.getAnnotations(Target)` members; container and retention reuse `GroovyAnnotationMetadataBuilder`, widened to public.
- Python: a `java.lang.annotation.Target` written on the Python declaration (like `@Inherited`), otherwise the Java annotation's own declaration when the name resolves through the Java visitor context; the container from the declaration's `repeated` name or the Java `@Repeatable`; retention from a written `@Retention` or the builder (a Python-declared annotation is `RUNTIME`).

Everything is additive; no existing accessor changes what it returns.

### Tests

`JavaAnnotationElementSpec`, `KotlinAnnotationElementSpec`, `GroovyAnnotationElementSpec` and `PythonAnnotationElementSpec` cover source-declared and classpath annotations, the defaults, an empty `@Target`, nested containers and copies of the element. The full `:micronaut-inject-kotlin:test` (866), `:micronaut-inject-python-test:test` (609) and `:micronaut-inject-python:test` (125) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
