### PR TITLE
Keep type annotations written on a primitive type use (javac and Groovy)

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/PrimitiveElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/PrimitiveElement.java
@@ -16,11 +16,17 @@
 package io.micronaut.inject.ast;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate;
 import org.jspecify.annotations.Nullable;
 
+import java.lang.annotation.Annotation;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * A {@link ClassElement} of primitive types.
@@ -43,6 +49,8 @@ public final class PrimitiveElement implements ArrayableClassElement {
     private final String boxedTypeName;
     private final AnnotationMetadata annotationMetadata;
     @Nullable
+    private final MutableAnnotationMetadataDelegate<AnnotationMetadata> typeAnnotationMetadata;
+    @Nullable
     private final String doc;
 
     /**
@@ -50,7 +58,7 @@ public final class PrimitiveElement implements ArrayableClassElement {
      * @param name The type name
      */
     private PrimitiveElement(String name, @Nullable Class<?> boxedType) {
-        this(name, boxedType == null ? "<>" : boxedType.getName(), 0, AnnotationMetadata.EMPTY_METADATA, null);
+        this(name, boxedType == null ? "<>" : boxedType.getName(), 0, AnnotationMetadata.EMPTY_METADATA, null, null);
     }
 
     /**
@@ -61,11 +69,17 @@ public final class PrimitiveElement implements ArrayableClassElement {
      * @param annotationMetadata The annotation metadata
      * @param doc                The optional documentation
      */
-    private PrimitiveElement(String name, String boxedTypeName, int arrayDimensions, AnnotationMetadata annotationMetadata, @Nullable String doc) {
+    private PrimitiveElement(String name,
+                             String boxedTypeName,
+                             int arrayDimensions,
+                             AnnotationMetadata annotationMetadata,
+                             @Nullable MutableAnnotationMetadataDelegate<AnnotationMetadata> typeAnnotationMetadata,
+                             @Nullable String doc) {
         this.typeName = name;
         this.arrayDimensions = arrayDimensions;
         this.boxedTypeName = boxedTypeName;
         this.annotationMetadata = annotationMetadata;
+        this.typeAnnotationMetadata = typeAnnotationMetadata;
         this.doc = doc;
     }
 
@@ -124,21 +138,121 @@ public final class PrimitiveElement implements ArrayableClassElement {
 
     @Override
     public AnnotationMetadata getAnnotationMetadata() {
+        if (typeAnnotationMetadata != null) {
+            return typeAnnotationMetadata.getAnnotationMetadata();
+        }
         return annotationMetadata;
+    }
+
+    /**
+     * The type annotations written on this use of the primitive, such as {@code @A int}, when the element
+     * was created for such a use with {@link #withTypeAnnotationMetadata(MutableAnnotationMetadataDelegate)};
+     * they are the same annotations {@link #getAnnotationMetadata()} returns. The shared constants have none.
+     *
+     * @return The type annotation metadata
+     * @since 5.3.0
+     */
+    @Override
+    public MutableAnnotationMetadataDelegate<AnnotationMetadata> getTypeAnnotationMetadata() {
+        if (typeAnnotationMetadata != null) {
+            return typeAnnotationMetadata;
+        }
+        return ArrayableClassElement.super.getTypeAnnotationMetadata();
     }
 
     @Override
     public PrimitiveElement withArrayDimensions(int arrayDimensions) {
-        return new PrimitiveElement(typeName, boxedTypeName, arrayDimensions, annotationMetadata, doc);
+        return new PrimitiveElement(typeName, boxedTypeName, arrayDimensions, annotationMetadata, typeAnnotationMetadata, doc);
     }
 
     @Override
     public PrimitiveElement withAnnotationMetadata(AnnotationMetadata annotationMetadata) {
-        return new PrimitiveElement(typeName, boxedTypeName, arrayDimensions, annotationMetadata, doc);
+        return new PrimitiveElement(typeName, boxedTypeName, arrayDimensions, annotationMetadata, null, doc);
+    }
+
+    /**
+     * A copy of this element carrying the type annotations written on a use of the primitive, such as
+     * {@code @A int}. The delegate answers {@link #getAnnotationMetadata()} and
+     * {@link #getTypeAnnotationMetadata()}, and receives the annotations a visitor adds to the element, so a
+     * use of a primitive can be annotated at compilation time like a use of any other type.
+     *
+     * @param typeAnnotationMetadata The type annotation metadata of the use
+     * @return The annotated copy; it still equals the shared constant
+     * @since 5.3.0
+     */
+    public PrimitiveElement withTypeAnnotationMetadata(MutableAnnotationMetadataDelegate<AnnotationMetadata> typeAnnotationMetadata) {
+        return new PrimitiveElement(typeName, boxedTypeName, arrayDimensions, AnnotationMetadata.EMPTY_METADATA, typeAnnotationMetadata, doc);
     }
 
     private PrimitiveElement withDoc(String doc) {
-        return new PrimitiveElement(typeName, boxedTypeName, arrayDimensions, annotationMetadata, doc);
+        return new PrimitiveElement(typeName, boxedTypeName, arrayDimensions, annotationMetadata, typeAnnotationMetadata, doc);
+    }
+
+    private MutableAnnotationMetadataDelegate<AnnotationMetadata> getAnnotationMetadataToWrite() {
+        if (typeAnnotationMetadata == null) {
+            throw new UnsupportedOperationException("A primitive without type annotations cannot be annotated at compilation time");
+        }
+        return typeAnnotationMetadata;
+    }
+
+    @Override
+    public <T extends Annotation> Element annotate(String annotationType, Consumer<AnnotationValueBuilder<T>> consumer) {
+        getAnnotationMetadataToWrite().annotate(annotationType, consumer);
+        return this;
+    }
+
+    @Override
+    public Element annotate(String annotationType) {
+        getAnnotationMetadataToWrite().annotate(annotationType);
+        return this;
+    }
+
+    @Override
+    public <T extends Annotation> Element annotate(Class<T> annotationType, Consumer<AnnotationValueBuilder<T>> consumer) {
+        getAnnotationMetadataToWrite().annotate(annotationType, consumer);
+        return this;
+    }
+
+    @Override
+    public <T extends Annotation> Element annotate(Class<T> annotationType) {
+        getAnnotationMetadataToWrite().annotate(annotationType);
+        return this;
+    }
+
+    @Override
+    public <T extends Annotation> Element annotate(AnnotationValue<T> annotationValue) {
+        getAnnotationMetadataToWrite().annotate(annotationValue);
+        return this;
+    }
+
+    @Override
+    public Element removeAnnotation(String annotationType) {
+        getAnnotationMetadataToWrite().removeAnnotation(annotationType);
+        return this;
+    }
+
+    @Override
+    public <T extends Annotation> Element removeAnnotation(Class<T> annotationType) {
+        getAnnotationMetadataToWrite().removeAnnotation(annotationType);
+        return this;
+    }
+
+    @Override
+    public <T extends Annotation> Element removeAnnotationIf(Predicate<AnnotationValue<T>> predicate) {
+        getAnnotationMetadataToWrite().removeAnnotationIf(predicate);
+        return this;
+    }
+
+    @Override
+    public Element removeStereotype(String annotationType) {
+        getAnnotationMetadataToWrite().removeStereotype(annotationType);
+        return this;
+    }
+
+    @Override
+    public <T extends Annotation> Element removeStereotype(Class<T> annotationType) {
+        getAnnotationMetadataToWrite().removeStereotype(annotationType);
+        return this;
     }
 
     @Override

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
@@ -122,6 +122,30 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
         return buildTypeAnnotationsForClass(element);
     }
 
+    /**
+     * Builds the type annotation metadata of a type use that has no element of its own to look the metadata up
+     * for, such as an annotated use of a primitive, from the cache entry the language implementation built for
+     * it. Mutations are written to the entry, so every element created for the same use sees them.
+     *
+     * @param cacheEntry  The cache entry
+     * @param description The description of the use, for {@link Object#toString()}
+     * @return The type annotation metadata
+     * @since 5.3.0
+     */
+    public ElementAnnotationMetadata buildTypeAnnotations(AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata cacheEntry, Object description) {
+        return new AbstractElementAnnotationMetadata() {
+            @Override
+            protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookup() {
+                return cacheEntry;
+            }
+
+            @Override
+            public String toString() {
+                return description.toString();
+            }
+        };
+    }
+
     @Override
     public ElementAnnotationMetadata buildGenericTypeAnnotations(GenericElement element) {
         if (element instanceof GenericPlaceholderElement placeholderElement) {

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/PropertyElementAnnotationMetadata.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/PropertyElementAnnotationMetadata.java
@@ -71,21 +71,13 @@ public final class PropertyElementAnnotationMetadata implements ElementAnnotatio
             ParameterElement[] parameters = setter.getParameters();
             if (parameters.length > 0) {
                 ParameterElement parameter = parameters[0];
-                MutableAnnotationMetadataDelegate<?> typeAnnotationMetadata = parameter.getType().getTypeAnnotationMetadata();
-                if (!typeAnnotationMetadata.isEmpty()) {
-                    writeElements.add(typeAnnotationMetadata);
-                    readElements.add(typeAnnotationMetadata);
-                }
+                addTypeAnnotations(parameter.getType(), writeElements, readElements);
             }
         }
         if (constructorParameter != null) {
             writeElements.add(constructorParameter);
             readElements.add(constructorParameter);
-            MutableAnnotationMetadataDelegate<?> typeAnnotationMetadata = constructorParameter.getType().getTypeAnnotationMetadata();
-            if (!typeAnnotationMetadata.isEmpty()) {
-                writeElements.add(typeAnnotationMetadata);
-                readElements.add(typeAnnotationMetadata);
-            }
+            addTypeAnnotations(constructorParameter.getType(), writeElements, readElements);
         }
         if (field != null && (!field.isSynthetic() || includeSynthetic)) {
             ClassElement genericFieldType = field.getGenericType();
@@ -106,22 +98,14 @@ public final class PropertyElementAnnotationMetadata implements ElementAnnotatio
                 MutableAnnotationMetadataDelegate<?> fieldAnnotationMetadata = propertyFieldAnnotationMetadata(field);
                 writeElements.add(fieldAnnotationMetadata);
                 readElements.add(fieldAnnotationMetadata);
-                MutableAnnotationMetadataDelegate<?> typeAnnotationMetadata = field.getType().getTypeAnnotationMetadata();
-                if (!typeAnnotationMetadata.isEmpty()) {
-                    writeElements.add(typeAnnotationMetadata);
-                    readElements.add(typeAnnotationMetadata);
-                }
+                addTypeAnnotations(field.getType(), writeElements, readElements);
             }
         }
 
         if (getter != null && (!getter.isSynthetic() || includeSynthetic)) {
             writeElements.add(getter.getMethodAnnotationMetadata());
             readElements.add(getter.getMethodAnnotationMetadata());
-            MutableAnnotationMetadataDelegate<?> typeAnnotationMetadata = getter.getReturnType().getTypeAnnotationMetadata();
-            if (!typeAnnotationMetadata.isEmpty()) {
-                writeElements.add(typeAnnotationMetadata);
-                readElements.add(typeAnnotationMetadata);
-            }
+            addTypeAnnotations(getter.getReturnType(), writeElements, readElements);
         }
 
         // The instance AnnotationMetadata of each element can change after a modification
@@ -225,5 +209,22 @@ public final class PropertyElementAnnotationMetadata implements ElementAnnotatio
      */
     public AnnotationMetadata getWriteAnnotationMetadata() {
         return propertyWriteAnnotationMetadata;
+    }
+
+    /**
+     * Reads the type annotations of a member's type through the property and writes to them, unless the type is
+     * a primitive: its type annotations are the annotations written on a use of the primitive, readable, but no
+     * element to annotate.
+     */
+    private static void addTypeAnnotations(ClassElement type,
+                                           List<MutableAnnotationMetadataDelegate<?>> writeElements,
+                                           List<AnnotationMetadata> readElements) {
+        MutableAnnotationMetadataDelegate<?> typeAnnotationMetadata = type.getTypeAnnotationMetadata();
+        if (!typeAnnotationMetadata.isEmpty()) {
+            if (!type.isPrimitive()) {
+                writeElements.add(typeAnnotationMetadata);
+            }
+            readElements.add(typeAnnotationMetadata);
+        }
     }
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
@@ -304,6 +304,24 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
         throw new IllegalArgumentException("Cannot establish name for node type: " + element.getClass().getName());
     }
 
+    /**
+     * Lookup or build the metadata of the type annotations written on the given class node, such as those on a
+     * primitive type use, keyed by the node.
+     *
+     * @param classNode The class node
+     * @return The metadata
+     * @since 5.3.0
+     */
+    public CachedAnnotationMetadata lookupOrBuildForTypeAnnotations(ClassNode classNode) {
+        var annotatedNode = new AnnotatedNode();
+        List<AnnotationNode> typeAnnotations = classNode.getTypeAnnotations();
+        if (CollectionUtils.isNotEmpty(typeAnnotations)) {
+            annotatedNode.addAnnotations(typeAnnotations);
+        }
+        // ClassNode equality is by name; the annotations belong to this use of the type
+        return lookupOrBuild(new TypeUseKey(classNode), annotatedNode);
+    }
+
     @Override
     protected List<? extends AnnotationNode> getAnnotationsForType(AnnotatedNode element) {
         List<AnnotationNode> annotations = element.getAnnotations();
@@ -652,4 +670,24 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
         return ((MethodNode) member).getName();
     }
 
+    /**
+     * A cache key for the type annotations of one use of a type, compared by the identity of the node.
+     */
+    private static final class TypeUseKey {
+        private final ClassNode classNode;
+
+        TypeUseKey(ClassNode classNode) {
+            this.classNode = classNode;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof TypeUseKey that && that.classNode == classNode;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(classNode);
+        }
+    }
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
@@ -30,6 +30,7 @@ import io.micronaut.inject.ast.ElementModifier;
 import io.micronaut.inject.ast.PrimitiveElement;
 import io.micronaut.inject.ast.WildcardElement;
 import io.micronaut.inject.ast.annotation.AbstractAnnotationElement;
+import io.micronaut.inject.ast.annotation.AbstractElementAnnotationMetadataFactory;
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.ClassHelper;
@@ -217,7 +218,15 @@ public abstract class AbstractGroovyElement extends AbstractAnnotationElement {
             return newClassElement(declaredElement, getNativeType().annotatedNode(), genericsType, redirectType, parentTypeArguments, visitedTypes, isRawTypeParameter);
         }
         if (ClassHelper.isPrimitiveType(classNode)) {
-            return PrimitiveElement.valueOf(classNode.getName());
+            PrimitiveElement primitiveElement = PrimitiveElement.valueOf(classNode.getName());
+            if (CollectionUtils.isNotEmpty(classNode.getTypeAnnotations())) {
+                // A type annotation on a primitive, such as @A int: an annotated copy of the shared constant
+                var factory = (AbstractElementAnnotationMetadataFactory<?, ?>) elementAnnotationMetadataFactory;
+                return primitiveElement.withTypeAnnotationMetadata(
+                    factory.buildTypeAnnotations(visitorContext.getAnnotationMetadataBuilder().lookupOrBuildForTypeAnnotations(classNode), classNode)
+                );
+            }
+            return primitiveElement;
         }
         if (classNode.isEnum()) {
             return new GroovyEnumElement(visitorContext, new GroovyNativeElement.Class(classNode), elementAnnotationMetadataFactory);

--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/AnnotatedPrimitiveElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/AnnotatedPrimitiveElementSpec.groovy
@@ -1,0 +1,89 @@
+package io.micronaut.ast.groovy.visitor
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.inject.ast.PrimitiveElement
+
+class AnnotatedPrimitiveElementSpec extends AbstractBeanDefinitionSpec {
+
+    private static final String SOURCE = '''
+package test
+
+import java.lang.annotation.*
+
+class Test {
+
+    public @TypeAnn("f") int field
+
+    public int plain
+
+    public @TypeAnn("r") boolean method(@TypeAnn("p") long param) {
+        return true
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+@interface TypeAnn {
+    String value() default ""
+}
+'''
+
+    void "test a type annotation on a primitive is kept on an annotated copy of the shared constant"() {
+        given:
+        def element = buildClassElement('test.Test', SOURCE)
+        def type = element.getFields().find { it.name == 'field' }.getType()
+
+        expect:
+        type.isPrimitive()
+        type.name == 'int'
+        type instanceof PrimitiveElement
+        type.getAnnotationMetadata().stringValue('test.TypeAnn').get() == 'f'
+        type.getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'f'
+
+        and: "the annotated copy still equals the shared constant"
+        type == PrimitiveElement.INT
+        type.hashCode() == PrimitiveElement.INT.hashCode()
+        PrimitiveElement.INT.getAnnotationMetadata().isEmpty()
+    }
+
+    void "test a primitive without a type annotation is the shared constant"() {
+        given:
+        def element = buildClassElement('test.Test', SOURCE)
+        def type = element.getFields().find { it.name == 'plain' }.getType()
+
+        expect:
+        type.is(PrimitiveElement.INT)
+        type.getTypeAnnotationMetadata().isEmpty()
+    }
+
+    void "test an annotated use of a primitive can be annotated like any other type use"() {
+        given:
+        def element = buildClassElement('test.Test', SOURCE)
+        def field = element.getFields().find { it.name == 'field' }
+
+        when:
+        field.getType().annotate('test.Added')
+
+        then: "the next element created for the same use sees it, the shared constant does not"
+        field.getType().getTypeAnnotationMetadata().hasAnnotation('test.Added')
+        field.getType().hasAnnotation('test.Added')
+        !PrimitiveElement.INT.hasAnnotation('test.Added')
+
+        when: "a primitive without type annotations has no element to annotate"
+        element.getFields().find { it.name == 'plain' }.getType().annotate('test.Added')
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    void "test return and parameter types"() {
+        given:
+        def element = buildClassElement('test.Test', SOURCE)
+        def method = element.getMethods().find { it.name == 'method' }
+
+        expect:
+        method.getReturnType().isPrimitive()
+        method.getReturnType().getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'r'
+        method.getParameters()[0].getType().getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'p'
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -202,6 +202,18 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
         return annotationMirror.getAnnotationType().asElement();
     }
 
+    /**
+     * Lookup or build the metadata of the type annotations written on the given type mirror, such as those on
+     * a primitive type use, keyed by the mirror.
+     *
+     * @param typeMirror The type mirror
+     * @return The metadata
+     * @since 5.3.0
+     */
+    public CachedAnnotationMetadata lookupOrBuildForTypeMirror(TypeMirror typeMirror) {
+        return lookupOrBuild(typeMirror, new AnnotationsElement(typeMirror));
+    }
+
     @Override
     protected List<? extends AnnotationMirror> getAnnotationsForType(Element element) {
         var expanded = new ArrayList<AnnotationMirror>();

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -32,6 +32,7 @@ import io.micronaut.inject.ast.PrimitiveElement;
 import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.ast.WildcardElement;
 import io.micronaut.inject.ast.annotation.AbstractAnnotationElement;
+import io.micronaut.inject.ast.annotation.AbstractElementAnnotationMetadataFactory;
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 
 import javax.lang.model.element.Element;
@@ -341,7 +342,15 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement impl
                 .toArray();
         }
         if (type instanceof PrimitiveType pt) {
-            return PrimitiveElement.valueOf(pt.getKind().name(), doc);
+            PrimitiveElement primitiveElement = PrimitiveElement.valueOf(pt.getKind().name(), doc);
+            if (!pt.getAnnotationMirrors().isEmpty()) {
+                // A type annotation on a primitive, such as @A int: an annotated copy of the shared constant
+                var factory = (AbstractElementAnnotationMetadataFactory<?, ?>) elementAnnotationMetadataFactory;
+                return primitiveElement.withTypeAnnotationMetadata(
+                    factory.buildTypeAnnotations(visitorContext.getAnnotationMetadataBuilder().lookupOrBuildForTypeMirror(pt), pt)
+                );
+            }
+            return primitiveElement;
         }
         if (type instanceof WildcardType wt) {
             return resolveWildcard(owner, declaredTypeArguments, visitedTypes, representedTypeParameter, wt, doc);

--- a/inject-java/src/test/groovy/io/micronaut/annotation/AnnotatedPrimitiveElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/AnnotatedPrimitiveElementSpec.groovy
@@ -1,0 +1,99 @@
+package io.micronaut.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.PrimitiveElement
+
+class AnnotatedPrimitiveElementSpec extends AbstractTypeElementSpec {
+
+    private static final String SOURCE = '''
+package test;
+
+import java.lang.annotation.*;
+
+class Test {
+
+    public @TypeAnn("f") int field;
+
+    public int plain;
+
+    public @TypeAnn("array") int[] array;
+
+    public @TypeAnn("r") boolean method(@TypeAnn("p") long param) {
+        return true;
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+@interface TypeAnn {
+    String value() default "";
+}
+'''
+
+    void "test a type annotation on a primitive is kept on an annotated copy of the shared constant"() {
+        given:
+        def element = buildClassElement(SOURCE)
+        def field = element.getFields().find { it.name == 'field' }
+        def type = field.getType()
+
+        expect:
+        type.isPrimitive()
+        type.name == 'int'
+        type instanceof PrimitiveElement
+        type.getAnnotationMetadata().stringValue('test.TypeAnn').get() == 'f'
+        type.getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'f'
+
+        and: "the annotated copy still equals the shared constant"
+        type == PrimitiveElement.INT
+        type.hashCode() == PrimitiveElement.INT.hashCode()
+        !type.is(PrimitiveElement.INT)
+        PrimitiveElement.INT.getAnnotationMetadata().isEmpty()
+    }
+
+    void "test a primitive without a type annotation is the shared constant"() {
+        given:
+        def element = buildClassElement(SOURCE)
+        def type = element.getFields().find { it.name == 'plain' }.getType()
+
+        expect:
+        type.is(PrimitiveElement.INT)
+        type.getTypeAnnotationMetadata().isEmpty()
+    }
+
+    void "test an annotated use of a primitive can be annotated like any other type use"() {
+        given:
+        def element = buildClassElement(SOURCE)
+        def field = element.getFields().find { it.name == 'field' }
+
+        when:
+        field.getType().annotate('test.Added')
+
+        then: "the next element created for the same use sees it, the shared constant does not"
+        field.getType().getTypeAnnotationMetadata().hasAnnotation('test.Added')
+        field.getType().hasAnnotation('test.Added')
+        !PrimitiveElement.INT.hasAnnotation('test.Added')
+
+        when: "a primitive without type annotations has no element to annotate"
+        element.getFields().find { it.name == 'plain' }.getType().annotate('test.Added')
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    void "test return and parameter types and arrays of primitives"() {
+        given:
+        def element = buildClassElement(SOURCE)
+        def method = element.getMethods().find { it.name == 'method' }
+        def array = element.getFields().find { it.name == 'array' }.getType()
+
+        expect:
+        method.getReturnType().isPrimitive()
+        method.getReturnType().getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'r'
+        method.getParameters()[0].getType().getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'p'
+
+        and: "the annotation on the component of an array of primitives is kept through the array"
+        array.isArray()
+        array.isPrimitive()
+        array.fromArray().getTypeAnnotationMetadata().stringValue('test.TypeAnn').get() == 'array'
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/ast/visitor/AnnotatedPrimitiveElementSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/ast/visitor/AnnotatedPrimitiveElementSpec.groovy
@@ -1,0 +1,60 @@
+package io.micronaut.kotlin.processing.ast.visitor
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.PrimitiveElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+/**
+ * Pins the KSP behaviour that this change deliberately leaves alone: an annotated {@code Int} is a class
+ * element for {@code kotlin.Int}, a plain one the shared primitive constant.
+ */
+class AnnotatedPrimitiveElementSpec extends AbstractKotlinCompilerSpec {
+
+    void "test KSP primitives"() {
+        given:
+        PrimitiveVisitor.RESULTS.clear()
+        buildClassElement('test.PrimitiveBean', '''
+package test
+
+class PrimitiveBean {
+    var plain: Int = 0
+    var annotated: @TypeAnn("f") Int = 0
+}
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.TYPE)
+annotation class TypeAnn(val value: String = "")
+''')
+        def r = PrimitiveVisitor.RESULTS
+
+        expect:
+        r['plain.isPrimitive'] == true
+        r['plain.isConstant'] == true
+        r['plain.typeAnnotationsEmpty'] == true
+        r['annotated.isPrimitive'] == false
+        r['annotated.name'] == 'java.lang.Integer'
+        r['annotated.typeAnn'] == 'f'
+    }
+
+    static class PrimitiveVisitor implements TypeElementVisitor<Object, Object> {
+
+        static final Map<String, Object> RESULTS = [:]
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.name != 'test.PrimitiveBean') {
+                return
+            }
+            def plain = element.getFields().find { it.name == 'plain' }.getType()
+            RESULTS['plain.isPrimitive'] = plain.isPrimitive()
+            RESULTS['plain.isConstant'] = plain.is(PrimitiveElement.INT)
+            RESULTS['plain.typeAnnotationsEmpty'] = plain.getTypeAnnotationMetadata().isEmpty()
+            def annotated = element.getFields().find { it.name == 'annotated' }.getType()
+            RESULTS['annotated.isPrimitive'] = annotated.isPrimitive()
+            RESULTS['annotated.name'] = annotated.name
+            RESULTS['annotated.typeAnn'] = annotated.getTypeAnnotationMetadata().stringValue('test.TypeAnn').orElse(null)
+        }
+    }
+}

--- a/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -16,3 +16,4 @@ io.micronaut.kotlin.processing.aop.introduction.MyIsEnumInTypeArgumentSpec$MyCon
 io.micronaut.kotlin.processing.ast.visitor.KotlinAnnotationElementSpec$InheritedVisitor
 io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsVisitor
 io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsRecordingVisitor
+io.micronaut.kotlin.processing.ast.visitor.AnnotatedPrimitiveElementSpec$PrimitiveVisitor

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PythonAnnotatedPrimitiveSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PythonAnnotatedPrimitiveSpec.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.python.annotation.processing.test
+
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.PrimitiveElement
+
+/**
+ * Parity with javac and Groovy for a type annotation on a primitive: Python attaches an {@code Annotated[...]}
+ * on a parameter or an attribute to that declaration, and a type use inside a type argument is boxed for the
+ * generic, so the annotated primitive itself is only seen on its way to the boxed type argument.
+ */
+class PythonAnnotatedPrimitiveSpec extends AbstractPythonTypeElementSpec {
+
+    void "test primitives"() {
+        expect:
+        buildClassElement('''
+from typing import Annotated
+from micronaut.python.compiler import TestAnnotation
+
+class Primitives:
+    counts: list[Annotated[int, TestAnnotation("e")]]
+
+    def run(self, plain: int, annotated: Annotated[int, TestAnnotation("p")]) -> int:
+        return plain
+''') { ClassElement element ->
+            def method = element.findMethod('run').get()
+            def plain = method.getParameters().find { it.name == 'plain' }.getType()
+            assert plain.is(PrimitiveElement.INT)
+            assert plain.getTypeAnnotationMetadata().isEmpty()
+
+            def annotated = method.getParameters().find { it.name == 'annotated' }
+            assert annotated.hasAnnotation('io.micronaut.python.compiler.TestAnnotation')
+            assert annotated.getType() == PrimitiveElement.INT
+
+            def argument = element.getFields().find { it.name == 'counts' }.getGenericType().getFirstTypeArgument().get()
+            assert argument.name == 'java.lang.Integer'
+            assert argument.getTypeAnnotationMetadata().stringValue('io.micronaut.python.compiler.TestAnnotation').get() == 'e'
+            return element
+        }
+    }
+}

--- a/inject-python/src/main/java/io/micronaut/python/processing/util/PythonTypeResolver.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/util/PythonTypeResolver.java
@@ -172,6 +172,10 @@ public final class PythonTypeResolver {
             return baseType;
         }
         var metadata = visitorContext.getElementAnnotationMetadataFactory().buildMutable(annotationMetadata);
+        if (baseType instanceof PrimitiveElement primitiveElement) {
+            // A type annotation on a primitive, such as Annotated[int, ...]: an annotated copy of the shared constant
+            return primitiveElement.withTypeAnnotationMetadata(metadata);
+        }
         return new TypeAnnotatedClassElement(baseType, metadata);
     }
 


### PR DESCRIPTION
### What this does

A type annotation on a primitive, such as `@A int field` or `@Min(1) long param`, is no longer dropped by javac and Groovy. `AbstractJavaElement.newClassElement` and `AbstractGroovyElement.newClassElement` return an annotated copy of the shared `PrimitiveElement` constant when the `PrimitiveType` mirror's `getAnnotationMirrors()` (javac) or the `ClassNode`'s `getTypeAnnotations()` (Groovy) are non-empty:

- `PrimitiveElement.withTypeAnnotationMetadata(MutableAnnotationMetadataDelegate)` (`@since 5.3.0`) creates the copy; `getAnnotationMetadata()` and `getTypeAnnotationMetadata()` answer with the written annotations. The delegate is built from the builder's cache entry for that use (`JavaAnnotationMetadataBuilder.lookupOrBuildForTypeMirror`, `GroovyAnnotationMetadataBuilder.lookupOrBuildForTypeAnnotations`, the latter keyed by node identity because `ClassNode` equality is by name), so a mutation is visible to every element created for the same use, exactly as for class types.
- `equals`/`hashCode` stay on name and array dimensions, so the annotated copy equals the constant; an unannotated primitive is still the shared constant, and calling `annotate(...)` on it still throws.
- `AbstractElementAnnotationMetadataFactory.buildTypeAnnotations(CachedAnnotationMetadata, Object)` builds the delegate for a type use that has no element of its own.
- `PropertyElementAnnotationMetadata` reads a primitive member type's type annotations through the property but no longer writes property mutations into them.
- Python: `PythonTypeResolver` wrapped an annotated primitive type use in a `TypeAnnotatedClassElement`; it now returns the annotated copy of the constant, so the element still is a `PrimitiveElement` and equals the constant. Python attaches an `Annotated[...]` on a parameter or attribute to that declaration and boxes a type argument for the generic, which the Python test pins.

### Why

The CDI Lite language model that micronaut-cdi builds on the AST reports the annotations of every type use, primitives included (`AnnotatedTypes.verifyPrimitiveField`, the type annotations in `EnumMembers.verifyConstructors`). Today the processor reaches into javac's mirrors for them; KSP and Groovy get nothing.

### A deviation from the plan

The plan called for the primitive's type annotations to be read-only. That does not survive contact with micronaut-validation: its `ValidationVisitor` annotates any parameter type that carries a constraint with `@RequiresValidation`, and constraints such as `@Min` target `TYPE_USE`, so with this change an `@Min(1) int` parameter type carries the constraint and a throwing delegate broke `:micronaut-inject-java:compileTestGroovy` (which runs the validation processor). The annotated copy is therefore writable like any other type use, backed by the cache entry; the semantics for the constant are unchanged.

### KSP

Left alone on purpose: `AbstractKotlinElement.newClassElement` already makes an annotated `Int` a class element for `kotlin.Int` carrying the annotations, and turning it into a primitive would change `isPrimitive()` and the written `Argument` types for every annotated Kotlin primitive parameter. `AnnotatedPrimitiveElementSpec` in `inject-kotlin` pins that behaviour so the change can be discussed separately.

### Tests

`AnnotatedPrimitiveElementSpec` in `inject-java` and `inject-groovy` (field, return and parameter types, arrays, equality with the constant, mutation visible to the next lookup, the constant still rejecting mutation), in `inject-kotlin` (the pinned KSP behaviour) and `PythonAnnotatedPrimitiveSpec` in `inject-python-test`. Full `:micronaut-inject-java:test` (5282), `:micronaut-inject-groovy:test` (1130), `:micronaut-inject-kotlin:test` (866), `:micronaut-inject-python-test:test` (609) and `:micronaut-inject-python:test` (125) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
