### PR TITLE
Add getSourceAnnotations(): the annotations of an element as the source wrote them

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -29,6 +29,7 @@ import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.InstantiatedMember;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Retainable;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.core.io.service.SoftServiceLoader;
@@ -57,6 +58,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -394,7 +396,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         CachedAnnotationMetadata cachedAnnotationMetadata = MUTATED_ANNOTATION_METADATA.get(key);
         if (cachedAnnotationMetadata == null) {
             AnnotationMetadata annotationMetadata = buildInternal(element);
-            cachedAnnotationMetadata = new DefaultCachedAnnotationMetadata(annotationMetadata);
+            cachedAnnotationMetadata = new DefaultCachedAnnotationMetadata(annotationMetadata, () -> readSourceAnnotations(element));
             // Don't use `computeIfAbsent` as it can lead to a concurrent exception because the cache is accessed during in `buildInternal`
             MUTATED_ANNOTATION_METADATA.put(key, cachedAnnotationMetadata);
         }
@@ -476,6 +478,81 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @return The annotations
      */
     protected abstract List<? extends A> getAnnotationsForType(T element);
+
+    /**
+     * Obtain the annotations written on the given element, as written: unlike
+     * {@link #getAnnotationsForType(Object)} a repeatable container is <b>not</b> unwrapped.
+     *
+     * @param element The element
+     * @return The annotations in source order
+     * @since 5.3.0
+     */
+    protected abstract List<? extends A> getWrittenAnnotations(T element);
+
+    /**
+     * Read the annotations written on the given element as the source wrote them: in source order, a repeatable
+     * annotation written once is itself, a written container is the container, repetitions arrive in the
+     * container the compiler synthesizes for them, no mapper, remapper,
+     * transformer or stereotype is applied, and every value carries the annotation interface's retention and its
+     * defaults for the members the use left out, empty values included.
+     *
+     * @param element The element
+     * @return The annotations, or an empty list
+     * @see io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate#getSourceAnnotations()
+     * @since 5.3.0
+     */
+    @NonNull
+    public List<AnnotationValue<?>> readSourceAnnotations(T element) {
+        List<? extends A> written = getWrittenAnnotations(element);
+        if (written.isEmpty()) {
+            return List.of();
+        }
+        List<AnnotationValue<?>> result = new ArrayList<>(written.size());
+        boolean wasValidating = validating;
+        // The values were validated when the metadata was built; do not report the same problems twice
+        validating = false;
+        try {
+            for (A annotationMirror : written) {
+                result.add(readSourceAnnotation(element, annotationMirror));
+            }
+        } finally {
+            validating = wasValidating;
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private AnnotationValue<?> readSourceAnnotation(T element, A annotationMirror) {
+        String annotationName = getAnnotationTypeName(annotationMirror);
+        T annotationType = getTypeForAnnotation(annotationMirror);
+        RetentionPolicy retentionPolicy = getRetentionPolicy(annotationType);
+        Map<? extends T, ?> elementValues = readAnnotationRawValues(annotationMirror);
+        Map<CharSequence, Object> annotationValues = CollectionUtils.newLinkedHashMap(elementValues.size());
+        for (Map.Entry<? extends T, ?> entry : elementValues.entrySet()) {
+            T member = entry.getKey();
+            if (member == null) {
+                continue;
+            }
+            readAnnotationRawValues(element, annotationName, member, getAnnotationMemberName(member), entry.getValue(), annotationValues);
+        }
+        unwrapEvaluatedExpressions(annotationValues);
+        Map<? extends T, ?> nativeDefaults = readAnnotationDefaultValues(annotationName, annotationType, true);
+        Map<CharSequence, Object> defaultValues = getAnnotationDefaults(annotationType, annotationName, nativeDefaults, new HashMap<>());
+        if (defaultValues == null) {
+            defaultValues = Collections.emptyMap();
+        } else {
+            unwrapEvaluatedExpressions(defaultValues);
+        }
+        return new AnnotationValue<>(annotationName, annotationValues, defaultValues, retentionPolicy);
+    }
+
+    private static void unwrapEvaluatedExpressions(Map<CharSequence, Object> values) {
+        // The source wrote a string; the expression reference belongs to the metadata that is compiled
+        for (Map.Entry<CharSequence, Object> entry : values.entrySet()) {
+            if (entry.getValue() instanceof EvaluatedExpressionReference reference) {
+                entry.setValue(reference.annotationValue());
+            }
+        }
+    }
 
     /**
      * Build the type hierarchy for the given element.
@@ -2329,6 +2406,18 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
          */
         void markCleared();
 
+        /**
+         * The annotations as the source wrote them on the element this entry was built for.
+         *
+         * @return The annotations as written, or an empty list
+         * @see io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate#getSourceAnnotations()
+         * @since 5.3.0
+         */
+        @NonNull
+        default List<AnnotationValue<?>> getSourceAnnotations() {
+            return List.of();
+        }
+
     }
 
     /**
@@ -2435,6 +2524,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         public void markCleared() {
             current().markCleared();
         }
+
+        @Override
+        public List<AnnotationValue<?>> getSourceAnnotations() {
+            return shared.getSourceAnnotations();
+        }
     }
 
     private static final class DefaultCachedAnnotationMetadata implements CachedAnnotationMetadata {
@@ -2442,12 +2536,31 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         private AnnotationMetadata annotationMetadata;
         private boolean isMutated;
         private boolean cleared;
+        @Nullable
+        private Supplier<List<AnnotationValue<?>>> sourceAnnotationsSupplier;
+        @Nullable
+        private List<AnnotationValue<?>> sourceAnnotations;
 
         public DefaultCachedAnnotationMetadata(AnnotationMetadata annotationMetadata) {
+            this(annotationMetadata, null);
+        }
+
+        public DefaultCachedAnnotationMetadata(AnnotationMetadata annotationMetadata,
+                                               @Nullable Supplier<List<AnnotationValue<?>>> sourceAnnotationsSupplier) {
             if (annotationMetadata instanceof AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata) {
                 throw new IllegalStateException();
             }
             this.annotationMetadata = annotationMetadata;
+            this.sourceAnnotationsSupplier = sourceAnnotationsSupplier;
+        }
+
+        @Override
+        public List<AnnotationValue<?>> getSourceAnnotations() {
+            if (sourceAnnotations == null) {
+                sourceAnnotations = sourceAnnotationsSupplier == null ? List.of() : sourceAnnotationsSupplier.get();
+                sourceAnnotationsSupplier = null;
+            }
+            return sourceAnnotations;
         }
 
         @Override

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractAnnotationElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractAnnotationElement.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -77,6 +78,15 @@ public abstract class AbstractAnnotationElement implements io.micronaut.inject.a
      */
     protected MutableAnnotationMetadataDelegate<?> getAnnotationMetadataToWrite() {
         return getElementAnnotationMetadata();
+    }
+
+    @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        if (presetAnnotationMetadata != null) {
+            // The preset metadata replaced what was built from the source, which is what is asked for here
+            return elementAnnotationMetadataFactory.build(this).getSourceAnnotations();
+        }
+        return getElementAnnotationMetadata().getSourceAnnotations();
     }
 
     @Override

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
@@ -34,11 +34,13 @@ import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.ast.WildcardElement;
 import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Abstract element annotation metadata factory.
@@ -90,6 +92,21 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
 
     @Override
     public ElementAnnotationMetadata buildMutable(AnnotationMetadata originalAnnotationMetadata) {
+        return buildMutable(originalAnnotationMetadata, List::of);
+    }
+
+    /**
+     * Builds mutable metadata that is not backed by a cache entry, such as the type annotations a language
+     * implementation builds for a type use, together with the annotations the source wrote for it.
+     *
+     * @param originalAnnotationMetadata The metadata
+     * @param sourceAnnotations          The annotations as written, read once when first asked for
+     * @return The element annotation metadata
+     * @see MutableAnnotationMetadataDelegate#getSourceAnnotations()
+     * @since 5.3.0
+     */
+    public ElementAnnotationMetadata buildMutable(AnnotationMetadata originalAnnotationMetadata,
+                                                  Supplier<List<AnnotationValue<?>>> sourceAnnotations) {
         if (originalAnnotationMetadata instanceof AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata) {
             throw new IllegalStateException();
         }
@@ -99,10 +116,20 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
         return new MutableElementAnnotationMetadata() {
 
             private AnnotationMetadata thisAnnotationMetadata = originalAnnotationMetadata;
+            @Nullable
+            private List<AnnotationValue<?>> resolvedSourceAnnotations;
 
             @Override
             public AnnotationMetadata getAnnotationMetadata() {
                 return thisAnnotationMetadata;
+            }
+
+            @Override
+            public List<AnnotationValue<?>> getSourceAnnotations() {
+                if (resolvedSourceAnnotations == null) {
+                    resolvedSourceAnnotations = sourceAnnotations.get();
+                }
+                return resolvedSourceAnnotations;
             }
 
             @Override

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
@@ -36,6 +36,7 @@ import io.micronaut.inject.ast.WildcardElement;
 import org.jspecify.annotations.NullUnmarked;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -309,6 +310,12 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
             }
 
             @Override
+            public List<AnnotationValue<?>> getSourceAnnotations() {
+                // A property is synthesized from its getter, setter and field; no source writes on it
+                return List.of();
+            }
+
+            @Override
             public String toString() {
                 return propertyElement.toString();
             }
@@ -501,6 +508,12 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
                 return annotationMetadata;
             }
             return getCacheEntry();
+        }
+
+        @Override
+        public List<AnnotationValue<?>> getSourceAnnotations() {
+            // What the source wrote does not change when the metadata is mutated
+            return getCacheEntry().getSourceAnnotations();
         }
 
         @Override

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/ElementMutableAnnotationMetadataDelegate.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/ElementMutableAnnotationMetadataDelegate.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.Internal;
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -41,6 +42,11 @@ public interface ElementMutableAnnotationMetadataDelegate<R> extends MutableAnno
 
     @Override
     MutableAnnotationMetadataDelegate<?> getAnnotationMetadata();
