### PR TITLE
Let a refresh read the catalog it is rebuilding

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -95,10 +95,11 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
      */
     private ResolverState writeState = state;
     /**
-     * Whether {@link #refresh(Runnable)} is building a replacement state. Guarded by
-     * {@link #catalogLock}.
+     * The thread {@link #refresh(Runnable)} is building a replacement state on, or {@code null}
+     * outside a refresh. Written under {@link #catalogLock}, read without it by every lookup.
      */
-    private boolean refreshing;
+    @SuppressWarnings("java:S3077") // a thread reference, not a mutable object
+    private volatile Thread refreshingThread;
     private final EnvironmentProperties environmentProperties = EnvironmentProperties.fork(CURRENT_ENV);
 
     /**
@@ -158,10 +159,27 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
         synchronized (catalogLock) {
             ResolverState empty = new ResolverState();
             writeState = empty;
-            if (!refreshing) {
+            if (refreshingThread == null) {
                 state = empty;
             }
         }
+    }
+
+    /**
+     * The state a lookup reads from. Outside a refresh that is the published state. On the thread
+     * that is rebuilding the catalogs it is the replacement being built, so the rebuild sees the
+     * properties it has contributed so far: a {@link PropertySource} whose keys depend on what the
+     * resolver already holds (micronaut-test-resources contributes only the keys the environment
+     * cannot resolve) must be answered from the catalog being built, not from the one the rebuild
+     * is replacing. Every other thread keeps reading the published state until the rebuild is
+     * published in one step.
+     *
+     * @return The state to read the catalogs and the caches from
+     */
+    private ResolverState readState() {
+        // Only the refreshing thread takes the `writeState` branch, and it holds `catalogLock` for
+        // the whole rebuild, so it reads a field that no other thread can be writing.
+        return refreshingThread == Thread.currentThread() ? writeState : state;
     }
 
     /**
@@ -176,17 +194,17 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
      */
     void refresh(Runnable rebuild) {
         synchronized (catalogLock) {
-            if (refreshing) {
+            if (refreshingThread != null) {
                 // Already inside a refresh, its outermost call publishes.
                 rebuild.run();
                 return;
             }
-            refreshing = true;
+            refreshingThread = Thread.currentThread();
             try {
                 rebuild.run();
                 state = writeState;
             } finally {
-                refreshing = false;
+                refreshingThread = null;
                 writeState = state;
             }
         }
@@ -315,7 +333,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
         if (StringUtils.isEmpty(name)) {
             return false;
         }
-        ResolverState currentState = state;
+        ResolverState currentState = readState();
         Boolean result = currentState.containsCache.get(name);
         if (result == null) {
             for (PropertyCatalog convention : CONVENTIONS) {
@@ -478,7 +496,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
         ConversionCacheKey cacheKey = new ConversionCacheKey(name, requiredType);
         // A single read of the state, so the catalogs and the caches this lookup consults cannot be
         // replaced underneath it by a concurrent refresh.
-        ResolverState currentState = state;
+        ResolverState currentState = readState();
         Object cached = cacheableType ? currentState.resolvedValueCache.get(cacheKey) : null;
         if (cached != null) {
             return cached == NO_VALUE ? Optional.empty() : Optional.of((T) cached);
@@ -624,7 +642,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
         Map<String, Object> map = new HashMap<>();
         boolean isNested = transformation == MapFormat.MapTransformation.NESTED;
         Arrays
-            .stream(getCatalog(state, keyConvention == StringConvention.RAW ? PropertyCatalog.RAW : PropertyCatalog.GENERATED))
+            .stream(getCatalog(readState(), keyConvention == StringConvention.RAW ? PropertyCatalog.RAW : PropertyCatalog.GENERATED))
             .filter(Objects::nonNull)
             .map(Map::entrySet)
             .flatMap(Collection::stream)
@@ -1092,7 +1110,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
                 return resolveEntriesForKey(writeState, name, true, propertyCatalog);
             }
         }
-        return resolveEntriesForKey(state, name, propertyCatalog);
+        return resolveEntriesForKey(readState(), name, propertyCatalog);
     }
 
     @Nullable
@@ -1141,7 +1159,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
      * Subclasses can override to reset caches.
      */
     protected void resetCaches() {
-        ResolverState currentState = state;
+        ResolverState currentState = readState();
         currentState.containsCache.clear();
         currentState.resolvedValueCache.clear();
         currentState.placeholderResolutionCache.clear();

--- a/inject/src/test/groovy/io/micronaut/context/env/RefreshLazyPropertySourceSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/RefreshLazyPropertySourceSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.context.env
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class RefreshLazyPropertySourceSpec extends Specification {
+
+    void "a property source that only contributes keys the environment does not have survives a refresh"() {
+        given:
+        def ctx = ApplicationContext.builder().start()
+        Environment env = ctx.environment
+        // Mimics micronaut-test-resources' LazyTestResourcesPropertySourceLoader, which contributes
+        // only the keys the environment does not already resolve.
+        def lazy = new PropertySource() {
+            @Override
+            String getName() { "lazy" }
+
+            @Override
+            Object get(String key) { key == "my.lazy.prop" ? "lazy-value" : null }
+
+            @Override
+            Iterator<String> iterator() {
+                env.containsProperties("my.lazy.prop") ? Collections.emptyIterator() : ["my.lazy.prop"].iterator()
+            }
+        }
+        env.addPropertySource(lazy)
+
+        expect:
+        env.getProperty("my.lazy.prop", String).get() == "lazy-value"
+
+        when:
+        def changes = env.refreshAndDiff()
+
+        then:
+        env.getProperty("my.lazy.prop", String).isPresent()
+        changes.isEmpty()
+
+        cleanup:
+        ctx.close()
+    }
+}


### PR DESCRIPTION
## Problem

After `Environment#refresh()`, every property contributed by micronaut-test-resources disappears from the environment, so the `/refresh` endpoint fails with:

```
PropertyNotFoundException: No property found for name [datasources.<name>.username]
```

thrown from `io.micronaut.jdbc.BaseDatasourceFactory#checkAndUpdateUsernameChange`, a `RefreshEventListener`. This is the last failing test on the control-panel core 5.2 bump PR micronaut-projects/micronaut-control-panel#659; the full diagnosis is in https://github.com/micronaut-projects/micronaut-core/issues/13110#issuecomment-5646127164.

## Mechanism

- micronaut-test-resources-core's `LazyTestResourcesPropertySourceLoader$LazyPropertySource#computeKeys` contributes only the keys the environment does not already resolve: it filters its produced keys with `key -> !propertyResolver.containsProperties(key)`, where the resolver is the `Environment`.
- `DefaultEnvironment#refreshProperties` runs `dropProperties(); readProperties();` inside `propertyPlaceholderResolver.refresh(...)`. Since #13079 ("Publish a refreshed property catalog atomically") the rebuild writes into a replacement `writeState` while lookups keep reading the pre-refresh `state` — `PropertySourcePropertyResolver#reset()` only empties `writeState` while `refreshing` is set, whereas 5.1.x cleared the live catalog before the re-read.
- So during the re-read `env.containsProperties(key)` answers `true` from the old catalog, the lazy source filters its keys out, and the new catalog is published without them. `refreshAndDiff` then reports them as removed and `BaseDatasourceFactory` calls `getRequiredProperty` on a key that no longer exists.

## Fix

Keep #13079's atomic publication for concurrent external lookups, but make reads performed *by the rebuild itself* see the catalog being built: `readState()` returns `writeState` when the current thread is the one refreshing, and the published `state` otherwise. The `refreshing` boolean becomes a `refreshingThread` reference, which is all the extra state this needs.

The rebuild therefore sees what it has contributed so far, as it did before #13079, while every other thread still flips from the pre-refresh catalog to the post-refresh one in a single step. The global catalog clear that #13079 removed (#12941) stays removed.

## Test

`inject/src/test/groovy/io/micronaut/context/env/RefreshLazyPropertySourceSpec.groovy` adds a property source that mimics the lazy test-resources source — its `iterator()` yields the key only while `env.containsProperties` says the environment lacks it — and asserts the property survives `refreshAndDiff()` with an empty diff. It fails on `5.2.x` today and passes on 5.1.x and with this change.

```
./gradlew :micronaut-inject:test --tests '*RefreshLazyPropertySourceSpec*'
./gradlew :micronaut-inject:test --tests 'io.micronaut.context.env.*'   # 210 tests, green
```

Diagnosed in #13110; unblocks micronaut-projects/micronaut-control-panel#659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)