### PR TITLE
Report annotation member defaults for Python as for the other languages

### DIFF
--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/AnnotationMemberDefaultsSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/AnnotationMemberDefaultsSpec.groovy
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.annotation.processing.test
+
+import io.micronaut.core.annotation.AnnotationClassValue
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+/**
+ * Asserts that annotation member defaults of every kind declared on a Python decorator are reported identically to
+ * the three JVM languages. The sibling copies of this spec live in the inject-java, inject-kotlin and inject-groovy
+ * test suites and share the expectation literals below.
+ */
+class AnnotationMemberDefaultsSpec extends AbstractPythonTypeElementSpec {
+
+    private void compileTestSource() {
+        buildBeanDefinition('python', 'Test', '''
+from enum import Enum
+from jakarta.inject import Singleton
+
+def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
+    def decorator(func):
+        return func
+    return decorator
+
+class Colour(Enum):
+    RED = "RED"
+    GREEN = "GREEN"
+
+class Target:
+    pass
+
+@micronaut_annotation("defaults.Nested")
+def nested_ann(name: str = "nested"):
+    def decorator(target):
+        return target
+    return decorator
+
+@micronaut_annotation("defaults.Defaults")
+def defaults_ann(
+    stringValue: str = "foo",
+    emptyStringValue: str = "",
+    intValue: int = 42,
+    enumValue: Colour = Colour.GREEN,
+    classValue: type = Target,
+    stringArray: list[str] = ["a", "b"],
+    emptyArray: list[str] = [],
+):
+    def decorator(target):
+        return target
+    return decorator
+
+@Singleton
+@defaults_ann()
+class Test:
+    pass
+''')
+    }
+
+    /**
+     * The defaults reported by {@link io.micronaut.inject.visitor.VisitorContext#getAnnotationDefaultValues(String)},
+     * which asks for every declared default including empty ones.
+     *
+     * <p>This is the JVM literal of the sibling specs minus the {@code nested} member, which has no Python
+     * equivalent: a Python decorator member cannot declare another decorator application as its default.</p>
+     */
+    static final String EXPECTED_FROM_CONTEXT =
+            "[classValue:AnnotationClassValue(python.Target), " +
+            "emptyArray:String[], " +
+            "emptyStringValue:String(), " +
+            "enumValue:String(GREEN), " +
+            "intValue:Integer(42), " +
+            "stringArray:String[String(a), String(b)], " +
+            "stringValue:String(foo)]"
+
+    /**
+     * The defaults baked into the written annotation metadata and seen through
+     * {@link io.micronaut.core.annotation.AnnotationValue#getDefaultValues()}. The empty string default is
+     * omitted, which is the deliberate metadata size optimization documented on
+     * {@code JavaAnnotationMetadataBuilder#isValidDefaultValue} and the point of the second read.
+     *
+     * <p>Two shapes differ from the JVM languages, both because the Python class is visited before its generated
+     * Java annotation type exists, so the member types are not yet known: a class value is written as the class
+     * name rather than an {@code AnnotationClassValue}, and a list value as a {@code List} rather than an array.
+     * A member value given at a usage site is written the same way, so the defaults are not a special case.</p>
+     */
+    static final String EXPECTED_FROM_ANNOTATION =
+            "[classValue:String(python.Target), " +
+            "emptyArray:List[], " +
+            "enumValue:String(GREEN), " +
+            "intValue:Integer(42), " +
+            "stringArray:List[String(a), String(b)], " +
+            "stringValue:String(foo)]"
+
+    void 'test every annotation member default is reported through the visitor context'() {
+        given:
+        DefaultsRecordingVisitor.reset()
+
+        when:
+        compileTestSource()
+        def defaults = DefaultsRecordingVisitor.fromContext
+
+        then: 'every declared default is reported, including the empty string and the empty array'
+        defaults != null
+        defaults.keySet()*.toString() as Set == [
+                'stringValue', 'emptyStringValue', 'intValue', 'enumValue',
+                'classValue', 'stringArray', 'emptyArray'
+        ] as Set
+
+        and: 'constants, enum constants, class literals and arrays all resolve'
+        defaults['stringValue'] == 'foo'
+        defaults['emptyStringValue'] == ''
+        defaults['intValue'] == 42
+        defaults['enumValue'] == 'GREEN'
+        defaults['classValue'] instanceof AnnotationClassValue
+        defaults['classValue'].name == 'python.Target'
+        defaults['stringArray'] as List == ['a', 'b']
+        defaults['emptyArray'].length == 0
+
+        and: 'the result is identical to the other languages'
+        DefaultsRecordingVisitor.describe(defaults) == EXPECTED_FROM_CONTEXT
+    }
+
+    void 'test annotation member defaults are visible on the AnnotationValue read from the element API'() {
+        given:
+        DefaultsRecordingVisitor.reset()
+
+        when:
+        compileTestSource()
+        def defaults = DefaultsRecordingVisitor.fromAnnotation
+
+        then: 'the written metadata carries every default except the empty string'
+        defaults != null
+        defaults.keySet()*.toString() as Set == [
+                'stringValue', 'intValue', 'enumValue',
+                'classValue', 'stringArray', 'emptyArray'
+        ] as Set
+
+        and:
+        defaults['enumValue'] == 'GREEN'
+        defaults['classValue'] == 'python.Target'
+        defaults['stringArray'] as List == ['a', 'b']
+        defaults['emptyArray'].isEmpty()
+
+        and: 'the result is identical to the other languages'
+        DefaultsRecordingVisitor.describe(defaults) == EXPECTED_FROM_ANNOTATION
+    }
+
+    static class DefaultsRecordingVisitor implements TypeElementVisitor<Object, Object> {
+
+        static Map<CharSequence, Object> fromContext = null
+        static Map<CharSequence, Object> fromAnnotation = null
+
+        static void reset() {
+            fromContext = null
+            fromAnnotation = null
+        }
+
+        /**
+         * Renders the defaults in a language neutral form so that the language suites can compare against the
+         * same literal.
+         */
+        static String describe(Map<CharSequence, Object> values) {
+            if (values == null) {
+                return "<not recorded>"
+            }
+            return values.collectEntries { k, v -> [(k.toString()): render(v)] }
+                    .sort { it.key }
+                    .toString()
+        }
+
+        private static String render(Object v) {
+            if (v == null) {
+                return "null"
+            }
+            if (v.getClass().isArray()) {
+                return "${v.getClass().componentType.simpleName}[" + (v as Object[]).collect { render(it) }.join(", ") + "]"
+            }
+            if (v instanceof Collection) {
+                return "List[" + v.collect { render(it) }.join(", ") + "]"
+            }
+            if (v instanceof AnnotationClassValue) {
+                return "AnnotationClassValue(${v.name})"
+            }
+            if (v instanceof AnnotationValue) {
+                return "AnnotationValue(${v.annotationName}, ${v.values})"
+            }
+            return "${v.getClass().simpleName}(${v})"
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.simpleName != "Test") {
+                return
+            }
+            // The class is visited twice: once as the Python class, and once as the Java stub generated for it.
+            // Only the Python class carries the decorator, while the annotation type only exists as a Java class
+            // element in the second round, which is where the visitor context can resolve its defaults.
+            def contextDefaults = context.getAnnotationDefaultValues("defaults.Defaults")
+            if (contextDefaults) {
+                fromContext = contextDefaults
+            }
+            def annotation = element.getAnnotation("defaults.Defaults")
+            if (annotation != null) {
+                fromAnnotation = annotation.getDefaultValues()
+            }
+        }
+    }
+}

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/DecoratorMemberDefaultSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/DecoratorMemberDefaultSpec.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.python.annotation.processing.test
+
+import io.micronaut.inject.BeanDefinition
+
+/**
+ * Defaults declared on Python decorator members.
+ */
+class DecoratorMemberDefaultSpec extends AbstractPythonTypeElementSpec {
+
+    void "test enum constant default on a typed member"() {
+        given:
+        def pythonCode = '''
+from enum import Enum
+from jakarta.inject import Singleton
+
+def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
+    def decorator(func):
+        return func
+    return decorator
+
+class Colour(Enum):
+    RED = "RED"
+    GREEN = "GREEN"
+
+@micronaut_annotation("defaults.Defaults")
+def defaults_ann(enumValue: Colour = Colour.GREEN):
+    def decorator(target):
+        return target
+    return decorator
+
+@Singleton
+@defaults_ann()
+class Test:
+    pass
+'''
+
+        when:
+        def context = buildContext(pythonCode)
+        BeanDefinition definition = context.getBeanDefinition(context.classLoader.loadClass("python.Test"))
+
+        then: 'the generated annotation type declares the enum constant as its default'
+        definition.getAnnotation("defaults.Defaults").getDefaultValues() == [enumValue: "GREEN"]
+
+        cleanup:
+        context?.close()
+    }
+
+    void "test enum constant set at the usage site"() {
+        given:
+        def pythonCode = '''
+from enum import Enum
+from jakarta.inject import Singleton
+
+def micronaut_annotation(name, repeated=None, annotationTypeTarget=False):
+    def decorator(func):
+        return func
+    return decorator
+
+class Colour(Enum):
+    RED = "RED"
+    GREEN = "GREEN"
+
+@micronaut_annotation("usage.Usage")
+def usage_ann(enumValue: Colour = None):
+    def decorator(target):
+        return target
+    return decorator
+
+@Singleton
+@usage_ann(enumValue=Colour.RED)
+class Test:
+    pass
+'''
+
+        when:
+        def context = buildContext(pythonCode)
+        BeanDefinition definition = context.getBeanDefinition(context.classLoader.loadClass("python.Test"))
+
+        then:
+        definition.stringValue("usage.Usage", "enumValue").get() == "RED"
+
+        cleanup:
+        context?.close()
+    }
+}