+
+    @Override
+    default List<AnnotationValue<?>> getSourceAnnotations() {
+        return getAnnotationMetadata().getSourceAnnotations();
+    }
 
     @Override
     default <T extends Annotation> R annotate(String annotationType, Consumer<AnnotationValueBuilder<T>> consumer) {

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/GenericPlaceholderElementAnnotationMetadata.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/GenericPlaceholderElementAnnotationMetadata.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.ast.annotation;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.ast.ClassElement;
@@ -53,6 +54,11 @@ public final class GenericPlaceholderElementAnnotationMetadata extends AbstractE
     @Override
     protected MutableAnnotationMetadataDelegate<?> getAnnotationMetadataToWrite() {
         return genericPlaceholderElement.getGenericTypeAnnotationMetadata();
+    }
+
+    @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        return genericPlaceholderElement.getGenericTypeAnnotationMetadata().getSourceAnnotations();
     }
 
     @Override

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/MethodElementAnnotationMetadata.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/MethodElementAnnotationMetadata.java
@@ -16,8 +16,11 @@
 package io.micronaut.inject.ast.annotation;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.ast.MethodElement;
+
+import java.util.List;
 
 /**
  * The element annotation metadata for a method element.
@@ -53,5 +56,11 @@ public final class MethodElementAnnotationMetadata extends AbstractElementAnnota
     @Override
     protected MutableAnnotationMetadataDelegate<?> getAnnotationMetadataToWrite() {
         return writeAnnotationMetadata;
+    }
+
+    @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        // The method's own annotations, not those of the owning type
+        return writeAnnotationMetadata.getSourceAnnotations();
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/MutableAnnotationMetadataDelegate.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/MutableAnnotationMetadataDelegate.java
@@ -18,9 +18,12 @@ package io.micronaut.inject.ast.annotation;
 import io.micronaut.core.annotation.AnnotationMetadataDelegate;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.ArgumentUtils;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -160,4 +163,31 @@ public interface MutableAnnotationMetadataDelegate<R> extends AnnotationMetadata
         throw new UnsupportedOperationException("Element of type [" + getClass() + "] does not support adding annotations at compilation time");
     }
 
+    /**
+     * The annotations the source wrote on this element, type use or type variable, in source order and as
+     * written.
+     *
+     * <p>Unlike the metadata returned by {@link #getAnnotationMetadata()}, this is the declaration as the
+     * compiler sees it: a repeatable annotation written once is itself, a container the source wrote is the
+     * container, two or more repetitions arrive in the container the compiler synthesizes for them, as the
+     * class file would carry them, and nothing an {@link io.micronaut.inject.annotation.AnnotationMapper},
+     * {@link io.micronaut.inject.annotation.AnnotationRemapper},
+     * {@link io.micronaut.inject.annotation.AnnotationTransformer} or a visitor's {@code annotate(...)} added
+     * appears, nor any stereotype. Each value carries the annotation interface's retention and its defaults for
+     * the members the use left out, empty strings and arrays included.</p>
+     *
+     * <p>For a type variable it is what was written at this use of the variable (nothing, if the use wrote
+     * nothing), or the annotations of the type parameter declaration when the element comes from
+     * {@link io.micronaut.inject.ast.ClassElement#getDeclaredGenericPlaceholders()} or
+     * {@link io.micronaut.inject.ast.MethodElement#getDeclaredTypeVariables()}. It is empty for an element no
+     * source backs, such as one created by reflection or {@code ClassElement.of(String)}.</p>
+     *
+     * @return The annotations as written, or an empty list
+     * @since 5.3.0
+     */
+    @Experimental
+    @NonNull
+    default List<AnnotationValue<?>> getSourceAnnotations() {
+        return List.of();
+    }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/MutatedMethodElementAnnotationMetadata.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/MutatedMethodElementAnnotationMetadata.java
@@ -16,8 +16,11 @@
 package io.micronaut.inject.ast.annotation;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.ast.MethodElement;
