### PR TITLE
Groovy declared generic placeholders and array class literal members

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -710,8 +710,18 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
     @NonNull
     @Override
     public List<? extends GenericPlaceholderElement> getDeclaredGenericPlaceholders() {
-        //noinspection unchecked
-        return (List<? extends GenericPlaceholderElement>) getBoundGenericTypes();
+        // The variables the class declares, not the arguments of this use of it: for List<String> that is E
+        GenericsType[] genericsTypes = classNode.redirect().getGenericsTypes();
+        if (genericsTypes == null) {
+            return Collections.emptyList();
+        }
+        var placeholders = new ArrayList<GenericPlaceholderElement>(genericsTypes.length);
+        for (GenericsType genericsType : genericsTypes) {
+            if (genericsType.isPlaceholder() && newClassElement(genericsType) instanceof GenericPlaceholderElement placeholder) {
+                placeholders.add(placeholder);
+            }
+        }
+        return placeholders;
     }
 
     private List<PropertyNode> getPropertyNodes() {

--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyDeclaredGenericPlaceholdersSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyDeclaredGenericPlaceholdersSpec.groovy
@@ -1,0 +1,64 @@
+package io.micronaut.ast.groovy.visitor
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.core.annotation.AnnotationClassValue
+import io.micronaut.inject.ast.GenericPlaceholderElement
+
+class GroovyDeclaredGenericPlaceholdersSpec extends AbstractBeanDefinitionSpec {
+
+    void "test the declared generic placeholders of a parameterized use are the declared variables, not the arguments"() {
+        given:
+        def element = buildClassElement('test.Test', '''
+package test
+
+import java.util.*
+
+class Test<T extends CharSequence> {
+    List<String> list
+    Map<String, Integer> map
+    T variable
+    String plain
+}
+''')
+        def list = element.getFields().find { it.name == 'list' }.getType()
+        def map = element.getFields().find { it.name == 'map' }.getType()
+
+        expect:
+        element.getDeclaredGenericPlaceholders()*.variableName == ['T']
+        element.getDeclaredGenericPlaceholders()[0].getBounds()*.name == ['java.lang.CharSequence']
+
+        and: "the arguments of the use are still the bound generic types"
+        list.getBoundGenericTypes()*.name == ['java.lang.String']
+        map.getBoundGenericTypes()*.name == ['java.lang.String', 'java.lang.Integer']
+
+        and: "the declared variables come from the declaration"
+        list.getDeclaredGenericPlaceholders().every { it instanceof GenericPlaceholderElement }
+        list.getDeclaredGenericPlaceholders()*.variableName == ['E']
+        map.getDeclaredGenericPlaceholders()*.variableName == ['K', 'V']
+        element.getFields().find { it.name == 'plain' }.getType().getDeclaredGenericPlaceholders().isEmpty()
+    }
+
+    void "test an array class literal member"() {
+        given:
+        def element = buildClassElement('test.Test', '''
+package test
+
+import java.lang.annotation.*
+
+@Types(type = String[], types = [String[], String])
+class Test {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Types {
+    Class<?> type()
+    Class<?>[] types()
+}
+''')
+        def annotation = element.getAnnotation('test.Types')
+
+        expect:
+        annotation.getValues().get('type') == new AnnotationClassValue<>('[Ljava.lang.String;')
+        (annotation.getValues().get('types') as AnnotationClassValue[])*.name == ['[Ljava.lang.String;', 'java.lang.String']
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -42,6 +42,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.AbstractAnnotationValueVisitor8;
 import javax.lang.model.util.Elements;
@@ -575,6 +576,56 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
     /**
      * Meta annotation value visitor class.
      */
+    /**
+     * The name recorded for a class literal member value: the binary name of a class, the keyword of a
+     * primitive, and for an array such as {@code String[].class} or {@code int[][].class} the name
+     * {@link Class#getName()} gives it.
+     *
+     * @param type The type of the literal
+     * @return The name, or null when the type is not one a class literal can denote
+     */
+    @Nullable
+    private static String classLiteralName(TypeMirror type) {
+        if (type instanceof DeclaredType declaredType) {
+            if (declaredType.asElement() instanceof TypeElement element) {
+                return JavaModelUtils.getClassName(element);
+            }
+            return null;
+        }
+        if (type instanceof PrimitiveType primitiveType) {
+            return primitiveType.getKind().name().toLowerCase(Locale.ENGLISH);
+        }
+        if (type instanceof ArrayType arrayType) {
+            TypeMirror componentType = arrayType.getComponentType();
+            if (componentType instanceof DeclaredType declaredType) {
+                if (declaredType.asElement() instanceof TypeElement element) {
+                    return JavaModelUtils.getClassArrayName(element);
+                }
+                return null;
+            }
+            if (componentType instanceof PrimitiveType primitiveType) {
+                return "[" + primitiveDescriptor(primitiveType.getKind());
+            }
+            String componentName = classLiteralName(componentType);
+            return componentName == null ? null : "[" + componentName;
+        }
+        return null;
+    }
+
+    private static String primitiveDescriptor(TypeKind kind) {
+        return switch (kind) {
+            case BOOLEAN -> "Z";
+            case BYTE -> "B";
+            case SHORT -> "S";
+            case INT -> "I";
+            case LONG -> "J";
+            case CHAR -> "C";
+            case FLOAT -> "F";
+            case DOUBLE -> "D";
+            default -> throw new IllegalArgumentException("Not a primitive: " + kind);
+        };
+    }
+
     private class MetadataAnnotationValueVisitor extends AbstractAnnotationValueVisitor8<Object, Object> {
         private final Element originatingElement;
         private final ExecutableElement member;
@@ -648,14 +699,9 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
 
         @Override
         public Object visitType(TypeMirror t, Object o) {
-            if (t instanceof DeclaredType type) {
-                Element typeElement = type.asElement();
-                if (typeElement instanceof TypeElement element) {
-                    String className = JavaModelUtils.getClassName(element);
-                    resolvedValue = new AnnotationClassValue<>(className);
-                }
-            } else if (t instanceof PrimitiveType primitiveType) {
-                resolvedValue = new AnnotationClassValue<>(primitiveType.getKind().name().toLowerCase(Locale.ENGLISH));
+            String className = classLiteralName(t);
+            if (className != null) {
+                resolvedValue = new AnnotationClassValue<>(className);
             }
             return null;
         }
@@ -797,23 +843,9 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
 
             @Override
             public Object visitType(TypeMirror t, Object o) {
-                if (t instanceof DeclaredType type) {
-                    Element typeElement = type.asElement();
-                    if (typeElement instanceof TypeElement element) {
-                        final String className = JavaModelUtils.getClassName(element);
-                        values.add(new AnnotationClassValue<>(className));
-                    }
-                } else if (t instanceof PrimitiveType primitiveType) {
-                    values.add(new AnnotationClassValue<>(primitiveType.getKind().name().toLowerCase(Locale.ENGLISH)));
-                } else if (t instanceof ArrayType arrayType) {
-                    TypeMirror componentType = arrayType.getComponentType();
-                    if (componentType instanceof DeclaredType declaredType) {
-                        Element typeElement = declaredType.asElement();
-                        if (typeElement instanceof TypeElement element) {
-                            final String className = JavaModelUtils.getClassArrayName(element);
-                            values.add(new AnnotationClassValue<>(className));
-                        }
-                    }
+                String className = classLiteralName(t);
+                if (className != null) {
+                    values.add(new AnnotationClassValue<>(className));
                 }
                 return null;
             }

--- a/inject-java/src/test/groovy/io/micronaut/annotation/ArrayClassLiteralMemberSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/ArrayClassLiteralMemberSpec.groovy
@@ -1,0 +1,61 @@
+package io.micronaut.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.AnnotationClassValue
+
+class ArrayClassLiteralMemberSpec extends AbstractTypeElementSpec {
+
+    void "test an array class literal is recorded as a class value, alone and in an array member"() {
+        given:
+        def element = buildClassElement('''
+package test;
+
+import java.lang.annotation.*;
+import java.util.List;
+
+@Types(type = String[].class, primitiveType = int[].class, nested = int[][].class, types = {String[].class, int[].class, List[][].class, String.class, long.class})
+class Test {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Types {
+    Class<?> type();
+    Class<?> primitiveType();
+    Class<?> nested();
+    Class<?>[] types();
+}
+''')
+        def annotation = element.getAnnotation('test.Types')
+
+        expect:
+        annotation.getValues().get('type') == new AnnotationClassValue<>('[Ljava.lang.String;')
+        annotation.getValues().get('primitiveType') == new AnnotationClassValue<>('[I')
+        annotation.getValues().get('nested') == new AnnotationClassValue<>('[[I')
+        (annotation.getValues().get('types') as AnnotationClassValue[])*.name == ['[Ljava.lang.String;', '[I', '[[Ljava.util.List;', 'java.lang.String', 'long']
+
+        and: "the names are the ones Class.getName() gives"
+        Class.forName(annotation.getValues().get('type').name) == String[]
+        Class.forName(annotation.getValues().get('nested').name) == int[][]
+    }
+
+    void "test the declared generic placeholders of a parameterized use are the declared variables"() {
+        given:
+        def element = buildClassElement('''
+package test;
+
+import java.util.*;
+
+class Test<T> {
+    List<String> list;
+    Map<String, Integer> map;
+    T variable;
+}
+''')
+
+        expect:
+        element.getDeclaredGenericPlaceholders()*.variableName == ['T']
+        element.getFields().find { it.name == 'list' }.getType().getDeclaredGenericPlaceholders()*.variableName == ['E']
+        element.getFields().find { it.name == 'map' }.getType().getDeclaredGenericPlaceholders()*.variableName == ['K', 'V']
+        element.getFields().find { it.name == 'list' }.getType().getBoundGenericTypes()*.name == ['java.lang.String']
+    }
+}

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/ast/visitor/KotlinDeclaredGenericPlaceholdersSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/ast/visitor/KotlinDeclaredGenericPlaceholdersSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.kotlin.processing.ast.visitor
+
+import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+/**
+ * Parity with javac and Groovy: the declared generic placeholders of a parameterized use are the variables the
+ * class declares, not the arguments of the use.
+ */
+class KotlinDeclaredGenericPlaceholdersSpec extends AbstractKotlinCompilerSpec {
+
+    void "test the declared generic placeholders of a parameterized use are the declared variables"() {
+        given:
+        PlaceholdersVisitor.RESULTS.clear()
+        buildClassElement('test.PlaceholdersBean', '''
+package test
+
+class PlaceholdersBean<T : CharSequence> {
+    var list: MutableList<String>? = null
+    var map: MutableMap<String, Int>? = null
+    var variable: T? = null
+}
+''')
+        def r = PlaceholdersVisitor.RESULTS
+
+        expect:
+        r['class'] == ['T']
+        r['list.bound'] == ['java.lang.String']
+        r['list.declared'] == ['E']
+        r['map.declared'] == ['K', 'V']
+    }
+
+    static class PlaceholdersVisitor implements TypeElementVisitor<Object, Object> {
+
+        static final Map<String, Object> RESULTS = [:]
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.name != 'test.PlaceholdersBean') {
+                return
+            }
+            RESULTS['class'] = element.getDeclaredGenericPlaceholders()*.variableName
+            def list = element.getFields().find { it.name == 'list' }.getType()
+            RESULTS['list.bound'] = list.getBoundGenericTypes()*.name
+            RESULTS['list.declared'] = list.getDeclaredGenericPlaceholders()*.variableName
+            RESULTS['map.declared'] = element.getFields().find { it.name == 'map' }.getType().getDeclaredGenericPlaceholders()*.variableName
+        }
+    }
+}

--- a/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-kotlin/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -16,3 +16,4 @@ io.micronaut.kotlin.processing.aop.introduction.MyIsEnumInTypeArgumentSpec$MyCon
 io.micronaut.kotlin.processing.ast.visitor.KotlinAnnotationElementSpec$InheritedVisitor
 io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsVisitor
 io.micronaut.kotlin.processing.annotations.InheritedPropertyAnnotationMutationSpec$IgnorePropsRecordingVisitor
+io.micronaut.kotlin.processing.ast.visitor.KotlinDeclaredGenericPlaceholdersSpec$PlaceholdersVisitor

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PythonDeclaredGenericPlaceholdersSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/PythonDeclaredGenericPlaceholdersSpec.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.python.annotation.processing.test
+
+import io.micronaut.inject.ast.ClassElement
+
+/**
+ * Parity with javac, Groovy and KSP: the declared generic placeholders of a parameterized use are the
+ * variables the type declares, not the arguments of the use.
+ */
+class PythonDeclaredGenericPlaceholdersSpec extends AbstractPythonTypeElementSpec {
+
+    void "test the declared generic placeholders of a parameterized use are the declared variables"() {
+        expect:
+        buildClassElement('''
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+
+class Holder(Generic[T]):
+    items: list[str]
+    mapping: dict[str, int]
+''') { ClassElement element ->
+            assert element.getDeclaredGenericPlaceholders()*.variableName == ['T']
+            def items = element.getFields().find { it.name == 'items' }.getType()
+            assert items.getBoundGenericTypes()*.name == ['java.lang.String']
+            assert items.getDeclaredGenericPlaceholders()*.variableName == ['E']
+            def mapping = element.getFields().find { it.name == 'mapping' }.getType()
+            assert mapping.getDeclaredGenericPlaceholders()*.variableName == ['K', 'V']
+            return element
+        }
+    }
+}


### PR DESCRIPTION
### What this does

Two small fixes found while building the CDI Lite language model (`jakarta.enterprise.lang.model`) that micronaut-cdi builds on top of `io.micronaut.inject.ast`:

- **Groovy `getDeclaredGenericPlaceholders()`**: `GroovyClassElement` returned `getBoundGenericTypes()` cast, which for a parameterized use such as `List<String>` yields the arguments rather than the declared variables (and a `ClassCastException` on access). It now reads the declared variables from `classNode.redirect().getGenericsTypes()`; `getBoundGenericTypes()` is unchanged. Groovy-only, corrective.
- **`String[].class` annotation members (javac)**: `MetadataAnnotationValueVisitor.visitType` recorded a class literal for a `DeclaredType` and a `PrimitiveType` only, so an `ArrayType` member vanished from the `AnnotationValue`. An array class literal is now recorded as an `AnnotationClassValue` named as `Class.getName()` names it (`[Ljava.lang.String;`, `[I`, `[[I`), in a single member and in an array member alike; the array-member path already did this for a declared component and now shares the code.

### Tests

`ArrayClassLiteralMemberSpec` (inject-java), `GroovyDeclaredGenericPlaceholdersSpec` (inject-groovy), `KotlinDeclaredGenericPlaceholdersSpec` (inject-kotlin) and `PythonDeclaredGenericPlaceholdersSpec` (inject-python-test) assert the same declared-variables answer in all four languages. Full `:micronaut-inject-java:test` (5280), `:micronaut-inject-groovy:test` (1128) and `:micronaut-inject-kotlin:test` (866) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