--- a/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/IntroductionAdviceSpec.groovy
+++ b/inject-python-test/src/test/groovy/io/micronaut/python/annotation/processing/test/IntroductionAdviceSpec.groovy
@@ -766,7 +766,7 @@ import java
 MethodInterceptor = java.type("io.micronaut.aop.MethodInterceptor")
 
 @Introduction
-def Stub(value: str = ""):
+def Stub(value: str = "stubbed"):
     def class_decorator(cls):
         return cls
     return class_decorator
@@ -795,8 +795,8 @@ class AbstractBean(ABC):
         Value bean = getBean(context, "python.AbstractBean").asPolyglotValue()
         def interceptor = getBean(context, "python.StubIntroduction")
 
-        then: "the introduction returns the decorator's declared default, an empty string"
-        bean.invokeMember("is_abstract").asString() == ""
+        then: "the introduction returns the decorator's declared default"
+        bean.invokeMember("is_abstract").asString() == "stubbed"
         bean.invokeMember("non_abstract").asString() == "good"
         interceptor.invoked == 1
 

--- a/inject-python-test/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-python-test/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -22,3 +22,4 @@ io.micronaut.python.annotation.processing.test.annotate.AnnotationMetadataSpec$M
 io.micronaut.python.annotation.processing.test.annotate.InheritedParameterAnnotationMutationSpec$InheritedParameterMutationVisitor
 io.micronaut.python.compiler.FailingTypeElementVisitor
 io.micronaut.python.annotation.processing.test.PythonAnnotationElementSpec$InheritedVisitor