+
+import java.util.List;
 
 /**
  * The mutated element annotation metadata for a method element.
@@ -54,5 +57,11 @@ public final class MutatedMethodElementAnnotationMetadata extends AbstractElemen
     @Override
     protected MutableAnnotationMetadataDelegate<?> getAnnotationMetadataToWrite() {
         return writeAnnotationMetadata;
+    }
+
+    @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        // The method's own annotations, not those of the owning type
+        return writeAnnotationMetadata.getSourceAnnotations();
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/WildcardElementAnnotationMetadata.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/WildcardElementAnnotationMetadata.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.ast.annotation;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.ast.ClassElement;
@@ -53,6 +54,11 @@ public final class WildcardElementAnnotationMetadata extends AbstractElementAnno
     @Override
     protected MutableAnnotationMetadataDelegate<?> getAnnotationMetadataToWrite() {
         return wildcardElement.getGenericTypeAnnotationMetadata();
+    }
+
+    @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        return wildcardElement.getGenericTypeAnnotationMetadata().getSourceAnnotations();
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
@@ -305,6 +305,12 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
     }
 
     @Override
+    protected List<? extends AnnotationNode> getWrittenAnnotations(AnnotatedNode element) {
+        // Unlike getAnnotationsForType, a repeatable container is kept as the source wrote it
+        return element.getAnnotations();
+    }
+
+    @Override
     protected List<? extends AnnotationNode> getAnnotationsForType(AnnotatedNode element) {
         List<AnnotationNode> annotations = element.getAnnotations();
         var expanded = new ArrayList<AnnotationNode>(annotations.size());

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyGenericPlaceholderElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyGenericPlaceholderElement.java
@@ -16,6 +16,7 @@
 package io.micronaut.ast.groovy.visitor;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -108,6 +109,12 @@ final class GroovyGenericPlaceholderElement extends GroovyClassElement implement
     }
 
     @NonNull
+    @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        // What was written at this use of the variable, or on its declaration
+        return getGenericTypeAnnotationMetadata().getSourceAnnotations();
+    }
+
     @Override
     public MutableAnnotationMetadataDelegate<AnnotationMetadata> getGenericTypeAnnotationMetadata() {
         if (genericTypeAnnotationMetadata == null) {

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyWildcardElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyWildcardElement.java
@@ -16,6 +16,7 @@
 package io.micronaut.ast.groovy.visitor;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -75,6 +76,12 @@ final class GroovyWildcardElement extends GroovyClassElement implements Wildcard
     }
 
     @NonNull
+    @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        // What was written at this use of the variable, or on its declaration
+        return getGenericTypeAnnotationMetadata().getSourceAnnotations();
+    }
+
     @Override
     public MutableAnnotationMetadataDelegate<AnnotationMetadata> getGenericTypeAnnotationMetadata() {
         if (genericTypeAnnotationMetadata == null) {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/SourceAnnotationsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/SourceAnnotationsSpec.groovy
@@ -1,0 +1,157 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.core.annotation.AnnotationValue
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+class SourceAnnotationsSpec extends AbstractBeanDefinitionSpec {
+
+    private static final String SOURCE = '''
+package test
+
+import java.lang.annotation.*
+
+@MyRepeatable("a")
+@MyRepeatable("b")
+@jakarta.inject.Singleton
+class MyBean {
+
+    @MyRepeatable("single")
+    @Defaults(name = "x")
+    public String field
+
+    @MyRepeatables([@MyRepeatable("c1"), @MyRepeatable("c2")])
+    public String containerField
+
+    @MyRepeatable("m")
+    public String method(@MyRepeatable("p") String param) {
+        return null
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE])
+@Repeatable(MyRepeatables)
+@interface MyRepeatable {
+    String value()
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE])
+@interface MyRepeatables {
+    MyRepeatable[] value()
+}
+
+@Retention(RetentionPolicy.SOURCE)
+@interface Defaults {
+    String name()
+    String description() default ""
+    int count() default 3
+}
+'''
+
+    void "test the source view of a class keeps repeatable annotations as written and adds no stereotype"() {
+        given:
+        def element = buildClassElement('test.MyBean', SOURCE)
+
+        when:
+        def source = element.getSourceAnnotations()
+
+        then: "two repetitions arrive in the container the Groovy compiler synthesizes for them"
+        names(source) == ['jakarta.inject.Singleton', 'test.MyRepeatables']
+        nested(source[1]) == ['a', 'b']
+        source.every { it.retentionPolicy == RetentionPolicy.RUNTIME }
+
+        and: "the metadata adds the scope stereotype, the source view does not"
+        element.getAnnotationMetadata().hasDeclaredStereotype(AnnotationUtil.SCOPE)
+        !source.any { it.annotationName == AnnotationUtil.SCOPE }
+    }
+
+    void "test the source view of a field carries the defaults for the members it left out, empty ones included"() {
+        given:
+        def element = buildClassElement('test.MyBean', SOURCE)
+        def field = element.getFields().find { it.name == 'field' }
+
+        when:
+        def source = field.getSourceAnnotations()
+
+        then:
+        names(source) == ['test.MyRepeatable', 'test.Defaults']
+        source[0].stringValue().get() == 'single'
+
+        and:
+        AnnotationValue<?> defaults = source[1]
+        defaults.retentionPolicy == RetentionPolicy.SOURCE
+        defaults.stringValue('name').get() == 'x'
+        defaults.getDefaultValues().get('description') == ''
+        defaults.getDefaultValues().get('count') == 3
+        !defaults.getValues().containsKey('description')
+    }
+
+    void "test a container the source wrote is the container"() {
+        given:
+        def element = buildClassElement('test.MyBean', SOURCE)
+        def field = element.getFields().find { it.name == 'containerField' }
+
+        when:
+        def source = field.getSourceAnnotations()
+
+        then:
+        names(source) == ['test.MyRepeatables']
+        nested(source[0]) == ['c1', 'c2']
+
+        and:
+        field.getAnnotationMetadata().getAnnotationValuesByName('test.MyRepeatable').size() == 2
+    }
+
+    void "test a method and its parameter"() {
+        given:
+        def element = buildClassElement('test.MyBean', SOURCE)
+        def method = element.getMethods().find { it.name == 'method' }
+
+        expect:
+        names(method.getSourceAnnotations()) == ['test.MyRepeatable']
+        method.getSourceAnnotations()[0].stringValue().get() == 'm'
+        names(method.getParameters()[0].getSourceAnnotations()) == ['test.MyRepeatable']
+        method.getParameters()[0].getSourceAnnotations()[0].stringValue().get() == 'p'
+
+        and:
+        method.getAnnotationMetadata().hasAnnotation('jakarta.inject.Singleton')
+        !method.getSourceAnnotations().any { it.annotationName == 'jakarta.inject.Singleton' }
+    }
+
+    void "test what a visitor adds does not appear and the meta-annotations of an annotation interface do"() {
+        given:
+        def element = buildClassElement('test.MyAnn', '''
+package test
+
+import java.lang.annotation.*
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+@interface MyAnn {
+}
+''')
+
+        when:
+        element.annotate('test.Added')
+
+        then:
+        element.getAnnotationMetadata().hasDeclaredAnnotation('test.Added')
+        !element.getAnnotationMetadata().hasDeclaredAnnotation(Retention.name)
+        names(element.getSourceAnnotations()) == [Retention.name, Target.name]
+        element.getSourceAnnotations()[0].stringValue().get() == 'SOURCE'
+    }
+
+    private static List<String> names(List<AnnotationValue<?>> values) {
+        return values*.annotationName
+    }
+
+    private static List<String> nested(AnnotationValue<?> container) {
+        return (container.getValues().get('value') as AnnotationValue[]).collect { it.stringValue().get() }
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -203,6 +203,12 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
     }
 
     @Override
+    protected List<? extends AnnotationMirror> getWrittenAnnotations(Element element) {
+        // Unlike getAnnotationsForType, a repeatable container is kept as the source wrote it
+        return element.getAnnotationMirrors();
+    }
+
+    @Override
     protected List<? extends AnnotationMirror> getAnnotationsForType(Element element) {
         var expanded = new ArrayList<AnnotationMirror>();
         for (AnnotationMirror annotation : element.getAnnotationMirrors()) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaElementAnnotationMetadataFactory.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaElementAnnotationMetadataFactory.java
@@ -16,7 +16,11 @@
 package io.micronaut.annotation.processing;
 
 import io.micronaut.annotation.processing.visitor.AbstractJavaElement;
+import io.micronaut.annotation.processing.visitor.JavaGenericPlaceholderElement;
 import io.micronaut.annotation.processing.visitor.JavaNativeElement;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.GenericPlaceholderElement;
@@ -31,6 +35,8 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
+import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Java element annotation metadata factory.
@@ -77,13 +83,29 @@ public final class JavaElementAnnotationMetadataFactory extends AbstractElementA
         if (typeMirror == null) {
             return super.lookupTypeAnnotationsForClass(classElement);
         }
+        TypeMirror writtenMirror = typeMirror;
+        if (classElement.getArrayDimensions() > 0 && !(typeMirror instanceof ArrayType)) {
+            // An array made with toArray() from a component: the metadata reads the component's annotations,
+            // as before, but no source wrote this dimension
+            return new SourceAnnotationsCachedAnnotationMetadata(metadataBuilder.lookupOrBuild(clazz, new AnnotationsElement(typeMirror)), List::of);
+        }
+        // Every dimension of an array holds its own mirror; the metadata keeps reading the innermost one,
+        // as it did when all the dimensions shared it
+        while (typeMirror instanceof ArrayType arrayType && arrayType.getComponentType() instanceof ArrayType) {
+            typeMirror = arrayType.getComponentType();
+        }
         if (typeMirror instanceof ArrayType arrayType) {
             if (!hasJSpecifyAnnotations(arrayType) && !hasJSpecifyAnnotations(arrayType.getComponentType())) {
                 // Backward compatibility for Micronaut type annotations support
                 typeMirror = arrayType.getComponentType();
             }
         }
-        return metadataBuilder.lookupOrBuild(clazz, new AnnotationsElement(typeMirror));
+        AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata cached = metadataBuilder.lookupOrBuild(clazz, new AnnotationsElement(typeMirror));
+        if (typeMirror == writtenMirror) {
+            return cached;
+        }
+        // The source view is exact per dimension
+        return new SourceAnnotationsCachedAnnotationMetadata(cached, () -> metadataBuilder.readSourceAnnotations(new AnnotationsElement(writtenMirror)));
     }
 
     private boolean hasJSpecifyAnnotations(TypeMirror element) {
@@ -105,13 +127,72 @@ public final class JavaElementAnnotationMetadataFactory extends AbstractElementA
         } else {
             placeholderJavaElement = genericNativeType.element();
         }
-        return metadataBuilder.lookupOrBuild(genericNativeType, placeholderJavaElement);
+        AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata cached = metadataBuilder.lookupOrBuild(genericNativeType, placeholderJavaElement);
+        // The metadata falls back to the type parameter declaration when a use of the variable wrote nothing;
+        // the source view does not: a use reports what was written at the use, a declaration reports the
+        // annotations of the type parameter
+        boolean declaration = placeholderElement instanceof JavaGenericPlaceholderElement javaPlaceholder && javaPlaceholder.isDeclaration();
+        Element sourceElement = declaration ? genericNativeType.element() : new AnnotationsElement(placeholderTypeVariable);
+        return new SourceAnnotationsCachedAnnotationMetadata(cached, () -> metadataBuilder.readSourceAnnotations(sourceElement));
     }
 
     @Override
     protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupTypeAnnotationsForWildcard(WildcardElement wildcardElement) {
         var wildcard = (WildcardType) wildcardElement.getGenericNativeType();
         return metadataBuilder.lookupOrBuild(wildcard, new AnnotationsElement(wildcard));
+    }
+
+    /**
+     * A cache entry whose source annotations are read from a different element than the metadata was built
+     * from: the metadata of a type use is shared, the source view is exact.
+     */
+    private static final class SourceAnnotationsCachedAnnotationMetadata implements AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata {
+
+        private final AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata delegate;
+        @Nullable
+        private Supplier<List<AnnotationValue<?>>> sourceAnnotationsSupplier;
+        @Nullable
+        private List<AnnotationValue<?>> sourceAnnotations;
+
+        SourceAnnotationsCachedAnnotationMetadata(AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata delegate,
+                                                  Supplier<List<AnnotationValue<?>>> sourceAnnotationsSupplier) {
+            this.delegate = delegate;
+            this.sourceAnnotationsSupplier = sourceAnnotationsSupplier;
+        }
+
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return delegate.getAnnotationMetadata();
+        }
+
+        @Override
+        public boolean isMutated() {
+            return delegate.isMutated();
+        }
+
+        @Override
+        public void update(AnnotationMetadata annotationMetadata) {
+            delegate.update(annotationMetadata);
+        }
+
+        @Override
+        public boolean wasCleared() {
+            return delegate.wasCleared();
+        }
+
+        @Override
+        public void markCleared() {
+            delegate.markCleared();
+        }
+
+        @Override
+        public List<AnnotationValue<?>> getSourceAnnotations() {
+            if (sourceAnnotations == null) {
+                sourceAnnotations = sourceAnnotationsSupplier.get();
+                sourceAnnotationsSupplier = null;
+            }
+            return sourceAnnotations;
+        }
     }
 
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -265,7 +265,7 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement impl
                                          Set<TypeMirror> visitedTypes,
                                          boolean isTypeVariable,
                                          @Nullable String doc) {
-        return newClassElement(owner, type, declaredTypeArguments, visitedTypes, isTypeVariable, false, null, null, doc);
+        return newClassElement(owner, type, declaredTypeArguments, visitedTypes, isTypeVariable, false, null, doc);
     }
 
     private ClassElement newClassElement(@Nullable JavaNativeElement owner,
@@ -277,7 +277,6 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement impl
                                          boolean isRawTypeParameter,
                                          @Nullable
                                          TypeParameterElement representedTypeParameter,
-                                         @Nullable ArrayType arrayType,
                                          @Nullable String doc) {
         if (declaredTypeArguments == null) {
             declaredTypeArguments = Collections.emptyMap();
@@ -320,7 +319,7 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement impl
                     );
                 }
                 return new JavaClassElement(
-                    new JavaNativeElement.Class(typeElement, arrayType == null ? type : arrayType, owner),
+                    new JavaNativeElement.Class(typeElement, type, owner),
                     elementAnnotationMetadataFactory,
                     visitorContext,
                     typeMirrorArguments,
@@ -336,9 +335,12 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement impl
             return resolveTypeVariable(owner, declaredTypeArguments, visitedTypes, tv, isRawTypeParameter, doc);
         }
         if (type instanceof ArrayType at) {
-            TypeMirror componentType = at.getComponentType();
-            return newClassElement(owner, componentType, declaredTypeArguments, visitedTypes, isTypeVariable, false, null, at, doc)
-                .toArray();
+            // The component holds its own mirror; each dimension holds the mirror of that dimension
+            ClassElement componentElement = newClassElement(owner, at.getComponentType(), declaredTypeArguments, visitedTypes, isTypeVariable, false, null, doc);
+            if (componentElement instanceof JavaClassElement javaComponentElement) {
+                return javaComponentElement.toArray(at);
+            }
+            return componentElement.toArray();
         }
         if (type instanceof PrimitiveType pt) {
             return PrimitiveElement.valueOf(pt.getKind().name(), doc);
@@ -433,7 +435,7 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement impl
                 String variableName = typeParameter.getSimpleName().toString();
                 resolved.put(
                     variableName,
-                    newClassElement(getNativeType(), typeParameterMirror, parentTypeArguments, visitedTypes, typeParameterMirror instanceof TypeVariable, false, typeParameter, null, null)
+                    newClassElement(getNativeType(), typeParameterMirror, parentTypeArguments, visitedTypes, typeParameterMirror instanceof TypeVariable, false, typeParameter, null)
                 );
             }
         } else {
@@ -444,7 +446,7 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement impl
                 String variableName = typeParameter.getSimpleName().toString();
                 resolved.put(
                     variableName,
-                    newClassElement(getNativeType(), typeParameter.asType(), parentTypeArguments, visitedTypes, true, isRaw, null, null, null)
+                    newClassElement(getNativeType(), typeParameter.asType(), parentTypeArguments, visitedTypes, true, isRaw, null, null)
                 );
             }
         }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -610,6 +610,33 @@ public class JavaClassElement extends AbstractTypeAwareJavaElement implements Ar
         return new JavaClassElement(nativeType, elementAnnotationMetadataFactory, visitorContext, typeArguments, resolvedTypeArguments, arrayDimensions, false, doc);
     }
 
+    /**
+     * The array of this element for the given array mirror, which holds the type annotations written on that
+     * dimension. The component keeps its own mirror, so every dimension of a nested array carries its own.
+     *
+     * @param arrayType The mirror of the array whose component this element is
+     * @return The array element
+     */
+    ClassElement toArray(ArrayType arrayType) {
+        JavaNativeElement.Class nativeType = getNativeType();
+        return new JavaClassElement(
+            new JavaNativeElement.Class(nativeType.element(), arrayType, nativeType.owner()),
+            elementAnnotationMetadataFactory, visitorContext, typeArguments, resolvedTypeArguments, arrayDimensions + 1, false, doc);
+    }
+
+    /**
+     * Marks a placeholder built from a type parameter as the declaration of the type variable.
+     *
+     * @param element The element built for the type parameter
+     * @return The placeholder
+     */
+    static GenericPlaceholderElement asDeclaredPlaceholder(ClassElement element) {
+        if (element instanceof JavaGenericPlaceholderElement placeholder) {
+            return placeholder.asDeclaration();
+        }
+        return (GenericPlaceholderElement) element;
+    }
+
     @Override
     public String getSimpleName() {
         if (simpleName == null) {
@@ -831,7 +858,7 @@ public class JavaClassElement extends AbstractTypeAwareJavaElement implements Ar
     public List<? extends GenericPlaceholderElement> getDeclaredGenericPlaceholders() {
         return classElement.getTypeParameters().stream()
             // we want the *declared* variables, so we don't pass in our genericsInfo.
-            .map(tpe -> (GenericPlaceholderElement) newClassElement(tpe.asType(), Collections.emptyMap()))
+            .map(tpe -> asDeclaredPlaceholder(newClassElement(tpe.asType(), Collections.emptyMap())))
             .toList();
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaEnumElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaEnumElement.java
@@ -28,6 +28,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -152,6 +153,14 @@ class JavaEnumElement extends JavaClassElement implements EnumElement {
     @Override
     public ClassElement withArrayDimensions(int arrayDimensions) {
         return new JavaEnumElement(getNativeType(), elementAnnotationMetadataFactory, visitorContext, arrayDimensions, doc);
+    }
+
+    @Override
+    ClassElement toArray(ArrayType arrayType) {
+        JavaNativeElement.Class nativeType = getNativeType();
+        return new JavaEnumElement(
+            new JavaNativeElement.Class(nativeType.element(), arrayType, nativeType.owner()),
+            elementAnnotationMetadataFactory, visitorContext, getArrayDimensions() + 1, doc);
     }
 
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaGenericPlaceholderElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaGenericPlaceholderElement.java
@@ -16,6 +16,7 @@
 package io.micronaut.annotation.processing.visitor;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
@@ -29,6 +30,7 @@ import io.micronaut.inject.ast.annotation.GenericPlaceholderElementAnnotationMet
 import io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate;
 
 import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeVariable;
 import java.util.List;
 import java.util.Objects;
@@ -43,7 +45,7 @@ import java.util.function.Function;
  * @since 3.1.0
  */
 @Internal
-final class JavaGenericPlaceholderElement extends JavaClassElement implements GenericPlaceholderElement {
+public final class JavaGenericPlaceholderElement extends JavaClassElement implements GenericPlaceholderElement {
     final TypeVariable realTypeVariable;
     private final JavaNativeElement.Placeholder genericNativeType;
     private final Element declaredElement;
@@ -52,6 +54,7 @@ final class JavaGenericPlaceholderElement extends JavaClassElement implements Ge
     private final List<JavaClassElement> bounds;
     private final boolean isRawType;
     private final ElementAnnotationMetadata typeAnnotationMetadata;
+    private boolean declaration;
     @Nullable
     private ElementAnnotationMetadata genericTypeAnnotationMetadata;
 
@@ -118,6 +121,12 @@ final class JavaGenericPlaceholderElement extends JavaClassElement implements Ge
     }
 
     @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        // What was written at this use of the variable, or on its declaration
+        return getGenericTypeAnnotationMetadata().getSourceAnnotations();
+    }
+
+    @Override
     public MutableAnnotationMetadataDelegate<AnnotationMetadata> getGenericTypeAnnotationMetadata() {
         if (genericTypeAnnotationMetadata == null) {
             genericTypeAnnotationMetadata = elementAnnotationMetadataFactory.buildGenericTypeAnnotations(this);
@@ -171,12 +180,45 @@ final class JavaGenericPlaceholderElement extends JavaClassElement implements Ge
 
     @Override
     public ClassElement withArrayDimensions(int arrayDimensions) {
-        return new JavaGenericPlaceholderElement(genericNativeType, realTypeVariable, declaredElement, resolved, bounds, elementAnnotationMetadataFactory, arrayDimensions, isRawType, doc);
+        return copy(arrayDimensions);
+    }
+
+    @Override
+    ClassElement toArray(ArrayType arrayType) {
+        // A placeholder has no mirror per array dimension
+        return toArray();
     }
 
     @Override
     protected JavaClassElement copyThis() {
-        return new JavaGenericPlaceholderElement(genericNativeType, realTypeVariable, declaredElement, resolved, bounds, elementAnnotationMetadataFactory, arrayDimensions, isRawType, doc);
+        return copy(arrayDimensions);
+    }
+
+    private JavaGenericPlaceholderElement copy(int arrayDimensions) {
+        var copy = new JavaGenericPlaceholderElement(genericNativeType, realTypeVariable, declaredElement, resolved, bounds, elementAnnotationMetadataFactory, arrayDimensions, isRawType, doc);
+        copy.declaration = declaration;
+        return copy;
+    }
+
+    /**
+     * Whether this element is the declaration of the type variable, as returned by
+     * {@link ClassElement#getDeclaredGenericPlaceholders()} and {@link io.micronaut.inject.ast.MethodElement#getDeclaredTypeVariables()},
+     * rather than a use of it.
+     *
+     * @return True if this is the declaration
+     * @since 5.3.0
+     */
+    public boolean isDeclaration() {
+        return declaration;
+    }
+
+    /**
+     * @return A copy of this element marked as the declaration of the type variable
+     */
+    JavaGenericPlaceholderElement asDeclaration() {
+        JavaGenericPlaceholderElement copy = copy(arrayDimensions);
+        copy.declaration = true;
+        return copy;
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -239,7 +239,7 @@ public class JavaMethodElement extends AbstractJavaMemberElement implements Meth
     @Override
     public List<? extends GenericPlaceholderElement> getDeclaredTypeVariables() {
         return executableElement.getTypeParameters().stream()
-            .map(tpe -> (GenericPlaceholderElement) newClassElement(tpe.asType(), Collections.emptyMap()))
+            .map(tpe -> JavaClassElement.asDeclaredPlaceholder(newClassElement(tpe.asType(), Collections.emptyMap())))
             .toList();
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaWildcardElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaWildcardElement.java
@@ -16,6 +16,7 @@
 package io.micronaut.annotation.processing.visitor;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
@@ -28,6 +29,7 @@ import io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate;
 import io.micronaut.inject.ast.annotation.WildcardElementAnnotationMetadata;
 
 import javax.lang.model.type.WildcardType;
+import javax.lang.model.type.ArrayType;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -73,6 +75,12 @@ final class JavaWildcardElement extends JavaClassElement implements WildcardElem
     @Override
     public Optional<ClassElement> getResolved() {
         return Optional.of(upperBound);
+    }
+
+    @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        // What was written at this use of the variable, or on its declaration
+        return getGenericTypeAnnotationMetadata().getSourceAnnotations();
     }
 
     @Override
@@ -139,6 +147,11 @@ final class JavaWildcardElement extends JavaClassElement implements WildcardElem
             throw new UnsupportedOperationException("Can't create array of wildcard");
         }
         return this;
+    }
+
+    @Override
+    ClassElement toArray(ArrayType arrayType) {
+        return toArray();
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/annotation/SourceAnnotationsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/SourceAnnotationsSpec.groovy
@@ -1,0 +1,235 @@
+package io.micronaut.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.GenericPlaceholderElement
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+class SourceAnnotationsSpec extends AbstractTypeElementSpec {
+
+    private static final String SOURCE = '''
+package test;
+
+import java.lang.annotation.*;
+
+@MyRepeatable("a")
+@MyRepeatable("b")
+@jakarta.inject.Singleton
+class MyBean<@TypeAnn("class-var") T> {
+
+    @MyRepeatable("single")
+    @Defaults(name = "x")
+    public @TypeAnn("field-type") String field;
+
+    @MyRepeatables({@MyRepeatable("c1"), @MyRepeatable("c2")})
+    public T typeVarField;
+
+    public @TypeAnn("component") String @TypeAnn("outer") [] @TypeAnn("inner") [] arrayField;
+
+    @MyRepeatable("m")
+    public <@TypeAnn("method-var") M> M method(@MyRepeatable("p") String param) {
+        return null;
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
+@Repeatable(MyRepeatables.class)
+@interface MyRepeatable {
+    String value();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
+@interface MyRepeatables {
+    MyRepeatable[] value();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@interface TypeAnn {
+    String value() default "";
+}
+
+@Retention(RetentionPolicy.SOURCE)
+@interface Defaults {
+    String name();
+    String description() default "";
+    String[] tags() default {};
+    int count() default 3;
+}
+'''
+
+    void "test the source view of a class keeps repeatable annotations as written and adds no stereotype"() {
+        given:
+        def element = buildClassElement(SOURCE)
+
+        when:
+        def source = element.getSourceAnnotations()
+
+        then: "in source order; two repetitions arrive in the container javac synthesizes for them"
+        names(source) == ['test.MyRepeatables', 'jakarta.inject.Singleton']
+        nested(source[0]) == ['a', 'b']
+        source.every { it.retentionPolicy == RetentionPolicy.RUNTIME }
+
+        and: "the metadata adds the scope stereotype, the source view does not"
+        element.getAnnotationMetadata().hasDeclaredStereotype(AnnotationUtil.SCOPE)
+        !source.any { it.annotationName == AnnotationUtil.SCOPE }
+    }
+
+    void "test the source view of a field carries the defaults for the members it left out, empty ones included"() {
+        given:
+        def element = buildClassElement(SOURCE)
+        def field = element.getFields().find { it.name == 'field' }
+
+        when:
+        def source = field.getSourceAnnotations()
+
+        then:
+        names(source) == ['test.MyRepeatable', 'test.Defaults']
+        source[0].stringValue().get() == 'single'
+
+        and:
+        AnnotationValue<?> defaults = source[1]
+        defaults.retentionPolicy == RetentionPolicy.SOURCE
+        defaults.stringValue('name').get() == 'x'
+        defaults.getDefaultValues().keySet()*.toString().sort() == ['count', 'description', 'tags']
+        defaults.getDefaultValues().get('description') == ''
+        defaults.getDefaultValues().get('tags') == [] as String[]
+        defaults.getDefaultValues().get('count') == 3
+        !defaults.getValues().containsKey('description')
+
+        and: "the field type reports the type-use annotations; javac applies MyRepeatable, which targets FIELD and TYPE_USE, to both"
+        names(field.getType().getTypeAnnotationMetadata().getSourceAnnotations()) == ['test.MyRepeatable', 'test.TypeAnn']
+        field.getType().getTypeAnnotationMetadata().getSourceAnnotations()[1].stringValue().get() == 'field-type'
+    }
+
+    void "test a container the source wrote is the container"() {
+        given:
+        def element = buildClassElement(SOURCE)
+        def field = element.getFields().find { it.name == 'typeVarField' }
+
+        when:
+        def source = field.getSourceAnnotations()
+
+        then:
+        names(source) == ['test.MyRepeatables']
+        nested(source[0]) == ['c1', 'c2']
+
+        and: "the metadata sees the unwrapped repetitions"
+        element.getAnnotationMetadata() != null
+        field.getAnnotationMetadata().getAnnotationValuesByName('test.MyRepeatable').size() == 2
+    }
+
+    void "test a use of a type variable reports what the use wrote, its declaration the type parameter annotations"() {
+        given:
+        def element = buildClassElement(SOURCE)
+        def field = element.getFields().find { it.name == 'typeVarField' }
+        def use = (GenericPlaceholderElement) field.getGenericType()
+        def declaration = element.getDeclaredGenericPlaceholders()[0]
+
+        expect: "the metadata of an unannotated use still falls back to the declaration"
+        use.getGenericTypeAnnotationMetadata().hasAnnotation('test.TypeAnn')
+
+        and: "the source view does not"
+        use.getGenericTypeAnnotationMetadata().getSourceAnnotations().isEmpty()
+        use.getSourceAnnotations().isEmpty()
+
+        and: "the declaration reports the annotations of the type parameter"
+        names(declaration.getGenericTypeAnnotationMetadata().getSourceAnnotations()) == ['test.TypeAnn']
+        declaration.getGenericTypeAnnotationMetadata().getSourceAnnotations()[0].stringValue().get() == 'class-var'
+        names(declaration.getSourceAnnotations()) == ['test.TypeAnn']
+    }
+
+    void "test a method, its parameter and its declared type variable"() {
+        given:
+        def element = buildClassElement(SOURCE)
+        def method = element.getMethods().find { it.name == 'method' }
+
+        expect:
+        names(method.getSourceAnnotations()) == ['test.MyRepeatable']
+        method.getSourceAnnotations()[0].stringValue().get() == 'm'
+        names(method.getParameters()[0].getSourceAnnotations()) == ['test.MyRepeatable']
+        method.getParameters()[0].getSourceAnnotations()[0].stringValue().get() == 'p'
+
+        and: "the method annotation metadata combines the class annotations, the source view does not"
+        method.getAnnotationMetadata().hasAnnotation('jakarta.inject.Singleton')
+        !method.getSourceAnnotations().any { it.annotationName == 'jakarta.inject.Singleton' }
+
+        and:
+        def typeVariable = method.getDeclaredTypeVariables()[0]
+        names(typeVariable.getGenericTypeAnnotationMetadata().getSourceAnnotations()) == ['test.TypeAnn']
+        typeVariable.getGenericTypeAnnotationMetadata().getSourceAnnotations()[0].stringValue().get() == 'method-var'
+        ((GenericPlaceholderElement) method.getGenericReturnType()).getGenericTypeAnnotationMetadata().getSourceAnnotations().isEmpty()
+    }
+
+    void "test every dimension of an array reports its own type annotations while the metadata is unchanged"() {
+        given:
+        def element = buildClassElement(SOURCE)
+        def arrayType = element.getFields().find { it.name == 'arrayField' }.getType()
+
+        expect:
+        arrayType.getArrayDimensions() == 2
+        values(arrayType.getTypeAnnotationMetadata().getSourceAnnotations()) == ['outer']
+        values(arrayType.fromArray().getTypeAnnotationMetadata().getSourceAnnotations()) == ['inner']
+        values(arrayType.fromArray().fromArray().getTypeAnnotationMetadata().getSourceAnnotations()) == ['component']
+
+        and: "the metadata keeps answering with the component's annotations, as before"
+        arrayType.getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'component'
+        arrayType.fromArray().getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'component'
+        arrayType.fromArray().fromArray().getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'component'
+
+        and: "an array made from the component holds no mirror for the new dimension"
+        arrayType.fromArray().fromArray().toArray().getTypeAnnotationMetadata().getSourceAnnotations().isEmpty()
+    }
+
+    void "test what a visitor adds does not appear and the meta-annotations of an annotation interface do"() {
+        given:
+        def element = buildClassElement('''
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+@interface MyAnn {
+}
+''')
+
+        when:
+        element.annotate('test.Added')
+
+        then:
+        element.getAnnotationMetadata().hasDeclaredAnnotation('test.Added')
+        !element.getAnnotationMetadata().hasDeclaredAnnotation(Retention.name)
+        names(element.getSourceAnnotations()) == [Retention.name, Target.name]
+        element.getSourceAnnotations()[0].stringValue().get() == 'SOURCE'
+        element.getSourceAnnotations()[1].stringValues() == ['TYPE'] as String[]
+
+        and: "a copy with preset metadata still reports what the source wrote"
+        names(element.withAnnotationMetadata(element.getAnnotationMetadata()).getSourceAnnotations()) == [Retention.name, Target.name]
+    }
+
+    void "test an element no source backs reports nothing"() {
+        expect:
+        ClassElement.of(String).getSourceAnnotations().isEmpty()
+        ClassElement.of('test.Missing').getSourceAnnotations().isEmpty()
+    }
+
+    private static List<String> names(List<AnnotationValue<?>> values) {
+        return values*.annotationName
+    }
+
+    private static List<String> values(List<AnnotationValue<?>> values) {
+        return values.collect { it.stringValue().get() }
+    }
+
+    private static List<String> nested(AnnotationValue<?> container) {
+        return (container.getValues().get('value') as AnnotationValue[]).collect { it.stringValue().get() }
+    }
+}

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
@@ -105,6 +105,16 @@ internal class KotlinAnnotationMetadataBuilder(
         TODO("Not yet implemented")
     }
 
+    override fun getWrittenAnnotations(element: KSAnnotated): List<KSAnnotation> {
+        // Unlike getAnnotationsForType, a repeatable container is kept as the source wrote it and the
+        // annotations of a property are not fused into those of its accessors and setter parameter
+        var annotated = element
+        if (annotated is KotlinAnnotationType) {
+            annotated = annotated.type
+        }
+        return annotated.annotations.toList()
+    }
+
     override fun getAnnotationsForType(element: KSAnnotated): MutableList<out KSAnnotation> {
         val annotationMirrors : MutableList<KSAnnotation> = mutableListOf()
 

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinElementAnnotationMetadataFactory.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinElementAnnotationMetadataFactory.kt
@@ -17,6 +17,8 @@ package io.micronaut.kotlin.processing.annotation
 
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
+import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.Element
@@ -118,10 +120,36 @@ internal class KotlinElementAnnotationMetadataFactory(
         if (kotlinPlaceholderElement.genericNativeType.owner == null) {
             throw ProcessingException(placeholderElement, "Type annotations an a generic placeholder require the owner element to be specified!")
         }
-        return metadataBuilder.lookupOrBuild(
+        val cached = metadataBuilder.lookupOrBuild(
             kotlinPlaceholderElement.genericNativeType,
             kotlinPlaceholderElement.genericNativeType.declaration
         )
+        val useType = kotlinPlaceholderElement.genericNativeType.type ?: return cached
+        // The metadata of a use of a type variable is that of its declaration; the source view reports
+        // what was written at the use
+        return SourceAnnotationsCachedAnnotationMetadata(cached) {
+            metadataBuilder.readSourceAnnotations(KotlinAnnotations(useType.annotations))
+        }
+    }
+
+    private class SourceAnnotationsCachedAnnotationMetadata(
+        private val delegate: CachedAnnotationMetadata,
+        supplier: () -> List<AnnotationValue<*>>
+    ) : CachedAnnotationMetadata {
+
+        private val resolvedSourceAnnotations: List<AnnotationValue<*>> by lazy(supplier)
+
+        override fun getAnnotationMetadata(): AnnotationMetadata = delegate.annotationMetadata
+
+        override fun isMutated() = delegate.isMutated
+
+        override fun update(annotationMetadata: AnnotationMetadata) = delegate.update(annotationMetadata)
+
+        override fun wasCleared() = delegate.wasCleared()
+
+        override fun markCleared() = delegate.markCleared()
+
+        override fun getSourceAnnotations() = resolvedSourceAnnotations
     }
 
     override fun lookupTypeAnnotationsForWildcard(wildcardElement: WildcardElement): CachedAnnotationMetadata {

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
@@ -243,7 +243,8 @@ internal abstract class AbstractKotlinElement<T : KotlinNativeElement>(
         owner: KotlinNativeElement,
         typeParameter: KSTypeParameter,
         parentTypeArguments: Map<String, ClassElement>,
-        visitedTypes: MutableSet<Any> = HashSet()
+        visitedTypes: MutableSet<Any> = HashSet(),
+        useType: KSType? = null
     ): ClassElement {
         val variableName = typeParameter.name.asString()
         val found = parentTypeArguments[variableName]
@@ -278,7 +279,7 @@ internal abstract class AbstractKotlinElement<T : KotlinNativeElement>(
         }.toList()
 
         return KotlinGenericPlaceholderElement(
-            KotlinTypeParameterNativeElement(typeParameter, owner),
+            KotlinTypeParameterNativeElement(typeParameter, owner, useType),
             bound,
             bounds,
             declaringElement,
@@ -615,7 +616,8 @@ internal abstract class AbstractKotlinElement<T : KotlinNativeElement>(
                     owner!!,
                     typeDeclaration,
                     parentTypeArguments,
-                    visitedTypes
+                    visitedTypes,
+                    type
                 )
             }
         }

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinGenericPlaceholderElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinGenericPlaceholderElement.kt
@@ -16,6 +16,7 @@
 package io.micronaut.kotlin.processing.visitor
 
 import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.Element
@@ -96,6 +97,9 @@ internal class KotlinGenericPlaceholderElement(
     override fun getAnnotationMetadataToWrite() = resolvedGenericTypeAnnotationMetadata
 
     override fun getGenericTypeAnnotationMetadata() = resolvedGenericTypeAnnotationMetadata
+
+    // What was written at this use of the variable, or on its declaration
+    override fun getSourceAnnotations(): List<AnnotationValue<*>> = getGenericTypeAnnotationMetadata().sourceAnnotations
 
     override fun getTypeAnnotationMetadata() = resolvedTypeAnnotationMetadata
 

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinNativeElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinNativeElement.kt
@@ -242,7 +242,12 @@ class KotlinPropertyGetterNativeElement(
 
 class KotlinTypeParameterNativeElement(
     val declaration: KSTypeParameter,
-    owner: KotlinNativeElement
+    owner: KotlinNativeElement,
+    /**
+     * The type of the use of the variable, when the element is a use rather than the declaration.
+     * Not part of the identity: a use and the declaration share their metadata.
+     */
+    val type: KSType? = null
 ) : KotlinNativeElement(declaration, owner) {
 
     override fun toString(): String {

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinTypeArgumentElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinTypeArgumentElement.kt
@@ -16,6 +16,7 @@
 package io.micronaut.kotlin.processing.visitor
 
 import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.GenericElement
@@ -90,6 +91,9 @@ internal class KotlinTypeArgumentElement(
     override fun getAnnotationMetadataToWrite() = resolvedGenericTypeAnnotationMetadata
 
     override fun getGenericTypeAnnotationMetadata() = resolvedGenericTypeAnnotationMetadata
+
+    // What was written at this use of the variable, or on its declaration
+    override fun getSourceAnnotations(): List<AnnotationValue<*>> = getGenericTypeAnnotationMetadata().sourceAnnotations
 
     override fun getTypeAnnotationMetadata() = resolvedTypeAnnotationMetadata
 

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinWildcardElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinWildcardElement.kt
@@ -17,6 +17,7 @@ package io.micronaut.kotlin.processing.visitor
 
 import com.google.devtools.ksp.symbol.Variance
 import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy
 import io.micronaut.inject.ast.ArrayableClassElement
 import io.micronaut.inject.ast.ClassElement
@@ -72,6 +73,9 @@ internal class KotlinWildcardElement(
     override fun getAnnotationMetadataToWrite() = resolvedGenericTypeAnnotationMetadata
 
     override fun getGenericTypeAnnotationMetadata() = resolvedGenericTypeAnnotationMetadata
+
+    // What was written at this use of the variable, or on its declaration
+    override fun getSourceAnnotations(): List<AnnotationValue<*>> = getGenericTypeAnnotationMetadata().sourceAnnotations
 
     override fun getTypeAnnotationMetadata() = resolvedTypeAnnotationMetadata
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/SourceAnnotationsSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/SourceAnnotationsSpec.groovy
@@ -1,0 +1,161 @@
+package io.micronaut.kotlin.processing.annotations
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.GenericPlaceholderElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+import java.lang.annotation.RetentionPolicy
+
+/**
+ * KSP symbols can only be read while the compilation runs, so the elements are read in a visitor and the
+ * results recorded.
+ */
+class SourceAnnotationsSpec extends AbstractKotlinCompilerSpec {
+
+    void "test the source view under KSP"() {
+        given:
+        SourceVisitor.RESULTS.clear()
+        buildClassElement('test.MyBean', '''
+package test
+
+@MyRepeatable("a")
+@MyRepeatable("b")
+@jakarta.inject.Singleton
+class MyBean<@TypeAnn("class-var") T> {
+
+    @field:MyRepeatable("single")
+    @field:Defaults(name = "x")
+    var field: @TypeAnn("field-type") String = ""
+
+    var typeVarField: T? = null
+
+    @MyRepeatable("m")
+    fun <@TypeAnn("method-var") M> method(@MyRepeatable("p") param: String): M? = null
+}
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE, AnnotationTarget.TYPE_PARAMETER)
+@Repeatable
+annotation class MyRepeatable(val value: String)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.TYPE_PARAMETER)
+annotation class TypeAnn(val value: String = "")
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FIELD)
+annotation class Defaults(val name: String, val description: String = "", val tags: Array<String> = [], val count: Int = 3)
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+annotation class MyAnn
+''')
+        def r = SourceVisitor.RESULTS
+
+        expect: "the class: repetitions as written, no stereotype"
+        r['class.names'] == ['test.MyRepeatable', 'test.MyRepeatable', 'jakarta.inject.Singleton']
+        r['class.values'] == ['a', 'b']
+        r['class.retentions'].every { it == RetentionPolicy.RUNTIME }
+        r['class.metadataHasScope'] == true
+        r['class.sourceHasScope'] == false
+
+        and: "the field, with the defaults it left out, empty ones included"
+        r['field.names'] == ['test.MyRepeatable', 'test.Defaults']
+        r['field.single'] == 'single'
+        r['field.defaults.retention'] == RetentionPolicy.SOURCE
+        r['field.defaults.name'] == 'x'
+        r['field.defaults.description'] == ''
+        r['field.defaults.tags'] == [] as String[]
+        r['field.defaults.count'] == 3
+        r['field.defaults.hasDescriptionValue'] == false
+        r['field.type.names'] == ['test.TypeAnn']
+        r['field.type.value'] == 'field-type'
+
+        and: "a use of a type variable reports what the use wrote, the declaration the type parameter annotations"
+        r['use.metadataHasTypeAnn'] == true
+        r['use.source'] == []
+        r['declaration.names'] == ['test.TypeAnn']
+        r['declaration.value'] == 'class-var'
+        r['declaration.element.names'] == ['test.TypeAnn']
+
+        and: "a method, its parameter and its declared type variable"
+        r['method.names'] == ['test.MyRepeatable']
+        r['method.value'] == 'm'
+        r['parameter.names'] == ['test.MyRepeatable']
+        r['parameter.value'] == 'p'
+        r['method.metadataHasSingleton'] == true
+        r['method.sourceHasSingleton'] == false
+        r['method.typeVariable.names'] == ['test.TypeAnn']
+        r['method.typeVariable.value'] == 'method-var'
+
+        and: "what a visitor adds does not appear and the meta-annotations of an annotation class do"
+        r['ann.metadataHasAdded'] == true
+        r['ann.names'] == ['kotlin.annotation.Retention', 'kotlin.annotation.Target']
+    }
+
+    static class SourceVisitor implements TypeElementVisitor<Object, Object> {
+
+        static final Map<String, Object> RESULTS = [:]
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.name != 'test.MyBean' || !element.hasDeclaredAnnotation('test.MyRepeatable') || !context.getClassElement('test.MyAnn').isPresent()) {
+                return
+            }
+            def source = element.getSourceAnnotations()
+            RESULTS['class.names'] = names(source)
+            RESULTS['class.values'] = source.findAll { it.annotationName == 'test.MyRepeatable' }.collect { it.stringValue().get() }
+            RESULTS['class.retentions'] = source*.retentionPolicy
+            RESULTS['class.metadataHasScope'] = element.getAnnotationMetadata().hasDeclaredStereotype(AnnotationUtil.SCOPE)
+            RESULTS['class.sourceHasScope'] = source.any { it.annotationName == AnnotationUtil.SCOPE }
+
+            def field = element.getFields().find { it.name == 'field' }
+            def fieldSource = field.getSourceAnnotations()
+            RESULTS['field.names'] = names(fieldSource)
+            RESULTS['field.single'] = fieldSource[0].stringValue().get()
+            AnnotationValue<?> defaults = fieldSource[1]
+            RESULTS['field.defaults.retention'] = defaults.retentionPolicy
+            RESULTS['field.defaults.name'] = defaults.stringValue('name').get()
+            RESULTS['field.defaults.description'] = defaults.getDefaultValues().get('description')
+            RESULTS['field.defaults.tags'] = defaults.getDefaultValues().get('tags')
+            RESULTS['field.defaults.count'] = defaults.getDefaultValues().get('count')
+            RESULTS['field.defaults.hasDescriptionValue'] = defaults.getValues().containsKey('description')
+            def fieldType = field.getType().getTypeAnnotationMetadata().getSourceAnnotations()
+            RESULTS['field.type.names'] = names(fieldType)
+            RESULTS['field.type.value'] = fieldType[0].stringValue().get()
+
+            def use = (GenericPlaceholderElement) element.getFields().find { it.name == 'typeVarField' }.getGenericType()
+            RESULTS['use.metadataHasTypeAnn'] = use.getGenericTypeAnnotationMetadata().hasAnnotation('test.TypeAnn')
+            RESULTS['use.source'] = names(use.getGenericTypeAnnotationMetadata().getSourceAnnotations())
+            def declaration = element.getDeclaredGenericPlaceholders()[0]
+            def declarationSource = declaration.getGenericTypeAnnotationMetadata().getSourceAnnotations()
+            RESULTS['declaration.names'] = names(declarationSource)
+            RESULTS['declaration.value'] = declarationSource[0].stringValue().get()
+            RESULTS['declaration.element.names'] = names(declaration.getSourceAnnotations())
+
+            def method = element.getMethods().find { it.name == 'method' }
+            RESULTS['method.names'] = names(method.getSourceAnnotations())
+            RESULTS['method.value'] = method.getSourceAnnotations()[0].stringValue().get()
+            RESULTS['parameter.names'] = names(method.getParameters()[0].getSourceAnnotations())
+            RESULTS['parameter.value'] = method.getParameters()[0].getSourceAnnotations()[0].stringValue().get()
+            RESULTS['method.metadataHasSingleton'] = method.getAnnotationMetadata().hasAnnotation('jakarta.inject.Singleton')
+            RESULTS['method.sourceHasSingleton'] = method.getSourceAnnotations().any { it.annotationName == 'jakarta.inject.Singleton' }
+            def typeVariable = method.getDeclaredTypeVariables()[0].getGenericTypeAnnotationMetadata().getSourceAnnotations()
+            RESULTS['method.typeVariable.names'] = names(typeVariable)
+            RESULTS['method.typeVariable.value'] = typeVariable[0].stringValue().get()
+
+            def ann = context.getClassElement('test.MyAnn').get()
+            ann.annotate('test.Added')
+            RESULTS['ann.metadataHasAdded'] = ann.getAnnotationMetadata().hasDeclaredAnnotation('test.Added')
+            RESULTS['ann.names'] = names(ann.getSourceAnnotations())
+        }
+
+        private static List<String> names(List<AnnotationValue<?>> values) {
+            return values*.annotationName
+        }
+    }
+}

--- a/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -16,3 +16,4 @@ io.micronaut.kotlin.processing.aop.introduction.MyIsEnumInTypeArgumentSpec$MyCon
 io.micronaut.kotlin.processing.ast.visitor.KotlinAnnotationElementSpec$InheritedVisitor
 io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsVisitor
 io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsRecordingVisitor
+io.micronaut.kotlin.processing.annotations.SourceAnnotationsSpec$SourceVisitor

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PythonSourceAnnotationsSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PythonSourceAnnotationsSpec.groovy
@@ -1,0 +1,71 @@
+package io.micronaut.python.annotation.processing.test
+
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.python.compiler.RepeatableAnnotation
+
+import java.lang.annotation.RetentionPolicy
+
+class PythonSourceAnnotationsSpec extends AbstractPythonTypeElementSpec {
+
+    void "test the source view of a Python class, method, parameter and type use"() {
+        expect:
+        buildClassElement('''
+from typing import Annotated
+from jakarta.inject import Singleton
+from micronaut.python.compiler import RepeatableAnnotation, PrimitiveTypesAnnotation, TestAnnotation
+
+@RepeatableAnnotation("first")
+@RepeatableAnnotation("second")
+@Singleton
+class Repeated:
+    value: Annotated[str, TestAnnotation("f")]
+    items: list[Annotated[str, TestAnnotation("e")]]
+
+    @PrimitiveTypesAnnotation(intValue=7)
+    def run(self, name: Annotated[str, TestAnnotation("p")], plain: str) -> Annotated[str, TestAnnotation("r")]:
+        return name
+''') { ClassElement element ->
+            def source = element.getSourceAnnotations()
+            assert source*.annotationName == [RepeatableAnnotation.name, RepeatableAnnotation.name, AnnotationUtil.SINGLETON]
+            assert source[0].stringValue().get() == 'first'
+            assert source[1].stringValue().get() == 'second'
+            assert source.every { it.retentionPolicy == RetentionPolicy.RUNTIME }
+
+            // the metadata folds the repetitions into the container and adds the scope stereotype
+            assert element.getAnnotationMetadata().hasDeclaredStereotype(AnnotationUtil.SCOPE)
+            assert element.getAnnotationValuesByType(RepeatableAnnotation).size() == 2
+            assert !source.any { it.annotationName == AnnotationUtil.SCOPE }
+
+            def method = element.findMethod('run').get()
+            AnnotationValue<?> primitives = method.getSourceAnnotations().find { it.annotationName == 'io.micronaut.python.compiler.PrimitiveTypesAnnotation' }
+            assert primitives != null
+            assert primitives.intValue('intValue').getAsInt() == 7
+            assert !primitives.getValues().containsKey('stringValue')
+            assert primitives.getDefaultValues().containsKey('stringValue')
+            assert method.getAnnotationMetadata().hasAnnotation(AnnotationUtil.SINGLETON)
+            assert !method.getSourceAnnotations().any { it.annotationName == AnnotationUtil.SINGLETON }
+
+            // Python attaches an Annotated[...] on a parameter or an attribute to that declaration, and to the
+            // type use only inside a type argument
+            def name = method.getParameters().find { it.name == 'name' }
+            assert name.getSourceAnnotations()*.annotationName == ['io.micronaut.python.compiler.TestAnnotation']
+            assert name.getSourceAnnotations()[0].stringValue().get() == 'p'
+            assert name.getType().getTypeAnnotationMetadata().getSourceAnnotations().isEmpty()
+            def value = element.getFields().find { it.name == 'value' }
+            assert value.getSourceAnnotations()*.annotationName == ['io.micronaut.python.compiler.TestAnnotation']
+            def itemsArgument = element.getFields().find { it.name == 'items' }.getGenericType().getFirstTypeArgument().get()
+            assert itemsArgument.getTypeAnnotationMetadata().getSourceAnnotations()*.annotationName == ['io.micronaut.python.compiler.TestAnnotation']
+            assert itemsArgument.getTypeAnnotationMetadata().getSourceAnnotations()[0].stringValue().get() == 'e'
+            assert itemsArgument.getTypeAnnotationMetadata().getSourceAnnotations()[0].getDefaultValues().containsKey('value')
+            assert method.getParameters().find { it.name == 'plain' }.getType().getTypeAnnotationMetadata().getSourceAnnotations().isEmpty()
+
+            // what a visitor adds does not appear
+            element.annotate('test.Added')
+            assert element.getAnnotationMetadata().hasDeclaredAnnotation('test.Added')
+            assert !element.getSourceAnnotations().any { it.annotationName == 'test.Added' }
+            return element
+        }
+    }
+}

--- a/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonAnnotationMetadataBuilder.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonAnnotationMetadataBuilder.java
@@ -25,6 +25,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.annotation.AnnotationMapper;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
@@ -52,6 +53,7 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -306,6 +308,13 @@ public final class PythonAnnotationMetadataBuilder extends AbstractAnnotationMet
     }
 
     @Override
+    protected List<? extends DecoratorDef> getWrittenAnnotations(ElementDef element) {
+        // Python writes no repeatable containers, a repeated decorator is written once per repetition, and the
+        // decorators of a synthesized annotation declaration are the decorators applied to its declaring function
+        return getAnnotationsForType(element);
+    }
+
+    @Override
     protected List<? extends DecoratorDef> getAnnotationsForType(ElementDef element) {
         if (element instanceof AnnotationMemberDef memberDef) {
             List<DecoratorDef> memberAnnotations = toDecoratorDefs(memberDef.getAnnotationMetadata());
@@ -517,6 +526,30 @@ public final class PythonAnnotationMetadataBuilder extends AbstractAnnotationMet
         for (Map.Entry<?, ?> entry : decoratorDef.members().entrySet()) {
             String memberName = AnnotationNames.memberName(entry.getKey());
             defaultValues.put(resolveMemberDef(annotationName, javaAnnotationType, memberName), entry.getValue());
+        }
+        return defaultValues;
+    }
+
+    @Override
+    protected Map<? extends ElementDef, ?> readAnnotationDefaultValues(String annotationName, ElementDef annotationType, boolean includeEmptyValues) {
+        Map<? extends ElementDef, ?> pythonDefaults = readAnnotationDefaultValues(annotationName, annotationType);
+        if (!pythonDefaults.isEmpty()) {
+            return pythonDefaults;
+        }
+        // A Java annotation used from Python: the defaults are the ones the Java builder reads
+        JavaVisitorContext javaVisitorContext = visitorContext.getJavaVisitorContext();
+        ClassElement javaAnnotationType = getJavaAnnotationType(annotationName);
+        if (javaVisitorContext == null || javaAnnotationType == null) {
+            return pythonDefaults;
+        }
+        Map<CharSequence, Object> javaDefaults = javaVisitorContext.getAnnotationMetadataBuilder().getAnnotationDefaultValues(annotationName);
+        Map<ElementDef, Object> defaultValues = CollectionUtils.newLinkedHashMap(javaDefaults.size());
+        for (Map.Entry<CharSequence, Object> entry : javaDefaults.entrySet()) {
+            Object value = entry.getValue();
+            if (!includeEmptyValues && (value instanceof String str && str.isEmpty() || value != null && value.getClass().isArray() && Array.getLength(value) == 0)) {
+                continue;
+            }
+            defaultValues.put(resolveMemberDef(annotationName, javaAnnotationType, entry.getKey().toString()), value);
         }
         return defaultValues;
     }

--- a/inject-python/src/main/java/io/micronaut/python/processing/element/TypeAnnotatedClassElement.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/element/TypeAnnotatedClassElement.java
@@ -69,6 +69,12 @@ public record TypeAnnotatedClassElement(
     }
 
     @Override
+    public List<AnnotationValue<?>> getSourceAnnotations() {
+        // The declaration of the type; what was written at this use is on getTypeAnnotationMetadata()
+        return delegate.getSourceAnnotations();
+    }
+
+    @Override
     public <T extends Annotation> ClassElement annotate(String annotationType, Consumer<AnnotationValueBuilder<T>> consumer) {
         typeAnnotationMetadata.annotate(annotationType, consumer);
         return this;

--- a/inject-python/src/main/java/io/micronaut/python/processing/util/PythonTypeResolver.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/util/PythonTypeResolver.java
@@ -165,13 +165,12 @@ public final class PythonTypeResolver {
         if (decorators.isEmpty()) {
             return baseType;
         }
-        AnnotationMetadata annotationMetadata = visitorContext
-            .getAnnotationMetadataBuilder()
-            .buildDeclared(new AttributeDef("$typeUse", null, null, null, decorators, null, false, null));
+        var typeUse = new AttributeDef("$typeUse", null, null, null, decorators, null, false, null);
+        AnnotationMetadata annotationMetadata = visitorContext.getAnnotationMetadataBuilder().buildDeclared(typeUse);
         if (annotationMetadata.isEmpty()) {
             return baseType;
         }
-        var metadata = visitorContext.getElementAnnotationMetadataFactory().buildMutable(annotationMetadata);
+        var metadata = typeUseMetadata(visitorContext, annotationMetadata, typeUse);
         return new TypeAnnotatedClassElement(baseType, metadata);
     }
 
@@ -324,14 +323,24 @@ public final class PythonTypeResolver {
         }
         ClassElement resolvedType = resolvePythonTypeToJava(members.getFirst(), visitorContext, boundGenerics);
         ClassElement boxedType = boxPrimitiveTypeIfNeeded(resolvedType, visitorContext);
-        AnnotationMetadata annotationMetadata = visitorContext
-            .getAnnotationMetadataBuilder()
-            .buildDeclared(new AttributeDef("$typeUse", union.toString(), union, null, List.of(), null, false, null));
+        var typeUse = new AttributeDef("$typeUse", union.toString(), union, null, List.of(), null, false, null);
+        AnnotationMetadata annotationMetadata = visitorContext.getAnnotationMetadataBuilder().buildDeclared(typeUse);
         if (annotationMetadata.isEmpty()) {
             return boxedType;
         }
-        var metadata = visitorContext.getElementAnnotationMetadataFactory().buildMutable(annotationMetadata);
+        var metadata = typeUseMetadata(visitorContext, annotationMetadata, typeUse);
         return new TypeAnnotatedClassElement(boxedType, metadata);
+    }
+
+    /**
+     * The type annotation metadata of a type use, with the source view reading the decorators written on it.
+     */
+    private static ElementAnnotationMetadata typeUseMetadata(PythonVisitorContext visitorContext,
+                                                             AnnotationMetadata annotationMetadata,
+                                                             AttributeDef typeUse) {
+        var builder = visitorContext.getAnnotationMetadataBuilder();
+        return visitorContext.getElementAnnotationMetadataFactory()
+            .buildMutable(annotationMetadata, () -> builder.readSourceAnnotations(typeUse));
     }
 
     /**


### PR DESCRIPTION
### What this does

Adds an "as written" view of an element's annotations beside the annotation metadata:

```java
// io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate
@Experimental
default List<AnnotationValue<?>> getSourceAnnotations() { return List.of(); }
```

Because `Element extends MutableAnnotationMetadataDelegate<Element>`, it is reachable as `element.getSourceAnnotations()`, `classElement.getTypeAnnotationMetadata().getSourceAnnotations()` and `genericElement.getGenericTypeAnnotationMetadata().getSourceAnnotations()`.

The list is the declaration as the compiler sees it, in source order:
- a repeatable annotation written once is itself, a container the source wrote is the container; two or more repetitions arrive in the container the compiler synthesizes for them (javac and Groovy both hand that over, as the class file would; Python and KSP hand over the repetitions);
- nothing an `AnnotationMapper`, `AnnotationRemapper`, `AnnotationTransformer` or a visitor's `annotate(...)` added appears, nor any stereotype;
- each value carries the interface's retention and its defaults for the members the use left out, empty strings and arrays included (`readAnnotationDefaultValues(name, type, true)`);
- for a type variable it is what was written at this use (nothing if the use wrote nothing), or the type parameter's annotations when the element comes from `getDeclaredGenericPlaceholders()` / `getDeclaredTypeVariables()`;
- empty for an element no source backs (`ClassElement.of(...)`, reflection, synthesized properties).

### Why

The CDI Lite language model (`jakarta.enterprise.lang.model`) that micronaut-cdi builds on top of the AST promises exactly this, and the metadata record answers none of it by design (repetitions are folded into their container, mapper output and stereotypes are indistinguishable from what was written, empty defaults are dropped). Today the processor reads javac's mirrors for it, which leaves KSP, Groovy and Python compilations behind.

### How

- `AbstractAnnotationMetadataBuilder` gains `protected abstract List<? extends A> getWrittenAnnotations(T element)` (javac `getAnnotationMirrors()`, not `getAnnotationsForType`, which unwraps containers; KSP `annotations`; Groovy `getAnnotations()`; Python the decorators) and a public `readSourceAnnotations(T element)` that reads the raw member values and the defaults and skips `processAnnotation` entirely. Evaluated-expression strings stay strings, validation is not re-run. The list is cached lazily on the `CachedAnnotationMetadata` entry; `AbstractElementAnnotationMetadata` delegates to it.
- javac placeholders: `JavaElementAnnotationMetadataFactory.lookupTypeAnnotationsForGenericPlaceholder` keeps its fallback to the `TypeParameterElement` for the metadata; the source view reads the `TypeVariable` mirror for a use and the type parameter for a declaration. Declarations are marked on `JavaGenericPlaceholderElement` (`isDeclaration()`, now public and `@Internal`) by `getDeclaredGenericPlaceholders()` / `getDeclaredTypeVariables()`; cache keys are unchanged.
- javac arrays: `AbstractJavaElement.newClassElement` now builds the leaf with the leaf mirror and gives each dimension its own `JavaNativeElement.Class` holding that dimension's `ArrayType` (`JavaClassElement.toArray(ArrayType)`; `withArrayDimensions(n-1)` keeps taking `getComponentType()`). The compatibility swap in `lookupTypeAnnotationsForClass` ("component annotations stand for the array's unless JSpecify") is unchanged; because the dimensions used to share the innermost array mirror, the swap now first walks to the innermost array so multi-dimensional arrays answer exactly as before. Only `getSourceAnnotations()` is exact per dimension; an array made with `toArray()` from a component reports nothing for the synthetic dimension.
- KSP: `KotlinTypeParameterNativeElement` keeps the use's `KSType` (not part of equality, so metadata stays shared); the factory reads the use's annotations for the source view.
- Groovy: the type-annotation lookups already pass a synthetic node holding the type annotations, so the view works through `getWrittenAnnotations`.
- Python: the defaults of a Java annotation used from Python, which the Python builder never read, come from the Java builder for the source view (the three-argument `readAnnotationDefaultValues`, which also serves `getAnnotationDefaultValues`); the metadata path is unchanged. A type use built by `PythonTypeResolver` gets its source view through a new `AbstractElementAnnotationMetadataFactory.buildMutable(AnnotationMetadata, Supplier)` overload, and `TypeAnnotatedClassElement` forwards the element view to its delegate. Python attaches an `Annotated[...]` on a parameter or attribute to that declaration, and to the type use only inside a type argument; the view reports it where Python put it.

Not touched, as agreed: `JavaMethodElement.returnType`'s JSpecify `@NonNull` annotate call, `MutableAnnotationMetadata.addDeclaredRepeatable`, and KSP's boxing of annotated primitives.

### Tests

`SourceAnnotationsSpec` in `inject-java`, `inject-kotlin`, `inject-groovy` and `PythonSourceAnnotationsSpec` in `inject-python-test`: repetitions, a written container, defaults with empty values, stereotypes absent, `annotate(...)` absent, meta-annotations of an annotation interface present, type-use annotations, use versus declaration of a type variable, per-dimension array annotations with the metadata unchanged. The full `:micronaut-inject-java:test` (5286), `:micronaut-inject-groovy:test` (1131), `:micronaut-inject-kotlin:test` (866), `:micronaut-inject-python-test:test` (609) and `:micronaut-inject-python:test` (125) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