+io.micronaut.python.annotation.processing.test.AnnotationMemberDefaultsSpec$DefaultsRecordingVisitor

--- a/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationStubGenerator.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/PythonAnnotationStubGenerator.java
@@ -91,7 +91,11 @@ final class PythonAnnotationStubGenerator {
                     memberBuilder.addAnnotation(toAnnotationDef(memberDecorator, visitorContext));
                 }
             }
-            ExpressionDef defaultValue = annotationDefaultValue(decoratorDef.members().get(memberName), memberType);
+            ExpressionDef defaultValue = annotationDefaultValue(
+                decoratorDef.members().get(memberName),
+                memberType,
+                annotationMemberElement(memberName, decoratorDef, visitorContext)
+            );
             if (defaultValue != null) {
                 memberBuilder.withDefault(defaultValue);
             }
@@ -148,6 +152,9 @@ final class PythonAnnotationStubGenerator {
         if (annotationArrayType != null) {
             return annotationArrayType;
         }
+        if (isClassLiteralType(typeRef)) {
+            return ClassTypeDef.of(Class.class);
+        }
         ClassElement classElement = visitorContext.getTypeResolver().resolve(typeRef, Map.of());
         if (classElement.getName().equals(Object.class.getName()) && decoratorDef.members().get(memberName) instanceof String) {
             return TypeDef.STRING;
@@ -167,6 +174,25 @@ final class PythonAnnotationStubGenerator {
         return TypeDef.of(componentElement).array();
     }
 
+    /**
+     * Resolves the element a member's default value has to satisfy: the member type itself, or, for an array
+     * member, its component type. Returns {@code null} when the member has no declared type, or when it is a
+     * {@code Class} member, which the default conversion handles from the {@link TypeDef} alone.
+     */
+    private static @Nullable ClassElement annotationMemberElement(String memberName, DecoratorDef decoratorDef, PythonVisitorContext visitorContext) {
+        TypeRef typeRef = decoratorDef.memberTypes().get(memberName);
+        if (typeRef == null) {
+            return null;
+        }
+        if (isPythonListType(typeRef.name()) && typeRef.typeArguments().size() == 1) {
+            typeRef = typeRef.typeArguments().getFirst();
+        }
+        if (isClassLiteralType(typeRef)) {
+            return null;
+        }
+        return visitorContext.getTypeResolver().resolve(typeRef, Map.of());
+    }
+
     private static boolean isPythonListType(String typeName) {
         return "list".equals(typeName) || "List".equals(typeName) || "typing.List".equals(typeName);
     }
@@ -178,17 +204,23 @@ final class PythonAnnotationStubGenerator {
             || Class.class.getName().equals(typeRef.name());
     }
 
-    private static @Nullable ExpressionDef annotationDefaultValue(Object defaultValue, TypeDef memberType) {
+    private static @Nullable ExpressionDef annotationDefaultValue(
+        Object defaultValue,
+        TypeDef memberType,
+        @Nullable ClassElement memberElement
+    ) {
         if (defaultValue == null) {
-            return null;
-        }
-        if (defaultValue instanceof String stringValue && stringValue.startsWith("Name(")) {
             return null;
         }
         if (memberType instanceof TypeDef.Array arrayType) {
             Object[] elements = arrayElements(defaultValue);
             if (elements.length == 0) {
                 return new ExpressionDef.Constant(arrayType, new Object[0]);
+            }
+            if (isEnumMemberType(memberElement) || isClassMemberType(arrayType.componentType())) {
+                return ExpressionDef.constant(Arrays.stream(elements)
+                    .map(element -> referenceDefaultValue(element, arrayType.componentType(), memberElement))
+                    .toArray());
             }
             if (arrayType.componentType().equals(TypeDef.STRING)) {
                 return ExpressionDef.constant(Arrays.stream(elements).map(String::valueOf).toArray(String[]::new));
@@ -200,11 +232,43 @@ final class PythonAnnotationStubGenerator {
             }
             return ExpressionDef.constant(converted);
         }
+        if (isEnumMemberType(memberElement) || isClassMemberType(memberType)) {
+            return referenceDefaultValue(defaultValue, memberType, memberElement);
+        }
         Object converted = convertDefaultValue(defaultValue, memberType);
         if (memberType instanceof TypeDef.Primitive) {
             return ExpressionDef.primitiveConstant(converted);
         }
         return ExpressionDef.constant(converted);
+    }
+
+    private static boolean isEnumMemberType(@Nullable ClassElement memberElement) {
+        return memberElement != null && AnnotationNames.isEnumMember(memberElement);
+    }
+
+    private static boolean isClassMemberType(TypeDef typeDef) {
+        return typeDef instanceof ClassTypeDef classTypeDef && Class.class.getName().equals(classTypeDef.getName());
+    }
+
+    /**
+     * Renders a default that has to be written as a reference rather than a literal: an enum constant as
+     * {@code Type.CONSTANT} and a {@code Class} member as {@code Type.class}, matching what a member value given
+     * at a usage site produces.
+     */
+    private static ExpressionDef referenceDefaultValue(
+        Object defaultValue,
+        TypeDef componentType,
+        @Nullable ClassElement memberElement
+    ) {
+        if (isEnumMemberType(memberElement) && componentType instanceof ClassTypeDef enumType) {
+            return enumType.getStaticField(enumConstantName(defaultValue), enumType);
+        }
+        return classLiteralDefaultValue(defaultValue, componentType);
+    }
+
+    private static ExpressionDef classLiteralDefaultValue(Object defaultValue, TypeDef componentType) {
+        String className = AnnotationNames.rawTypeName(String.valueOf(defaultValue));
+        return ClassTypeDef.of(className).getStaticField("class", componentType);
     }
 
     private static Object[] arrayElements(Object defaultValue) {

--- a/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonAnnotationMetadataBuilder.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/annotation/PythonAnnotationMetadataBuilder.java
@@ -25,6 +25,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.annotation.AnnotationMapper;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
@@ -508,6 +509,11 @@ public final class PythonAnnotationMetadataBuilder extends AbstractAnnotationMet
 
     @Override
     protected Map<? extends ElementDef, ?> readAnnotationDefaultValues(String annotationName, ElementDef annotationType) {
+        return readAnnotationDefaultValues(annotationName, annotationType, false);
+    }
+
+    @Override
+    protected Map<? extends ElementDef, ?> readAnnotationDefaultValues(String annotationName, ElementDef annotationType, boolean includeEmptyValues) {
         DecoratorDef decoratorDef = findDecoratorDef(annotationName);
         if (decoratorDef == null) {
             return Map.of();
@@ -515,10 +521,33 @@ public final class PythonAnnotationMetadataBuilder extends AbstractAnnotationMet
         ClassElement javaAnnotationType = getJavaAnnotationType(annotationName);
         Map<ElementDef, Object> defaultValues = new LinkedHashMap<>();
         for (Map.Entry<?, ?> entry : decoratorDef.members().entrySet()) {
+            if (!isValidDefaultValue(entry.getValue(), includeEmptyValues)) {
+                continue;
+            }
             String memberName = AnnotationNames.memberName(entry.getKey());
             defaultValues.put(resolveMemberDef(annotationName, javaAnnotationType, memberName), entry.getValue());
         }
         return defaultValues;
+    }
+
+    /**
+     * A Python decorator parameter without a default is reported by the processor as a {@code null} member value,
+     * which is no default at all. Beyond that the same rule the other languages apply holds: an empty string
+     * default is only recorded when empty values are asked for, while an empty list default is always recorded.
+     * The rationale is documented on {@code JavaAnnotationMetadataBuilder#isValidDefaultValue}.
+     *
+     * @param defaultValue       The member value reported by the processor
+     * @param includeEmptyValues Whether empty values should be included
+     * @return Whether the default should be recorded
+     */
+    private static boolean isValidDefaultValue(@Nullable Object defaultValue, boolean includeEmptyValues) {
+        if (defaultValue == null) {
+            return false;
+        }
+        if (defaultValue instanceof CharSequence charSequence) {
+            return includeEmptyValues || StringUtils.isNotEmpty(charSequence);
+        }
+        return true;
     }
 
     @Override

--- a/inject-python/src/main/java/io/micronaut/python/processing/util/PythonValues.java
+++ b/inject-python/src/main/java/io/micronaut/python/processing/util/PythonValues.java
@@ -53,6 +53,22 @@ public final class PythonValues {
         if (value instanceof Value polyglotValue) {
             return toJava(polyglotValue);
         }
+        if (value instanceof List<?> list) {
+            // A Python list handed to Java as a List is a view onto the guest object, and reading it once the
+            // compilation context has closed fails with "The Context is already closed". Copy it out eagerly.
+            List<Object> converted = new ArrayList<>(list.size());
+            for (Object element : list) {
+                converted.add(toJava(element));
+            }
+            return converted;
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<Object, Object> converted = new LinkedHashMap<>(map.size());
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                converted.put(toJava(entry.getKey()), toJava(entry.getValue()));
+            }
+            return converted;
+        }
         return value;
     }
 

--- a/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
+++ b/inject-python/src/main/resources/GRAALPY-VFS/io.micronaut/micronaut-inject-python/src/micronaut_processor.py
@@ -301,7 +301,7 @@ class MicronautAstVisitor(ast.NodeVisitor):
 
                     # Only check for micronaut decorators on top-level functions (not nested)
                     if self.current_class is None and not was_in_function and is_micronaut_decorator(node, self):
-                        arg_dict = extract_arg_defaults(node)
+                        arg_dict = extract_arg_defaults(node, self)
                         member_decorators = extract_arg_decorators(self, node)
                         member_types = extract_arg_types(self, node)
                         # Filter out micronaut_annotation decorators as they are internal helpers
@@ -2239,10 +2239,14 @@ def _resolve_java_constant(visitor, name_parts):
 
     return None
 
-def extract_arg_defaults(func_node):
+def extract_arg_defaults(func_node, visitor=None):
     """
     Given an ast.FunctionDef node, return an ordered dictionary
     mapping argument names to their default values (or None).
+
+    Defaults are converted the same way member values given at a usage site are, so that an
+    enum constant, a class reference, a list or a nested decorator reaches the Java side in the
+    shape the stub generator expects rather than as an AST repr.
     """
     arg_names = [a.arg for a in func_node.args.args]
     defaults = func_node.args.defaults
@@ -2251,24 +2255,13 @@ def extract_arg_defaults(func_node):
     num_no_defaults = len(arg_names) - len(defaults)
     default_values = [None]*num_no_defaults + defaults
 
-    # Evaluate AST nodes to their actual values if needed
-    # (here just represent as ast.dump for illustration)
     arg_dict = {}
     for arg, default in zip(arg_names, default_values):
         member_name = normalize_python_keyword_alias(arg)
         if default is None:
             arg_dict[member_name] = None
         else:
-            try:
-                # Try to evaluate the value if it's a constant
-                val = ast.literal_eval(default)
-            except _LITERAL_EVAL_ERRORS:
-                # Handle Name nodes (class references) specially
-                if isinstance(default, ast.Name):
-                    val = default.id
-                else:
-                    val = ast.dump(default)
-            arg_dict[member_name] = val
+            arg_dict[member_name] = convert_ast_value(default, visitor)
 
     return arg_dict
 

--- a/inject-python/src/test/resources/python-tests/test_micronaut_processor.py
+++ b/inject-python/src/test/resources/python-tests/test_micronaut_processor.py
@@ -75,6 +75,21 @@ class FunctionShapeTest(unittest.TestCase):
         defaults = processor.extract_arg_defaults(self.func("def dec(prefix='x', count=1, flag=True, ref=Other, empty=''): pass"))
         self.assertEqual({"prefix": "x", "count": 1, "flag": True, "ref": "Other", "empty": ""}, defaults)
 
+    def test_argument_defaults_convert_non_literal_expressions(self):
+        visitor, _ = visit("""
+from enum import Enum
+class Colour(Enum):
+    RED = "RED"
+""")
+        defaults = processor.extract_arg_defaults(
+            self.func("def dec(enumValue=Colour.RED, names=['a', 'b'], ref=Colour): pass"),
+            visitor,
+        )
+        # the Java side takes the constant name from the last segment, however the reference was resolved
+        self.assertEqual("RED", defaults["enumValue"].split(".")[-1])
+        self.assertEqual(["a", "b"], defaults["names"])
+        self.assertEqual("pkg.Colour", defaults["ref"])
+
 
 class TypeAnnotationTest(unittest.TestCase):
     def test_simple_generic_forward_and_union_types(self):


### PR DESCRIPTION
Follows #13160, which settled the annotation member defaults contract for Java, Kotlin and Groovy and deliberately left Python out of scope. Two things were wrong there.

### An enum-constant default on a typed decorator member generated uncompilable Java

`extract_arg_defaults` hand-rolled its value conversion — `ast.literal_eval`, a special case for `ast.Name`, then `ast.dump` for everything else — while every member value given at a *usage* site goes through `convert_ast_value`, which understands attribute chains, lists, tuples, dicts and nested decorator calls. So an enum-constant default reached the stub generator as the AST repr and was written into the generated annotation type verbatim:

```
Pyronaut processing failed: incompatible types: java.lang.String cannot be converted to python.Colour
  Colour enumValue() default "Attribute(value=Name(id='Colour', ctx=Load()), attr='GREEN', ctx=Load())";
```

`extract_arg_defaults` now takes the visitor and delegates to `convert_ast_value`, and `PythonAnnotationStubGenerator` renders a default that has to be a reference rather than a literal as one — an enum constant as `Type.CONSTANT`, a `Class` member as `Type.class` — in scalar and in array position, matching what a usage-site value already produced. A scalar `type` member is now typed as `Class`, as a `list[type]` member already was.

Resolving the enum type through `getRawClassElement`, the way the usage path does, is not an option on the defaults path: the member type is a `PythonEnumElement`, which has no copy constructor, so the `TypeDef` the member was declared with is used directly.

### Python did not implement the empty-string distinction

`PythonAnnotationMetadataBuilder` only overrode the two-argument `readAnnotationDefaultValues`, so it always reported empty string defaults. It now implements the three-argument form and applies the rule documented on `JavaAnnotationMetadataBuilder.isValidDefaultValue`: written bean definition metadata omits empty *string* defaults, `VisitorContext.getAnnotationDefaultValues` includes them, and an empty list default is always kept. A decorator parameter with no default at all arrives as a null member value and is not a default in either mode; an explicitly set empty string is a usage value and is kept as before (`UntypedDecoratorMemberSpec` still passes).

`IntroductionAdviceSpec` asserted that an introduction returning the annotation value yields the empty string — that omission observed through the advice. Its decorator now declares a non-empty default, so the test keeps asserting what it is about.

### Polyglot list views leaking into metadata

A Python list reaching Java as a `java.util.List` is a view onto the guest object; reading it after the compilation context closes fails with `IllegalStateException: The Context is already closed`. `PythonValues` converted a polyglot `Value` but passed such a view through, so a `list` member default was written into annotation metadata as a live `PolyglotList`. It is now copied out eagerly, along with the equivalent `Map` view.

### Tests

`inject-python-test` gains `AnnotationMemberDefaultsSpec`, the Python sibling of the spec #13160 added to the three JVM suites, sharing its expectation literal for the visitor-context read. Two shapes still differ on the *written metadata* read, both because the Python class is visited before its generated Java annotation type exists, so member types are not yet known: a class value is written as the class name rather than an `AnnotationClassValue`, and a list value as a `List` rather than an array. A member value given at a usage site is written the same way, so the defaults are not a special case; the spec documents and asserts this.

`./gradlew :micronaut-inject-python:check :micronaut-inject-python-test:check :micronaut-context-python:check :micronaut-context-python-netty:check :test-suite-python:check -Ppython-ci --continue` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)